### PR TITLE
Fix/team self service create flow

### DIFF
--- a/docs/admin-ui/api-keys.md
+++ b/docs/admin-ui/api-keys.md
@@ -31,7 +31,7 @@ Team developers with the `key.create_self` permission can create their own API k
 
 ### How it works
 
-1. An admin enables self-service on the team (see [Teams](teams.md#self-service-key-policy))
+1. An admin leaves self-service enabled on the team or enables it later in team settings (see [Teams](teams.md#self-service-key-policy))
 2. A team developer signs in and navigates to API Keys
 3. The simplified creation form shows policy constraints (max budget, required expiry, etc.)
 4. The developer creates a key — the backend forces the owner to the current session user

--- a/docs/admin-ui/teams.md
+++ b/docs/admin-ui/teams.md
@@ -14,9 +14,10 @@ Teams are the working unit for developers, applications, keys, and team-level bu
 ## Typical workflow
 
 1. Create the team inside an organization
-2. Set team-specific budgets and rate limits across all time windows
-3. Add team members with the correct role
-4. Choose whether the team inherits the organization asset set or narrows it to selected assets
+2. Confirm the self-service key policy for developers
+3. Set team-specific budgets and rate limits across all time windows
+4. Add team members with the correct role
+5. Choose whether the team inherits the organization asset set or narrows it to selected assets
 
 ## Rate limit fields
 
@@ -32,7 +33,7 @@ All limits are optional. Only configured limits are enforced. Team limits act as
 
 ## Self-Service Key Policy
 
-Teams can allow their developers to create their own API keys without admin involvement. This is configured per team in the Team Detail page under the **Self-Service Keys** card (visible to team admins and above).
+Teams can allow their developers to create their own API keys without admin involvement. New teams start with self-service enabled by default in the create form, and you can review or tighten the policy later in the Team Detail page under the **Self-Service Keys** card (visible to team admins and above).
 
 ### Policy fields
 
@@ -48,11 +49,10 @@ When a developer creates a key through self-service, the backend enforces all of
 
 ### Enabling self-service
 
-1. Open the team detail page
-2. Find the **Self-Service Keys** card
-3. Toggle the switch to enable
-4. Set the constraint fields as needed
-5. Save — developers with `team_developer` role can now create keys
+1. Create a new team or open an existing team detail page
+2. Leave **Allow developers to create personal API keys** enabled, or turn it on in the **Self-Service Keys** card
+3. Set optional constraint fields only if the team needs tighter guardrails
+4. Save — developers with `team_developer` role can now create keys
 
 ## Why this matters
 

--- a/src/api/admin/endpoints/teams.py
+++ b/src/api/admin/endpoints/teams.py
@@ -62,6 +62,36 @@ def _validate_model_limit_dict(value: Any, field_name: str) -> dict[str, int] | 
     return result if result else None
 
 
+def _resolve_self_service_policy(
+    payload: dict[str, Any],
+    *,
+    existing_team: dict[str, Any] | None = None,
+    default_enabled: bool,
+) -> tuple[bool, int | None, float | None, bool, int | None]:
+    enabled_default = existing_team.get("self_service_keys_enabled", default_enabled) if existing_team is not None else default_enabled
+    max_keys_default = existing_team.get("self_service_max_keys_per_user") if existing_team is not None else None
+    budget_default = existing_team.get("self_service_budget_ceiling") if existing_team is not None else None
+    require_expiry_default = (
+        existing_team.get("self_service_require_expiry", False) if existing_team is not None else False
+    )
+    max_expiry_days_default = existing_team.get("self_service_max_expiry_days") if existing_team is not None else None
+
+    enabled = bool(payload.get("self_service_keys_enabled", enabled_default))
+    max_keys = optional_int(payload.get("self_service_max_keys_per_user", max_keys_default), "self_service_max_keys_per_user")
+    budget_ceiling = payload.get("self_service_budget_ceiling", budget_default)
+    if budget_ceiling is not None:
+        try:
+            budget_ceiling = float(budget_ceiling)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="self_service_budget_ceiling must be a number")
+    require_expiry = bool(payload.get("self_service_require_expiry", require_expiry_default))
+    max_expiry_days = optional_int(
+        payload.get("self_service_max_expiry_days", max_expiry_days_default),
+        "self_service_max_expiry_days",
+    )
+    return enabled, max_keys, budget_ceiling, require_expiry, max_expiry_days
+
+
 async def _require_team_access(
     request: Request,
     scope: AuthScope,
@@ -307,16 +337,10 @@ async def create_team(
     tpd_limit = optional_int(payload.get("tpd_limit"), "tpd_limit")
     model_rpm_limit = _validate_model_limit_dict(payload.get("model_rpm_limit"), "model_rpm_limit")
     model_tpm_limit = _validate_model_limit_dict(payload.get("model_tpm_limit"), "model_tpm_limit")
-    ss_keys_enabled = bool(payload.get("self_service_keys_enabled", False))
-    ss_max_keys = optional_int(payload.get("self_service_max_keys_per_user"), "self_service_max_keys_per_user")
-    ss_budget_ceiling = payload.get("self_service_budget_ceiling")
-    if ss_budget_ceiling is not None:
-        try:
-            ss_budget_ceiling = float(ss_budget_ceiling)
-        except (TypeError, ValueError):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="self_service_budget_ceiling must be a number")
-    ss_require_expiry = bool(payload.get("self_service_require_expiry", False))
-    ss_max_expiry_days = optional_int(payload.get("self_service_max_expiry_days"), "self_service_max_expiry_days")
+    ss_keys_enabled, ss_max_keys, ss_budget_ceiling, ss_require_expiry, ss_max_expiry_days = _resolve_self_service_policy(
+        payload,
+        default_enabled=True,
+    )
 
     await db.execute_raw(
         """
@@ -412,16 +436,11 @@ async def update_team(
     model_tpm_limit = _validate_model_limit_dict(
         payload.get("model_tpm_limit", existing_team.get("model_tpm_limit")), "model_tpm_limit"
     )
-    ss_keys_enabled = bool(payload.get("self_service_keys_enabled", existing_team.get("self_service_keys_enabled", False)))
-    ss_max_keys = optional_int(payload.get("self_service_max_keys_per_user", existing_team.get("self_service_max_keys_per_user")), "self_service_max_keys_per_user")
-    ss_budget_ceiling = payload.get("self_service_budget_ceiling", existing_team.get("self_service_budget_ceiling"))
-    if ss_budget_ceiling is not None:
-        try:
-            ss_budget_ceiling = float(ss_budget_ceiling)
-        except (TypeError, ValueError):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="self_service_budget_ceiling must be a number")
-    ss_require_expiry = bool(payload.get("self_service_require_expiry", existing_team.get("self_service_require_expiry", False)))
-    ss_max_expiry_days = optional_int(payload.get("self_service_max_expiry_days", existing_team.get("self_service_max_expiry_days")), "self_service_max_expiry_days")
+    ss_keys_enabled, ss_max_keys, ss_budget_ceiling, ss_require_expiry, ss_max_expiry_days = _resolve_self_service_policy(
+        payload,
+        existing_team=existing_team,
+        default_enabled=False,
+    )
 
     await db.execute_raw(
         """

--- a/tests/test_ui_rate_limits.py
+++ b/tests/test_ui_rate_limits.py
@@ -212,6 +212,59 @@ async def test_ui_create_endpoints_accept_rate_limits(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_ui_create_team_defaults_self_service_enabled(client, test_app):
+    fake_db = FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={"organization_id": "org-ss-default"},
+    )
+    team = await client.post(
+        "/ui/api/teams",
+        headers=headers,
+        json={"team_id": "team-ss-default", "organization_id": "org-ss-default"},
+    )
+
+    assert team.status_code == 200
+    payload = team.json()
+    assert payload["self_service_keys_enabled"] is True
+    assert payload["self_service_max_keys_per_user"] is None
+    assert payload["self_service_budget_ceiling"] is None
+    assert payload["self_service_require_expiry"] is False
+    assert payload["self_service_max_expiry_days"] is None
+
+
+@pytest.mark.asyncio
+async def test_ui_create_team_can_disable_self_service_explicitly(client, test_app):
+    fake_db = FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={"organization_id": "org-ss-disabled"},
+    )
+    team = await client.post(
+        "/ui/api/teams",
+        headers=headers,
+        json={
+            "team_id": "team-ss-disabled",
+            "organization_id": "org-ss-disabled",
+            "self_service_keys_enabled": False,
+        },
+    )
+
+    assert team.status_code == 200
+    assert team.json()["self_service_keys_enabled"] is False
+
+
+@pytest.mark.asyncio
 async def test_ui_update_endpoints_persist_rate_limits(client, test_app):
     fake_db = FakeAdminDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()

--- a/ui/src/components/admin/TeamSelfServicePolicySection.tsx
+++ b/ui/src/components/admin/TeamSelfServicePolicySection.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import ToggleSwitch from '../ToggleSwitch';
+import { ChevronRight, Info, Key } from 'lucide-react';
+
+type Props = {
+  enabled: boolean;
+  maxKeysPerUser: string;
+  budgetCeiling: string;
+  requireExpiry: boolean;
+  maxExpiryDays: string;
+  disabled?: boolean;
+  onEnabledChange: (value: boolean) => void;
+  onMaxKeysPerUserChange: (value: string) => void;
+  onBudgetCeilingChange: (value: string) => void;
+  onRequireExpiryChange: (value: boolean) => void;
+  onMaxExpiryDaysChange: (value: string) => void;
+};
+
+export default function TeamSelfServicePolicySection({
+  enabled,
+  maxKeysPerUser,
+  budgetCeiling,
+  requireExpiry,
+  maxExpiryDays,
+  disabled = false,
+  onEnabledChange,
+  onMaxKeysPerUserChange,
+  onBudgetCeilingChange,
+  onRequireExpiryChange,
+  onMaxExpiryDaysChange,
+}: Props) {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  return (
+    <div className="space-y-3">
+      <div className="p-3 rounded-lg bg-gray-50 border border-gray-200 space-y-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-2.5">
+            <Key className="w-4 h-4 text-indigo-600 mt-0.5 shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-gray-800">Allow developers to create personal API keys</p>
+              <p className="text-xs text-gray-500 mt-0.5">
+                Recommended for most teams. Developers can create their own keys within the team policy.
+              </p>
+            </div>
+          </div>
+          <ToggleSwitch
+            checked={enabled}
+            onCheckedChange={onEnabledChange}
+            disabled={disabled}
+            aria-label="Toggle self-service key creation"
+          />
+        </div>
+
+        <div className="flex items-center gap-2 px-3 py-2.5 rounded-lg bg-indigo-50 border border-indigo-200 text-xs text-indigo-700">
+          <Info className="w-3.5 h-3.5 shrink-0" />
+          <span>Leave the optional limits blank unless this team needs tighter self-service guardrails.</span>
+        </div>
+
+        {enabled && (
+          <>
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((current) => !current)}
+              disabled={disabled}
+              className="flex items-center gap-1.5 text-xs font-medium text-indigo-700 hover:text-indigo-800 disabled:opacity-50"
+            >
+              <ChevronRight className={`w-3.5 h-3.5 transition-transform ${showAdvanced ? 'rotate-90' : ''}`} />
+              Optional self-service limits
+            </button>
+
+            {showAdvanced && (
+              <div className="ml-6 pl-3 border-l-2 border-indigo-200 space-y-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1.5">Max keys per user</label>
+                    <input
+                      value={maxKeysPerUser}
+                      onChange={(event) => onMaxKeysPerUserChange(event.target.value)}
+                      type="number"
+                      min="1"
+                      placeholder="Unlimited"
+                      disabled={disabled}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1.5">Budget ceiling ($)</label>
+                    <div className="relative">
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
+                      <input
+                        value={budgetCeiling}
+                        onChange={(event) => onBudgetCeilingChange(event.target.value)}
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        placeholder="No ceiling"
+                        disabled={disabled}
+                        className="w-full pl-7 pr-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="p-3 rounded-lg bg-white border border-gray-200 space-y-3">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-medium text-gray-800">Require an expiry date</p>
+                      <p className="text-xs text-gray-500 mt-0.5">
+                        Enable this if self-service keys must always expire.
+                      </p>
+                    </div>
+                    <ToggleSwitch
+                      checked={requireExpiry}
+                      onCheckedChange={onRequireExpiryChange}
+                      disabled={disabled}
+                      aria-label="Toggle self-service expiry requirement"
+                    />
+                  </div>
+
+                  {requireExpiry && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1.5">Max expiry days</label>
+                      <input
+                        value={maxExpiryDays}
+                        onChange={(event) => onMaxExpiryDaysChange(event.target.value)}
+                        type="number"
+                        min="1"
+                        placeholder="No limit"
+                        disabled={disabled}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/OrganizationDetail.tsx
+++ b/ui/src/pages/OrganizationDetail.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
 import { useApi } from '../lib/hooks';
-import { callableTargets, organizations, teams as teamsApi } from '../lib/api';
-import { buildCatalogAssetTargets, buildParentScopedAssetTargets } from '../lib/assetAccess';
+import { callableTargets, organizations } from '../lib/api';
+import { buildCatalogAssetTargets } from '../lib/assetAccess';
 import { useAuth } from '../lib/auth';
 import Modal from '../components/Modal';
 import UserSearchSelect from '../components/UserSearchSelect';
@@ -84,11 +84,18 @@ export default function OrganizationDetail() {
   const isPlatformAdmin = userRole === 'platform_admin';
   const [tab, setTab] = useState<TabId>('overview');
 
+  useEffect(() => {
+    const hashTab = location.hash.replace('#', '');
+    if (hashTab === 'overview' || hashTab === 'teams' || hashTab === 'members' || hashTab === 'assets') {
+      setTab(hashTab);
+    }
+  }, [location.hash]);
+
   /* ── data ── */
   const { data: org, loading: orgLoading, refetch: refetchOrg } = useApi(
     () => organizations.get(orgId!), [orgId],
   );
-  const { data: orgTeams, loading: teamsLoading, refetch: refetchTeams } = useApi(
+  const { data: orgTeams, loading: teamsLoading } = useApi(
     () => organizations.teams(orgId!), [orgId],
   );
   const { data: orgMembers, loading: membersLoading, refetch: refetchMembers } = useApi(
@@ -240,64 +247,11 @@ export default function OrganizationDetail() {
     }
   };
 
-  /* ── create team modal ── */
-  const [showCreateTeam, setShowCreateTeam] = useState(false);
-  const [teamForm, setTeamForm] = useState({
-    team_alias: '',
-    max_budget: '',
-    rpm_limit: '',
-    tpm_limit: '',
-    rph_limit: '',
-    rpd_limit: '',
-    tpd_limit: '',
-    asset_access_mode: 'inherit' as 'inherit' | 'restrict',
-    selected_callable_keys: [] as string[],
-  });
-  const [teamError, setTeamError] = useState<string | null>(null);
-
-  const { data: childTeamAssetVisibility, loading: childTeamAssetVisibilityLoading } = useApi(
-    () => (
-      showCreateTeam && teamForm.asset_access_mode === 'restrict'
-        ? organizations.assetVisibility(orgId!)
-        : Promise.resolve(null)
-    ),
-    [orgId, showCreateTeam, teamForm.asset_access_mode],
-  );
-
-  const handleCreateTeam = async () => {
-    setSaving(true);
-    setTeamError(null);
-    try {
-      const created = await teamsApi.create({
-        team_alias: teamForm.team_alias || undefined,
-        organization_id: orgId,
-        max_budget: teamForm.max_budget ? Number(teamForm.max_budget) : undefined,
-        rpm_limit: teamForm.rpm_limit ? Number(teamForm.rpm_limit) : undefined,
-        tpm_limit: teamForm.tpm_limit ? Number(teamForm.tpm_limit) : undefined,
-        rph_limit: teamForm.rph_limit ? Number(teamForm.rph_limit) : undefined,
-        rpd_limit: teamForm.rpd_limit ? Number(teamForm.rpd_limit) : undefined,
-        tpd_limit: teamForm.tpd_limit ? Number(teamForm.tpd_limit) : undefined,
-      });
-      let assetAccessError: string | null = null;
-      if (teamForm.asset_access_mode === 'restrict') {
-        try {
-          await teamsApi.updateAssetAccess(created.team_id, {
-            mode: 'restrict',
-            selected_callable_keys: teamForm.selected_callable_keys,
-          });
-        } catch (err: any) {
-          assetAccessError = err?.message || 'Team created, but asset access could not be updated.';
-        }
-      }
-      setShowCreateTeam(false);
-      setTeamForm({ team_alias: '', max_budget: '', rpm_limit: '', tpm_limit: '', rph_limit: '', rpd_limit: '', tpd_limit: '', asset_access_mode: 'inherit', selected_callable_keys: [] });
-      refetchTeams();
-      setPageError(assetAccessError);
-    } catch (err: any) {
-      setTeamError(err?.message || 'Failed to create team');
-    } finally {
-      setSaving(false);
-    }
+  const openCreateTeam = () => {
+    const params = new URLSearchParams();
+    params.set('organization_id', orgId || '');
+    params.set('return_to', `${location.pathname}#teams`);
+    navigate(`/teams/new?${params.toString()}`);
   };
 
   /* ── add member modal ── */
@@ -360,11 +314,6 @@ export default function OrganizationDetail() {
     ? Math.round((orgAssetSummary.selected_total / orgAssetSummary.selectable_total) * 100)
     : null;
 
-  const childTeamAssetTargets = buildParentScopedAssetTargets(
-    childTeamAssetVisibility?.callable_targets?.items || [],
-    teamForm.selected_callable_keys,
-    teamForm.asset_access_mode,
-  );
   const orgAssetTargets = buildCatalogAssetTargets(
     (callableTargetPage?.data || []) as any[],
     form.selected_callable_keys,
@@ -601,7 +550,7 @@ export default function OrganizationDetail() {
                 <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
                   <h3 className="text-sm font-semibold text-gray-900">Teams</h3>
                   <button
-                    onClick={() => { setTeamError(null); setTeamForm({ team_alias: '', max_budget: '', rpm_limit: '', tpm_limit: '', rph_limit: '', rpd_limit: '', tpd_limit: '', asset_access_mode: 'inherit', selected_callable_keys: [] }); setShowCreateTeam(true); }}
+                    onClick={openCreateTeam}
                     className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-blue-600 border border-blue-200 bg-blue-50 rounded-lg hover:bg-blue-100 transition-colors"
                   >
                     <Plus className="w-3 h-3" /> Add Team
@@ -921,7 +870,7 @@ export default function OrganizationDetail() {
                 All Teams {teamList.length > 0 && `(${teamList.length})`}
               </h3>
               <button
-                onClick={() => { setTeamError(null); setTeamForm({ team_alias: '', max_budget: '', rpm_limit: '', tpm_limit: '', rph_limit: '', rpd_limit: '', tpd_limit: '', asset_access_mode: 'inherit', selected_callable_keys: [] }); setShowCreateTeam(true); }}
+                onClick={openCreateTeam}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
                 <Plus className="w-3.5 h-3.5" /> Add Team
@@ -952,7 +901,7 @@ export default function OrganizationDetail() {
                   <tr>
                     <td colSpan={5} className="px-5 py-12 text-center text-sm text-gray-400">
                       No teams yet.{' '}
-                      <button onClick={() => setShowCreateTeam(true)} className="text-blue-600 hover:underline">Add the first one</button>
+                      <button onClick={openCreateTeam} className="text-blue-600 hover:underline">Add the first one</button>
                     </td>
                   </tr>
                 ) : (
@@ -1261,114 +1210,6 @@ export default function OrganizationDetail() {
             </div>
           </div>
         )}
-
-      {/* ── Create Team Modal ── */}
-      <Modal open={showCreateTeam} onClose={() => setShowCreateTeam(false)} title="Add Team to Organization">
-        <div className="space-y-4">
-          {teamError && (
-            <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{teamError}</div>
-          )}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Team Name</label>
-            <input
-              value={teamForm.team_alias}
-              onChange={(e) => setTeamForm({ ...teamForm, team_alias: e.target.value })}
-              placeholder="Engineering"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Max Budget ($)</label>
-              <input
-                type="number"
-                value={teamForm.max_budget}
-                onChange={(e) => setTeamForm({ ...teamForm, max_budget: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-            </div>
-            <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
-              Team access starts from this organization's allowed assets. Use the section below to keep the full set or narrow it.
-            </div>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">RPM Limit</label>
-              <input
-                type="number"
-                value={teamForm.rpm_limit}
-                onChange={(e) => setTeamForm({ ...teamForm, rpm_limit: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">TPM Limit</label>
-              <input
-                type="number"
-                value={teamForm.tpm_limit}
-                onChange={(e) => setTeamForm({ ...teamForm, tpm_limit: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">RPH Limit</label>
-              <input
-                type="number"
-                value={teamForm.rph_limit}
-                onChange={(e) => setTeamForm({ ...teamForm, rph_limit: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                placeholder="Requests per hour"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">RPD Limit</label>
-              <input
-                type="number"
-                value={teamForm.rpd_limit}
-                onChange={(e) => setTeamForm({ ...teamForm, rpd_limit: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                placeholder="Requests per day"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">TPD Limit</label>
-              <input
-                type="number"
-                value={teamForm.tpd_limit}
-                onChange={(e) => setTeamForm({ ...teamForm, tpd_limit: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                placeholder="Tokens per day"
-              />
-            </div>
-          </div>
-          <AssetAccessEditor
-            title="Team Asset Access"
-            description="New teams inherit the organization asset ceiling by default. Switch to restrict if this team should only use a smaller subset."
-            mode={teamForm.asset_access_mode}
-            allowModeSelection
-            onModeChange={(mode) => setTeamForm((c) => ({
-              ...c,
-              asset_access_mode: mode === 'restrict' ? 'restrict' : 'inherit',
-              selected_callable_keys: mode === 'restrict' ? c.selected_callable_keys : [],
-            }))}
-            targets={childTeamAssetTargets}
-            selectedKeys={teamForm.selected_callable_keys}
-            onSelectedKeysChange={(selected_callable_keys) => setTeamForm({ ...teamForm, selected_callable_keys })}
-            loading={childTeamAssetVisibilityLoading}
-            disabled={saving}
-          />
-          <div className="flex justify-end gap-3 pt-2">
-            <button onClick={() => setShowCreateTeam(false)} className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg transition-colors">Cancel</button>
-            <button
-              onClick={handleCreateTeam}
-              disabled={saving || childTeamAssetVisibilityLoading}
-              className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"
-            >
-              {saving ? 'Creating…' : 'Create Team'}
-            </button>
-          </div>
-        </div>
-      </Modal>
 
       {/* ── Add Member Modal ── */}
       <Modal open={showAddMember} onClose={() => setShowAddMember(false)} title="Add Organization Member">

--- a/ui/src/pages/TeamCreate.tsx
+++ b/ui/src/pages/TeamCreate.tsx
@@ -4,6 +4,7 @@ import { useApi } from '../lib/hooks';
 import { teams, organizations } from '../lib/api';
 import { buildParentScopedAssetTargets } from '../lib/assetAccess';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
+import TeamSelfServicePolicySection from '../components/admin/TeamSelfServicePolicySection';
 import ToggleSwitch from '../components/ToggleSwitch';
 import { useAuth } from '../lib/auth';
 import {
@@ -114,6 +115,7 @@ export default function TeamCreate() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const preselectedOrgId = searchParams.get('organization_id') || '';
+  const returnTo = searchParams.get('return_to') || '';
   const { session, authMode } = useAuth();
   const userRole = session?.role || (authMode === 'master_key' ? 'platform_admin' : '');
   const permissions = new Set(session?.effective_permissions || []);
@@ -149,6 +151,11 @@ export default function TeamCreate() {
   const [tpdValue, setTpdValue] = useState('');
   const [assetMode, setAssetMode] = useState<'inherit' | 'restrict'>('inherit');
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [selfServiceEnabled, setSelfServiceEnabled] = useState(true);
+  const [selfServiceMaxKeysPerUser, setSelfServiceMaxKeysPerUser] = useState('');
+  const [selfServiceBudgetCeiling, setSelfServiceBudgetCeiling] = useState('');
+  const [selfServiceRequireExpiry, setSelfServiceRequireExpiry] = useState(false);
+  const [selfServiceMaxExpiryDays, setSelfServiceMaxExpiryDays] = useState('');
   const [blocked, setBlocked] = useState(false);
 
   /* selected org details */
@@ -184,6 +191,13 @@ export default function TeamCreate() {
 
   const isReady = teamName.trim().length > 0 && selectedOrgId.length > 0;
 
+  const resetSelfServicePolicy = () => {
+    setSelfServiceMaxKeysPerUser('');
+    setSelfServiceBudgetCeiling('');
+    setSelfServiceRequireExpiry(false);
+    setSelfServiceMaxExpiryDays('');
+  };
+
   const handleCreate = async () => {
     if (!teamName.trim()) { setNameError(true); return; }
     if (!selectedOrgId) { setError('Please select an organization.'); return; }
@@ -199,6 +213,16 @@ export default function TeamCreate() {
         rph_limit: rphEnabled && rphValue ? Number(rphValue) : undefined,
         rpd_limit: rpdEnabled && rpdValue ? Number(rpdValue) : undefined,
         tpd_limit: tpdEnabled && tpdValue ? Number(tpdValue) : undefined,
+        self_service_keys_enabled: selfServiceEnabled,
+        self_service_max_keys_per_user:
+          selfServiceEnabled && selfServiceMaxKeysPerUser ? Number(selfServiceMaxKeysPerUser) : undefined,
+        self_service_budget_ceiling:
+          selfServiceEnabled && selfServiceBudgetCeiling ? Number(selfServiceBudgetCeiling) : undefined,
+        self_service_require_expiry: selfServiceEnabled && selfServiceRequireExpiry ? true : undefined,
+        self_service_max_expiry_days:
+          selfServiceEnabled && selfServiceRequireExpiry && selfServiceMaxExpiryDays
+            ? Number(selfServiceMaxExpiryDays)
+            : undefined,
       };
 
       const created = await teams.create(payload);
@@ -231,7 +255,7 @@ export default function TeamCreate() {
     }
   };
 
-  const handleCancel = () => navigate('/teams');
+  const handleCancel = () => navigate(returnTo || '/teams');
 
   /* ─────────────── render ─────────────── */
   return (
@@ -579,6 +603,36 @@ export default function TeamCreate() {
                 )}
               </div>
             </div>
+          </div>
+
+          <div className="border-t border-gray-200" />
+
+          {/* ── Developer Key Access ── */}
+          <div>
+            <SectionHeading>Developer Key Access</SectionHeading>
+            <TeamSelfServicePolicySection
+              enabled={selfServiceEnabled}
+              maxKeysPerUser={selfServiceMaxKeysPerUser}
+              budgetCeiling={selfServiceBudgetCeiling}
+              requireExpiry={selfServiceRequireExpiry}
+              maxExpiryDays={selfServiceMaxExpiryDays}
+              disabled={saving}
+              onEnabledChange={(value) => {
+                setSelfServiceEnabled(value);
+                if (!value) {
+                  resetSelfServicePolicy();
+                }
+              }}
+              onMaxKeysPerUserChange={setSelfServiceMaxKeysPerUser}
+              onBudgetCeilingChange={setSelfServiceBudgetCeiling}
+              onRequireExpiryChange={(value) => {
+                setSelfServiceRequireExpiry(value);
+                if (!value) {
+                  setSelfServiceMaxExpiryDays('');
+                }
+              }}
+              onMaxExpiryDaysChange={setSelfServiceMaxExpiryDays}
+            />
           </div>
 
           <div className="border-t border-gray-200" />


### PR DESCRIPTION
## Summary

  This fixes the team creation flow so newly created teams are immediately usable for developer self-service API key creation.

  Before this change:

  - team creation flows did not expose self-service key policy
  - new teams were created with self_service_keys_enabled = false
  - team_developer users could be added successfully, but the API Keys self-service flow showed an empty team dropdown

  After this change:

  - new teams default to self-service enabled
  - optional self-service guardrails remain unset unless explicitly configured
  - the Organization Detail “Add Team” flow now reuses the canonical Teams create form instead of maintaining a separate duplicate form

  ## What Changed

  ### Backend

  - Changed team creation in src/api/admin/endpoints/teams.py so omitted self_service_keys_enabled defaults to true
  - Kept optional self-service constraint fields nullable/unset by default
  - Added a small shared helper to keep self-service policy parsing consistent between create and update paths

  ### Frontend

  - Added a compact self-service policy section to the canonical create flow in ui/src/pages/TeamCreate.tsx
  - Added ui/src/components/admin/TeamSelfServicePolicySection.tsx to keep the UI minimal:
      - main toggle enabled by default
      - advanced limits hidden behind progressive disclosure
      - optional fields only set when the user explicitly enters them
  - Removed the duplicate team-create modal from ui/src/pages/OrganizationDetail.tsx
  - Routed Organization Detail “Add Team” into the Teams create form with the org preselected and return navigation back to the org Teams tab

  ### Tests and Docs

  - Added focused API regressions in tests/test_ui_rate_limits.py for:
      - default self-service enabled on team create
      - explicit disable still respected
  - Updated docs:
      - docs/admin-ui/teams.md
      - docs/admin-ui/api-keys.md

  ## Why

  The backend already enforced self-service key policy correctly, but the main UI creation flows never exposed it. That made newly created teams effectively unusable for team_developer self-
  service unless an admin later discovered and edited the separate Team Detail policy screen.

  This change fixes the product gap at the source:

  - safe backend default
  - one canonical create flow
  - minimal UI footprint
  - no duplicated team-create logic drifting over time

  ## Verification

  Passed:

  - uv run ruff check src/api/admin/endpoints/teams.py tests/test_ui_rate_limits.py
  - uv run pytest tests/test_ui_rate_limits.py tests/test_ui_self_service_keys.py
  - cd ui && npm run build

  Manual curl verification also confirmed:

  - new Groq model registration through admin API
  - org/team visibility inheritance
  - developer self-service key creation
  - successful /v1/chat/completions call through the developer-created key