### PR TITLE
Reporting and query layer optimization

### DIFF
--- a/prisma/migrations/20260310170000_admin_reporting_perf_indexes/migration.sql
+++ b/prisma/migrations/20260310170000_admin_reporting_perf_indexes/migration.sql
@@ -1,0 +1,15 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Large append-only spend log table: keep write overhead low with BRIN on time.
+CREATE INDEX IF NOT EXISTS "deltallm_spendlogs_start_time_brin_idx"
+  ON "deltallm_spendlogs" USING BRIN ("start_time");
+
+-- Admin reporting joins/searches hit these smaller lookup tables frequently.
+CREATE INDEX IF NOT EXISTS "deltallm_teamtable_team_alias_trgm_idx"
+  ON "deltallm_teamtable" USING GIN ("team_alias" gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "deltallm_organizationtable_name_trgm_idx"
+  ON "deltallm_organizationtable" USING GIN ("organization_name" gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "deltallm_verificationtoken_key_name_trgm_idx"
+  ON "deltallm_verificationtoken" USING GIN ("key_name" gin_trgm_ops);

--- a/src/ui/routes.py
+++ b/src/ui/routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, date, datetime, time
 from decimal import Decimal
+import logging
 from pathlib import Path
 import secrets
 from time import perf_counter
@@ -21,6 +22,7 @@ from src.providers.resolution import provider_presets, resolve_provider, validat
 from src.router import build_deployment_registry
 
 ui_router = APIRouter(tags=["UI"])
+logger = logging.getLogger(__name__)
 
 
 def _dist_dir() -> Path:
@@ -44,6 +46,22 @@ def _db_or_503(request: Request) -> Any:
     if db is None:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Database unavailable")
     return db
+
+
+def _log_admin_query_timing(name: str, started_at: float, **context: Any) -> None:
+    elapsed_ms = int((perf_counter() - started_at) * 1000)
+    if not logger.isEnabledFor(logging.DEBUG) and elapsed_ms < 500:
+        return
+
+    details = " ".join(f"{key}={value}" for key, value in context.items() if value not in (None, "", []))
+    message = f"Admin query completed: name={name} latency_ms={elapsed_ms}"
+    if details:
+        message = f"{message} {details}"
+
+    if elapsed_ms >= 500:
+        logger.info(message)
+    else:
+        logger.debug(message)
 
 
 def _model_entries(app: Any) -> list[dict[str, Any]]:
@@ -466,13 +484,77 @@ def _apply_org_scope_to_spendlogs(
     clauses: list[str],
     params: list[Any],
     org_ids: list[str],
+    *,
+    table_alias: str | None = None,
 ) -> None:
     if not org_ids:
         clauses.append("1 = 0")
         return
+    team_column = f"{table_alias}.team_id" if table_alias else "team_id"
     placeholders = ", ".join(f"${len(params) + i + 1}" for i in range(len(org_ids)))
     params.extend(org_ids)
-    clauses.append(f"team_id IN (SELECT team_id FROM deltallm_teamtable WHERE organization_id IN ({placeholders}))")
+    clauses.append(
+        f"{team_column} IN (SELECT team_id FROM deltallm_teamtable WHERE organization_id IN ({placeholders}))"
+    )
+
+
+def _grouped_spend_config(group_by: str) -> dict[str, Any]:
+    if group_by == "model":
+        return {
+            "group_expr": "s.model",
+            "display_expr": "NULL",
+            "group_by_exprs": ["s.model"],
+            "search_clause": "s.model ILIKE ${i}",
+        }
+    if group_by == "organization":
+        return {
+            "joins": [
+                "LEFT JOIN deltallm_teamtable t ON t.team_id = s.team_id",
+                "LEFT JOIN deltallm_organizationtable o ON o.organization_id = t.organization_id",
+            ],
+            "group_expr": "COALESCE(t.organization_id, 'none')",
+            "display_expr": "NULLIF(TRIM(COALESCE(o.organization_name, '')), '')",
+            "group_by_exprs": [
+                "COALESCE(t.organization_id, 'none')",
+                "NULLIF(TRIM(COALESCE(o.organization_name, '')), '')",
+            ],
+            "search_clause": "(COALESCE(t.organization_id, 'none') ILIKE ${i} OR COALESCE(o.organization_name, '') ILIKE ${i})",
+        }
+    if group_by == "team":
+        return {
+            "joins": ["LEFT JOIN deltallm_teamtable t ON t.team_id = s.team_id"],
+            "group_expr": "COALESCE(s.team_id, 'none')",
+            "display_expr": "NULLIF(TRIM(COALESCE(t.team_alias, '')), '')",
+            "group_by_exprs": [
+                "COALESCE(s.team_id, 'none')",
+                "NULLIF(TRIM(COALESCE(t.team_alias, '')), '')",
+            ],
+            "search_clause": "(COALESCE(s.team_id, 'none') ILIKE ${i} OR COALESCE(t.team_alias, '') ILIKE ${i})",
+        }
+    if group_by == "api_key":
+        return {
+            "joins": ["LEFT JOIN deltallm_verificationtoken vt ON vt.token = s.api_key"],
+            "group_expr": "s.api_key",
+            "display_expr": "NULLIF(TRIM(COALESCE(vt.key_name, '')), '')",
+            "group_by_exprs": [
+                "s.api_key",
+                "NULLIF(TRIM(COALESCE(vt.key_name, '')), '')",
+            ],
+            "search_clause": "(s.api_key ILIKE ${i} OR COALESCE(vt.key_name, '') ILIKE ${i})",
+        }
+    if group_by == "provider":
+        return {
+            "group_expr": "COALESCE(s.api_base, 'unknown')",
+            "display_expr": "NULL",
+            "group_by_exprs": ["COALESCE(s.api_base, 'unknown')"],
+            "search_clause": "COALESCE(s.api_base, 'unknown') ILIKE ${i}",
+        }
+    return {
+        "group_expr": "COALESCE(s.\"user\", 'anonymous')",
+        "display_expr": "NULL",
+        "group_by_exprs": ["COALESCE(s.\"user\", 'anonymous')"],
+        "search_clause": "COALESCE(s.\"user\", 'anonymous') ILIKE ${i}",
+    }
 
 
 @ui_router.get("/ui/api/spend/summary", dependencies=[Depends(require_admin_permission(Permission.SPEND_READ))])
@@ -483,6 +565,7 @@ async def spend_summary(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
+    started_at = perf_counter()
     scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.SPEND_READ)
     db = _db_or_503(request)
     clauses: list[str] = []
@@ -514,61 +597,152 @@ async def spend_summary(
         """,
         *params,
     )
+    _log_admin_query_timing(
+        "spend_summary",
+        started_at,
+        start_date=start_date.isoformat() if start_date else None,
+        end_date=end_date.isoformat() if end_date else None,
+        scoped=not scope.is_platform_admin,
+    )
     return _to_json_value(dict(rows[0] if rows else {}))
 
 
 @ui_router.get("/ui/api/spend/report", dependencies=[Depends(require_admin_permission(Permission.SPEND_READ))])
 async def spend_report(
     request: Request,
-    group_by: str = Query(default="day", pattern="^(model|provider|day|user|team)$"),
+    group_by: str = Query(default="day", pattern="^(model|provider|day|user|team|organization|api_key)$"),
     start_date: date | None = Query(default=None),
     end_date: date | None = Query(default=None),
+    search: str | None = Query(default=None),
+    limit: int = Query(default=5, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
+    started_at = perf_counter()
     scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.SPEND_READ)
     db = _db_or_503(request)
-    group_column = {
-        "model": "model",
-        "provider": "api_base",
-        "day": "DATE(start_time)",
-        "user": "COALESCE(\"user\", 'anonymous')",
-        "team": "COALESCE(team_id, 'none')",
-    }[group_by]
+    if group_by == "day":
+        clauses: list[str] = []
+        params: list[Any] = []
+        if start_date is not None:
+            params.append(_date_start(start_date))
+            clauses.append(f"start_time >= ${len(params)}::timestamp")
+        if end_date is not None:
+            params.append(_date_end(end_date))
+            clauses.append(f"start_time <= ${len(params)}::timestamp")
+        if not scope.is_platform_admin:
+            _apply_org_scope_to_spendlogs(clauses, params, scope.org_ids)
 
+        where_sql = ""
+        if clauses:
+            where_sql = " WHERE " + " AND ".join(clauses)
+
+        rows = await db.query_raw(
+            f"""
+            SELECT
+                DATE(start_time) AS group_key,
+                COALESCE(SUM(spend), 0) AS total_spend,
+                COUNT(*) AS request_count,
+                COALESCE(SUM(total_tokens), 0) AS total_tokens
+            FROM deltallm_spendlogs
+            {where_sql}
+            GROUP BY DATE(start_time)
+            ORDER BY group_key ASC
+            """,
+            *params,
+        )
+        _log_admin_query_timing(
+            "spend_report_day",
+            started_at,
+            start_date=start_date.isoformat() if start_date else None,
+            end_date=end_date.isoformat() if end_date else None,
+            scoped=not scope.is_platform_admin,
+        )
+        return {
+            "group_by": group_by,
+            "breakdown": [_to_json_value(dict(row)) for row in rows],
+        }
+
+    config = _grouped_spend_config(group_by)
     clauses: list[str] = []
     params: list[Any] = []
+    joins = list(config.get("joins", []))
+    group_expr = config["group_expr"]
+    display_expr = config["display_expr"]
+    group_by_sql = ", ".join(config.get("group_by_exprs", [group_expr]))
+
     if start_date is not None:
         params.append(_date_start(start_date))
-        clauses.append(f"start_time >= ${len(params)}::timestamp")
+        clauses.append(f"s.start_time >= ${len(params)}::timestamp")
     if end_date is not None:
         params.append(_date_end(end_date))
-        clauses.append(f"start_time <= ${len(params)}::timestamp")
+        clauses.append(f"s.start_time <= ${len(params)}::timestamp")
+    if search:
+        params.append(f"%{search.strip()}%")
+        clauses.append(config["search_clause"].format(i=len(params)))
     if not scope.is_platform_admin:
-        _apply_org_scope_to_spendlogs(clauses, params, scope.org_ids)
+        _apply_org_scope_to_spendlogs(clauses, params, scope.org_ids, table_alias="s")
+
+    join_sql = ""
+    if joins:
+        join_sql = "\n        " + "\n        ".join(joins)
 
     where_sql = ""
     if clauses:
         where_sql = " WHERE " + " AND ".join(clauses)
 
+    page_params = [*params, limit, offset]
+    limit_idx = len(params) + 1
+    offset_idx = len(params) + 2
     rows = await db.query_raw(
         f"""
+        WITH grouped AS (
+            SELECT
+                {group_expr} AS group_key,
+                {display_expr} AS display_name,
+                COALESCE(SUM(s.spend), 0) AS total_spend,
+                COUNT(*) AS request_count,
+                COALESCE(SUM(s.total_tokens), 0) AS total_tokens
+            FROM deltallm_spendlogs s
+            {join_sql}
+            {where_sql}
+            GROUP BY {group_by_sql}
+        )
         SELECT
-            {group_column} AS group_key,
-            COALESCE(SUM(spend), 0) AS total_spend,
-            COUNT(*) AS request_count,
-            COALESCE(SUM(total_tokens), 0) AS total_tokens
-        FROM deltallm_spendlogs
-        {where_sql}
-        GROUP BY {group_column}
-        ORDER BY group_key ASC
+            group_key,
+            display_name,
+            total_spend,
+            request_count,
+            total_tokens,
+            COUNT(*) OVER() AS total_count
+        FROM grouped
+        ORDER BY total_spend DESC, group_key ASC
+        LIMIT ${limit_idx}
+        OFFSET ${offset_idx}
         """,
-        *params,
+        *page_params,
+    )
+    total = int((rows[0] if rows else {}).get("total_count") or 0)
+    _log_admin_query_timing(
+        "spend_report_grouped",
+        started_at,
+        group_by=group_by,
+        search=search.strip() if search else None,
+        limit=limit,
+        offset=offset,
+        scoped=not scope.is_platform_admin,
     )
 
     return {
         "group_by": group_by,
-        "breakdown": [_to_json_value(dict(row)) for row in rows],
+        "data": [_to_json_value({k: v for k, v in dict(row).items() if k != "total_count"}) for row in rows],
+        "pagination": {
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + limit < total,
+        },
     }
 
 
@@ -585,6 +759,7 @@ async def request_logs(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
+    started_at = perf_counter()
     scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.SPEND_READ)
     db = _db_or_503(request)
 
@@ -637,6 +812,16 @@ async def request_logs(
     )
 
     total = int((total_rows[0] if total_rows else {}).get("total") or 0)
+    _log_admin_query_timing(
+        "request_logs",
+        started_at,
+        model=model,
+        team_id=team_id,
+        user_id=user_id,
+        limit=limit,
+        offset=offset,
+        scoped=not scope.is_platform_admin,
+    )
 
     return {
         "logs": [_to_json_value(dict(row)) for row in logs],

--- a/tests/test_ui_rbac_scoping.py
+++ b/tests/test_ui_rbac_scoping.py
@@ -95,6 +95,91 @@ async def test_spend_report_not_scoped_for_platform_admin(client, test_app, monk
 
 
 @pytest.mark.asyncio
+async def test_grouped_spend_report_applies_org_scope_for_non_platform(client, test_app, monkeypatch):
+    fake_db = FakeSpendDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.ui.routes.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=False,
+            org_ids=["org-1"],
+            team_ids=[],
+        ),
+    )
+
+    response = await client.get(
+        "/ui/api/spend/report?group_by=organization&limit=5&offset=0",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+    assert response.status_code == 200
+
+    assert len(fake_db.calls) == 1
+    query, params = fake_db.calls[0]
+    assert "s.team_id IN (SELECT team_id FROM deltallm_teamtable WHERE organization_id IN" in query
+    assert "LEFT JOIN deltallm_teamtable t ON t.team_id = s.team_id" in query
+    assert "COUNT(*) OVER()" in query
+    assert "org-1" in params
+
+
+@pytest.mark.asyncio
+async def test_grouped_spend_report_supports_api_key_search(client, test_app, monkeypatch):
+    fake_db = FakeSpendDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.ui.routes.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=True,
+            org_ids=[],
+            team_ids=[],
+        ),
+    )
+
+    response = await client.get(
+        "/ui/api/spend/report?group_by=api_key&search=sk-test&limit=5&offset=0",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+    assert response.status_code == 200
+
+    assert len(fake_db.calls) == 1
+    query, params = fake_db.calls[0]
+    assert "LEFT JOIN deltallm_verificationtoken vt ON vt.token = s.api_key" in query
+    assert "vt.key_name" in query
+    assert "ILIKE" in query
+    assert "%sk-test%" in params
+    assert "ORDER BY total_spend DESC" in query
+
+
+@pytest.mark.asyncio
+async def test_grouped_spend_report_for_model_does_not_group_by_null_constant(client, test_app, monkeypatch):
+    fake_db = FakeSpendDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.ui.routes.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=True,
+            org_ids=[],
+            team_ids=[],
+        ),
+    )
+
+    response = await client.get(
+        "/ui/api/spend/report?group_by=model&limit=5&offset=0",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+    assert response.status_code == 200
+
+    query, _ = fake_db.calls[0]
+    assert "GROUP BY s.model" in query
+    assert "GROUP BY s.model, NULL" not in query
+
+
+@pytest.mark.asyncio
 async def test_spend_endpoints_cast_date_filters_to_timestamp(client, test_app, monkeypatch):
     fake_db = FakeSpendDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -16,6 +16,7 @@ import {
   Settings,
   LogOut,
   Zap,
+  Sparkles,
   Menu,
   X,
   ChevronDown,
@@ -50,7 +51,7 @@ const navEntries: NavEntry[] = [
     type: 'group',
     key: 'ai-gateway',
     label: 'AI Gateway',
-    icon: Workflow,
+    icon: Sparkles,
     children: [
       { type: 'item', to: '/models', icon: Box, label: 'Models' },
       { type: 'item', to: '/route-groups', icon: Workflow, label: 'Route Groups', adminOnly: true },
@@ -126,6 +127,10 @@ function parentNavClass(isActive: boolean) {
   );
 }
 
+function childNavPanelClass() {
+  return 'mx-3 mt-1 border-l border-gray-800 pl-5';
+}
+
 function SidebarContent({
   visibleEntries,
   displayEmail,
@@ -190,7 +195,7 @@ function SidebarContent({
                 {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
               </button>
               {isExpanded && (
-                <div id={groupPanelId} className="mt-1 ml-6 border-l border-gray-800 pl-2" role="group" aria-label={entry.label}>
+                <div id={groupPanelId} className={childNavPanelClass()} role="group" aria-label={entry.label}>
                   {entry.children.map((child) => {
                     const ChildIcon = child.icon;
                     return (
@@ -243,7 +248,11 @@ export default function Layout() {
   const displayEmail = authMode === 'master_key' ? 'Master Key' : (session?.email || 'Unknown');
   const displayRole = session?.role || (authMode === 'master_key' ? 'platform_admin' : '');
   const isPlatformAdmin = displayRole === 'platform_admin';
-  const permissions = new Set((session?.effective_permissions || []).map((item) => String(item)));
+  const permissionKeys = useMemo(
+    () => (session?.effective_permissions || []).map((item) => String(item)).sort(),
+    [session?.effective_permissions]
+  );
+  const permissions = useMemo(() => new Set(permissionKeys), [permissionKeys]);
 
   const visibleEntries = useMemo(
     () =>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -104,6 +104,22 @@ export interface SpendLog {
   request_tags?: string[];
 }
 
+export type SpendGroupBy = 'model' | 'organization' | 'team' | 'api_key';
+
+export interface SpendGroupRow {
+  group_key: string;
+  display_name?: string | null;
+  total_spend: number;
+  total_tokens: number;
+  request_count: number;
+}
+
+export interface SpendGroupReport {
+  group_by: SpendGroupBy | 'provider' | 'user';
+  data: SpendGroupRow[];
+  pagination: Pagination;
+}
+
 export interface ServiceAccount {
   service_account_id: string;
   team_id: string;
@@ -238,6 +254,18 @@ export const spend = {
     if (start_date) qs.set('start_date', start_date);
     if (end_date) qs.set('end_date', end_date);
     return apiFetch<any>(`/ui/api/spend/report?${qs.toString()}`);
+  },
+  groupedReport: (
+    group_by: SpendGroupBy,
+    params?: { start_date?: string; end_date?: string; search?: string; limit?: number; offset?: number }
+  ) => {
+    const qs = new URLSearchParams({ group_by });
+    if (params?.start_date) qs.set('start_date', params.start_date);
+    if (params?.end_date) qs.set('end_date', params.end_date);
+    if (params?.search) qs.set('search', params.search);
+    if (params?.limit != null) qs.set('limit', String(params.limit));
+    if (params?.offset != null) qs.set('offset', String(params.offset));
+    return apiFetch<SpendGroupReport>(`/ui/api/spend/report?${qs.toString()}`);
   },
   logs: (params?: Record<string, string>) => {
     const qs = new URLSearchParams(params || {});

--- a/ui/src/pages/Usage.tsx
+++ b/ui/src/pages/Usage.tsx
@@ -1,13 +1,34 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useApi } from '../lib/hooks';
-import { spend, type SpendLog } from '../lib/api';
+import { spend, type SpendGroupBy, type SpendGroupRow, type SpendLog } from '../lib/api';
 import Card from '../components/Card';
 import DataTable from '../components/DataTable';
 import StatCard from '../components/StatCard';
 import Modal from '../components/Modal';
 import { DollarSign, Zap, Hash, Calendar } from 'lucide-react';
 import { XAxis, YAxis, Tooltip, ResponsiveContainer, AreaChart, Area } from 'recharts';
+
+const SPEND_GROUP_OPTIONS: Array<{ value: SpendGroupBy; label: string }> = [
+  { value: 'model', label: 'Model' },
+  { value: 'organization', label: 'Organization' },
+  { value: 'team', label: 'Team' },
+  { value: 'api_key', label: 'API Key' },
+];
+
+const SPEND_GROUP_LABELS: Record<SpendGroupBy, string> = {
+  model: 'Model',
+  organization: 'Organization',
+  team: 'Team',
+  api_key: 'API Key',
+};
+
+const SPEND_SEARCH_PLACEHOLDERS: Record<SpendGroupBy, string> = {
+  model: 'Filter models...',
+  organization: 'Filter organizations...',
+  team: 'Filter teams...',
+  api_key: 'Filter API keys...',
+};
 
 function fmt(n: number | null | undefined): string {
   if (n == null) return '$0.00';
@@ -37,42 +58,97 @@ function DetailItem({ label, value, mono = false }: { label: string; value: Reac
   );
 }
 
+function renderSpendGroupValue(groupBy: SpendGroupBy, row: SpendGroupRow) {
+  if (groupBy === 'model') {
+    return <span className="font-medium">{row.group_key}</span>;
+  }
+  if (groupBy === 'api_key') {
+    return (
+      <div>
+        <div className="font-medium">{row.display_name || 'Unnamed key'}</div>
+        <code className="text-xs text-gray-500">
+          {row.group_key.length > 18 ? `${row.group_key.slice(0, 18)}...` : row.group_key}
+        </code>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <div className="font-medium">{row.display_name || row.group_key}</div>
+      {row.display_name && <div className="text-xs text-gray-500">{row.group_key}</div>}
+    </div>
+  );
+}
+
 export default function Usage() {
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [tab, setTab] = useState<'overview' | 'logs'>('overview');
   const [selectedLog, setSelectedLog] = useState<SpendLog | null>(null);
+  const [spendBy, setSpendBy] = useState<SpendGroupBy>('model');
+  const [spendSearchInput, setSpendSearchInput] = useState('');
+  const [spendSearch, setSpendSearch] = useState('');
+  const [spendOffset, setSpendOffset] = useState(0);
+  const [logsOffset, setLogsOffset] = useState(0);
+  const spendPageSize = 5;
+  const logsPageSize = 25;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSpendSearch(spendSearchInput.trim());
+      setSpendOffset(0);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [spendSearchInput]);
+
+  useEffect(() => {
+    setSpendOffset(0);
+  }, [spendBy, startDate, endDate]);
+
+  useEffect(() => {
+    setLogsOffset(0);
+  }, [startDate, endDate]);
 
   const { data: summary } = useApi(() => spend.summary(startDate, endDate), [startDate, endDate]);
   const { data: dailyReport } = useApi(() => spend.report('day', startDate, endDate), [startDate, endDate]);
-  const { data: modelReport } = useApi(() => spend.report('model', startDate, endDate), [startDate, endDate]);
-  const { data: userReport } = useApi(() => spend.report('user', startDate, endDate), [startDate, endDate]);
-  const { data: teamReport } = useApi(() => spend.report('team', startDate, endDate), [startDate, endDate]);
-  const { data: logsData, loading: logsLoading } = useApi(() => spend.logs({ limit: '50' }), []);
+  const { data: spendGroupsData, loading: spendGroupsLoading } = useApi(
+    () =>
+      spend.groupedReport(spendBy, {
+        start_date: startDate || undefined,
+        end_date: endDate || undefined,
+        search: spendSearch || undefined,
+        limit: spendPageSize,
+        offset: spendOffset,
+      }),
+    [spendBy, startDate, endDate, spendSearch, spendOffset]
+  );
+  const { data: logsData, loading: logsLoading } = useApi(
+    () => {
+      const params: Record<string, string> = {
+        limit: String(logsPageSize),
+        offset: String(logsOffset),
+      };
+      if (startDate) params.start_date = startDate;
+      if (endDate) params.end_date = endDate;
+      return spend.logs(params);
+    },
+    [startDate, endDate, logsOffset]
+  );
 
   const daily = (dailyReport?.breakdown || []).map((r: any) => ({ date: r.group_key, total_spend: r.total_spend }));
-  const perModel = (modelReport?.breakdown || []).map((r: any) => ({ model: r.group_key, total_spend: r.total_spend, total_tokens: r.total_tokens, request_count: r.request_count }));
-  const perKey = (userReport?.breakdown || []).map((r: any) => ({ api_key: r.group_key, total_spend: r.total_spend, request_count: r.request_count }));
-  const perTeam = (teamReport?.breakdown || []).map((r: any) => ({ team_id: r.group_key, total_spend: r.total_spend, request_count: r.request_count }));
+  const spendGroups = spendGroupsData?.data || [];
+  const spendGroupsPagination = spendGroupsData?.pagination;
   const logs = logsData?.logs || [];
+  const logsPagination = logsData?.pagination;
 
-  const modelColumns = [
-    { key: 'model', header: 'Model', render: (r: any) => <span className="font-medium">{r.model}</span> },
+  const spendGroupColumns = [
+    {
+      key: 'group_key',
+      header: SPEND_GROUP_LABELS[spendBy],
+      render: (row: SpendGroupRow) => renderSpendGroupValue(spendBy, row),
+    },
     { key: 'total_spend', header: 'Spend', render: (r: any) => fmt(r.total_spend) },
     { key: 'total_tokens', header: 'Tokens', render: (r: any) => fmtNum(r.total_tokens) },
-    { key: 'request_count', header: 'Requests', render: (r: any) => fmtNum(r.request_count) },
-  ];
-
-  const keyColumns = [
-    { key: 'api_key', header: 'API Key', render: (r: any) => <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded">{(r.api_key || '').substring(0, 12)}...</code> },
-    { key: 'key_name', header: 'Name', render: (r: any) => r.key_name || <span className="text-gray-400">—</span> },
-    { key: 'total_spend', header: 'Spend', render: (r: any) => fmt(r.total_spend) },
-    { key: 'request_count', header: 'Requests', render: (r: any) => fmtNum(r.request_count) },
-  ];
-
-  const teamColumns = [
-    { key: 'team_id', header: 'Team', render: (r: any) => <span className="font-medium">{r.team_id}</span> },
-    { key: 'total_spend', header: 'Spend', render: (r: any) => fmt(r.total_spend) },
     { key: 'request_count', header: 'Requests', render: (r: any) => fmtNum(r.request_count) },
   ];
 
@@ -137,17 +213,36 @@ export default function Usage() {
             )}
           </Card>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-            <Card title="Spend by Model">
-              <DataTable columns={modelColumns} data={perModel || []} emptyMessage="No model data" />
-            </Card>
-            <Card title="Spend by API Key">
-              <DataTable columns={keyColumns} data={perKey || []} emptyMessage="No key data" />
-            </Card>
-          </div>
-
-          <Card title="Spend by Team">
-            <DataTable columns={teamColumns} data={perTeam || []} emptyMessage="No team data" />
+          <Card title="Spend by">
+            <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="inline-flex w-full flex-wrap rounded-lg border border-gray-200 bg-gray-50 p-1 lg:w-auto">
+                {SPEND_GROUP_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    onClick={() => setSpendBy(option.value)}
+                    className={`rounded-md px-3 py-2 text-sm transition-colors ${
+                      spendBy === option.value ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-600 hover:text-gray-900'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+              <input
+                value={spendSearchInput}
+                onChange={(e) => setSpendSearchInput(e.target.value)}
+                placeholder={SPEND_SEARCH_PLACEHOLDERS[spendBy]}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 lg:w-72"
+              />
+            </div>
+            <DataTable
+              columns={spendGroupColumns}
+              data={spendGroups}
+              loading={spendGroupsLoading}
+              emptyMessage={`No ${SPEND_GROUP_LABELS[spendBy].toLowerCase()} spend data`}
+              pagination={spendGroupsPagination}
+              onPageChange={setSpendOffset}
+            />
           </Card>
         </>
       ) : (
@@ -161,6 +256,8 @@ export default function Usage() {
             loading={logsLoading}
             emptyMessage="No request logs yet"
             onRowClick={setSelectedLog}
+            pagination={logsPagination}
+            onPageChange={setLogsOffset}
           />
         </Card>
       )}


### PR DESCRIPTION
1. Reporting and query layer

  - src/ui/routes.py now supports unified grouped spend reporting for Model, Organization, Team, and API Key.
  - It adds server-side search, pagination, org-scoped filtering, and a single-query grouped report path using COUNT(*) OVER() instead of separate count/data queries.
  - It also fixes the Model tab regression where grouped SQL was incorrectly emitting GROUP BY s.model, NULL.
  - It adds timing logs for admin reporting endpoints only.

  2. Usage page UX

  - ui/src/pages/Usage.tsx was refactored from multiple separate “Spend by …” tables into one unified Spend by card with tabs/switches.
  - That view now supports:
      - Model, Organization, Team, API Key
      - partial-match search
      - pagination with default top 5
  - The Spend Logs table also now has pagination.
  - ui/src/lib/api.ts adds typed grouped-report client support for that UI.

  3. Sidebar navigation polish

  - ui/src/components/Layout.tsx includes:
      - the AI Gateway icon change to Sparkles
      - consistent right-side spacing for child menu items
      - a fix so an expanded parent with an active child can still be collapsed manually