### PR TITLE
The docs flow failed on first boot because the container ran prisma d…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ EXPOSE 4000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD curl -fsS "http://localhost:${PORT}/health/liveliness" || exit 1
 
-CMD ["sh", "-c", "prisma db push --schema=./prisma/schema.prisma --accept-data-loss && uvicorn src.main:app --host ${HOST} --port ${PORT}"]
+CMD ["sh", "-c", "attempt=0; until prisma db push --schema=./prisma/schema.prisma --accept-data-loss; do attempt=$((attempt + 1)); if [ \"$attempt\" -ge 30 ]; then echo 'Database never became reachable for Prisma schema push' >&2; exit 1; fi; echo \"Waiting for database before Prisma schema push... (${attempt}/30)\"; sleep 2; done; exec uvicorn src.main:app --host ${HOST} --port ${PORT}"]


### PR DESCRIPTION
…b push only once and exited if Postgres was not reachable yet (P1001: Can't reach database server at db:5432). I fixed

  that in Dockerfile by adding bounded retry logic before starting uvicorn