### PR TITLE
Harden routing policy runtime behavior

### DIFF
--- a/docs/admin-ui/route-groups.md
+++ b/docs/admin-ui/route-groups.md
@@ -61,6 +61,131 @@ Start with the default behavior unless you need one of these:
 - a specific routing strategy
 - a draft, publish, rollback, or simulation workflow for routing changes
 
+## Routing Policy Basics
+
+A route-group policy should stay small and explicit.
+
+In practice, that means:
+
+- choose one routing strategy
+- optionally override member `enabled`, `weight`, or `priority`
+- optionally override the group timeout
+- optionally override retry behavior
+
+The supported policy fields today are:
+
+- `mode`
+- `strategy`
+- `members`
+- `timeouts.global_ms` or `timeouts.global_seconds`
+- `retry.max_attempts`
+- `retry.retryable_error_classes`
+
+## Policy Modes
+
+The UI can present policy modes as shortcuts:
+
+- `weighted`: use weighted traffic splitting
+- `fallback`: use ordered primary and standby behavior
+
+How they behave:
+
+- `weighted` maps to the `weighted` strategy if you do not set a strategy explicitly
+- `fallback` maps to `priority-based-routing` if you do not set a strategy explicitly
+
+Do not plan around these as live runtime modes yet:
+
+- `conditional`
+- `adaptive`
+
+Those are not active route-policy behaviors in the runtime today.
+
+## Which Policy Should I Use?
+
+Choose by goal:
+
+- use `simple-shuffle` when the deployments are roughly equal
+- use `weighted` when you want a controlled traffic split
+- use `priority-based-routing` or `fallback` when one deployment should be primary
+- use `least-busy` when you are smoothing burst traffic
+- use `latency-based-routing` when end-user latency matters most
+- use `cost-based-routing` when cost matters most
+- use `rate-limit-aware` when provider limits are the problem
+
+For most teams, one of these three is enough:
+
+- `simple-shuffle`
+- `weighted`
+- `priority-based-routing`
+
+## Simple Policy Examples
+
+Weighted rollout:
+
+```json
+{
+  "mode": "weighted",
+  "members": [
+    {"deployment_id": "dep-primary", "weight": 9},
+    {"deployment_id": "dep-canary", "weight": 1}
+  ]
+}
+```
+
+Primary plus standby:
+
+```json
+{
+  "mode": "fallback",
+  "members": [
+    {"deployment_id": "dep-primary", "priority": 0},
+    {"deployment_id": "dep-standby", "priority": 1}
+  ]
+}
+```
+
+Latency-sensitive route group:
+
+```json
+{
+  "strategy": "latency-based-routing",
+  "timeouts": {"global_seconds": 45},
+  "retry": {"max_attempts": 1}
+}
+```
+
+Quota-aware route group:
+
+```json
+{
+  "strategy": "rate-limit-aware"
+}
+```
+
+## Member Overrides
+
+Member overrides let the group behave differently without editing the underlying deployment definition.
+
+- `enabled`: take a member out of rotation without removing it
+- `weight`: change traffic share for `weighted`
+- `priority`: control order for `priority-based-routing` or `fallback`
+
+## Good Operating Pattern
+
+Use this workflow:
+
+1. Create the route group and add members
+2. Start with `simple-shuffle` or `weighted`
+3. Simulate before publishing policy changes
+4. Publish only after the selection summary looks right
+5. Check `/health/deployments` and `/health/fallback-events` after rollout
+
+The simulation view is especially useful for:
+
+- checking weighted splits
+- confirming fallback order
+- confirming prompt-derived tag routing
+
 ## Prompt Binding
 
 Prompt binding belongs on the route group because the group decides where a prompt is applied.

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -46,7 +46,44 @@ These strategy names are valid today:
 - `weighted`
 - `rate-limit-aware`
 
-See [Routing & Failover](../features/routing.md) for when to use each one.
+Short version:
+
+- `simple-shuffle`: best default when deployments are equivalent
+- `weighted`: use for planned traffic splits
+- `priority-based-routing`: use for primary and standby routing
+- `least-busy`: use for burst balancing
+- `latency-based-routing`: use for latency-sensitive traffic
+- `cost-based-routing`: use for lowest-cost routing
+- `usage-based-routing`: use to spread quota usage
+- `rate-limit-aware`: use to avoid hot deployments near RPM or TPM caps
+- `tag-based-routing`: use when tags decide eligibility and you want the route group to make that explicit
+
+For non-text workloads, usage-aware routing can also use these deployment fields when they are configured:
+
+- `image_pm_limit`
+- `audio_seconds_pm_limit`
+- `char_pm_limit`
+- `rerank_units_pm_limit`
+
+See [Routing & Failover](../features/routing.md) for the full behavior and setup examples.
+
+## Route-Group Policy Support
+
+Route-group policies currently support:
+
+- `mode`
+- `strategy`
+- `members`
+- `timeouts.global_ms` or `timeouts.global_seconds`
+- `retry.max_attempts`
+- `retry.retryable_error_classes`
+
+Helpful shortcut modes:
+
+- `weighted` maps to `weighted`
+- `fallback` maps to `priority-based-routing`
+
+Do not treat `conditional` or `adaptive` as active runtime policy behaviors today.
 
 ## Fallback Configuration
 

--- a/docs/features/routing.md
+++ b/docs/features/routing.md
@@ -45,25 +45,303 @@ For each request, DeltaLLM:
 
 1. Resolves the requested model name to a model group
 2. Removes unhealthy or cooled-down deployments
-3. Applies any tag and priority filters
-4. Selects one deployment with the active routing strategy
-5. Retries or falls back if the call fails in a retryable way
+3. Applies request tag filtering when `metadata.tags` is present
+4. Optionally skips deployments already above configured RPM or TPM limits
+5. Selects one deployment with the active routing strategy
+6. Retries or falls back if the call fails in a retryable way
+
+## Pick A Strategy Fast
+
+If you do not want to think too hard about routing on day one, use this:
+
+- `simple-shuffle` for most gateways
+- `weighted` when you want a planned traffic split such as `90/10`
+- `priority-based-routing` when you want a primary deployment with a clear standby
+- `least-busy` when one deployment tends to get stuck with more in-flight work
+- `rate-limit-aware` when provider quotas are the main problem
+
+Everything else is useful, but usually only after you have a specific reason.
 
 ## Routing Strategies
 
 Set the global default in `router_settings.routing_strategy`, or override it with a route-group policy in the Admin UI.
 
-| Strategy | What it does | Good default for |
+| Strategy | What it does | Use it when |
 | --- | --- | --- |
-| `simple-shuffle` | Weighted random choice across healthy deployments | Most teams |
-| `least-busy` | Chooses the deployment with the fewest in-flight requests | Uneven traffic |
-| `latency-based-routing` | Prefers the deployment with the best recent latency | Latency-sensitive workloads |
-| `cost-based-routing` | Chooses the cheapest deployment by configured token cost | Cost control |
-| `usage-based-routing` | Prefers deployments with the lowest current RPM/TPM utilization | Shared fleets |
-| `tag-based-routing` | Matches request metadata tags to deployment tags | Region or capability routing |
-| `priority-based-routing` | Uses the lowest priority number first | Primary and fallback setups |
-| `weighted` | Weighted random choice using `weight` | Planned traffic splits |
-| `rate-limit-aware` | Avoids deployments that are near configured RPM/TPM limits | Provider quota protection |
+| `simple-shuffle` | Randomly picks a healthy deployment | You want a low-maintenance default |
+| `weighted` | Randomly picks by `model_info.weight` | You want a deliberate traffic split |
+| `priority-based-routing` | Tries the lowest `priority` number first | You want primary and standby behavior |
+| `least-busy` | Picks the deployment with the fewest active requests | Queue depth matters more than strict weighting |
+| `latency-based-routing` | Prefers the best recent latency, while keeping new members eligible | Response time matters most |
+| `cost-based-routing` | Prefers the lowest estimated unit cost for the request mode | You want the cheapest acceptable path |
+| `usage-based-routing` | Prefers the deployment with the lowest current RPM/TPM utilization | You share quota across providers or keys |
+| `rate-limit-aware` | Avoids deployments near configured RPM/TPM limits | You need to stay away from provider caps |
+| `tag-based-routing` | Uses the same tag-filtered eligible pool as other strategies, then applies weighted choice | You want a route group that is explicitly tag-driven |
+
+### Strategy Details
+
+#### `simple-shuffle`
+
+What it does:
+- Picks randomly from the healthy eligible pool
+- Ignores `weight`
+
+Use it when:
+- Deployments are roughly equivalent
+- You want the simplest setup
+- You are starting out and want predictable behavior
+
+Avoid it when:
+- You need a planned percentage split
+- One deployment should clearly be preferred over another
+
+Setup:
+
+```yaml
+router_settings:
+  routing_strategy: simple-shuffle
+```
+
+#### `weighted`
+
+What it does:
+- Picks randomly, but higher `weight` gets more traffic over time
+- Good for controlled rollout, canarying, or provider mix changes
+
+Use it when:
+- You want `90/10`, `80/20`, or `50/50`
+- You want gradual migration from one deployment to another
+
+Required deployment metadata:
+- `model_info.weight`
+
+Setup:
+
+```yaml
+model_list:
+  - model_name: gpt-4o-mini
+    deployment_id: primary
+    deltallm_params: {model: openai/gpt-4o-mini}
+    model_info: {weight: 9}
+  - model_name: gpt-4o-mini
+    deployment_id: canary
+    deltallm_params: {model: openai/gpt-4o-mini}
+    model_info: {weight: 1}
+
+router_settings:
+  routing_strategy: weighted
+```
+
+#### `priority-based-routing`
+
+What it does:
+- Tries all priority `0` deployments first
+- Only falls through to higher numbers like `1` or `2` if the higher-priority pool is unavailable
+
+Use it when:
+- You have a preferred primary provider
+- You want a warm standby deployment
+- Order matters more than spreading traffic
+
+Required deployment metadata:
+- `model_info.priority`
+
+Setup:
+
+```yaml
+model_list:
+  - model_name: gpt-4o-mini
+    deployment_id: primary
+    deltallm_params: {model: openai/gpt-4o-mini}
+    model_info: {priority: 0}
+  - model_name: gpt-4o-mini
+    deployment_id: standby
+    deltallm_params: {model: openai/gpt-4o-mini}
+    model_info: {priority: 1}
+
+router_settings:
+  routing_strategy: priority-based-routing
+```
+
+#### `least-busy`
+
+What it does:
+- Chooses the deployment with the fewest active in-flight requests
+- Useful when latency is mostly driven by queue depth
+
+Use it when:
+- Deployments are similar, but traffic can clump
+- You want better balancing during bursts
+
+Avoid it when:
+- You need explicit rollout percentages
+- Cost or provider quota is the main concern
+
+Setup:
+
+```yaml
+router_settings:
+  routing_strategy: least-busy
+```
+
+#### `latency-based-routing`
+
+What it does:
+- Uses recent observed latency to prefer faster deployments
+- New or unsampled deployments stay eligible instead of being starved forever
+
+Use it when:
+- User-facing latency matters more than cost
+- Providers behave differently by region or load
+
+Avoid it when:
+- You do not have enough steady traffic to build meaningful latency history
+
+Setup:
+
+```yaml
+router_settings:
+  routing_strategy: latency-based-routing
+```
+
+#### `cost-based-routing`
+
+What it does:
+- Estimates the cheapest eligible deployment for the current request mode
+- Works best when deployment pricing metadata is accurate
+
+Use it when:
+- You have multiple providers for the same workload
+- Cost control matters more than tiny latency differences
+
+Make sure you set pricing metadata that matches the workload:
+- token costs for chat, completions, embeddings, and rerank
+- image pricing for image generation
+- audio pricing for speech or transcription where applicable
+
+Setup:
+
+```yaml
+router_settings:
+  routing_strategy: cost-based-routing
+```
+
+#### `usage-based-routing`
+
+What it does:
+- Looks at recent request-per-minute and token-per-minute usage
+- Prefers the least utilized deployment
+
+Use it when:
+- Several deployments share quota ceilings
+- You want to spread demand before you hit provider-side limits
+
+Best with:
+- accurate `rpm_limit` and `tpm_limit`
+- steady traffic patterns
+- matching per-unit limits for non-text workloads, such as `image_pm_limit`, `audio_seconds_pm_limit`, `char_pm_limit`, or `rerank_units_pm_limit`
+
+Setup:
+
+```yaml
+model_list:
+  - model_name: gpt-4o-mini
+    deployment_id: east
+    deltallm_params: {model: openai/gpt-4o-mini}
+    model_info: {rpm_limit: 600, tpm_limit: 300000}
+  - model_name: gpt-4o-mini
+    deployment_id: west
+    deltallm_params: {model: openai/gpt-4o-mini}
+    model_info: {rpm_limit: 600, tpm_limit: 300000}
+
+router_settings:
+  routing_strategy: usage-based-routing
+```
+
+#### `rate-limit-aware`
+
+What it does:
+- Filters out deployments already close to their configured RPM or TPM ceilings
+- Then picks from the remaining pool
+
+Use it when:
+- Hitting provider rate limits is your biggest operational problem
+- You want to stay away from hot deployments before they fail
+
+Required deployment metadata:
+- `model_info.rpm_limit`
+- `model_info.tpm_limit`
+
+For non-text workloads, `rate-limit-aware` uses matching per-unit limits when present:
+- `model_info.image_pm_limit`
+- `model_info.audio_seconds_pm_limit`
+- `model_info.char_pm_limit`
+- `model_info.rerank_units_pm_limit`
+
+Optional extra safety:
+- enable `router_settings.enable_pre_call_checks`
+
+Setup:
+
+```yaml
+router_settings:
+  routing_strategy: rate-limit-aware
+  enable_pre_call_checks: true
+```
+
+#### `tag-based-routing`
+
+What it does:
+- Uses the same request-tag eligibility filtering that DeltaLLM already applies before strategy selection
+- Then uses weighted choice across the remaining tag-matched pool
+
+Important:
+- DeltaLLM already respects `metadata.tags` as a general eligibility filter before strategy selection
+- Choose `tag-based-routing` when you want the route-group policy itself to communicate that tags are the main routing signal
+
+Use it when:
+- You route by region, tenant tier, compliance boundary, or capability tag
+- Prompts or callers attach tags such as `["eu"]` or `["vip"]`
+
+Required deployment metadata:
+- `model_info.tags`
+
+Setup:
+
+```yaml
+model_list:
+  - model_name: gpt-4o-mini
+    deployment_id: eu
+    deltallm_params: {model: openai/gpt-4o-mini}
+    model_info: {tags: ["eu"]}
+  - model_name: gpt-4o-mini
+    deployment_id: us
+    deltallm_params: {model: openai/gpt-4o-mini}
+    model_info: {tags: ["us"]}
+```
+
+Client request:
+
+```json
+{
+  "model": "gpt-4o-mini",
+  "messages": [{"role": "user", "content": "hello"}],
+  "metadata": {"tags": ["eu"]}
+}
+```
+
+## Which Metadata Matters
+
+Use these deployment fields when you need more control:
+
+- `model_info.weight` for `weighted`
+- `model_info.priority` for `priority-based-routing`
+- `model_info.tags` for tag-aware routing
+- `model_info.rpm_limit` and `model_info.tpm_limit` for usage-aware and rate-limit-aware routing
+- `model_info.image_pm_limit` for image-generation quota-aware routing
+- `model_info.audio_seconds_pm_limit` and `model_info.char_pm_limit` for audio quota-aware routing
+- `model_info.rerank_units_pm_limit` for rerank quota-aware routing
+- pricing metadata for `cost-based-routing`
 
 ## Retries and Cooldowns
 
@@ -109,15 +387,10 @@ deltallm_settings:
 
 ## Advanced Routing Controls
 
-Use these fields on each deployment when you need more control:
+Use these settings when routing needs a little more control:
 
-- `model_info.weight` for weighted routing
-- `model_info.priority` for primary and standby ordering
-- `model_info.tags` for tag-based routing
-- `model_info.rpm_limit` and `model_info.tpm_limit` for rate-limit-aware routing
-- `router_settings.enable_pre_call_checks` if you want DeltaLLM to filter out deployments already above their configured RPM or TPM limits before the provider call
-
-You can also define `router_settings.model_group_alias` if clients should request a friendly alias instead of the underlying group name.
+- `router_settings.enable_pre_call_checks` filters out deployments already above configured RPM or TPM limits before the provider call
+- `router_settings.model_group_alias` lets clients call a friendly alias instead of the real group name
 
 ## Monitor Routing
 

--- a/src/chat/executor.py
+++ b/src/chat/executor.py
@@ -12,6 +12,7 @@ from src.models.requests import ChatCompletionRequest
 from src.providers.registry import resolve_chat_upstream
 from src.providers.signing import apply_request_signing
 from src.router.router import Deployment
+from src.router.usage import record_router_usage
 
 
 @dataclass
@@ -52,51 +53,47 @@ async def execute_chat(
 
     apply_default_params(upstream_payload, deployment.model_info)
 
-    await request.app.state.router_state_backend.increment_active(deployment.deployment_id)
     upstream_start = perf_counter()
-    try:
-        request_url = f"{api_base}{endpoint}"
-        signed_headers, body_override = apply_request_signing(
-            params=params,
-            method="POST",
-            url=request_url,
-            headers=headers,
-            json_body=upstream_payload,
+    request_url = f"{api_base}{endpoint}"
+    signed_headers, body_override = apply_request_signing(
+        params=params,
+        method="POST",
+        url=request_url,
+        headers=headers,
+        json_body=upstream_payload,
+    )
+    if body_override is not None:
+        response = await request.app.state.http_client.post(
+            request_url,
+            headers=signed_headers,
+            content=body_override,
+            timeout=timeout,
         )
-        if body_override is not None:
-            response = await request.app.state.http_client.post(
-                request_url,
-                headers=signed_headers,
-                content=body_override,
-                timeout=timeout,
-            )
-        else:
-            response = await request.app.state.http_client.post(
-                request_url,
-                headers=signed_headers,
-                json=upstream_payload,
-                timeout=timeout,
-            )
-        if response.status_code >= 400:
-            status_exc = httpx.HTTPStatusError(
-                f"Upstream chat call failed with status {response.status_code}",
-                request=httpx.Request("POST", request_url),
-                response=response,
-            )
-            raise adapter.map_error(status_exc)
-        data = response.json()
-        canonical = await adapter.translate_response(data, payload.model)
-        canonical_payload = canonical.model_dump(mode="json")
+    else:
+        response = await request.app.state.http_client.post(
+            request_url,
+            headers=signed_headers,
+            json=upstream_payload,
+            timeout=timeout,
+        )
+    if response.status_code >= 400:
+        status_exc = httpx.HTTPStatusError(
+            f"Upstream chat call failed with status {response.status_code}",
+            request=httpx.Request("POST", request_url),
+            response=response,
+        )
+        raise adapter.map_error(status_exc)
+    data = response.json()
+    canonical = await adapter.translate_response(data, payload.model)
+    canonical_payload = canonical.model_dump(mode="json")
 
-        total_tokens = int((canonical_payload.get("usage") or {}).get("total_tokens") or 0)
-        await request.app.state.router_state_backend.increment_usage(deployment.deployment_id, total_tokens)
-        return canonical_payload, (perf_counter() - upstream_start) * 1000
-    finally:
-        await request.app.state.router_state_backend.decrement_active(deployment.deployment_id)
-        await request.app.state.router_state_backend.record_latency(
-            deployment.deployment_id,
-            (perf_counter() - upstream_start) * 1000,
-        )
+    await record_router_usage(
+        request.app.state.router_state_backend,
+        deployment.deployment_id,
+        mode="chat",
+        usage=canonical_payload.get("usage"),
+    )
+    return canonical_payload, (perf_counter() - upstream_start) * 1000
 
 
 async def open_stream_with_first_chunk(

--- a/src/config.py
+++ b/src/config.py
@@ -75,6 +75,10 @@ class ModelInfo(BaseModel):
     output_vector_size: int | None = None
     rpm_limit: int | None = None
     tpm_limit: int | None = None
+    image_pm_limit: int | None = None
+    audio_seconds_pm_limit: int | None = None
+    char_pm_limit: int | None = None
+    rerank_units_pm_limit: int | None = None
     max_tokens: int | None = None
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None

--- a/src/router/policy_validation.py
+++ b/src/router/policy_validation.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 from src.router.router import RoutingStrategy
 
 ALLOWED_POLICY_MODES = {"fallback", "weighted", "conditional", "adaptive"}
-ALLOWED_POLICY_KEYS = {"mode", "strategy", "members", "timeouts", "retry", "conditions", "constraints", "health"}
-ALLOWED_TIMEOUT_KEYS = {"global_ms", "global_seconds", "member_ms", "member_seconds"}
+ALLOWED_POLICY_KEYS = {"mode", "strategy", "members", "timeouts", "retry"}
+ALLOWED_TIMEOUT_KEYS = {"global_ms", "global_seconds"}
 ALLOWED_RETRY_KEYS = {"max_attempts", "retryable_error_classes"}
 ALLOWED_RETRYABLE_ERROR_CLASSES = {
     "timeout",
@@ -15,15 +16,6 @@ ALLOWED_RETRYABLE_ERROR_CLASSES = {
     "content_policy_violation",
     "generic",
 }
-ALLOWED_CONSTRAINT_KEYS = {
-    "provider_allowlist",
-    "provider_denylist",
-    "max_input_tokens",
-    "max_output_tokens",
-    "max_total_tokens",
-    "max_cost_usd",
-}
-ALLOWED_HEALTH_KEYS = {"cooldown_seconds", "circuit_breaker_failures", "circuit_breaker_window_seconds"}
 
 
 def _normalize_int(value: Any, field_name: str, *, minimum: int = 0) -> int:
@@ -82,6 +74,10 @@ def validate_route_policy(
         if mode not in ALLOWED_POLICY_MODES:
             allowed = ", ".join(sorted(ALLOWED_POLICY_MODES))
             raise ValueError(f"mode must be one of: {allowed}")
+        if mode == "conditional":
+            raise ValueError("mode 'conditional' is not supported by the runtime; use a concrete strategy instead")
+        if mode == "adaptive":
+            raise ValueError("mode 'adaptive' is not supported by the runtime; use a concrete strategy instead")
         normalized["mode"] = mode
 
     if "strategy" in normalized:
@@ -125,12 +121,14 @@ def validate_route_policy(
         if timeout_unknown:
             raise ValueError(f"unknown timeouts fields: {', '.join(timeout_unknown)}")
         validated_timeouts: dict[str, Any] = {}
-        for field_name in ("global_ms", "member_ms"):
-            if field_name in timeouts:
-                validated_timeouts[field_name] = _normalize_int(timeouts[field_name], f"timeouts.{field_name}", minimum=1)
-        for field_name in ("global_seconds", "member_seconds"):
-            if field_name in timeouts:
-                validated_timeouts[field_name] = _normalize_float(timeouts[field_name], f"timeouts.{field_name}", minimum=0.001)
+        if "global_ms" in timeouts:
+            validated_timeouts["global_ms"] = _normalize_int(timeouts["global_ms"], "timeouts.global_ms", minimum=1)
+        if "global_seconds" in timeouts:
+            validated_timeouts["global_seconds"] = _normalize_float(
+                timeouts["global_seconds"],
+                "timeouts.global_seconds",
+                minimum=0.001,
+            )
         normalized["timeouts"] = validated_timeouts
 
     if "retry" in normalized:
@@ -152,60 +150,6 @@ def validate_route_policy(
             validated_retry["retryable_error_classes"] = values
         normalized["retry"] = validated_retry
 
-    if "conditions" in normalized:
-        conditions = normalized.get("conditions")
-        if not isinstance(conditions, list):
-            raise ValueError("conditions must be a list")
-        for idx, condition in enumerate(conditions):
-            if not isinstance(condition, dict):
-                raise ValueError(f"conditions[{idx}] must be an object")
-
-    if "constraints" in normalized:
-        constraints = normalized.get("constraints")
-        if not isinstance(constraints, dict):
-            raise ValueError("constraints must be an object")
-        constraint_unknown = sorted([key for key in constraints.keys() if key not in ALLOWED_CONSTRAINT_KEYS])
-        if constraint_unknown:
-            raise ValueError(f"unknown constraints fields: {', '.join(constraint_unknown)}")
-        validated_constraints: dict[str, Any] = {}
-        for field_name in ("provider_allowlist", "provider_denylist"):
-            if field_name in constraints:
-                validated_constraints[field_name] = _normalize_string_list(constraints[field_name], f"constraints.{field_name}")
-        for field_name in ("max_input_tokens", "max_output_tokens", "max_total_tokens"):
-            if field_name in constraints:
-                validated_constraints[field_name] = _normalize_int(constraints[field_name], f"constraints.{field_name}", minimum=1)
-        if "max_cost_usd" in constraints:
-            validated_constraints["max_cost_usd"] = _normalize_float(
-                constraints["max_cost_usd"],
-                "constraints.max_cost_usd",
-                minimum=0.0,
-            )
-        normalized["constraints"] = validated_constraints
-
-    if "health" in normalized:
-        health = normalized.get("health")
-        if not isinstance(health, dict):
-            raise ValueError("health must be an object")
-        health_unknown = sorted([key for key in health.keys() if key not in ALLOWED_HEALTH_KEYS])
-        if health_unknown:
-            raise ValueError(f"unknown health fields: {', '.join(health_unknown)}")
-        validated_health: dict[str, Any] = {}
-        if "cooldown_seconds" in health:
-            validated_health["cooldown_seconds"] = _normalize_int(health["cooldown_seconds"], "health.cooldown_seconds", minimum=1)
-        if "circuit_breaker_failures" in health:
-            validated_health["circuit_breaker_failures"] = _normalize_int(
-                health["circuit_breaker_failures"],
-                "health.circuit_breaker_failures",
-                minimum=1,
-            )
-        if "circuit_breaker_window_seconds" in health:
-            validated_health["circuit_breaker_window_seconds"] = _normalize_int(
-                health["circuit_breaker_window_seconds"],
-                "health.circuit_breaker_window_seconds",
-                minimum=1,
-            )
-        normalized["health"] = validated_health
-
     valid_member_ids = {item.strip() for item in (available_member_ids or set()) if item and item.strip()}
     if valid_member_ids:
         referenced_ids = {
@@ -223,6 +167,27 @@ def validate_route_policy(
         active_members = [{"deployment_id": member_id, "enabled": True} for member_id in sorted(valid_member_ids)]
     if not active_members:
         raise ValueError("policy results in empty active member pool")
+
+    mode = normalized.get("mode")
+    strategy = normalized.get("strategy")
+    if mode == "fallback":
+        if strategy in (None, ""):
+            normalized["strategy"] = RoutingStrategy.PRIORITY_BASED.value
+        elif strategy != RoutingStrategy.PRIORITY_BASED.value:
+            warnings.append("Fallback mode is advisory when strategy is set explicitly; strategy takes precedence.")
+        if "members" in normalized:
+            prioritized_members: list[dict[str, Any]] = []
+            for index, member in enumerate(normalized["members"]):
+                updated_member = deepcopy(member)
+                if updated_member.get("priority") is None:
+                    updated_member["priority"] = index
+                prioritized_members.append(updated_member)
+            normalized["members"] = prioritized_members
+    elif mode == "weighted":
+        if strategy in (None, ""):
+            normalized["strategy"] = RoutingStrategy.WEIGHTED.value
+        elif strategy != RoutingStrategy.WEIGHTED.value:
+            warnings.append("Weighted mode is advisory when strategy is set explicitly; strategy takes precedence.")
 
     if "mode" in normalized and normalized["mode"] == "weighted":
         has_weight = any(isinstance(member, dict) and member.get("weight") is not None for member in active_members)

--- a/src/router/router.py
+++ b/src/router/router.py
@@ -17,6 +17,7 @@ from src.router.strategies import (
     TagBasedStrategy,
     UsageBasedStrategy,
     WeightedStrategy,
+    usage_within_limits,
 )
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,10 @@ class Deployment:
     output_cost_per_token: float = 0.0
     rpm_limit: int | None = None
     tpm_limit: int | None = None
+    image_pm_limit: int | None = None
+    audio_seconds_pm_limit: int | None = None
+    char_pm_limit: int | None = None
+    rerank_units_pm_limit: int | None = None
 
 
 @dataclass
@@ -185,16 +190,17 @@ class Router:
         if not deployments:
             return []
 
-        tags = request_context.get("metadata", {}).get("tags") or []
-        filtered = deployments
-        if tags:
-            filtered = [d for d in filtered if d.tags and all(tag in d.tags for tag in tags)]
+        metadata = request_context.get("metadata")
+        request_tags = metadata.get("tags") if isinstance(metadata, dict) else None
+        normalized_tags = [tag.strip() for tag in request_tags if isinstance(tag, str) and tag.strip()] if isinstance(request_tags, list) else []
+        if not normalized_tags:
+            return list(deployments)
 
-        if not filtered:
-            return []
-
-        top_priority = min(int(d.priority) for d in filtered)
-        return [d for d in filtered if int(d.priority) == top_priority]
+        return [
+            deployment
+            for deployment in deployments
+            if deployment.tags and all(tag in deployment.tags for tag in normalized_tags)
+        ]
 
     async def _apply_pre_call_checks(self, deployments: list[Deployment]) -> list[Deployment]:
         if not deployments:
@@ -204,12 +210,7 @@ class Router:
         candidates: list[Deployment] = []
         for deployment in deployments:
             dep_usage = usage.get(deployment.deployment_id, {})
-            rpm = dep_usage.get("rpm", 0)
-            tpm = dep_usage.get("tpm", 0)
-
-            rpm_ok = deployment.rpm_limit is None or rpm < deployment.rpm_limit
-            tpm_ok = deployment.tpm_limit is None or tpm < deployment.tpm_limit
-            if rpm_ok and tpm_ok:
+            if usage_within_limits(deployment, dep_usage):
                 candidates.append(deployment)
 
         return candidates
@@ -437,4 +438,12 @@ def _deployment_from_entry(model_name: str, entry: dict[str, Any], index: int) -
         output_cost_per_token=float(model_info.get("output_cost_per_token", 0.0) or 0.0),
         rpm_limit=(int(model_info["rpm_limit"]) if model_info.get("rpm_limit") is not None else params.get("rpm")),
         tpm_limit=(int(model_info["tpm_limit"]) if model_info.get("tpm_limit") is not None else params.get("tpm")),
+        image_pm_limit=(int(model_info["image_pm_limit"]) if model_info.get("image_pm_limit") is not None else None),
+        audio_seconds_pm_limit=(
+            int(model_info["audio_seconds_pm_limit"]) if model_info.get("audio_seconds_pm_limit") is not None else None
+        ),
+        char_pm_limit=(int(model_info["char_pm_limit"]) if model_info.get("char_pm_limit") is not None else None),
+        rerank_units_pm_limit=(
+            int(model_info["rerank_units_pm_limit"]) if model_info.get("rerank_units_pm_limit") is not None else None
+        ),
     )

--- a/src/router/state.py
+++ b/src/router/state.py
@@ -4,11 +4,13 @@ import json
 import logging
 import time
 from datetime import UTC, datetime
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, Mapping, Protocol
 
 from src.models.errors import ServiceUnavailableError
 
 logger = logging.getLogger(__name__)
+
+USAGE_COUNTER_NAMES = ("rpm", "tpm", "image_pm", "audio_seconds_pm", "char_pm", "rerank_units_pm")
 
 
 class DeploymentStateBackend(Protocol):
@@ -31,6 +33,13 @@ class DeploymentStateBackend(Protocol):
     ) -> dict[str, list[tuple[int, float]]]: ...
 
     async def increment_usage(self, deployment_id: str, tokens: int, window: str | None = None) -> None: ...
+
+    async def increment_usage_counters(
+        self,
+        deployment_id: str,
+        counters: Mapping[str, int],
+        window: str | None = None,
+    ) -> None: ...
 
     async def get_usage(self, deployment_id: str) -> dict[str, int]: ...
 
@@ -72,7 +81,7 @@ class RedisStateBackend:
         self.max_local_latency_samples = max(1, int(max_local_latency_samples))
         self._active: dict[str, int] = {}
         self._latency: dict[str, list[tuple[int, float]]] = {}
-        self._usage: dict[str, dict[str, int]] = {}
+        self._usage: dict[str, dict[str, Any]] = {}
         self._cooldown_until: dict[str, float] = {}
         self._health: dict[str, dict[str, Any]] = {}
         self._failures: dict[str, int] = {}
@@ -287,37 +296,66 @@ class RedisStateBackend:
         return windows
 
     async def increment_usage(self, deployment_id: str, tokens: int, window: str | None = None) -> None:
+        await self.increment_usage_counters(
+            deployment_id,
+            {"rpm": 1, "tpm": max(0, int(tokens))},
+            window=window,
+        )
+
+    async def increment_usage_counters(
+        self,
+        deployment_id: str,
+        counters: Mapping[str, int],
+        window: str | None = None,
+    ) -> None:
         minute = window or self._minute_window()
-        rpm_key = f"usage_rpm:{deployment_id}:{minute}"
-        tpm_key = f"usage_tpm:{deployment_id}:{minute}"
+        normalized = self._normalize_usage_counters(counters)
+        keys = {
+            counter_name: f"usage_{counter_name}:{deployment_id}:{minute}"
+            for counter_name in normalized
+        }
         try:
             pipe = self.redis.pipeline()
-            pipe.incr(rpm_key)
-            pipe.incrby(tpm_key, int(tokens))
-            pipe.expire(rpm_key, 120)
-            pipe.expire(tpm_key, 120)
+            for counter_name, counter_value in normalized.items():
+                key = keys[counter_name]
+                if counter_name == "rpm":
+                    pipe.incr(key)
+                elif counter_value > 0:
+                    pipe.incrby(key, int(counter_value))
+                pipe.expire(key, 120)
             await pipe.execute()
             self._mark_backend_healthy()
             return
         except Exception as exc:
             self._handle_backend_failure(exc)
-            usage = self._usage.setdefault(deployment_id, {"rpm": 0, "tpm": 0, "window": minute, "updated_at": int(time.time())})
+            usage = self._usage.setdefault(
+                deployment_id,
+                {"rpm": 0, "tpm": 0, "window": minute, "updated_at": int(time.time())},
+            )
             if usage.get("window") != minute:
-                usage["rpm"] = 0
-                usage["tpm"] = 0
-                usage["window"] = minute
-            usage["rpm"] = int(usage.get("rpm", 0)) + 1
-            usage["tpm"] = int(usage.get("tpm", 0)) + int(tokens)
+                usage = {"rpm": 0, "tpm": 0, "window": minute, "updated_at": int(time.time())}
+                self._usage[deployment_id] = usage
+            for counter_name, counter_value in normalized.items():
+                if counter_name == "rpm":
+                    usage["rpm"] = int(usage.get("rpm", 0)) + 1
+                    continue
+                if counter_value <= 0:
+                    continue
+                usage[counter_name] = int(usage.get(counter_name, 0)) + int(counter_value)
             usage["updated_at"] = int(time.time())
             self._touch_local_state(deployment_id, now=time.time())
 
     async def get_usage(self, deployment_id: str) -> dict[str, int]:
         minute = self._minute_window()
-        rpm_key = f"usage_rpm:{deployment_id}:{minute}"
-        tpm_key = f"usage_tpm:{deployment_id}:{minute}"
+        keys = [f"usage_{counter_name}:{deployment_id}:{minute}" for counter_name in USAGE_COUNTER_NAMES]
         try:
-            values = await self._redis_call("mget", [rpm_key, tpm_key])
-            return {"rpm": int(values[0] or 0), "tpm": int(values[1] or 0)}
+            values = await self._redis_call("mget", keys)
+            usage = {"rpm": int(values[0] or 0), "tpm": int(values[1] or 0)}
+            for counter_name, value in zip(USAGE_COUNTER_NAMES[2:], values[2:], strict=False):
+                parsed = int(value or 0)
+                if parsed > 0:
+                    usage[counter_name] = parsed
+            return usage
         except Exception as exc:
             self._handle_backend_failure(exc)
             self._prune_local_state()
@@ -327,10 +365,36 @@ class RedisStateBackend:
                 self._drop_local_state_if_unused(deployment_id)
                 return {"rpm": 0, "tpm": 0}
             self._touch_local_state(deployment_id, now=time.time())
-            return {"rpm": int(usage.get("rpm", 0)), "tpm": int(usage.get("tpm", 0))}
+            return self._materialize_usage_snapshot(usage)
 
     async def get_usage_batch(self, deployment_ids: list[str]) -> dict[str, dict[str, int]]:
         return {deployment_id: await self.get_usage(deployment_id) for deployment_id in deployment_ids}
+
+    @staticmethod
+    def _normalize_usage_counters(counters: Mapping[str, int]) -> dict[str, int]:
+        normalized = {"rpm": 1, "tpm": 0}
+        for counter_name in USAGE_COUNTER_NAMES:
+            if counter_name == "rpm":
+                continue
+            value = counters.get(counter_name)
+            if value is None:
+                continue
+            normalized[counter_name] = max(0, int(value))
+        if counters.get("rpm") is not None:
+            normalized["rpm"] = max(1, int(counters.get("rpm") or 1))
+        return normalized
+
+    @staticmethod
+    def _materialize_usage_snapshot(usage: Mapping[str, Any]) -> dict[str, int]:
+        snapshot = {
+            "rpm": int(usage.get("rpm", 0) or 0),
+            "tpm": int(usage.get("tpm", 0) or 0),
+        }
+        for counter_name in USAGE_COUNTER_NAMES[2:]:
+            value = int(usage.get(counter_name, 0) or 0)
+            if value > 0:
+                snapshot[counter_name] = value
+        return snapshot
 
     async def set_cooldown(self, deployment_id: str, duration_sec: int, reason: str) -> None:
         key = f"cooldown:{deployment_id}"

--- a/src/router/strategies.py
+++ b/src/router/strategies.py
@@ -6,6 +6,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from src.billing.cost import compute_billing_result
+
 
 @dataclass
 class DeploymentLike:
@@ -13,10 +15,15 @@ class DeploymentLike:
     weight: int = 1
     priority: int = 0
     tags: list[str] | None = None
+    model_info: dict[str, Any] | None = None
     input_cost_per_token: float = 0.0
     output_cost_per_token: float = 0.0
     rpm_limit: int | None = None
     tpm_limit: int | None = None
+    image_pm_limit: int | None = None
+    audio_seconds_pm_limit: int | None = None
+    char_pm_limit: int | None = None
+    rerank_units_pm_limit: int | None = None
 
 
 class StateBackendLike(Protocol):
@@ -39,6 +46,12 @@ class RoutingStrategyImpl(Protocol):
     ) -> DeploymentLike | None: ...
 
 
+def random_choice(deployments: list[DeploymentLike]) -> DeploymentLike | None:
+    if not deployments:
+        return None
+    return random.choice(deployments)
+
+
 def weighted_random_choice(deployments: list[DeploymentLike]) -> DeploymentLike | None:
     if not deployments:
         return None
@@ -46,7 +59,7 @@ def weighted_random_choice(deployments: list[DeploymentLike]) -> DeploymentLike 
     weights = [max(0, int(d.weight)) for d in deployments]
     total = sum(weights)
     if total <= 0:
-        return random.choice(deployments)
+        return random_choice(deployments)
 
     pick = random.uniform(0, total)
     cumulative = 0.0
@@ -64,7 +77,7 @@ class SimpleShuffleStrategy:
         deployments: list[DeploymentLike],
         context: dict[str, Any],
     ) -> DeploymentLike | None:
-        return weighted_random_choice(deployments)
+        return random_choice(deployments)
 
 
 class LeastBusyStrategy:
@@ -102,15 +115,23 @@ class LatencyBasedStrategy:
             [d.deployment_id for d in deployments],
             window_ms=self.window_size_ms,
         )
-        best: DeploymentLike | None = None
-        best_latency = float("inf")
+        scored: list[tuple[DeploymentLike, float]] = []
+        unsampled: list[DeploymentLike] = []
         for deployment in deployments:
             avg = self._weighted_avg(windows.get(deployment.deployment_id, []))
-            if avg < best_latency:
-                best_latency = avg
-                best = deployment
+            if math.isfinite(avg):
+                scored.append((deployment, avg))
+            else:
+                unsampled.append(deployment)
 
-        return best or weighted_random_choice(deployments)
+        if not scored:
+            return weighted_random_choice(deployments)
+
+        best_latency = min(score for _, score in scored)
+        candidates = [deployment for deployment, score in scored if score == best_latency]
+        if unsampled:
+            candidates.extend(unsampled)
+        return weighted_random_choice(candidates)
 
     def _weighted_avg(self, window: list[tuple[int, float]]) -> float:
         if not window:
@@ -137,10 +158,55 @@ class CostBasedStrategy:
         if not deployments:
             return None
 
-        return min(
-            deployments,
-            key=lambda d: float(d.input_cost_per_token) + float(d.output_cost_per_token),
+        best_deployment: DeploymentLike | None = None
+        best_cost = float("inf")
+        for deployment in deployments:
+            estimated_cost = self._estimated_unit_cost(deployment)
+            if estimated_cost < best_cost:
+                best_cost = estimated_cost
+                best_deployment = deployment
+        return best_deployment or weighted_random_choice(deployments)
+
+    @staticmethod
+    def _estimated_unit_cost(deployment: DeploymentLike) -> float:
+        info = dict(deployment.model_info or {})
+        info.setdefault("input_cost_per_token", float(deployment.input_cost_per_token))
+        info.setdefault("output_cost_per_token", float(deployment.output_cost_per_token))
+        mode = str(info.get("mode") or "chat").strip() or "chat"
+        result = compute_billing_result(
+            mode=mode,
+            usage=CostBasedStrategy._synthetic_usage_for_mode(mode),
+            model_info=info,
         )
+        if not result.pricing_fields_used:
+            return float("inf")
+        return float(result.cost)
+
+    @staticmethod
+    def _synthetic_usage_for_mode(mode: str) -> dict[str, int | float]:
+        if mode == "embedding":
+            return {"prompt_tokens": 1, "completion_tokens": 0}
+        if mode == "image_generation":
+            return {"images": 1}
+        if mode == "audio_speech":
+            return {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "input_audio_tokens": 1,
+                "output_audio_tokens": 1,
+                "input_characters": 1,
+                "output_characters": 1,
+                "duration_seconds": 1.0,
+            }
+        if mode == "audio_transcription":
+            return {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "input_audio_tokens": 1,
+                "duration_seconds": 1.0,
+                "billable_duration_seconds": 1.0,
+            }
+        return {"prompt_tokens": 1, "completion_tokens": 1}
 
 
 class UsageBasedStrategy:
@@ -161,49 +227,31 @@ class UsageBasedStrategy:
 
         for deployment in deployments:
             dep_usage = usage.get(deployment.deployment_id, {})
-            rpm_util = self._calc_utilization(dep_usage.get("rpm", 0), deployment.rpm_limit)
-            tpm_util = self._calc_utilization(dep_usage.get("tpm", 0), deployment.tpm_limit)
-            utilization = max(rpm_util, tpm_util)
+            utilization = usage_utilization_for_deployment(deployment, dep_usage)
             if utilization < best_utilization:
                 best_utilization = utilization
                 best = deployment
 
         return best or weighted_random_choice(deployments)
 
-    @staticmethod
-    def _calc_utilization(current: int, limit: int | None) -> float:
-        if not limit or limit <= 0:
-            return 0.0
-        return current / limit
-
-
 class TagBasedStrategy:
     def __init__(self, fallback_strategy: RoutingStrategyImpl | None = None):
-        self.fallback = fallback_strategy or SimpleShuffleStrategy()
+        self.fallback = fallback_strategy or WeightedStrategy()
 
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
     ) -> DeploymentLike | None:
-        request_tags = context.get("metadata", {}).get("tags") or []
-        if not request_tags:
-            return await self.fallback.select(deployments, context)
-
-        filtered = [
-            d
-            for d in deployments
-            if d.tags and all(tag in d.tags for tag in request_tags)
-        ]
-        if not filtered:
-            return None
-
-        return await self.fallback.select(filtered, context)
+        # Request-tag eligibility is already enforced by the router before strategy
+        # selection, so tag-based routing is intentionally just weighted selection on
+        # the remaining tag-matched pool.
+        return await self.fallback.select(deployments, context)
 
 
 class PriorityBasedStrategy:
     def __init__(self, fallback_strategy: RoutingStrategyImpl | None = None):
-        self.fallback = fallback_strategy or SimpleShuffleStrategy()
+        self.fallback = fallback_strategy or WeightedStrategy()
 
     async def select(
         self,
@@ -251,9 +299,57 @@ class RateLimitAwareStrategy:
         available: list[DeploymentLike] = []
         for deployment in deployments:
             dep_usage = usage.get(deployment.deployment_id, {})
-            rpm_util = dep_usage.get("rpm", 0) / (deployment.rpm_limit or float("inf"))
-            tpm_util = dep_usage.get("tpm", 0) / (deployment.tpm_limit or float("inf"))
-            if rpm_util < self.utilization_threshold and tpm_util < self.utilization_threshold:
+            utilization = usage_utilization_for_deployment(deployment, dep_usage)
+            if utilization < self.utilization_threshold:
                 available.append(deployment)
 
         return weighted_random_choice(available)
+
+
+def usage_utilization_for_deployment(
+    deployment: DeploymentLike,
+    usage: dict[str, int] | None,
+) -> float:
+    dep_usage = usage or {}
+    utilizations: list[float] = []
+
+    rpm_util = _calc_utilization(dep_usage.get("rpm", 0), deployment.rpm_limit)
+    if deployment.rpm_limit is not None:
+        utilizations.append(rpm_util)
+
+    mode = str((deployment.model_info or {}).get("mode") or "chat").strip().lower() or "chat"
+    if mode in {"chat", "embedding"}:
+        if deployment.tpm_limit is not None:
+            utilizations.append(_calc_utilization(dep_usage.get("tpm", 0), deployment.tpm_limit))
+    elif mode == "image_generation":
+        if deployment.image_pm_limit is not None:
+            utilizations.append(_calc_utilization(dep_usage.get("image_pm", 0), deployment.image_pm_limit))
+    elif mode in {"audio_speech", "audio_transcription"}:
+        if deployment.audio_seconds_pm_limit is not None:
+            utilizations.append(
+                _calc_utilization(dep_usage.get("audio_seconds_pm", 0), deployment.audio_seconds_pm_limit)
+            )
+        if deployment.char_pm_limit is not None:
+            utilizations.append(_calc_utilization(dep_usage.get("char_pm", 0), deployment.char_pm_limit))
+    elif mode == "rerank":
+        if deployment.rerank_units_pm_limit is not None:
+            utilizations.append(
+                _calc_utilization(dep_usage.get("rerank_units_pm", 0), deployment.rerank_units_pm_limit)
+            )
+    elif deployment.tpm_limit is not None:
+        utilizations.append(_calc_utilization(dep_usage.get("tpm", 0), deployment.tpm_limit))
+
+    return max(utilizations, default=0.0)
+
+
+def usage_within_limits(
+    deployment: DeploymentLike,
+    usage: dict[str, int] | None,
+) -> bool:
+    return usage_utilization_for_deployment(deployment, usage) < 1.0
+
+
+def _calc_utilization(current: int, limit: int | None) -> float:
+    if not limit or limit <= 0:
+        return 0.0
+    return current / limit

--- a/src/router/usage.py
+++ b/src/router/usage.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_router_usage(
+    *,
+    mode: str,
+    usage: Mapping[str, Any] | None,
+) -> dict[str, int]:
+    data = dict(usage or {})
+    counters: dict[str, int] = {"rpm": 1}
+
+    normalized_mode = mode.strip().lower() or "chat"
+    if normalized_mode in {"chat", "embedding"}:
+        token_count = _token_units(data)
+        if token_count > 0:
+            counters["tpm"] = token_count
+        return counters
+
+    if normalized_mode == "image_generation":
+        image_count = _to_int(data.get("images"))
+        if image_count > 0:
+            counters["image_pm"] = image_count
+        return counters
+
+    if normalized_mode in {"audio_speech", "audio_transcription"}:
+        duration_seconds = _duration_units(data)
+        if duration_seconds > 0:
+            counters["audio_seconds_pm"] = duration_seconds
+            return counters
+        character_count = _character_units(data)
+        if character_count > 0:
+            counters["char_pm"] = character_count
+        return counters
+
+    if normalized_mode == "rerank":
+        rerank_units = _to_int(data.get("rerank_units"))
+        if rerank_units > 0:
+            counters["rerank_units_pm"] = rerank_units
+        return counters
+
+    token_count = _token_units(data)
+    if token_count > 0:
+        counters["tpm"] = token_count
+        return counters
+
+    character_count = _character_units(data)
+    if character_count > 0:
+        counters["char_pm"] = character_count
+        return counters
+
+    image_count = _to_int(data.get("images"))
+    if image_count > 0:
+        counters["image_pm"] = image_count
+
+    return counters
+
+
+async def record_router_usage(
+    state_backend: Any,
+    deployment_id: str,
+    *,
+    mode: str,
+    usage: Mapping[str, Any] | None,
+) -> bool:
+    if not deployment_id:
+        return False
+
+    counters = normalize_router_usage(mode=mode, usage=usage)
+    try:
+        increment_usage_counters = getattr(state_backend, "increment_usage_counters", None)
+        if callable(increment_usage_counters):
+            await increment_usage_counters(deployment_id, counters)
+        else:
+            await state_backend.increment_usage(deployment_id, int(counters.get("tpm", 0)))
+        return True
+    except Exception as exc:
+        logger.warning(
+            "router usage recording failed for deployment=%s mode=%s: %s",
+            deployment_id,
+            mode,
+            exc,
+        )
+        return False
+
+
+def _token_units(data: Mapping[str, Any]) -> int:
+    total_tokens = _to_int(data.get("total_tokens"))
+    if total_tokens > 0:
+        return total_tokens
+
+    token_count = _to_int(data.get("prompt_tokens")) + _to_int(data.get("completion_tokens"))
+
+    input_audio_tokens = _to_int(data.get("input_audio_tokens"))
+    output_audio_tokens = _to_int(data.get("output_audio_tokens"))
+    if input_audio_tokens > 0 or output_audio_tokens > 0:
+        return token_count + input_audio_tokens + output_audio_tokens
+
+    return token_count + _to_int(data.get("audio_tokens"))
+
+
+def _duration_units(data: Mapping[str, Any]) -> int:
+    duration_seconds = _to_float(data.get("billable_duration_seconds"))
+    if duration_seconds <= 0:
+        duration_seconds = _to_float(data.get("duration_seconds"))
+    if duration_seconds <= 0:
+        return 0
+    return max(1, int(math.ceil(duration_seconds)))
+
+
+def _character_units(data: Mapping[str, Any]) -> int:
+    return sum(
+        _to_int(data.get(key))
+        for key in (
+            "input_characters",
+            "output_characters",
+            "characters",
+        )
+    )
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _to_float(value: Any) -> float:
+    try:
+        return max(0.0, float(value or 0))
+    except (TypeError, ValueError):
+        return 0.0

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -28,6 +28,7 @@ from src.models.errors import InvalidRequestError
 from src.models.requests import AudioSpeechRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.router.router import Deployment
+from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
 from src.routers.audit_helpers import emit_audit_event
 from src.routers.routing_decision import (
@@ -174,6 +175,12 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
             request_text=payload.input,
             response_payload=billing_payload,
             provider=api_provider,
+        )
+        await record_router_usage(
+            request.app.state.router_state_backend,
+            served_deployment.deployment_id,
+            mode="audio_speech",
+            usage=usage,
         )
         billing = compute_billing_result(mode="audio_speech", usage=usage, model_info=model_info)
         request_cost = billing.cost

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -27,6 +27,7 @@ from src.providers.resolution import (
     resolve_upstream_model,
 )
 from src.router.router import Deployment
+from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
 from src.routers.audit_helpers import emit_audit_event
 from src.routers.routing_decision import (
@@ -185,6 +186,12 @@ async def audio_transcriptions(
             response_payload=billing_payload,
             file_size_bytes=len(file_content),
             provider=api_provider,
+        )
+        await record_router_usage(
+            request.app.state.router_state_backend,
+            served_deployment.deployment_id,
+            mode="audio_transcription",
+            usage=usage,
         )
         billing = compute_billing_result(mode="audio_transcription", usage=usage, model_info=model_info)
         request_cost = billing.cost

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import json
 from time import perf_counter
 from typing import Any, Callable
 
@@ -26,6 +27,7 @@ from src.models.errors import InvalidRequestError, ServiceUnavailableError
 from src.models.requests import ChatCompletionRequest
 from src.providers.registry import resolve_chat_upstream
 from src.providers.resolution import resolve_provider
+from src.router.usage import record_router_usage
 from src.routers.routing_decision import (
     capture_initial_route_decision,
     route_failover_kwargs,
@@ -34,6 +36,31 @@ from src.routers.routing_decision import (
 )
 
 router = APIRouter(prefix="/v1", tags=["chat"])
+
+
+class _StreamUsageTracker:
+    def __init__(self) -> None:
+        self._usage: dict[str, Any] = {}
+
+    def add_line(self, line: str) -> None:
+        if not line.startswith("data:"):
+            return
+        payload = line[len("data:") :].strip()
+        if not payload or payload == "[DONE]" or '"usage"' not in payload:
+            return
+        try:
+            chunk = json.loads(payload)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(chunk, dict):
+            return
+        usage = chunk.get("usage")
+        if isinstance(usage, dict):
+            self._usage = dict(usage)
+
+    @property
+    def usage(self) -> dict[str, Any]:
+        return dict(self._usage)
 
 
 @router.post("/chat/completions", dependencies=[Depends(require_api_key), Depends(enforce_rate_limits)])
@@ -90,6 +117,7 @@ async def handle_chat_like_request(
                 stream_handler = getattr(request.app.state, "streaming_cache_handler", None)
                 stream_id = None
                 stream_write_context: StreamWriteContext | None = None
+                stream_usage = _StreamUsageTracker()
                 opened_stream = await request.app.state.failover_manager.execute_with_failover(
                     primary_deployment=primary,
                     model_group=model_group,
@@ -135,6 +163,7 @@ async def handle_chat_like_request(
                     try:
                         initial = opened_stream.first_line
                         if initial:
+                            stream_usage.add_line(initial)
                             if stream_id is not None and stream_handler is not None:
                                 stream_handler.add_chunk_from_line(stream_id, initial)
                             out_line = stream_line_transform(initial) if stream_line_transform is not None else initial
@@ -144,6 +173,7 @@ async def handle_chat_like_request(
                             if not line:
                                 continue
 
+                            stream_usage.add_line(line)
                             if stream_id is not None and stream_handler is not None:
                                 stream_handler.add_chunk_from_line(stream_id, line)
                                 if line.strip() == "data: [DONE]" and stream_write_context is not None:
@@ -153,6 +183,12 @@ async def handle_chat_like_request(
                             if out_line is None:
                                 continue
                             yield f"{out_line}\n\n"
+                        await record_router_usage(
+                            request.app.state.router_state_backend,
+                            served_deployment.deployment_id,
+                            mode="chat",
+                            usage=stream_usage.usage,
+                        )
                         await emit_stream_success(
                             request=request,
                             auth=auth,

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -25,6 +25,7 @@ from src.models.errors import InvalidRequestError
 from src.models.requests import EmbeddingRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.router.router import Deployment
+from src.router.usage import record_router_usage
 from src.routers.routing_decision import (
     capture_initial_route_decision,
     route_failover_kwargs,
@@ -210,6 +211,12 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
         deployment_model = data.pop("_deployment_model", None)
 
         usage = data.get("usage") or {}
+        await record_router_usage(
+            request.app.state.router_state_backend,
+            served_deployment.deployment_id,
+            mode="embedding",
+            usage=usage,
+        )
         _deploy_pricing = pricing_from_model_info(
             served_deployment.model_info,
             fallback_input_cost_per_token=served_deployment.input_cost_per_token,

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -27,6 +27,7 @@ from src.providers.resolution import (
     resolve_upstream_model,
 )
 from src.router.router import Deployment
+from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
 from src.routers.audit_helpers import emit_audit_event
 from src.routers.routing_decision import (
@@ -142,6 +143,12 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
 
         num_images = len(data.get("data", []))
         usage = {"images": num_images}
+        await record_router_usage(
+            request.app.state.router_state_backend,
+            served_deployment.deployment_id,
+            mode="image_generation",
+            usage=usage,
+        )
         request_cost = compute_cost(mode="image_generation", usage=usage, model_info=model_info)
         increment_request(
             model=payload.model, api_provider=api_provider,

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -23,6 +23,7 @@ from src.models.errors import InvalidRequestError
 from src.models.requests import RerankRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.router.router import Deployment
+from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
 from src.routers.audit_helpers import emit_audit_event
 from src.routers.routing_decision import (
@@ -133,6 +134,12 @@ async def rerank(request: Request, payload: RerankRequest):
         doc_count = len(payload.documents)
         query_tokens = len(payload.query.split())
         usage = {"prompt_tokens": query_tokens + doc_count * 50}
+        await record_router_usage(
+            request.app.state.router_state_backend,
+            served_deployment.deployment_id,
+            mode="rerank",
+            usage={"rerank_units": doc_count},
+        )
         request_cost = compute_cost(mode="rerank", usage=usage, model_info=model_info)
         increment_request(
             model=payload.model, api_provider=api_provider,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -14,6 +14,7 @@ from src.mcp.exceptions import MCPRateLimitError
 from src.mcp.exceptions import MCPToolTimeoutError
 from src.mcp.exceptions import MCPTransportError
 from src.mcp.models import MCPToolCallResult
+from src.models.errors import ServiceUnavailableError
 
 
 class BlockingChatGuardrail(CustomGuardrail):
@@ -143,9 +144,34 @@ async def test_chat_completion_success(client, test_app):
     assert response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
     assert response.headers.get("x-deltallm-route-deployment")
     assert response.headers.get("x-deltallm-route-fallback-used") == "false"
+    deployment_id = str(response.headers["x-deltallm-route-deployment"])
     payload = response.json()
     assert payload["object"] == "chat.completion"
     assert payload["choices"][0]["message"]["content"] == "ok"
+    usage = await test_app.state.router_state_backend.get_usage(deployment_id)
+    assert usage == {"rpm": 1, "tpm": 2}
+    latency = await test_app.state.router_state_backend.get_latency_window(deployment_id, 300_000)
+    assert len(latency) == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_success_ignores_router_usage_write_failure(client, test_app):
+    async def fail_usage(*args, **kwargs):  # noqa: ANN001, ANN201
+        del args, kwargs
+        raise ServiceUnavailableError(message="router usage unavailable")
+
+    test_app.state.router_state_backend.increment_usage_counters = fail_usage
+
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": False,
+    }
+
+    response = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert response.status_code == 200
+    assert response.json()["object"] == "chat.completion"
 
 
 @pytest.mark.asyncio
@@ -487,6 +513,29 @@ async def test_chat_completion_streaming_success(client, test_app):
     assert response.headers["content-type"].startswith("text/event-stream")
     assert response.headers.get("x-deltallm-route-group") == "gpt-4o-mini"
     assert response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
+    assert "data: [DONE]" in response.text
+    deployment_id = str(response.headers["x-deltallm-route-deployment"])
+    usage = await test_app.state.router_state_backend.get_usage(deployment_id)
+    assert usage == {"rpm": 1, "tpm": 0}
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_streaming_success_ignores_router_usage_write_failure(client, test_app):
+    async def fail_usage(*args, **kwargs):  # noqa: ANN001, ANN201
+        del args, kwargs
+        raise ServiceUnavailableError(message="router usage unavailable")
+
+    test_app.state.router_state_backend.increment_usage_counters = fail_usage
+
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": True,
+    }
+
+    response = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert response.status_code == 200
     assert "data: [DONE]" in response.text
 
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -38,8 +38,11 @@ async def test_embeddings_runs_success_callback(client, test_app):
     assert response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
     assert response.headers.get("x-deltallm-route-deployment")
     assert response.headers.get("x-deltallm-route-fallback-used") == "false"
+    deployment_id = str(response.headers["x-deltallm-route-deployment"])
     await asyncio.sleep(0.05)
     assert recorder.success == 1
+    usage = await test_app.state.router_state_backend.get_usage(deployment_id)
+    assert usage == {"rpm": 1, "tpm": 2}
 
 
 @pytest.mark.asyncio

--- a/tests/test_route_decision_multimodal.py
+++ b/tests/test_route_decision_multimodal.py
@@ -40,6 +40,8 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
     assert image_response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
     assert image_response.headers.get("x-deltallm-route-deployment")
     assert image_response.headers.get("x-deltallm-route-fallback-used") == "false"
+    image_usage = await test_app.state.router_state_backend.get_usage(image_response.headers["x-deltallm-route-deployment"])
+    assert image_usage == {"rpm": 1, "tpm": 0, "image_pm": 1}
     test_app.state.redis.store.clear()
 
     speech_response = await client.post(
@@ -52,6 +54,10 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
     assert speech_response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
     assert speech_response.headers.get("x-deltallm-route-deployment")
     assert speech_response.headers.get("x-deltallm-route-fallback-used") == "false"
+    speech_usage = await test_app.state.router_state_backend.get_usage(speech_response.headers["x-deltallm-route-deployment"])
+    assert speech_usage["rpm"] == 1
+    assert speech_usage.get("tpm", 0) == 0
+    assert speech_usage["char_pm"] > 0
     test_app.state.redis.store.clear()
 
     transcription_response = await client.post(
@@ -65,6 +71,12 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
     assert transcription_response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
     assert transcription_response.headers.get("x-deltallm-route-deployment")
     assert transcription_response.headers.get("x-deltallm-route-fallback-used") == "false"
+    transcription_usage = await test_app.state.router_state_backend.get_usage(
+        transcription_response.headers["x-deltallm-route-deployment"]
+    )
+    assert transcription_usage["rpm"] == 1
+    assert transcription_usage.get("tpm", 0) == 0
+    assert transcription_usage["audio_seconds_pm"] > 0
     test_app.state.redis.store.clear()
 
     rerank_response = await client.post(
@@ -77,3 +89,5 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
     assert rerank_response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
     assert rerank_response.headers.get("x-deltallm-route-deployment")
     assert rerank_response.headers.get("x-deltallm-route-fallback-used") == "false"
+    rerank_usage = await test_app.state.router_state_backend.get_usage(rerank_response.headers["x-deltallm-route-deployment"])
+    assert rerank_usage == {"rpm": 1, "tpm": 0, "rerank_units_pm": 2}

--- a/tests/test_route_policy_validation.py
+++ b/tests/test_route_policy_validation.py
@@ -17,7 +17,7 @@ def test_validate_route_policy_normalizes_members():
     assert normalized["mode"] == "weighted"
     assert normalized["members"][0]["weight"] == 3
     assert normalized["members"][0]["priority"] == 1
-    assert warnings == []
+    assert warnings == ["Weighted mode is advisory when strategy is set explicitly; strategy takes precedence."]
 
 
 def test_validate_route_policy_rejects_unknown_fields():
@@ -40,6 +40,31 @@ def test_validate_route_policy_validates_retry_and_timeouts_schema():
     assert normalized["timeouts"]["global_ms"] == 1200
     assert normalized["retry"]["max_attempts"] == 2
     assert normalized["retry"]["retryable_error_classes"] == ["timeout", "rate_limit"]
+
+
+def test_validate_route_policy_maps_fallback_mode_to_priority_strategy():
+    normalized, warnings = validate_route_policy(
+        {
+            "mode": "fallback",
+            "members": [{"deployment_id": "dep-a"}, {"deployment_id": "dep-b"}],
+        },
+        available_member_ids={"dep-a", "dep-b"},
+    )
+
+    assert warnings == []
+    assert normalized["strategy"] == "priority-based-routing"
+    assert normalized["members"][0]["priority"] == 0
+    assert normalized["members"][1]["priority"] == 1
+
+
+def test_validate_route_policy_rejects_unsupported_modes():
+    with pytest.raises(ValueError, match="mode 'adaptive' is not supported"):
+        validate_route_policy({"mode": "adaptive", "members": [{"deployment_id": "dep-a"}]})
+
+
+def test_validate_route_policy_rejects_runtime_unsupported_fields():
+    with pytest.raises(ValueError, match="unknown policy fields"):
+        validate_route_policy({"strategy": "weighted", "conditions": []})
 
 
 def test_validate_route_policy_rejects_unknown_member_reference():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from src.models.errors import ServiceUnavailableError
+import src.router.strategies as strategies_module
 from src.router import (
     HealthEndpointHandler,
     RedisStateBackend,
@@ -12,6 +13,7 @@ from src.router import (
     build_deployment_registry,
     build_route_group_policies,
 )
+from src.router.usage import normalize_router_usage
 
 
 @pytest.mark.asyncio
@@ -46,6 +48,412 @@ async def test_least_busy_strategy_selects_lowest_active_requests():
     selected = await router.select_deployment("gpt-4o-mini", {})
     assert selected is not None
     assert selected.deployment_id == "dep-b"
+
+
+@pytest.mark.asyncio
+async def test_request_tags_filter_candidates_before_strategy(monkeypatch):
+    monkeypatch.setattr(strategies_module.random, "choice", lambda deployments: deployments[-1])
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "gpt-4o-mini": [
+                {
+                    "deployment_id": "dep-tagged",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"tags": ["vip"]},
+                },
+                {
+                    "deployment_id": "dep-untagged",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"tags": []},
+                },
+            ]
+        }
+    )
+    router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("gpt-4o-mini", {"metadata": {"tags": ["vip"]}})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-tagged"
+
+
+@pytest.mark.asyncio
+async def test_tag_based_strategy_applies_tag_filtering():
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "gpt-4o-mini": [
+                {
+                    "deployment_id": "dep-tagged",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"tags": ["vip"]},
+                },
+                {
+                    "deployment_id": "dep-untagged",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                },
+            ]
+        }
+    )
+    router = Router(
+        strategy=RoutingStrategy.TAG_BASED,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("gpt-4o-mini", {"metadata": {"tags": ["vip"]}})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-tagged"
+
+
+def test_tag_based_strategy_is_weighted_selection_on_prefiltered_pool():
+    strategy = strategies_module.TagBasedStrategy()
+    assert isinstance(strategy.fallback, strategies_module.WeightedStrategy)
+
+
+@pytest.mark.asyncio
+async def test_priority_based_strategy_applies_priority_filtering(monkeypatch):
+    monkeypatch.setattr(strategies_module.random, "choice", lambda deployments: deployments[-1])
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "gpt-4o-mini": [
+                {
+                    "deployment_id": "dep-primary",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"priority": 0},
+                },
+                {
+                    "deployment_id": "dep-secondary",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"priority": 10},
+                },
+            ]
+        }
+    )
+    simple_router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+    priority_router = Router(
+        strategy=RoutingStrategy.PRIORITY_BASED,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+
+    simple_selected = await simple_router.select_deployment("gpt-4o-mini", {})
+    priority_selected = await priority_router.select_deployment("gpt-4o-mini", {})
+
+    assert simple_selected is not None
+    assert simple_selected.deployment_id == "dep-secondary"
+    assert priority_selected is not None
+    assert priority_selected.deployment_id == "dep-primary"
+
+
+@pytest.mark.asyncio
+async def test_latency_based_strategy_keeps_unsampled_members_eligible(monkeypatch):
+    monkeypatch.setattr(strategies_module.random, "uniform", lambda start, end: (start + end) * 0.75)
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "gpt-4o-mini": [
+                {"deployment_id": "dep-sampled", "deltallm_params": {"model": "openai/gpt-4o-mini"}},
+                {"deployment_id": "dep-unsampled", "deltallm_params": {"model": "openai/gpt-4o-mini"}},
+            ]
+        }
+    )
+    await state.record_latency("dep-sampled", 10.0)
+    router = Router(
+        strategy=RoutingStrategy.LATENCY_BASED,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("gpt-4o-mini", {})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-unsampled"
+
+
+@pytest.mark.asyncio
+async def test_cost_based_strategy_uses_mode_specific_pricing():
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "image-group": [
+                {
+                    "deployment_id": "dep-expensive",
+                    "deltallm_params": {"model": "openai/image"},
+                    "model_info": {"mode": "image_generation", "input_cost_per_image": 0.10},
+                },
+                {
+                    "deployment_id": "dep-cheap",
+                    "deltallm_params": {"model": "openai/image"},
+                    "model_info": {"mode": "image_generation", "input_cost_per_image": 0.02},
+                },
+            ]
+        }
+    )
+    router = Router(
+        strategy=RoutingStrategy.COST_BASED,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("image-group", {})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-cheap"
+
+
+@pytest.mark.asyncio
+async def test_usage_based_strategy_uses_router_state_usage():
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "gpt-4o-mini": [
+                {
+                    "deployment_id": "dep-a",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"rpm_limit": 10, "tpm_limit": 100},
+                },
+                {
+                    "deployment_id": "dep-b",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"rpm_limit": 10, "tpm_limit": 100},
+                },
+            ]
+        }
+    )
+    await state.increment_usage("dep-a", 80)
+    await state.increment_usage("dep-a", 0)
+    await state.increment_usage("dep-b", 5)
+    router = Router(
+        strategy=RoutingStrategy.USAGE_BASED,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("gpt-4o-mini", {})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-b"
+
+
+@pytest.mark.asyncio
+async def test_usage_based_strategy_uses_image_limits_when_configured():
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "image-group": [
+                {
+                    "deployment_id": "dep-hot",
+                    "deltallm_params": {"model": "openai/image"},
+                    "model_info": {"mode": "image_generation", "rpm_limit": 10, "image_pm_limit": 10},
+                },
+                {
+                    "deployment_id": "dep-cool",
+                    "deltallm_params": {"model": "openai/image"},
+                    "model_info": {"mode": "image_generation", "rpm_limit": 10, "image_pm_limit": 10},
+                },
+            ]
+        }
+    )
+    await state.increment_usage_counters("dep-hot", {"rpm": 1, "image_pm": 9})
+    await state.increment_usage_counters("dep-cool", {"rpm": 1, "image_pm": 1})
+    router = Router(
+        strategy=RoutingStrategy.USAGE_BASED,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("image-group", {})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-cool"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_aware_strategy_skips_hot_deployments():
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "gpt-4o-mini": [
+                {
+                    "deployment_id": "dep-hot",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"rpm_limit": 10, "tpm_limit": 100},
+                },
+                {
+                    "deployment_id": "dep-cool",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"rpm_limit": 10, "tpm_limit": 100},
+                },
+            ]
+        }
+    )
+    for _ in range(9):
+        await state.increment_usage("dep-hot", 0)
+    await state.increment_usage("dep-hot", 95)
+    router = Router(
+        strategy=RoutingStrategy.RATE_LIMIT_AWARE,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("gpt-4o-mini", {})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-cool"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_aware_strategy_uses_audio_limits_when_configured():
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "audio-group": [
+                {
+                    "deployment_id": "dep-hot",
+                    "deltallm_params": {"model": "openai/audio"},
+                    "model_info": {"mode": "audio_transcription", "rpm_limit": 10, "audio_seconds_pm_limit": 10},
+                },
+                {
+                    "deployment_id": "dep-cool",
+                    "deltallm_params": {"model": "openai/audio"},
+                    "model_info": {"mode": "audio_transcription", "rpm_limit": 10, "audio_seconds_pm_limit": 10},
+                },
+            ]
+        }
+    )
+    await state.increment_usage_counters("dep-hot", {"rpm": 1, "audio_seconds_pm": 9})
+    await state.increment_usage_counters("dep-cool", {"rpm": 1, "audio_seconds_pm": 1})
+    router = Router(
+        strategy=RoutingStrategy.RATE_LIMIT_AWARE,
+        state_backend=state,
+        config=RouterConfig(),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("audio-group", {})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-cool"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_checks_use_router_state_usage():
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "gpt-4o-mini": [
+                {
+                    "deployment_id": "dep-over",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"rpm_limit": 1, "tpm_limit": 10},
+                },
+                {
+                    "deployment_id": "dep-ok",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"rpm_limit": 10, "tpm_limit": 100},
+                },
+            ]
+        }
+    )
+    await state.increment_usage("dep-over", 20)
+    router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=state,
+        config=RouterConfig(enable_pre_call_checks=True),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("gpt-4o-mini", {})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-ok"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_checks_use_mode_specific_limits():
+    state = RedisStateBackend(redis=None)
+    registry = build_deployment_registry(
+        {
+            "rerank-group": [
+                {
+                    "deployment_id": "dep-over",
+                    "deltallm_params": {"model": "openai/rerank"},
+                    "model_info": {"mode": "rerank", "rpm_limit": 10, "rerank_units_pm_limit": 5},
+                },
+                {
+                    "deployment_id": "dep-ok",
+                    "deltallm_params": {"model": "openai/rerank"},
+                    "model_info": {"mode": "rerank", "rpm_limit": 10, "rerank_units_pm_limit": 5},
+                },
+            ]
+        }
+    )
+    await state.increment_usage_counters("dep-over", {"rpm": 1, "rerank_units_pm": 5})
+    router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=state,
+        config=RouterConfig(enable_pre_call_checks=True),
+        deployment_registry=registry,
+    )
+
+    selected = await router.select_deployment("rerank-group", {})
+
+    assert selected is not None
+    assert selected.deployment_id == "dep-ok"
+
+
+def test_normalize_router_usage_keeps_non_token_modes_out_of_tpm():
+    image_usage = normalize_router_usage(mode="image_generation", usage={"images": 2})
+    assert image_usage == {"rpm": 1, "image_pm": 2}
+
+    audio_usage = normalize_router_usage(
+        mode="audio_transcription",
+        usage={"duration_seconds": 1.2, "prompt_tokens": 99},
+    )
+    assert audio_usage == {"rpm": 1, "audio_seconds_pm": 2}
+
+    rerank_usage = normalize_router_usage(mode="rerank", usage={"rerank_units": 4, "prompt_tokens": 120})
+    assert rerank_usage == {"rpm": 1, "rerank_units_pm": 4}
+
+
+def test_normalize_router_usage_counts_multimodal_chat_tokens_without_total_tokens():
+    usage = normalize_router_usage(
+        mode="chat",
+        usage={
+            "prompt_tokens": 2,
+            "completion_tokens": 3,
+            "input_audio_tokens": 5,
+            "output_audio_tokens": 7,
+        },
+    )
+    assert usage == {"rpm": 1, "tpm": 17}
+
+    fallback_usage = normalize_router_usage(
+        mode="chat",
+        usage={"prompt_tokens": 2, "completion_tokens": 3, "audio_tokens": 11},
+    )
+    assert fallback_usage == {"rpm": 1, "tpm": 16}
 
 
 def test_build_deployment_registry_supports_explicit_route_groups():


### PR DESCRIPTION
## Summary

  This PR hardens the route-group and routing-policy runtime so the backend behavior matches the policy surface more closely, while keeping gateway request paths stable.

  It fixes gaps in strategy semantics, usage accounting, policy validation, and operator documentation.

  ## What changed

  ### Routing strategy behavior

  - made simple-shuffle truly unweighted random
  - kept weighted as weight-aware selection
  - kept request metadata.tags as the global eligibility filter
  - aligned tag-based-routing with actual runtime behavior: weighted selection on the already tag-filtered pool
  - kept priority-based-routing as the primary/standby style selector
  - improved latency-based-routing so unsampled members remain eligible instead of being starved
  - improved cost-based-routing to use mode-aware pricing inputs

  ### Usage-aware routing and pre-call checks

  - added mode-aware router usage normalization in src/router/usage.py
  - stopped non-text routes from polluting tpm
  - introduced structured counters:
      - rpm
      - tpm
      - image_pm
      - audio_seconds_pm
      - char_pm
      - rerank_units_pm
  - taught usage-aware routing and rate-limit-aware routing to consume the right counter when matching limits are configured
  - updated pre-call checks to use the same mode-aware limit logic

  ### Gateway request-path safety

  - made post-success router usage recording non-fatal so successful upstream responses do not fail because router-state recording failed
  - kept the write on the success path, but isolated it from request correctness
  - added multimodal token normalization so chat usage counts audio token details when total_tokens is absent

  ### Policy contract hardening

  - tightened route-policy validation so unsupported runtime fields and modes are rejected instead of silently accepted
  - kept the supported policy contract focused on what the backend actually executes today

  ### Docs

  - rewrote routing docs to explain each strategy in plain language
  - added “when to use this” guidance
  - documented the current runtime-supported policy fields only
  - documented non-text limit fields for usage-aware routing

  ## Why

  Before this change:

  - some routing strategies were effectively duplicates or partially redundant
  - usage-based routing only had reliable signal quality for some workloads
  - non-text traffic could distort token-based utilization
  - route-policy validation accepted fields that the runtime ignored
  - docs overstated what some policies did

  This PR closes those gaps and makes routing behavior more predictable for operators.

  ## Validation

  Verified with targeted backend coverage for:

  - chat and streaming chat
  - embeddings
  - multimodal routing decisions
  - text endpoints
  - health
  - MCP chat flows
  - routing strategy and policy validation behavior

  Also checked Ruff on the touched backend files.