### PR TITLE
fix: tighten people access provisioning flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ client = OpenAI(api_key="sk-...")
 
 # After: Through DeltaLLM
 client = OpenAI(
-    base_url="http://localhost:4000/v1",  # ← Just change this
+    base_url="http://localhost:4002/v1",  # ← Just change this
     api_key="sk-deltallm-key"
 )
 ```
@@ -107,7 +107,7 @@ docker compose --profile single up -d --build
 
 This starts:
 
-- DeltaLLM on `http://localhost:4000`
+- DeltaLLM on `http://localhost:4002`
 - PostgreSQL
 - Redis
 
@@ -116,13 +116,13 @@ This starts:
 Check liveliness:
 
 ```bash
-curl http://localhost:4000/health/liveliness
+curl http://localhost:4002/health/liveliness
 ```
 
 List available models:
 
 ```bash
-curl http://localhost:4000/v1/models \
+curl http://localhost:4002/v1/models \
   -H "Authorization: Bearer $DELTALLM_MASTER_KEY"
 ```
 
@@ -134,7 +134,7 @@ If this list is empty, you did not bootstrap a model and must either:
 ### 6. Send your first request
 
 ```bash
-curl http://localhost:4000/v1/chat/completions \
+curl http://localhost:4002/v1/chat/completions \
   -H "Authorization: Bearer $DELTALLM_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -147,7 +147,7 @@ curl http://localhost:4000/v1/chat/completions \
 
 ### 7. Open the Admin UI
 
-Open `http://localhost:4000`.
+Open `http://localhost:4002`.
 
 If you set `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` and `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD`, you can log in with that initial admin account. You can also keep using the master key for gateway calls.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,7 +82,7 @@ general_settings:
   # email_provider: smtp
   # email_from_address: no-reply@example.com
   # email_reply_to: support@example.com
-  # email_base_url: http://localhost:4000
+  # email_base_url: http://localhost:4002
   # email_worker_enabled: true
   # email_max_attempts: 5
   # email_retry_initial_seconds: 60
@@ -114,7 +114,7 @@ general_settings:
   # sso_authorize_url: https://idp.example.com/oauth2/authorize
   # sso_token_url: https://idp.example.com/oauth2/token
   # sso_userinfo_url: https://idp.example.com/oauth2/userinfo
-  # sso_redirect_uri: http://localhost:4000/auth/callback
+  # sso_redirect_uri: http://localhost:4002/auth/callback
   # sso_scope: openid email profile
   # sso_admin_email_list:
   #   - admin@example.com

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     profiles: ["single"]
     ports:
-      - "4000:4000"
+      - "4002:4000"
     environment:
       DELTALLM_CONFIG_PATH: /app/config/config.yaml
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}

--- a/docs/admin-ui/index.md
+++ b/docs/admin-ui/index.md
@@ -7,7 +7,7 @@ The DeltaLLM admin UI is the control plane for model deployments, route groups, 
 ## Access and authentication
 
 - **Development**: `http://localhost:5000`
-- **Single-port / Docker**: `http://localhost:4000`
+- **Single-port / Docker**: `http://localhost:4002`
 - **Email login** uses the platform account directory and session cookies
 - **Master key login** gives platform-admin access for local operations
 - **SSO** appears automatically when an identity provider is configured

--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -62,7 +62,7 @@ general_settings:
   email_provider: smtp
   email_from_address: no-reply@example.com
   email_reply_to: support@example.com
-  email_base_url: http://localhost:4000
+  email_base_url: http://localhost:4002
   email_worker_enabled: true
   email_max_attempts: 5
   email_retry_initial_seconds: 60

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -13,7 +13,7 @@ services:
   deltallm:
     build: .
     ports:
-      - "4000:4000"
+      - "4002:4000"
     environment:
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/deltallm
       - REDIS_URL=redis://redis:6379/0
@@ -93,6 +93,8 @@ The generated master key always satisfies DeltaLLM's validator: it is longer tha
 ```bash
 docker compose up -d
 ```
+
+With this host mapping, the Docker deployment is reachable at `http://localhost:4002`.
 
 ## Upgrading
 

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -56,11 +56,11 @@ prisma db push --schema=./prisma/schema.prisma --accept-data-loss
 Then it starts the API server.
 
 This starts:
-- DeltaLLM on port **4000**
+- DeltaLLM on port **4002** on the host (`4000` inside the container)
 - PostgreSQL 15 database
 - Redis 7 cache
 
-DeltaLLM is available at `http://localhost:4000`.
+DeltaLLM is available at `http://localhost:4002`.
 
 Once a model is available, see [Quick Start](quickstart.md) for `curl`, Python, and JavaScript usage examples.
 
@@ -162,7 +162,7 @@ volumes:
 
 ```bash
 docker build -t deltallm .
-docker run -p 4000:4000 \
+docker run -p 4002:4000 \
   -e DATABASE_URL="postgresql://..." \
   -e DELTALLM_MASTER_KEY="sk-your-key" \
   -e DELTALLM_SALT_KEY="your-salt-key" \
@@ -177,13 +177,13 @@ The image runs `prisma db push --schema=./prisma/schema.prisma --accept-data-los
 Verify the container is healthy:
 
 ```bash
-curl http://localhost:4000/health/liveliness
+curl http://localhost:4002/health/liveliness
 ```
 
 List the available models:
 
 ```bash
-curl http://localhost:4000/v1/models \
+curl http://localhost:4002/v1/models \
   -H "Authorization: Bearer $DELTALLM_MASTER_KEY"
 ```
 

--- a/docs/getting-started/mcp-quickstart.md
+++ b/docs/getting-started/mcp-quickstart.md
@@ -4,7 +4,7 @@ Use this guide when DeltaLLM is already running and you want your first successf
 
 This path assumes:
 
-- DeltaLLM is reachable on `http://localhost:4000` or `http://localhost:8000`
+- DeltaLLM is reachable on `http://localhost:4002` or `http://localhost:8000`
 - you already have a compatible MCP server that speaks JSON-RPC over `streamable_http`
 - you have either the DeltaLLM master key or admin UI access
 
@@ -22,7 +22,7 @@ In about five minutes you will:
 
 Use the DeltaLLM URL that matches your setup:
 
-- Docker quick start: `http://localhost:4000`
+- Docker quick start: `http://localhost:4002`
 - local backend: `http://localhost:8000`
 
 If your MCP server runs on your host machine:
@@ -33,7 +33,7 @@ If your MCP server runs on your host machine:
 Export the values once:
 
 ```bash
-export BASE="http://localhost:4000"
+export BASE="http://localhost:4002"
 export MASTER_KEY="YOUR_MASTER_KEY"
 ```
 

--- a/scripts/e2e_budget_threshold_notifications.sh
+++ b/scripts/e2e_budget_threshold_notifications.sh
@@ -20,7 +20,7 @@ require_bin curl
 require_bin docker
 require_bin jq
 
-BASE="${BASE:-http://127.0.0.1:4000}"
+BASE="${BASE:-http://127.0.0.1:4002}"
 MASTER_KEY="${MASTER_KEY:-${DELTALLM_MASTER_KEY:-}}"
 OPENAI_API_KEY="${OPENAI_API_KEY:-}"
 RUN_ID="${RUN_ID:-$(date +%s)}"

--- a/scripts/e2e_gateway_role_scenarios.sh
+++ b/scripts/e2e_gateway_role_scenarios.sh
@@ -19,7 +19,7 @@ require_bin() {
 require_bin curl
 require_bin jq
 
-BASE="${BASE:-http://127.0.0.1:4000}"
+BASE="${BASE:-http://127.0.0.1:4002}"
 MASTER_KEY="${MASTER_KEY:-${DELTALLM_MASTER_KEY:-}}"
 OPENAI_API_KEY="${OPENAI_API_KEY:-}"
 GROQ_API_KEY="${GROQ_API_KEY:-}"

--- a/scripts/e2e_governance_matrix.sh
+++ b/scripts/e2e_governance_matrix.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE="${BASE:-http://localhost:4000}"
+BASE="${BASE:-http://localhost:4002}"
 MASTER_KEY="${MASTER_KEY:-}"
 ORG_ID="${ORG_ID:-org-e2e-governance}"
 TEAM_ID="${TEAM_ID:-team-e2e-governance}"

--- a/scripts/e2e_invitation_recovery.sh
+++ b/scripts/e2e_invitation_recovery.sh
@@ -20,7 +20,7 @@ require_bin curl
 require_bin jq
 require_bin docker
 
-BASE="${BASE:-http://127.0.0.1:4000}"
+BASE="${BASE:-http://127.0.0.1:4002}"
 MASTER_KEY="${MASTER_KEY:-${DELTALLM_MASTER_KEY:-}}"
 RUN_ID="${RUN_ID:-$(date +%s)}"
 

--- a/scripts/e2e_mcp_governance.sh
+++ b/scripts/e2e_mcp_governance.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE="${BASE:-http://localhost:4000}"
+BASE="${BASE:-http://localhost:4002}"
 MASTER_KEY="${MASTER_KEY:-}"
 SERVER_ID="${SERVER_ID:-}"
 ORG_ID="${ORG_ID:-org-main}"

--- a/src/api/admin/endpoints/invitations.py
+++ b/src/api/admin/endpoints/invitations.py
@@ -82,7 +82,10 @@ async def list_invitations(
     service = getattr(request.app.state, "invitation_service", None)
     if service is None:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable")
-    invitations = await service.list_invitations(status=status_filter, search=search)
+    normalized_status = None if status_filter == "active" else status_filter
+    invitations = await service.list_invitations(status=normalized_status, search=search)
+    if status_filter == "active":
+        invitations = [item for item in invitations if item.get("status") in {"pending", "sent"}]
     visible = invitations if scope.is_platform_admin else [item for item in invitations if _can_manage_invitation(scope, item)]
     page = visible[offset : offset + limit]
     return {

--- a/src/api/admin/endpoints/rbac.py
+++ b/src/api/admin/endpoints/rbac.py
@@ -5,10 +5,11 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
-from src.auth.roles import Permission, validate_organization_role, validate_platform_role, validate_team_role
+from src.auth.roles import Permission, PlatformRole, validate_organization_role, validate_platform_role, validate_team_role
 from src.audit import AuditAction
 from src.api.admin.endpoints.common import db_or_503, emit_admin_mutation_audit, to_json_value
 from src.middleware.admin import require_admin_permission
+from src.services.access_provisioning_service import AccessProvisioningService
 
 router = APIRouter(tags=["Admin RBAC"])
 
@@ -149,6 +150,39 @@ async def list_principals(
     }
 
 
+@router.get("/ui/api/principals/summary", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+async def principals_summary(request: Request) -> dict[str, int]:
+    db = db_or_503(request)
+    rows = await db.query_raw(
+        """
+        SELECT
+            COUNT(*)::int AS total_accounts,
+            COUNT(*) FILTER (WHERE is_active)::int AS active_accounts,
+            COUNT(*) FILTER (WHERE role = $1)::int AS platform_admins,
+            COUNT(*) FILTER (WHERE mfa_enabled)::int AS mfa_enabled_accounts
+        FROM deltallm_platformaccount
+        """,
+        PlatformRole.ADMIN,
+    )
+    membership_rows = await db.query_raw(
+        """
+        SELECT
+            (SELECT COUNT(*)::int FROM deltallm_organizationmembership) AS organization_memberships,
+            (SELECT COUNT(*)::int FROM deltallm_teammembership) AS team_memberships
+        """
+    )
+    base = rows[0] if rows else {}
+    memberships = membership_rows[0] if membership_rows else {}
+    return {
+        "total_accounts": int(base.get("total_accounts") or 0),
+        "active_accounts": int(base.get("active_accounts") or 0),
+        "platform_admins": int(base.get("platform_admins") or 0),
+        "mfa_enabled_accounts": int(base.get("mfa_enabled_accounts") or 0),
+        "organization_memberships": int(memberships.get("organization_memberships") or 0),
+        "team_memberships": int(memberships.get("team_memberships") or 0),
+    }
+
+
 @router.post("/ui/api/rbac/accounts", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
 async def upsert_rbac_account(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
     request_start = perf_counter()
@@ -220,6 +254,63 @@ async def upsert_rbac_account(request: Request, payload: dict[str, Any]) -> dict
         resource_id=str(rows[0].get("account_id") or ""),
         request_payload=payload,
         response_payload=response if isinstance(response, dict) else None,
+    )
+    return response
+
+
+@router.post("/ui/api/rbac/provision", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+async def provision_person(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
+    request_start = perf_counter()
+    db = db_or_503(request)
+    identity_service = getattr(request.app.state, "platform_identity_service", None)
+    invitation_service = getattr(request.app.state, "invitation_service", None)
+    if identity_service is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Provisioning service unavailable")
+
+    mode = str(payload.get("mode") or "").strip()
+    if mode == "invite_email" and invitation_service is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable")
+
+    service = AccessProvisioningService(
+        db_client=db,
+        platform_identity_service=identity_service,
+        invitation_service=invitation_service,
+    )
+
+    try:
+        response = await service.provision_person(
+            email=str(payload.get("email") or ""),
+            mode=mode,
+            platform_role=str(payload.get("platform_role") or payload.get("role") or PlatformRole.ORG_USER),
+            password=str(payload.get("password") or "") or None,
+            is_active=bool(payload.get("is_active", True)),
+            organization_id=str(payload.get("organization_id") or "").strip() or None,
+            organization_role=str(payload.get("organization_role") or "") or None,
+            team_id=str(payload.get("team_id") or "").strip() or None,
+            team_role=str(payload.get("team_role") or "") or None,
+            invited_by_account_id=getattr(getattr(request.state, "platform_auth", None), "account_id", None),
+        )
+    except ValueError as exc:
+        detail = str(exc)
+        status_code = status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        raise HTTPException(status_code=status_code, detail=detail) from exc
+    except RuntimeError as exc:
+        if "invitation service unavailable" in str(exc):
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable") from exc
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Provisioning failed") from exc
+
+    mode = str(response.get("mode") or "")
+    action = AuditAction.ADMIN_INVITATION_CREATE if mode == "invite_email" else AuditAction.ADMIN_RBAC_ACCOUNT_UPSERT
+    resource_type = "invitation" if mode == "invite_email" else "platform_account"
+    resource_id = str(response.get("invitation_id") or response.get("account_id") or "")
+    await emit_admin_mutation_audit(
+        request=request,
+        request_start=request_start,
+        action=action,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        request_payload=payload,
+        response_payload=response,
     )
     return response
 

--- a/src/services/access_provisioning_service.py
+++ b/src/services/access_provisioning_service.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.auth.roles import (
+    OrganizationRole,
+    PlatformRole,
+    TeamRole,
+    validate_organization_role,
+    validate_platform_role,
+    validate_team_role,
+)
+from src.services.invitation_service import InvitationService
+from src.services.platform_identity_service import PlatformIdentityService
+
+
+class AccessProvisioningService:
+    def __init__(
+        self,
+        *,
+        db_client: Any,
+        platform_identity_service: PlatformIdentityService,
+        invitation_service: InvitationService | None,
+    ) -> None:
+        self.db = db_client
+        self.platform_identity_service = platform_identity_service
+        self.invitation_service = invitation_service
+
+    async def provision_person(
+        self,
+        *,
+        email: str,
+        mode: str,
+        platform_role: str | None = None,
+        password: str | None = None,
+        is_active: bool = True,
+        organization_id: str | None = None,
+        organization_role: str | None = None,
+        team_id: str | None = None,
+        team_role: str | None = None,
+        invited_by_account_id: str | None = None,
+    ) -> dict[str, Any]:
+        normalized_email = self.platform_identity_service.normalize_email(email)
+        if not normalized_email:
+            raise ValueError("email is required")
+
+        normalized_mode = str(mode or "").strip()
+        if normalized_mode not in {"invite_email", "create_account"}:
+            raise ValueError("invalid provisioning mode")
+
+        normalized_organization_id = str(organization_id or "").strip() or None
+        normalized_team_id = str(team_id or "").strip() or None
+        scope_type = self._scope_type(organization_id=normalized_organization_id, team_id=normalized_team_id)
+
+        if normalized_mode == "invite_email":
+            return await self._invite_person(
+                email=normalized_email,
+                organization_id=normalized_organization_id,
+                organization_role=organization_role,
+                team_id=normalized_team_id,
+                team_role=team_role,
+                invited_by_account_id=invited_by_account_id,
+                scope_type=scope_type,
+                platform_role=platform_role,
+                password=password,
+            )
+
+        return await self._create_account(
+            email=normalized_email,
+            platform_role=platform_role,
+            password=password,
+            is_active=is_active,
+            organization_id=normalized_organization_id,
+            organization_role=organization_role,
+            team_id=normalized_team_id,
+            team_role=team_role,
+            scope_type=scope_type,
+        )
+
+    async def _invite_person(
+        self,
+        *,
+        email: str,
+        organization_id: str | None,
+        organization_role: str | None,
+        team_id: str | None,
+        team_role: str | None,
+        invited_by_account_id: str | None,
+        scope_type: str,
+        platform_role: str | None,
+        password: str | None,
+    ) -> dict[str, Any]:
+        if password:
+            raise ValueError("password is not allowed when sending an invitation")
+        if platform_role and validate_platform_role(platform_role) != PlatformRole.ORG_USER:
+            raise ValueError("platform_admin cannot be invited by email")
+        if scope_type == "none":
+            raise ValueError("organization or team access is required when sending an invitation")
+
+        organization_role_value = (
+            validate_organization_role(organization_role or OrganizationRole.MEMBER)
+            if organization_id
+            else OrganizationRole.MEMBER
+        )
+        team_role_value = validate_team_role(team_role or TeamRole.VIEWER) if team_id else TeamRole.VIEWER
+        if self.invitation_service is None:
+            raise RuntimeError("invitation service unavailable")
+
+        invitation = await self.invitation_service.create_invitation(
+            email=email,
+            invited_by_account_id=invited_by_account_id,
+            organization_id=organization_id,
+            organization_role=organization_role_value,
+            team_id=team_id,
+            team_role=team_role_value,
+        )
+        return {
+            "mode": "invite_email",
+            **invitation,
+        }
+
+    async def _create_account(
+        self,
+        *,
+        email: str,
+        platform_role: str | None,
+        password: str | None,
+        is_active: bool,
+        organization_id: str | None,
+        organization_role: str | None,
+        team_id: str | None,
+        team_role: str | None,
+        scope_type: str,
+    ) -> dict[str, Any]:
+        if not password:
+            raise ValueError("password is required when creating an account manually")
+
+        role = validate_platform_role(platform_role or PlatformRole.ORG_USER)
+        if role == PlatformRole.ADMIN and scope_type != "none":
+            raise ValueError("platform_admin accounts cannot be provisioned with scoped memberships")
+
+        if self.db is not None and hasattr(self.db, "tx"):
+            async with self.db.tx() as tx:
+                identity_service = self.platform_identity_service.with_db(tx)
+                return await self._create_account_with_dependencies(
+                    identity_service=identity_service,
+                    email=email,
+                    password=password,
+                    role=role,
+                    is_active=is_active,
+                    organization_id=organization_id,
+                    organization_role=organization_role,
+                    team_id=team_id,
+                    team_role=team_role,
+                    scope_type=scope_type,
+                )
+
+        return await self._create_account_with_dependencies(
+            identity_service=self.platform_identity_service,
+            email=email,
+            password=password,
+            role=role,
+            is_active=is_active,
+            organization_id=organization_id,
+            organization_role=organization_role,
+            team_id=team_id,
+            team_role=team_role,
+            scope_type=scope_type,
+        )
+
+    async def _create_account_with_dependencies(
+        self,
+        *,
+        identity_service: PlatformIdentityService,
+        email: str,
+        password: str,
+        role: str,
+        is_active: bool,
+        organization_id: str | None,
+        organization_role: str | None,
+        team_id: str | None,
+        team_role: str | None,
+        scope_type: str,
+    ) -> dict[str, Any]:
+        identity_service.validate_password_policy(password)
+        existing = await identity_service.get_account_by_email(email)
+        if existing is not None:
+            raise ValueError("account already exists")
+
+        team_organization_id = await self._resolve_team_organization_id(team_id, db_client=identity_service.db) if team_id else None
+        if team_id and not team_organization_id:
+            raise ValueError("team not found")
+        if organization_id:
+            exists = await self._organization_exists(organization_id, db_client=identity_service.db)
+            if not exists:
+                raise ValueError("organization not found")
+        if organization_id and team_organization_id and team_organization_id != organization_id:
+            raise ValueError("team_id does not belong to organization_id")
+
+        account = await identity_service.create_account(
+            email=email,
+            role=role,
+            is_active=is_active,
+            password=password,
+        )
+        account_id = str(account.get("account_id") or "")
+        if not account_id:
+            raise RuntimeError("failed to create account")
+
+        if scope_type == "organization" and organization_id:
+            await identity_service.upsert_organization_membership(
+                account_id=account_id,
+                organization_id=organization_id,
+                role=validate_organization_role(organization_role or OrganizationRole.MEMBER),
+            )
+        elif scope_type == "team" and team_id:
+            team_org_id = team_organization_id or organization_id
+            if team_org_id:
+                await identity_service.upsert_organization_membership(
+                    account_id=account_id,
+                    organization_id=team_org_id,
+                    role=OrganizationRole.MEMBER,
+                )
+            await identity_service.upsert_team_membership(
+                account_id=account_id,
+                team_id=team_id,
+                role=validate_team_role(team_role or TeamRole.VIEWER),
+            )
+
+        created = await identity_service.get_account_by_id(account_id)
+        if created is None:
+            raise RuntimeError("failed to load created account")
+
+        return {
+            "mode": "create_account",
+            "account_id": str(created.get("account_id") or ""),
+            "email": str(created.get("email") or email),
+            "role": str(created.get("role") or role),
+            "is_active": bool(created.get("is_active", is_active)),
+            "organization_id": organization_id,
+            "team_id": team_id,
+            "scope_type": scope_type,
+        }
+
+    async def _organization_exists(self, organization_id: str, *, db_client: Any | None = None) -> bool:
+        query_client = db_client or self.db
+        if query_client is None or not organization_id:
+            return False
+        rows = await query_client.query_raw(
+            """
+            SELECT organization_id
+            FROM deltallm_organizationtable
+            WHERE organization_id = $1
+            LIMIT 1
+            """,
+            organization_id,
+        )
+        return bool(rows)
+
+    async def _resolve_team_organization_id(self, team_id: str, *, db_client: Any | None = None) -> str | None:
+        query_client = db_client or self.db
+        if query_client is None or not team_id:
+            return None
+        rows = await query_client.query_raw(
+            """
+            SELECT organization_id
+            FROM deltallm_teamtable
+            WHERE team_id = $1
+            LIMIT 1
+            """,
+            team_id,
+        )
+        if not rows:
+            return None
+        return str(rows[0].get("organization_id") or "").strip() or None
+
+    def _scope_type(self, *, organization_id: str | None, team_id: str | None) -> str:
+        if team_id:
+            return "team"
+        if organization_id:
+            return "organization"
+        return "none"

--- a/src/services/platform_identity_service.py
+++ b/src/services/platform_identity_service.py
@@ -510,6 +510,52 @@ class PlatformIdentityService:
             raise RuntimeError("failed to ensure account")
         return account
 
+    async def create_account(
+        self,
+        *,
+        email: str,
+        role: str = PlatformRole.ORG_USER,
+        is_active: bool = True,
+        password: str,
+    ) -> dict[str, Any]:
+        normalized_email = self.normalize_email(email)
+        if not normalized_email:
+            raise ValueError("email is required")
+        self.validate_password_policy(password)
+        if self.db is None:
+            return {
+                "account_id": "",
+                "email": normalized_email,
+                "role": role,
+                "is_active": is_active,
+            }
+
+        existing = await self.get_account_by_email(normalized_email)
+        if existing is not None:
+            raise ValueError("account already exists")
+
+        await self.db.execute_raw(
+            """
+            INSERT INTO deltallm_platformaccount (
+                account_id, email, role, is_active, force_password_change, mfa_enabled, created_at, updated_at
+            )
+            VALUES (gen_random_uuid(), $1, $2, $3, false, false, NOW(), NOW())
+            """,
+            normalized_email,
+            role,
+            is_active,
+        )
+        account = await self.get_account_by_email(normalized_email)
+        if account is None:
+            raise RuntimeError("failed to create account")
+        await self.set_password(account_id=str(account.get("account_id") or ""), new_password=password)
+        created = await self.get_account_by_email(normalized_email)
+        if created is None:
+            raise RuntimeError("failed to load created account")
+        if not str(created.get("password_hash") or "").strip():
+            raise RuntimeError("failed to set account password")
+        return created
+
     async def upsert_organization_membership(self, *, account_id: str, organization_id: str, role: str) -> None:
         if self.db is None:
             return

--- a/tests/services/test_platform_identity_service.py
+++ b/tests/services/test_platform_identity_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from src.services.platform_identity_service import PlatformIdentityService
+
+
+class FakePlatformIdentityDB:
+    def __init__(self) -> None:
+        self.accounts: dict[str, dict[str, object]] = {}
+
+    async def query_raw(self, query: str, *params):  # noqa: ANN201
+        if "WHERE lower(email) = lower($1)" in query:
+            email = str(params[0]).strip().lower()
+            for row in self.accounts.values():
+                if str(row.get("email") or "").lower() == email:
+                    return [dict(row)]
+            return []
+        return []
+
+    async def execute_raw(self, query: str, *params):  # noqa: ANN201
+        if "INSERT INTO deltallm_platformaccount" in query:
+            email = str(params[0]).strip().lower()
+            account_id = f"acct-{len(self.accounts) + 1}"
+            self.accounts[account_id] = {
+                "account_id": account_id,
+                "email": email,
+                "role": str(params[1]),
+                "is_active": bool(params[2]),
+                "force_password_change": False,
+                "mfa_enabled": False,
+                "password_hash": None,
+                "created_at": None,
+                "updated_at": None,
+                "last_login_at": None,
+            }
+            return 1
+        if "SET password_hash = $1" in query:
+            password_hash = str(params[0])
+            account_id = str(params[1])
+            row = self.accounts.get(account_id)
+            if row is None:
+                return 0
+            row["password_hash"] = password_hash
+            return 1
+        return 0
+
+
+class PasswordWriteDroppingIdentityService(PlatformIdentityService):
+    async def set_password(self, *, account_id: str, new_password: str) -> None:
+        self.validate_password_policy(new_password)
+        del account_id
+
+
+@pytest.mark.asyncio
+async def test_create_account_rejects_missing_password_write() -> None:
+    db = FakePlatformIdentityDB()
+    service = PasswordWriteDroppingIdentityService(db_client=db, salt="salt-key")
+
+    with pytest.raises(RuntimeError, match="failed to set account password"):
+        await service.create_account(
+            email="user@example.com",
+            password="very-secure-password",
+        )

--- a/tests/test_ui_access_provisioning.py
+++ b/tests/test_ui_access_provisioning.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import pytest
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.organizations = {"org-1": {"organization_id": "org-1"}}
+        self.teams = {"team-1": {"team_id": "team-1", "organization_id": "org-1"}}
+        self.principal_summary = {
+            "total_accounts": 3,
+            "active_accounts": 2,
+            "platform_admins": 1,
+            "mfa_enabled_accounts": 1,
+            "organization_memberships": 4,
+            "team_memberships": 2,
+        }
+
+    async def query_raw(self, query: str, *params):
+        if "FROM deltallm_organizationtable" in query:
+            organization_id = str(params[0])
+            row = self.organizations.get(organization_id)
+            return [row] if row else []
+        if "FROM deltallm_teamtable" in query:
+            team_id = str(params[0])
+            row = self.teams.get(team_id)
+            return [row] if row else []
+        if "FROM deltallm_platformaccount" in query and "COUNT(*) FILTER" in query:
+            return [self.principal_summary]
+        if "FROM deltallm_organizationmembership" in query and "team_memberships" in query:
+            return [self.principal_summary]
+        return []
+
+
+class StubIdentityService:
+    def __init__(
+        self,
+        db,
+        *,
+        accounts: dict[str, dict] | None = None,
+        organization_memberships: list[dict] | None = None,
+        team_memberships: list[dict] | None = None,
+    ) -> None:
+        self.db = db
+        self.accounts = accounts or {}
+        self.organization_memberships = organization_memberships or []
+        self.team_memberships = team_memberships or []
+
+    def with_db(self, db_client):
+        return StubIdentityService(
+            db_client,
+            accounts=self.accounts,
+            organization_memberships=self.organization_memberships,
+            team_memberships=self.team_memberships,
+        )
+
+    def normalize_email(self, email: str | None) -> str:
+        return str(email or "").strip().lower()
+
+    def validate_password_policy(self, raw_password: str) -> None:
+        if len(raw_password or "") < 12:
+            raise ValueError("password must be at least 12 characters")
+
+    async def get_account_by_email(self, email: str):
+        normalized = self.normalize_email(email)
+        return next((item for item in self.accounts.values() if item["email"] == normalized), None)
+
+    async def get_account_by_id(self, account_id: str):
+        return self.accounts.get(account_id)
+
+    async def create_account(self, *, email: str, role: str, is_active: bool, password: str):
+        self.validate_password_policy(password)
+        normalized = self.normalize_email(email)
+        if any(item["email"] == normalized for item in self.accounts.values()):
+            raise ValueError("account already exists")
+        account_id = f"acct-{len(self.accounts) + 1}"
+        record = {
+            "account_id": account_id,
+            "email": normalized,
+            "role": role,
+            "is_active": is_active,
+        }
+        self.accounts[account_id] = record
+        return record
+
+    async def upsert_organization_membership(self, *, account_id: str, organization_id: str, role: str) -> None:
+        self.organization_memberships.append(
+            {"account_id": account_id, "organization_id": organization_id, "role": role}
+        )
+
+    async def upsert_team_membership(self, *, account_id: str, team_id: str, role: str) -> None:
+        self.team_memberships.append(
+            {"account_id": account_id, "team_id": team_id, "role": role}
+        )
+
+
+class StubInvitationService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def create_invitation(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "invitation_id": "inv-1",
+            "account_id": "acct-pending",
+            "email": kwargs["email"],
+            "status": "sent",
+            "invite_scope_type": "team" if kwargs.get("team_id") else "organization",
+            "expires_at": "2026-04-01T00:00:00+00:00",
+            "metadata": {},
+        }
+
+
+@pytest.mark.asyncio
+async def test_provision_person_invite_mode_calls_invitation_service(client, test_app):
+    fake_db = FakeDB()
+    identity_service = StubIdentityService(fake_db)
+    invitation_service = StubInvitationService()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.platform_identity_service = identity_service
+    test_app.state.invitation_service = invitation_service
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/rbac/provision",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "email": "invitee@example.com",
+            "mode": "invite_email",
+            "organization_id": "org-1",
+            "organization_role": "org_member",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["mode"] == "invite_email"
+    assert invitation_service.calls == [
+        {
+            "email": "invitee@example.com",
+            "invited_by_account_id": None,
+            "organization_id": "org-1",
+            "organization_role": "org_member",
+            "team_id": None,
+            "team_role": "team_viewer",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provision_person_create_account_adds_org_membership(client, test_app):
+    fake_db = FakeDB()
+    identity_service = StubIdentityService(fake_db)
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.platform_identity_service = identity_service
+    test_app.state.invitation_service = StubInvitationService()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/rbac/provision",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "email": "new-user@example.com",
+            "mode": "create_account",
+            "platform_role": "org_user",
+            "password": "very-secure-password",
+            "organization_id": "org-1",
+            "organization_role": "org_admin",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["mode"] == "create_account"
+    assert payload["account_id"] == "acct-1"
+    assert identity_service.organization_memberships == [
+        {"account_id": "acct-1", "organization_id": "org-1", "role": "org_admin"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provision_person_create_account_team_scope_adds_parent_org_membership(client, test_app):
+    fake_db = FakeDB()
+    identity_service = StubIdentityService(fake_db)
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.platform_identity_service = identity_service
+    test_app.state.invitation_service = StubInvitationService()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/rbac/provision",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "email": "team-user@example.com",
+            "mode": "create_account",
+            "platform_role": "org_user",
+            "password": "very-secure-password",
+            "team_id": "team-1",
+            "team_role": "team_developer",
+        },
+    )
+
+    assert response.status_code == 200
+    assert identity_service.organization_memberships == [
+        {"account_id": "acct-1", "organization_id": "org-1", "role": "org_member"}
+    ]
+    assert identity_service.team_memberships == [
+        {"account_id": "acct-1", "team_id": "team-1", "role": "team_developer"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provision_person_create_account_rejects_existing_email(client, test_app):
+    fake_db = FakeDB()
+    identity_service = StubIdentityService(
+        fake_db,
+        accounts={"acct-1": {"account_id": "acct-1", "email": "existing@example.com", "role": "org_user", "is_active": True}},
+    )
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.platform_identity_service = identity_service
+    test_app.state.invitation_service = StubInvitationService()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/rbac/provision",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "email": "existing@example.com",
+            "mode": "create_account",
+            "platform_role": "org_user",
+            "password": "very-secure-password",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "account already exists"
+
+
+@pytest.mark.asyncio
+async def test_provision_person_create_account_succeeds_without_invitation_service(client, test_app):
+    fake_db = FakeDB()
+    identity_service = StubIdentityService(fake_db)
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.platform_identity_service = identity_service
+    test_app.state.invitation_service = None
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/rbac/provision",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "email": "manual-only@example.com",
+            "mode": "create_account",
+            "platform_role": "org_user",
+            "password": "very-secure-password",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["mode"] == "create_account"
+
+
+@pytest.mark.asyncio
+async def test_provision_person_invite_mode_requires_invitation_service(client, test_app):
+    fake_db = FakeDB()
+    identity_service = StubIdentityService(fake_db)
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.platform_identity_service = identity_service
+    test_app.state.invitation_service = None
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/rbac/provision",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "email": "invitee@example.com",
+            "mode": "invite_email",
+            "organization_id": "org-1",
+            "organization_role": "org_member",
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Invitation service unavailable"
+
+
+@pytest.mark.asyncio
+async def test_principals_summary_returns_global_totals(client, test_app):
+    fake_db = FakeDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.get(
+        "/ui/api/principals/summary",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == fake_db.principal_summary

--- a/tests/test_ui_invitations.py
+++ b/tests/test_ui_invitations.py
@@ -10,9 +10,10 @@ class _FakeInvitationService:
         self.create_calls: list[dict[str, object]] = []
         self.resend_calls: list[tuple[str, str | None]] = []
         self.cancel_calls: list[str] = []
+        self.list_calls: list[dict[str, object | None]] = []
 
     async def list_invitations(self, *, status=None, search=None):  # noqa: ANN001, ANN201
-        del status, search
+        self.list_calls.append({"status": status, "search": search})
         return [
             {
                 "invitation_id": "inv-1",
@@ -28,6 +29,22 @@ class _FakeInvitationService:
                 "invited_by_account_id": "acct-admin",
                 "inviter_email": "admin@example.com",
                 "message_email_id": "email-1",
+                "metadata": {"organization_invites": [{"organization_id": "org-1", "role": "org_member"}]},
+            },
+            {
+                "invitation_id": "inv-2",
+                "account_id": "acct-2",
+                "email": "accepted@example.com",
+                "status": "accepted",
+                "invite_scope_type": "organization",
+                "expires_at": "2026-01-02T00:00:00+00:00",
+                "accepted_at": "2026-01-01T12:00:00+00:00",
+                "cancelled_at": None,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T12:00:00+00:00",
+                "invited_by_account_id": "acct-admin",
+                "inviter_email": "admin@example.com",
+                "message_email_id": "email-2",
                 "metadata": {"organization_invites": [{"organization_id": "org-1", "role": "org_member"}]},
             }
         ]
@@ -74,8 +91,27 @@ async def test_list_invitations_returns_paginated_payload(client, test_app) -> N
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["pagination"]["total"] == 1
+    assert payload["pagination"]["total"] == 2
     assert payload["data"][0]["invitation_id"] == "inv-1"
+
+
+@pytest.mark.asyncio
+async def test_list_invitations_active_status_filters_before_pagination(client, test_app) -> None:
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    service = _FakeInvitationService()
+    test_app.state.invitation_service = service
+
+    response = await client.get(
+        "/ui/api/invitations",
+        headers={"Authorization": "Bearer mk-test"},
+        params={"status": "active"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert service.list_calls == [{"status": None, "search": None}]
+    assert payload["pagination"]["total"] == 1
+    assert [item["status"] for item in payload["data"]] == ["sent"]
 
 
 @pytest.mark.asyncio

--- a/ui/src/components/admin/InvitationPanel.tsx
+++ b/ui/src/components/admin/InvitationPanel.tsx
@@ -1,38 +1,15 @@
-import { useEffect, useState } from 'react';
-import type { FormEvent } from 'react';
-import { invitations, type Invitation } from '../../lib/api';
-import Modal from '../Modal';
-import { useToast } from '../ToastProvider';
-
-type TargetType = 'organization' | 'team';
-
-type OptionItem = {
-  organization_id?: string;
-  organization_name?: string | null;
-  team_id?: string;
-  team_alias?: string | null;
-};
+import type { Invitation, Pagination } from '../../lib/api';
 
 interface InvitationPanelProps {
-  orgList: OptionItem[];
-  teamList: OptionItem[];
-  initialOrganizationId?: string | null;
-  initialTeamId?: string | null;
+  items: Invitation[];
+  loading: boolean;
+  saving: boolean;
+  error?: string | null;
+  pagination: Pagination;
+  onPageChange: (offset: number) => void;
+  onResend: (invitationId: string) => void;
+  onCancel: (invitationId: string) => void;
 }
-
-const ORGANIZATION_ROLES = [
-  { value: 'org_member', label: 'Member' },
-  { value: 'org_owner', label: 'Owner' },
-  { value: 'org_admin', label: 'Admin' },
-  { value: 'org_billing', label: 'Billing' },
-  { value: 'org_auditor', label: 'Auditor' },
-] as const;
-
-const TEAM_ROLES = [
-  { value: 'team_admin', label: 'Admin' },
-  { value: 'team_developer', label: 'Developer' },
-  { value: 'team_viewer', label: 'Viewer' },
-] as const;
 
 const STATUS_STYLES: Record<Invitation['status'], string> = {
   pending: 'bg-amber-100 text-amber-800',
@@ -70,190 +47,46 @@ function describeScope(invitation: Invitation): string {
 }
 
 export default function InvitationPanel({
-  orgList,
-  teamList,
-  initialOrganizationId,
-  initialTeamId,
+  items,
+  loading,
+  saving,
+  error,
+  pagination,
+  onPageChange,
+  onResend,
+  onCancel,
 }: InvitationPanelProps) {
-  const { pushToast } = useToast();
-  const [items, setItems] = useState<Invitation[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState('');
-  const [showCreateModal, setShowCreateModal] = useState(false);
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState('active');
-  const [email, setEmail] = useState('');
-  const [targetType, setTargetType] = useState<TargetType>(initialTeamId ? 'team' : 'organization');
-  const [organizationId, setOrganizationId] = useState(initialOrganizationId || '');
-  const [teamId, setTeamId] = useState(initialTeamId || '');
-  const [organizationRole, setOrganizationRole] = useState<string>('org_member');
-  const [teamRole, setTeamRole] = useState<string>('team_viewer');
-
-  const loadInvitations = async () => {
-    setLoading(true);
-    setError('');
-    try {
-      const normalizedStatus = statusFilter === 'active' ? undefined : statusFilter;
-      const response = await invitations.list({
-        status: normalizedStatus,
-        search: search.trim() || undefined,
-        limit: 20,
-        offset: 0,
-      });
-      let nextItems = response.data || [];
-      if (statusFilter === 'active') {
-        nextItems = nextItems.filter((item) => item.status === 'pending' || item.status === 'sent');
-      }
-      setItems(nextItems);
-    } catch (err: any) {
-      setError(err?.message || 'Failed to load invitations');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    loadInvitations();
-  }, [search, statusFilter]);
-
-  const resetCreateForm = () => {
-    setEmail('');
-    setTargetType(initialTeamId ? 'team' : 'organization');
-    setOrganizationId(initialOrganizationId || orgList[0]?.organization_id || '');
-    setTeamId(initialTeamId || teamList[0]?.team_id || '');
-    setOrganizationRole('org_member');
-    setTeamRole('team_viewer');
-    setError('');
-  };
-
-  const openCreateModal = () => {
-    resetCreateForm();
-    setShowCreateModal(true);
-  };
-
-  const handleCreate = async (event: FormEvent) => {
-    event.preventDefault();
-    if (!email.trim()) {
-      setError('Email is required');
-      return;
-    }
-    if (targetType === 'organization' && !organizationId) {
-      setError('Select an organization');
-      return;
-    }
-    if (targetType === 'team' && !teamId) {
-      setError('Select a team');
-      return;
-    }
-    setSaving(true);
-    setError('');
-    try {
-      await invitations.create(
-        targetType === 'organization'
-          ? { email: email.trim(), organization_id: organizationId, organization_role: organizationRole }
-          : { email: email.trim(), team_id: teamId, team_role: teamRole }
-      );
-      setShowCreateModal(false);
-      pushToast({ tone: 'success', message: 'Invitation queued for delivery.' });
-      await loadInvitations();
-    } catch (err: any) {
-      setError(err?.message || 'Failed to create invitation');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleResend = async (invitationId: string) => {
-    setSaving(true);
-    setError('');
-    try {
-      await invitations.resend(invitationId);
-      pushToast({ tone: 'success', message: 'Invitation resent.' });
-      await loadInvitations();
-    } catch (err: any) {
-      setError(err?.message || 'Failed to resend invitation');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleCancel = async (invitationId: string) => {
-    if (!window.confirm('Cancel this invitation?')) return;
-    setSaving(true);
-    setError('');
-    try {
-      await invitations.cancel(invitationId);
-      pushToast({ tone: 'success', message: 'Invitation cancelled.' });
-      await loadInvitations();
-    } catch (err: any) {
-      setError(err?.message || 'Failed to cancel invitation');
-    } finally {
-      setSaving(false);
-    }
-  };
+  const currentPage = Math.floor(pagination.offset / pagination.limit) + 1;
+  const totalPages = Math.max(1, Math.ceil((pagination.total || 0) / pagination.limit));
+  const hasPrev = pagination.offset > 0;
+  const hasNext = pagination.has_more;
 
   return (
-    <div className="rounded-xl border border-gray-200 bg-white">
-      <div className="flex flex-col gap-3 border-b border-gray-200 px-5 py-4 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h3 className="text-sm font-semibold text-gray-900">Pending Invitations</h3>
-          <p className="mt-1 text-sm text-gray-500">Invite people by email before they activate their account.</p>
-        </div>
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <input
-            type="text"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Search invitations..."
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 sm:w-56"
-          />
-          <select
-            value={statusFilter}
-            onChange={(event) => setStatusFilter(event.target.value)}
-            className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            <option value="active">Active</option>
-            <option value="sent">Sent</option>
-            <option value="pending">Pending</option>
-            <option value="accepted">Accepted</option>
-            <option value="cancelled">Cancelled</option>
-            <option value="expired">Expired</option>
-          </select>
-          <button
-            type="button"
-            onClick={openCreateModal}
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
-          >
-            Invite by Email
-          </button>
-        </div>
-      </div>
-
-      {error && (
-        <div className="mx-5 mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+    <>
+      {error ? (
+        <div className="mx-4 mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           {error}
         </div>
-      )}
+      ) : null}
 
       {loading ? (
-        <div className="flex items-center justify-center py-10">
+        <div className="flex items-center justify-center py-12">
           <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" />
         </div>
       ) : items.length === 0 ? (
-        <div className="px-5 py-10 text-center text-sm text-gray-500">
+        <div className="px-5 py-14 text-center text-sm text-gray-500">
           No invitations match the current filter.
         </div>
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-100">
-                <th className="px-5 py-3 text-left text-xs font-semibold text-gray-500">Email</th>
-                <th className="px-5 py-3 text-left text-xs font-semibold text-gray-500">Scope</th>
-                <th className="px-5 py-3 text-left text-xs font-semibold text-gray-500">Status</th>
-                <th className="px-5 py-3 text-left text-xs font-semibold text-gray-500">Expires</th>
-                <th className="px-5 py-3 text-right text-xs font-semibold text-gray-500">Actions</th>
+              <tr className="border-b border-gray-200 bg-gray-50">
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">Email</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">Scope</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">Expires</th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-400">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -262,26 +95,28 @@ export default function InvitationPanel({
                 return (
                   <tr
                     key={item.invitation_id}
-                    className={index < items.length - 1 ? 'border-b border-gray-100' : undefined}
+                    className={`border-b border-gray-100 ${index === items.length - 1 ? 'border-b-0' : ''}`}
                   >
-                    <td className="px-5 py-3.5">
+                    <td className="px-4 py-3.5">
                       <div>
                         <p className="font-medium text-gray-900">{item.email}</p>
-                        {item.inviter_email && <p className="text-xs text-gray-400">Invited by {item.inviter_email}</p>}
+                        {item.inviter_email ? (
+                          <p className="text-xs text-gray-400">Invited by {item.inviter_email}</p>
+                        ) : null}
                       </div>
                     </td>
-                    <td className="px-5 py-3.5 text-gray-700">{describeScope(item)}</td>
-                    <td className="px-5 py-3.5">
+                    <td className="px-4 py-3.5 text-gray-700">{describeScope(item)}</td>
+                    <td className="px-4 py-3.5">
                       <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[item.status]}`}>
                         {item.status}
                       </span>
                     </td>
-                    <td className="px-5 py-3.5 text-gray-600">{formatDate(item.expires_at)}</td>
-                    <td className="px-5 py-3.5 text-right">
+                    <td className="px-4 py-3.5 text-gray-600">{formatDate(item.expires_at)}</td>
+                    <td className="px-4 py-3.5 text-right">
                       <div className="flex items-center justify-end gap-3">
                         <button
                           type="button"
-                          onClick={() => handleResend(item.invitation_id)}
+                          onClick={() => onResend(item.invitation_id)}
                           disabled={!isActive || saving}
                           className="text-sm font-medium text-blue-600 hover:text-blue-800 disabled:cursor-not-allowed disabled:text-gray-300"
                         >
@@ -289,7 +124,7 @@ export default function InvitationPanel({
                         </button>
                         <button
                           type="button"
-                          onClick={() => handleCancel(item.invitation_id)}
+                          onClick={() => onCancel(item.invitation_id)}
                           disabled={!isActive || saving}
                           className="text-sm font-medium text-red-600 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-300"
                         >
@@ -305,121 +140,32 @@ export default function InvitationPanel({
         </div>
       )}
 
-      <Modal open={showCreateModal} onClose={() => setShowCreateModal(false)} title="Invite User by Email">
-        <form onSubmit={handleCreate} className="space-y-4">
-          {error && (
-            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-              {error}
-            </div>
-          )}
-          <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">Email</label>
-            <input
-              type="email"
-              value={email}
-              onChange={(event) => { setEmail(event.target.value); setError(''); }}
-              placeholder="user@example.com"
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-              autoComplete="email"
-              data-autofocus="true"
-            />
-          </div>
-          <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">Scope</label>
-            <select
-              value={targetType}
-              onChange={(event) => {
-                const nextType = event.target.value as TargetType;
-                setTargetType(nextType);
-                setError('');
-              }}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-            >
-              <option value="organization">Organization</option>
-              <option value="team">Team</option>
-            </select>
-          </div>
-          {targetType === 'organization' ? (
-            <>
-              <div>
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">Organization</label>
-                <select
-                  value={organizationId}
-                  onChange={(event) => setOrganizationId(event.target.value)}
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  {orgList.map((item) => (
-                    <option key={item.organization_id} value={item.organization_id}>
-                      {item.organization_name || item.organization_id}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">Role</label>
-                <select
-                  value={organizationRole}
-                  onChange={(event) => setOrganizationRole(event.target.value)}
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  {ORGANIZATION_ROLES.map((role) => (
-                    <option key={role.value} value={role.value}>
-                      {role.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </>
-          ) : (
-            <>
-              <div>
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">Team</label>
-                <select
-                  value={teamId}
-                  onChange={(event) => setTeamId(event.target.value)}
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  {teamList.map((item) => (
-                    <option key={item.team_id} value={item.team_id}>
-                      {item.team_alias || item.team_id}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">Role</label>
-                <select
-                  value={teamRole}
-                  onChange={(event) => setTeamRole(event.target.value)}
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  {TEAM_ROLES.map((role) => (
-                    <option key={role.value} value={role.value}>
-                      {role.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </>
-          )}
-          <div className="flex items-center justify-end gap-3">
-            <button
-              type="button"
-              onClick={() => setShowCreateModal(false)}
-              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={saving}
-              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
-            >
-              {saving ? 'Sending…' : 'Send Invitation'}
-            </button>
-          </div>
-        </form>
-      </Modal>
-    </div>
+      <div className="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-4 py-3">
+        <span className="text-xs text-gray-500">
+          {loading
+            ? 'Loading…'
+            : `Showing ${Math.min(pagination.offset + 1, pagination.total || 0)}–${Math.min(pagination.offset + items.length, pagination.total || 0)} of ${pagination.total}`}
+        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-gray-400">
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            onClick={() => onPageChange(Math.max(0, pagination.offset - pagination.limit))}
+            disabled={!hasPrev || loading}
+            className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <button
+            onClick={() => onPageChange(pagination.offset + pagination.limit)}
+            disabled={!hasNext || loading}
+            className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </>
   );
 }

--- a/ui/src/components/admin/ProvisionPersonModal.tsx
+++ b/ui/src/components/admin/ProvisionPersonModal.tsx
@@ -1,0 +1,379 @@
+import { useEffect, useState } from 'react';
+import Modal from '../Modal';
+import { rbac, type ProvisionPersonResponse } from '../../lib/api';
+import { useToast } from '../ToastProvider';
+
+type ProvisionMode = 'invite_email' | 'create_account';
+type ScopeType = 'none' | 'organization' | 'team';
+
+type OptionItem = {
+  organization_id?: string;
+  organization_name?: string | null;
+  team_id?: string;
+  team_alias?: string | null;
+};
+
+interface ProvisionPersonModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: (result: ProvisionPersonResponse) => Promise<void> | void;
+  orgList: OptionItem[];
+  teamList: OptionItem[];
+  initialOrganizationId?: string | null;
+  initialTeamId?: string | null;
+}
+
+const PLATFORM_ROLES = [
+  { value: 'org_user', label: 'Organization User' },
+  { value: 'platform_admin', label: 'Platform Admin' },
+] as const;
+
+const ORGANIZATION_ROLES = [
+  { value: 'org_member', label: 'Member' },
+  { value: 'org_owner', label: 'Owner' },
+  { value: 'org_admin', label: 'Admin' },
+  { value: 'org_billing', label: 'Billing' },
+  { value: 'org_auditor', label: 'Auditor' },
+] as const;
+
+const TEAM_ROLES = [
+  { value: 'team_admin', label: 'Admin' },
+  { value: 'team_developer', label: 'Developer' },
+  { value: 'team_viewer', label: 'Viewer' },
+] as const;
+
+function defaultScopeType(initialOrganizationId?: string | null, initialTeamId?: string | null): ScopeType {
+  if (initialTeamId) return 'team';
+  if (initialOrganizationId) return 'organization';
+  return 'none';
+}
+
+export default function ProvisionPersonModal({
+  open,
+  onClose,
+  onSuccess,
+  orgList,
+  teamList,
+  initialOrganizationId,
+  initialTeamId,
+}: ProvisionPersonModalProps) {
+  const { pushToast } = useToast();
+  const [email, setEmail] = useState('');
+  const [mode, setMode] = useState<ProvisionMode>('invite_email');
+  const [platformRole, setPlatformRole] = useState('org_user');
+  const [scopeType, setScopeType] = useState<ScopeType>('none');
+  const [organizationId, setOrganizationId] = useState('');
+  const [organizationRole, setOrganizationRole] = useState('org_member');
+  const [teamId, setTeamId] = useState('');
+  const [teamRole, setTeamRole] = useState('team_viewer');
+  const [password, setPassword] = useState('');
+  const [isActive, setIsActive] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    setEmail('');
+    setMode('invite_email');
+    setPlatformRole('org_user');
+    setScopeType(defaultScopeType(initialOrganizationId, initialTeamId));
+    setOrganizationId(initialOrganizationId || orgList[0]?.organization_id || '');
+    setOrganizationRole('org_member');
+    setTeamId(initialTeamId || teamList[0]?.team_id || '');
+    setTeamRole('team_viewer');
+    setPassword('');
+    setIsActive(true);
+    setError('');
+  }, [open, initialOrganizationId, initialTeamId, orgList, teamList]);
+
+  useEffect(() => {
+    if (mode === 'invite_email' && platformRole !== 'org_user') {
+      setPlatformRole('org_user');
+    }
+  }, [mode, platformRole]);
+
+  useEffect(() => {
+    if (platformRole === 'platform_admin') {
+      setScopeType('none');
+      return;
+    }
+    if (scopeType === 'none' && (initialOrganizationId || initialTeamId) && mode === 'invite_email') {
+      setScopeType(defaultScopeType(initialOrganizationId, initialTeamId));
+    }
+  }, [initialOrganizationId, initialTeamId, mode, platformRole, scopeType]);
+
+  useEffect(() => {
+    if (scopeType !== 'team') return;
+    if (!teamList.some((item) => item.team_id === teamId)) {
+      setTeamId(teamList[0]?.team_id || '');
+    }
+  }, [scopeType, teamId, teamList]);
+
+  const submit = async () => {
+    const normalizedEmail = email.trim();
+    if (!normalizedEmail) {
+      setError('Email is required');
+      return;
+    }
+    if (mode === 'invite_email' && scopeType === 'none') {
+      setError('Select organization or team access for the invitation');
+      return;
+    }
+    if (mode === 'create_account' && !password.trim()) {
+      setError('Password is required when creating an account manually');
+      return;
+    }
+    if (scopeType === 'organization' && !organizationId) {
+      setError('Select an organization');
+      return;
+    }
+    if (scopeType === 'team' && !teamId) {
+      setError('Select a team');
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    try {
+      const payload = {
+        email: normalizedEmail,
+        mode,
+        platform_role: platformRole,
+        password: mode === 'create_account' ? password.trim() : undefined,
+        is_active: mode === 'create_account' ? isActive : undefined,
+        organization_id: scopeType === 'organization' ? organizationId : undefined,
+        organization_role: scopeType === 'organization' ? organizationRole : undefined,
+        team_id: scopeType === 'team' ? teamId : undefined,
+        team_role: scopeType === 'team' ? teamRole : undefined,
+      };
+      const result = await rbac.provisionPerson(payload);
+      pushToast({
+        tone: 'success',
+        message: mode === 'invite_email' ? 'Invitation queued for delivery.' : 'Account created.',
+      });
+      onClose();
+      void Promise.resolve(onSuccess(result)).catch((refreshError: any) => {
+        pushToast({
+          tone: 'info',
+          message: refreshError?.message || 'Person provisioned, but the list could not be refreshed. Reload to confirm the latest state.',
+        });
+      });
+    } catch (err: any) {
+      setError(err?.message || 'Failed to provision access');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={() => { if (!saving) onClose(); }} title="Add Person">
+      <div className="space-y-5">
+        {error ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        ) : null}
+
+        <section className="space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Identity</h3>
+            <p className="mt-1 text-xs text-gray-500">Choose who should receive access.</p>
+          </div>
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => { setEmail(event.target.value); setError(''); }}
+              placeholder="user@example.com"
+              autoComplete="email"
+              data-autofocus="true"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Onboarding</h3>
+            <p className="mt-1 text-xs text-gray-500">Choose whether to invite them by email or create the account directly.</p>
+          </div>
+          <div className="grid grid-cols-2 gap-2 rounded-xl bg-gray-100 p-1">
+            <button
+              type="button"
+              onClick={() => { setMode('invite_email'); setError(''); }}
+              className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                mode === 'invite_email' ? 'bg-white text-blue-700 shadow-sm' : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              Send invite email
+            </button>
+            <button
+              type="button"
+              onClick={() => { setMode('create_account'); setError(''); }}
+              className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                mode === 'create_account' ? 'bg-white text-blue-700 shadow-sm' : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              Create account manually
+            </button>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Access</h3>
+            <p className="mt-1 text-xs text-gray-500">Set the platform role and optional initial scope grant.</p>
+          </div>
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700">Platform role</label>
+            <select
+              value={platformRole}
+              onChange={(event) => { setPlatformRole(event.target.value); setError(''); }}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {PLATFORM_ROLES.filter((item) => mode === 'create_account' || item.value !== 'platform_admin').map((item) => (
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {platformRole !== 'platform_admin' ? (
+            <>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Initial access</label>
+                <select
+                  value={scopeType}
+                  onChange={(event) => { setScopeType(event.target.value as ScopeType); setError(''); }}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="none">No initial scope</option>
+                  <option value="organization">Organization</option>
+                  <option value="team">Team</option>
+                </select>
+              </div>
+
+              {scopeType === 'organization' ? (
+                <>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium text-gray-700">Organization</label>
+                    <select
+                      value={organizationId}
+                      onChange={(event) => { setOrganizationId(event.target.value); setError(''); }}
+                      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      {orgList.map((item) => (
+                        <option key={item.organization_id} value={item.organization_id}>
+                          {item.organization_name || item.organization_id}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium text-gray-700">Organization role</label>
+                    <select
+                      value={organizationRole}
+                      onChange={(event) => setOrganizationRole(event.target.value)}
+                      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      {ORGANIZATION_ROLES.map((item) => (
+                        <option key={item.value} value={item.value}>
+                          {item.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </>
+              ) : null}
+
+              {scopeType === 'team' ? (
+                <>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium text-gray-700">Team</label>
+                    <select
+                      value={teamId}
+                      onChange={(event) => { setTeamId(event.target.value); setError(''); }}
+                      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      {teamList.map((item) => (
+                        <option key={item.team_id} value={item.team_id}>
+                          {item.team_alias || item.team_id}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium text-gray-700">Team role</label>
+                    <select
+                      value={teamRole}
+                      onChange={(event) => setTeamRole(event.target.value)}
+                      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      {TEAM_ROLES.map((item) => (
+                        <option key={item.value} value={item.value}>
+                          {item.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </>
+              ) : null}
+            </>
+          ) : (
+            <div className="rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-blue-700">
+              Platform admins receive full control-plane access and do not need an initial organization or team grant.
+            </div>
+          )}
+        </section>
+
+        {mode === 'create_account' ? (
+          <section className="space-y-3">
+            <div>
+              <h3 className="text-sm font-semibold text-gray-900">Account setup</h3>
+              <p className="mt-1 text-xs text-gray-500">Manual creation sets the initial password immediately.</p>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Password</label>
+              <input
+                type="password"
+                value={password}
+                onChange={(event) => { setPassword(event.target.value); setError(''); }}
+                placeholder="At least 12 characters"
+                autoComplete="new-password"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={isActive}
+                onChange={(event) => setIsActive(event.target.checked)}
+                className="rounded border-gray-300"
+              />
+              Account active
+            </label>
+          </section>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={saving}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : mode === 'invite_email' ? 'Send Invitation' : 'Create Account'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1014,16 +1014,51 @@ export interface Invitation {
   metadata?: Record<string, unknown> | null;
 }
 
+export interface ProvisionPersonResponse {
+  mode: 'invite_email' | 'create_account';
+  account_id?: string;
+  invitation_id?: string;
+  email: string;
+  role?: string;
+  is_active?: boolean;
+  status?: string;
+  invite_scope_type?: 'organization' | 'team' | 'mixed';
+  organization_id?: string | null;
+  team_id?: string | null;
+  scope_type?: 'none' | 'organization' | 'team';
+}
+
+export interface PrincipalSummary {
+  total_accounts: number;
+  active_accounts: number;
+  platform_admins: number;
+  mfa_enabled_accounts: number;
+  organization_memberships: number;
+  team_memberships: number;
+}
+
 export const rbac = {
   principals: {
     list: (params?: { search?: string; limit?: number; offset?: number }) =>
       apiFetch<Paginated<Principal>>(withQuery('/ui/api/principals', params as any)),
+    summary: () => apiFetch<PrincipalSummary>('/ui/api/principals/summary'),
   },
   accounts: {
     upsert: (payload: any) => apiFetch<any>('/ui/api/rbac/accounts', { method: 'POST', json: payload }),
     delete: (accountId: string) =>
       apiFetch<any>(`/ui/api/rbac/accounts/${encodeURIComponent(accountId)}`, { method: 'DELETE' }),
   },
+  provisionPerson: (payload: {
+    email: string;
+    mode: 'invite_email' | 'create_account';
+    platform_role?: string;
+    password?: string;
+    is_active?: boolean;
+    organization_id?: string;
+    organization_role?: string;
+    team_id?: string;
+    team_role?: string;
+  }) => apiFetch<ProvisionPersonResponse>('/ui/api/rbac/provision', { method: 'POST', json: payload }),
   orgMemberships: {
     list: () => apiFetch<OrgMembership[]>('/ui/api/rbac/organization-memberships'),
     upsert: (payload: any) => apiFetch<any>('/ui/api/rbac/organization-memberships', { method: 'POST', json: payload }),
@@ -1039,7 +1074,7 @@ export const rbac = {
 };
 
 export const invitations = {
-  list: (params?: { status?: string; search?: string; limit?: number; offset?: number }) =>
+  list: (params?: { status?: Invitation['status'] | 'active'; search?: string; limit?: number; offset?: number }) =>
     apiFetch<Paginated<Invitation>>(withQuery('/ui/api/invitations', params as any)),
   create: (payload: {
     email: string;

--- a/ui/src/pages/RBACAccounts.tsx
+++ b/ui/src/pages/RBACAccounts.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { organizations, rbac, teams, users, type Principal, type ScopedAssetAccess } from '../lib/api';
-import { Plus, UserCog, ShieldCheck, Search, ChevronDown, ChevronRight, Building2, UsersRound, Trash2 } from 'lucide-react';
+import { invitations, organizations, rbac, teams, users, type Invitation, type Principal, type PrincipalSummary, type ScopedAssetAccess } from '../lib/api';
+import { Plus, UserCog, ShieldCheck, Search, Building2, UsersRound, Trash2, Mail } from 'lucide-react';
 import Modal from '../components/Modal';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
-import { IndexShell } from '../components/admin/shells';
+import { ContentCard, IndexShell } from '../components/admin/shells';
 import InvitationPanel from '../components/admin/InvitationPanel';
+import ProvisionPersonModal from '../components/admin/ProvisionPersonModal';
+import { useToast } from '../components/ToastProvider';
 
 const PLATFORM_ROLES = [
   { value: 'platform_admin', label: 'Platform Admin' },
@@ -52,20 +54,56 @@ function RoleBadge({ role }: { role: string }) {
   );
 }
 
+function MembershipCountBadge({ count, label }: { count: number; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600">
+      <span>{count}</span>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+type PeopleAccessTab = 'users' | 'invitations';
+type InvitationStatusFilter = Invitation['status'] | 'active';
+const EMPTY_PAGINATION = { total: 0, limit: 20, offset: 0, has_more: false };
+const EMPTY_SUMMARY: PrincipalSummary = {
+  total_accounts: 0,
+  active_accounts: 0,
+  platform_admins: 0,
+  mfa_enabled_accounts: 0,
+  organization_memberships: 0,
+  team_memberships: 0,
+};
+
 export default function RBACAccounts() {
-  const [searchParams] = useSearchParams();
+  const { pushToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [viewTab, setViewTab] = useState<PeopleAccessTab>('users');
   const [principals, setPrincipals] = useState<Principal[]>([]);
-  const [principalPagination, setPrincipalPagination] = useState({ total: 0, limit: 20, offset: 0, has_more: false });
+  const [principalPagination, setPrincipalPagination] = useState(EMPTY_PAGINATION);
+  const [principalSummary, setPrincipalSummary] = useState<PrincipalSummary>(EMPTY_SUMMARY);
+  const [principalLoading, setPrincipalLoading] = useState(true);
+  const [principalError, setPrincipalError] = useState('');
+  const [principalSearchInput, setPrincipalSearchInput] = useState('');
+  const [principalSearchTerm, setPrincipalSearchTerm] = useState('');
+  const [principalPageOffset, setPrincipalPageOffset] = useState(0);
+  const [invitationItems, setInvitationItems] = useState<Invitation[]>([]);
+  const [invitationPagination, setInvitationPagination] = useState(EMPTY_PAGINATION);
+  const [invitationLoading, setInvitationLoading] = useState(false);
+  const [invitationSaving, setInvitationSaving] = useState(false);
+  const [invitationError, setInvitationError] = useState('');
+  const [invitationSearchInput, setInvitationSearchInput] = useState('');
+  const [invitationSearchTerm, setInvitationSearchTerm] = useState('');
+  const [invitationStatusFilter, setInvitationStatusFilter] = useState<InvitationStatusFilter>('active');
+  const [invitationPageOffset, setInvitationPageOffset] = useState(0);
   const [orgList, setOrgList] = useState<any[]>([]);
   const [teamList, setTeamList] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [searchInput, setSearchInput] = useState('');
-  const [searchTerm, setSearchTerm] = useState('');
-  const [pageOffset, setPageOffset] = useState(0);
+  const [referenceLoading, setReferenceLoading] = useState(true);
   const pageSize = 20;
   const inviteOrganizationId = searchParams.get('invite_org_id');
   const inviteTeamId = searchParams.get('invite_team_id');
 
+  const [showProvisionModal, setShowProvisionModal] = useState(false);
   const [showAccountModal, setShowAccountModal] = useState(false);
   const [editAccount, setEditAccount] = useState<Principal | null>(null);
   const [formEmail, setFormEmail] = useState('');
@@ -73,7 +111,7 @@ export default function RBACAccounts() {
   const [formPassword, setFormPassword] = useState('');
   const [formActive, setFormActive] = useState(true);
 
-  const [expandedAccount, setExpandedAccount] = useState<string | null>(null);
+  const [selectedAccount, setSelectedAccount] = useState<Principal | null>(null);
 
   const [showOrgMembershipModal, setShowOrgMembershipModal] = useState(false);
   const [membershipAccountId, setMembershipAccountId] = useState('');
@@ -94,42 +132,103 @@ export default function RBACAccounts() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
+  const loadReferenceData = useCallback(async () => {
+    setReferenceLoading(true);
     try {
-      const [allPrincipals, orgs, tms] = await Promise.all([
-        rbac.principals.list({ search: searchTerm, limit: pageSize, offset: pageOffset }),
+      const [orgs, tms] = await Promise.all([
         organizations.list({ limit: 500 }).catch(() => ({ data: [], pagination: { total: 0, limit: 500, offset: 0, has_more: false } })),
         teams.list({ limit: 500 }).catch(() => ({ data: [], pagination: { total: 0, limit: 500, offset: 0, has_more: false } })),
       ]);
-      setPrincipals(allPrincipals?.data || []);
-      setPrincipalPagination(allPrincipals?.pagination || { total: 0, limit: pageSize, offset: pageOffset, has_more: false });
       setOrgList(orgs?.data || orgs || []);
       setTeamList(tms?.data || tms || []);
-    } catch (err: any) {
-      setError(err?.message || 'Failed to load accounts');
     } finally {
-      setLoading(false);
+      setReferenceLoading(false);
     }
-  }, [pageOffset, pageSize, searchTerm]);
+  }, []);
 
-  useEffect(() => { loadData(); }, [loadData]);
+  const loadPrincipals = useCallback(async () => {
+    setPrincipalLoading(true);
+    setPrincipalError('');
+    try {
+      const [response, summary] = await Promise.all([
+        rbac.principals.list({ search: principalSearchTerm, limit: pageSize, offset: principalPageOffset }),
+        rbac.principals.summary().catch(() => null),
+      ]);
+      setPrincipals(response?.data || []);
+      setPrincipalPagination(response?.pagination || { ...EMPTY_PAGINATION, limit: pageSize, offset: principalPageOffset });
+      if (summary) {
+        setPrincipalSummary(summary);
+      }
+    } catch (err: any) {
+      setPrincipalError(err?.message || 'Failed to load accounts');
+    } finally {
+      setPrincipalLoading(false);
+    }
+  }, [pageSize, principalPageOffset, principalSearchTerm]);
+
+  const loadInvitations = useCallback(async () => {
+    setInvitationLoading(true);
+    setInvitationError('');
+    try {
+      const response = await invitations.list({
+        status: invitationStatusFilter,
+        search: invitationSearchTerm || undefined,
+        limit: pageSize,
+        offset: invitationPageOffset,
+      });
+      setInvitationItems(response?.data || []);
+      setInvitationPagination(response?.pagination || { ...EMPTY_PAGINATION, limit: pageSize, offset: invitationPageOffset });
+    } catch (err: any) {
+      setInvitationError(err?.message || 'Failed to load invitations');
+    } finally {
+      setInvitationLoading(false);
+    }
+  }, [invitationPageOffset, invitationSearchTerm, invitationStatusFilter, pageSize]);
+
+  useEffect(() => { loadReferenceData(); }, [loadReferenceData]);
+  useEffect(() => { loadPrincipals(); }, [loadPrincipals]);
   useEffect(() => {
     const t = setTimeout(() => {
-      setSearchTerm(searchInput);
-      setPageOffset(0);
+      setPrincipalSearchTerm(principalSearchInput);
+      setPrincipalPageOffset(0);
     }, 250);
     return () => clearTimeout(t);
-  }, [searchInput]);
+  }, [principalSearchInput]);
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setInvitationSearchTerm(invitationSearchInput.trim());
+      setInvitationPageOffset(0);
+    }, 250);
+    return () => clearTimeout(t);
+  }, [invitationSearchInput]);
+  useEffect(() => {
+    if (viewTab !== 'invitations') return;
+    loadInvitations();
+  }, [loadInvitations, viewTab]);
+  useEffect(() => {
+    if (!selectedAccount) return;
+    const next = principals.find((acct) => acct.account_id === selectedAccount.account_id);
+    if (next) {
+      setSelectedAccount(next);
+    }
+  }, [principals, selectedAccount]);
+  useEffect(() => {
+    if (!inviteOrganizationId && !inviteTeamId) return;
+    if (referenceLoading) return;
+    setShowProvisionModal(true);
+  }, [inviteOrganizationId, inviteTeamId, referenceLoading]);
+
+  const clearInvitePrefill = useCallback(() => {
+    if (!inviteOrganizationId && !inviteTeamId) return;
+    const next = new URLSearchParams(searchParams);
+    next.delete('invite_org_id');
+    next.delete('invite_team_id');
+    setSearchParams(next, { replace: true });
+  }, [inviteOrganizationId, inviteTeamId, searchParams, setSearchParams]);
 
   const openCreateAccount = () => {
-    setEditAccount(null);
-    setFormEmail('');
-    setFormRole('org_user');
-    setFormPassword('');
-    setFormActive(true);
     setError('');
-    setShowAccountModal(true);
+    setShowProvisionModal(true);
   };
 
   const openEditAccount = (acct: Principal) => {
@@ -151,7 +250,7 @@ export default function RBACAccounts() {
       if (formPassword.trim()) data.password = formPassword.trim();
       await rbac.accounts.upsert(data);
       setShowAccountModal(false);
-      await loadData();
+      await loadPrincipals();
     } catch (err: any) {
       setError(err?.message || 'Failed to save account');
     } finally {
@@ -178,7 +277,7 @@ export default function RBACAccounts() {
         role: membershipOrgRole,
       });
       setShowOrgMembershipModal(false);
-      await loadData();
+      await loadPrincipals();
     } catch (err: any) {
       setError(err?.message || 'Failed to save membership');
     } finally {
@@ -205,7 +304,7 @@ export default function RBACAccounts() {
         role: membershipTeamRole,
       });
       setShowTeamMembershipModal(false);
-      await loadData();
+      await loadPrincipals();
     } catch (err: any) {
       setError(err?.message || 'Failed to save membership');
     } finally {
@@ -219,7 +318,10 @@ export default function RBACAccounts() {
     setError('');
     try {
       await rbac.accounts.delete(accountId);
-      await loadData();
+      if (selectedAccount?.account_id === accountId) {
+        setSelectedAccount(null);
+      }
+      await loadPrincipals();
     } catch (err: any) {
       setError(err?.message || 'Failed to delete account');
     } finally {
@@ -233,7 +335,7 @@ export default function RBACAccounts() {
     setError('');
     try {
       await rbac.orgMemberships.delete(membershipId);
-      await loadData();
+      await loadPrincipals();
     } catch (err: any) {
       setError(err?.message || 'Failed to delete organization membership');
     } finally {
@@ -247,7 +349,7 @@ export default function RBACAccounts() {
     setError('');
     try {
       await rbac.teamMemberships.delete(membershipId);
-      await loadData();
+      await loadPrincipals();
     } catch (err: any) {
       setError(err?.message || 'Failed to delete team membership');
     } finally {
@@ -311,231 +413,465 @@ export default function RBACAccounts() {
     return team?.team_alias || teamId.slice(0, 12) + '...';
   };
 
+  const handleInvitationResend = async (invitationId: string) => {
+    setInvitationSaving(true);
+    setInvitationError('');
+    try {
+      await invitations.resend(invitationId);
+      pushToast({ tone: 'success', message: 'Invitation resent.' });
+      await loadInvitations();
+    } catch (err: any) {
+      setInvitationError(err?.message || 'Failed to resend invitation');
+    } finally {
+      setInvitationSaving(false);
+    }
+  };
+
+  const handleInvitationCancel = async (invitationId: string) => {
+    if (!window.confirm('Cancel this invitation?')) return;
+    setInvitationSaving(true);
+    setInvitationError('');
+    try {
+      await invitations.cancel(invitationId);
+      pushToast({ tone: 'success', message: 'Invitation cancelled.' });
+      await loadInvitations();
+    } catch (err: any) {
+      setInvitationError(err?.message || 'Failed to cancel invitation');
+    } finally {
+      setInvitationSaving(false);
+    }
+  };
+
+  const totalAccounts = principalPagination.total;
+  const currentPage = Math.floor(principalPageOffset / pageSize) + 1;
+  const totalPages = Math.max(1, Math.ceil((principalPagination.total || 0) / pageSize));
+  const hasPrev = principalPageOffset > 0;
+  const hasNext = principalPagination.has_more;
+  const visibleCount = viewTab === 'users' ? principalPagination.total : invitationPagination.total;
+  const showPageNotice =
+    viewTab === 'users' &&
+    !!principalError &&
+    !showProvisionModal &&
+    !selectedAccount &&
+    !showAccountModal &&
+    !showOrgMembershipModal &&
+    !showTeamMembershipModal &&
+    !showUserAccessModal;
+
   return (
     <IndexShell
       title="People & Access"
       titleIcon={UserCog}
-      count={principalPagination.total}
-      description="Manage people, RBAC roles, and organization/team memberships"
+      count={visibleCount}
+      description={viewTab === 'users' ? 'Manage people, RBAC roles, and organization/team memberships. Summary cards reflect all platform accounts.' : 'Track and manage invitations across their lifecycle.'}
+      notice={showPageNotice ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{principalError}</div>
+      ) : undefined}
       action={(
         <button
           onClick={openCreateAccount}
           className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
         >
           <Plus className="h-4 w-4" />
-          Add User
+          Add Person
         </button>
       )}
       toolbar={(
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-          <input
-            type="text"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            placeholder="Search accounts..."
-            className="w-full rounded-lg border border-gray-300 py-2 pl-10 pr-4 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="inline-flex rounded-lg border border-gray-300 bg-white p-0.5">
+            <button
+              onClick={() => setViewTab('users')}
+              className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${viewTab === 'users' ? 'bg-blue-600 text-white shadow-sm' : 'text-gray-600 hover:bg-gray-50'}`}
+            >
+              <UsersRound className="h-3.5 w-3.5" />
+              Users
+            </button>
+            <button
+              onClick={() => setViewTab('invitations')}
+              className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${viewTab === 'invitations' ? 'bg-blue-600 text-white shadow-sm' : 'text-gray-600 hover:bg-gray-50'}`}
+            >
+              <Mail className="h-3.5 w-3.5" />
+              Invitations
+            </button>
+          </div>
+          <div className="relative flex-1 min-w-[260px]">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              value={viewTab === 'users' ? principalSearchInput : invitationSearchInput}
+              onChange={(e) => {
+                if (viewTab === 'users') {
+                  setPrincipalSearchInput(e.target.value);
+                  return;
+                }
+                setInvitationSearchInput(e.target.value);
+              }}
+              placeholder={viewTab === 'users' ? 'Search accounts...' : 'Search invitations...'}
+              className="w-full rounded-lg border border-gray-300 py-2 pl-10 pr-4 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          {viewTab === 'invitations' ? (
+            <select
+              value={invitationStatusFilter}
+              onChange={(e) => {
+                setInvitationStatusFilter(e.target.value as InvitationStatusFilter);
+                setInvitationPageOffset(0);
+              }}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="active">Active</option>
+              <option value="sent">Sent</option>
+              <option value="pending">Pending</option>
+              <option value="accepted">Accepted</option>
+              <option value="cancelled">Cancelled</option>
+              <option value="expired">Expired</option>
+            </select>
+          ) : null}
         </div>
       )}
+      summaryItems={[
+        { label: 'Active accounts', value: String(principalSummary.active_accounts) },
+        { label: 'Platform admins', value: String(principalSummary.platform_admins) },
+        { label: 'MFA enabled', value: String(principalSummary.mfa_enabled_accounts), icon: ShieldCheck, iconClassName: 'text-green-600' },
+        { label: 'Org memberships', value: String(principalSummary.organization_memberships), icon: Building2, iconClassName: 'text-blue-600' },
+        { label: 'Team memberships', value: String(principalSummary.team_memberships), icon: UsersRound, iconClassName: 'text-violet-600' },
+      ]}
     >
-      <div className="mb-6">
-        <InvitationPanel
-          orgList={orgList}
-          teamList={teamList}
-          initialOrganizationId={inviteOrganizationId}
-          initialTeamId={inviteTeamId}
-        />
-      </div>
-      {loading ? (
-        <div className="flex items-center justify-center py-12">
-          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" />
-        </div>
-      ) : principals.length === 0 ? (
-        <div className="rounded-xl border border-gray-200 bg-white py-12 text-center">
-          <UserCog className="mx-auto mb-3 h-12 w-12 text-gray-300" />
-          <p className="text-gray-500">No accounts found</p>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          {principals.map((acct) => {
-            const isExpanded = expandedAccount === acct.account_id;
-            const acctOrgMs = acct.organization_memberships || [];
-            const acctTeamMs = acct.team_memberships || [];
-
-            return (
-              <div key={acct.account_id} className="bg-white rounded-xl border border-gray-200 overflow-hidden">
-                <div
-                  className="flex items-center gap-4 px-5 py-4 cursor-pointer hover:bg-gray-50 transition-colors"
-                  onClick={() => setExpandedAccount(isExpanded ? null : acct.account_id)}
+      <ContentCard>
+        {viewTab === 'users' ? (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-200 bg-gray-50">
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">Account</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">Platform Role</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">Access</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">Last Login</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">Status</th>
+                    <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-400">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {principalLoading ? (
+                    <tr>
+                      <td colSpan={6} className="px-4 py-12 text-center">
+                        <div className="inline-flex items-center gap-3 text-sm text-gray-500">
+                          <div className="h-5 w-5 animate-spin rounded-full border-b-2 border-blue-600" />
+                          Loading accounts…
+                        </div>
+                      </td>
+                    </tr>
+                  ) : principals.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className="px-4 py-14 text-center">
+                        <UserCog className="mx-auto mb-3 h-10 w-10 text-gray-300" />
+                        <p className="text-sm font-medium text-gray-600">No accounts found</p>
+                        <p className="mt-1 text-xs text-gray-400">
+                          {principalSearchTerm ? 'Try a different search term.' : 'Create a platform account or send an invitation to get started.'}
+                        </p>
+                        {!principalSearchTerm ? (
+                          <button
+                            onClick={openCreateAccount}
+                            className="mt-4 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                          >
+                            <Plus className="h-4 w-4" />
+                            Add Person
+                          </button>
+                        ) : null}
+                      </td>
+                    </tr>
+                  ) : (
+                    principals.map((acct, index) => {
+                      const acctOrgMs = acct.organization_memberships || [];
+                      const acctTeamMs = acct.team_memberships || [];
+                      return (
+                        <tr
+                          key={acct.account_id}
+                          onClick={() => { setError(''); setSelectedAccount(acct); }}
+                          className={`cursor-pointer border-b border-gray-100 transition-colors hover:bg-blue-50/40 ${
+                            index === principals.length - 1 ? 'border-b-0' : ''
+                          }`}
+                        >
+                          <td className="px-4 py-3.5">
+                            <div className="flex items-center gap-3">
+                              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-blue-100 to-blue-200 text-xs font-bold text-blue-700">
+                                {(acct.email || '?')[0]?.toUpperCase()}
+                              </div>
+                              <div className="min-w-0">
+                                <div className="flex items-center gap-2">
+                                  <span className="truncate font-semibold text-gray-900">{acct.email}</span>
+                                  {acct.mfa_enabled ? <ShieldCheck className="h-4 w-4 shrink-0 text-green-500" /> : null}
+                                </div>
+                                <div className="mt-1 flex items-center gap-2 text-[11px] text-gray-400">
+                                  <code className="font-mono">{acct.account_id}</code>
+                                  {acct.runtime_user_id ? (
+                                    <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 font-medium text-indigo-600">
+                                      Runtime linked
+                                    </span>
+                                  ) : null}
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3.5">
+                            <RoleBadge role={acct.role} />
+                          </td>
+                          <td className="px-4 py-3.5">
+                            <div className="flex flex-wrap items-center gap-1.5">
+                              <MembershipCountBadge count={acctOrgMs.length} label={acctOrgMs.length === 1 ? 'org' : 'orgs'} />
+                              <MembershipCountBadge count={acctTeamMs.length} label={acctTeamMs.length === 1 ? 'team' : 'teams'} />
+                            </div>
+                          </td>
+                          <td className="px-4 py-3.5">
+                            <span className="text-xs text-gray-600">{formatDate(acct.last_login_at)}</span>
+                          </td>
+                          <td className="px-4 py-3.5">
+                            <div className="flex flex-wrap items-center gap-1.5">
+                              <span
+                                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                                  acct.is_active ? 'bg-emerald-50 text-emerald-700' : 'bg-red-100 text-red-700'
+                                }`}
+                              >
+                                {acct.is_active ? 'Active' : 'Disabled'}
+                              </span>
+                              {acct.force_password_change ? (
+                                <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">
+                                  Password reset required
+                                </span>
+                              ) : null}
+                            </div>
+                          </td>
+                          <td className="px-4 py-3.5" onClick={(e) => e.stopPropagation()}>
+                            <div className="flex items-center justify-end gap-1.5">
+                              <button
+                                onClick={() => { setError(''); setSelectedAccount(acct); }}
+                                className="rounded-lg bg-blue-50 px-2.5 py-1.5 text-xs font-medium text-blue-600 transition-colors hover:bg-blue-100"
+                              >
+                                View
+                              </button>
+                              <button
+                                onClick={() => openUserAssetAccess(acct)}
+                                disabled={!acct.runtime_user_id}
+                                title={acct.runtime_user_id ? 'Manage runtime asset access' : 'No linked runtime user'}
+                                className={`rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors ${
+                                  acct.runtime_user_id
+                                    ? 'bg-indigo-50 text-indigo-600 hover:bg-indigo-100'
+                                    : 'cursor-not-allowed bg-gray-100 text-gray-300'
+                                }`}
+                              >
+                                Asset Access
+                              </button>
+                              <button
+                                onClick={() => openEditAccount(acct)}
+                                className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100"
+                              >
+                                Edit
+                              </button>
+                              <button
+                                onClick={() => deleteAccount(acct.account_id, acct.email)}
+                                className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-50"
+                              >
+                                Delete
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <div className="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-4 py-3">
+              <span className="text-xs text-gray-500">
+                {principalLoading
+                  ? 'Loading…'
+                  : `Showing ${Math.min(principalPageOffset + 1, totalAccounts || 0)}–${Math.min(principalPageOffset + principals.length, totalAccounts || 0)} of ${totalAccounts}`}
+              </span>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-gray-400">
+                  Page {currentPage} of {totalPages}
+                </span>
+                <button
+                  onClick={() => setPrincipalPageOffset(Math.max(0, principalPageOffset - pageSize))}
+                  disabled={!hasPrev || principalLoading}
+                  className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                  <div className="flex-shrink-0">
-                    {isExpanded ? <ChevronDown className="w-4 h-4 text-gray-400" /> : <ChevronRight className="w-4 h-4 text-gray-400" />}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-gray-900 truncate">{acct.email}</span>
-                      <RoleBadge role={acct.role} />
-                      {!acct.is_active && (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">
-                          Disabled
-                        </span>
-                      )}
-                      {acct.mfa_enabled && (
-                        <ShieldCheck className="w-4 h-4 text-green-500" />
-                      )}
-                    </div>
-                    <div className="flex items-center gap-4 mt-1">
-                      <span className="text-xs text-gray-400">
-                        Last login: {formatDate(acct.last_login_at)}
-                      </span>
-                      <span className="text-xs text-gray-400">
-                        {acctOrgMs.length} org{acctOrgMs.length !== 1 ? 's' : ''} · {acctTeamMs.length} team{acctTeamMs.length !== 1 ? 's' : ''}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <button
-                      onClick={(e) => { e.stopPropagation(); openUserAssetAccess(acct); }}
-                      disabled={!acct.runtime_user_id}
-                      title={acct.runtime_user_id ? 'Manage runtime asset access' : 'No linked runtime user'}
-                      className={`text-sm font-medium ${
-                        acct.runtime_user_id
-                          ? 'text-indigo-600 hover:text-indigo-800'
-                          : 'cursor-not-allowed text-gray-300'
-                      }`}
-                    >
-                      Asset Access
-                    </button>
-                    <button
-                      onClick={(e) => { e.stopPropagation(); openEditAccount(acct); }}
-                      className="text-sm text-blue-600 hover:text-blue-800 font-medium"
-                    >
-                      Edit
-                    </button>
-                    <button
-                      onClick={(e) => { e.stopPropagation(); deleteAccount(acct.account_id, acct.email); }}
-                      className="text-sm text-red-600 hover:text-red-800 font-medium"
-                    >
-                      Delete
-                    </button>
-                  </div>
+                  Previous
+                </button>
+                <button
+                  onClick={() => setPrincipalPageOffset(principalPageOffset + pageSize)}
+                  disabled={!hasNext || principalLoading}
+                  className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </>
+        ) : (
+          <InvitationPanel
+            items={invitationItems}
+            loading={invitationLoading}
+            saving={invitationSaving}
+            error={invitationError}
+            pagination={invitationPagination}
+            onPageChange={setInvitationPageOffset}
+            onResend={handleInvitationResend}
+            onCancel={handleInvitationCancel}
+          />
+        )}
+      </ContentCard>
+
+      <Modal
+        open={!!selectedAccount}
+        onClose={() => setSelectedAccount(null)}
+        title={selectedAccount ? `Access Details · ${selectedAccount.email}` : 'Access Details'}
+      >
+        {selectedAccount ? (
+          <div className="space-y-5">
+            {error ? (
+              <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+            ) : null}
+            <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <RoleBadge role={selectedAccount.role} />
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                    selectedAccount.is_active ? 'bg-emerald-50 text-emerald-700' : 'bg-red-100 text-red-700'
+                  }`}
+                >
+                  {selectedAccount.is_active ? 'Active' : 'Disabled'}
+                </span>
+                {selectedAccount.mfa_enabled ? (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">
+                    <ShieldCheck className="h-3.5 w-3.5" />
+                    MFA enabled
+                  </span>
+                ) : null}
+                {selectedAccount.runtime_user_id ? (
+                  <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-600">
+                    Runtime user linked
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-3 grid grid-cols-1 gap-2 text-xs text-gray-500 sm:grid-cols-2">
+                <span>ID: {selectedAccount.account_id}</span>
+                <span>Created: {formatDate(selectedAccount.created_at)}</span>
+                <span>Last login: {formatDate(selectedAccount.last_login_at)}</span>
+                {selectedAccount.runtime_user_id ? <span>Runtime user: {selectedAccount.runtime_user_id}</span> : null}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+              <div>
+                <div className="mb-3 flex items-center justify-between">
+                  <h4 className="flex items-center gap-1.5 text-sm font-medium text-gray-700">
+                    <Building2 className="h-4 w-4" />
+                    Organization Memberships
+                  </h4>
+                  <button
+                    onClick={() => openAddOrgMembership(selectedAccount.account_id)}
+                    className="text-xs font-medium text-blue-600 hover:text-blue-800"
+                  >
+                    + Add
+                  </button>
                 </div>
-
-                {isExpanded && (
-                  <div className="border-t border-gray-100 px-5 py-4 bg-gray-50/50">
-                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h4 className="text-sm font-medium text-gray-700 flex items-center gap-1.5">
-                            <Building2 className="w-4 h-4" />
-                            Organization Memberships
-                          </h4>
+                {selectedAccount.organization_memberships.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-xs text-gray-400">
+                    No organization memberships
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {selectedAccount.organization_memberships.map((membership) => (
+                      <div key={membership.membership_id} className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-3 py-2.5">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-gray-900">{getOrgName(membership.organization_id)}</p>
+                          <p className="mt-0.5 text-[11px] text-gray-400">{membership.organization_id}</p>
+                        </div>
+                        <div className="flex items-center gap-2 pl-3">
+                          <RoleBadge role={membership.role} />
                           <button
-                            onClick={() => openAddOrgMembership(acct.account_id)}
-                            className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+                            onClick={() => deleteOrgMembership(membership.membership_id)}
+                            className="rounded-lg p-1 hover:bg-red-50"
+                            title="Remove organization membership"
                           >
-                            + Add
+                            <Trash2 className="h-3.5 w-3.5 text-red-500" />
                           </button>
                         </div>
-                        {acctOrgMs.length === 0 ? (
-                          <p className="text-xs text-gray-400 italic">No organization memberships</p>
-                        ) : (
-                          <div className="space-y-2">
-                            {acctOrgMs.map((m) => (
-                              <div key={m.membership_id} className="flex items-center justify-between bg-white rounded-lg px-3 py-2 border border-gray-200">
-                                <div>
-                                  <span className="text-sm text-gray-900">{getOrgName(m.organization_id)}</span>
-                                </div>
-                                <div className="flex items-center gap-2">
-                                  <RoleBadge role={m.role} />
-                                  <button
-                                    onClick={() => deleteOrgMembership(m.membership_id)}
-                                    className="p-1 hover:bg-red-50 rounded"
-                                    title="Remove organization membership"
-                                  >
-                                    <Trash2 className="w-3.5 h-3.5 text-red-500" />
-                                  </button>
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                        )}
                       </div>
-
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h4 className="text-sm font-medium text-gray-700 flex items-center gap-1.5">
-                            <UsersRound className="w-4 h-4" />
-                            Team Memberships
-                          </h4>
-                          <button
-                            onClick={() => openAddTeamMembership(acct.account_id)}
-                            className="text-xs text-blue-600 hover:text-blue-800 font-medium"
-                          >
-                            + Add
-                          </button>
-                        </div>
-                        {acctTeamMs.length === 0 ? (
-                          <p className="text-xs text-gray-400 italic">No team memberships</p>
-                        ) : (
-                          <div className="space-y-2">
-                            {acctTeamMs.map((m) => (
-                              <div key={m.membership_id} className="flex items-center justify-between bg-white rounded-lg px-3 py-2 border border-gray-200">
-                                <div>
-                                  <span className="text-sm text-gray-900">{getTeamName(m.team_id)}</span>
-                                </div>
-                                <div className="flex items-center gap-2">
-                                  <RoleBadge role={m.role} />
-                                  <button
-                                    onClick={() => deleteTeamMembership(m.membership_id)}
-                                    className="p-1 hover:bg-red-50 rounded"
-                                    title="Remove team membership"
-                                  >
-                                    <Trash2 className="w-3.5 h-3.5 text-red-500" />
-                                  </button>
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-
-                    <div className="mt-4 pt-3 border-t border-gray-200 flex items-center gap-4 text-xs text-gray-400">
-                      <span>ID: {acct.account_id}</span>
-                      <span>Created: {formatDate(acct.created_at)}</span>
-                    </div>
+                    ))}
                   </div>
                 )}
               </div>
-            );
-          })}
-        </div>
-      )}
-      <div className="mt-4 flex items-center justify-between text-xs text-gray-500">
-        <span>
-          Showing {principals.length} of {principalPagination.total}
-        </span>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => setPageOffset(Math.max(0, pageOffset - pageSize))}
-            disabled={pageOffset === 0 || loading}
-            className="px-3 py-1.5 border border-gray-300 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
-          >
-            Previous
-          </button>
-          <button
-            onClick={() => setPageOffset(pageOffset + pageSize)}
-            disabled={!principalPagination.has_more || loading}
-            className="px-3 py-1.5 border border-gray-300 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
-          >
-            Next
-          </button>
-        </div>
-      </div>
 
-      <Modal open={showAccountModal} onClose={() => setShowAccountModal(false)} title={editAccount ? 'Edit Account' : 'Create Account'}>
+              <div>
+                <div className="mb-3 flex items-center justify-between">
+                  <h4 className="flex items-center gap-1.5 text-sm font-medium text-gray-700">
+                    <UsersRound className="h-4 w-4" />
+                    Team Memberships
+                  </h4>
+                  <button
+                    onClick={() => openAddTeamMembership(selectedAccount.account_id)}
+                    className="text-xs font-medium text-blue-600 hover:text-blue-800"
+                  >
+                    + Add
+                  </button>
+                </div>
+                {selectedAccount.team_memberships.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-xs text-gray-400">
+                    No team memberships
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {selectedAccount.team_memberships.map((membership) => (
+                      <div key={membership.membership_id} className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-3 py-2.5">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-gray-900">{getTeamName(membership.team_id)}</p>
+                          <p className="mt-0.5 text-[11px] text-gray-400">{membership.team_id}</p>
+                        </div>
+                        <div className="flex items-center gap-2 pl-3">
+                          <RoleBadge role={membership.role} />
+                          <button
+                            onClick={() => deleteTeamMembership(membership.membership_id)}
+                            className="rounded-lg p-1 hover:bg-red-50"
+                            title="Remove team membership"
+                          >
+                            <Trash2 className="h-3.5 w-3.5 text-red-500" />
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </Modal>
+
+      <ProvisionPersonModal
+        open={showProvisionModal}
+        onClose={() => {
+          setShowProvisionModal(false);
+          clearInvitePrefill();
+        }}
+        onSuccess={async (result) => {
+          clearInvitePrefill();
+          const refreshTasks: Promise<unknown>[] = [loadPrincipals()];
+          if (result.mode === 'invite_email' || viewTab === 'invitations') {
+            refreshTasks.push(loadInvitations());
+          }
+          await Promise.all(refreshTasks);
+        }}
+        orgList={orgList}
+        teamList={teamList}
+        initialOrganizationId={inviteOrganizationId}
+        initialTeamId={inviteTeamId}
+      />
+
+      <Modal open={showAccountModal} onClose={() => setShowAccountModal(false)} title="Edit Account">
         <div className="space-y-4">
           {error && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{error}</div>
@@ -565,13 +901,13 @@ export default function RBACAccounts() {
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1.5">
-              {editAccount ? 'New Password (leave blank to keep current)' : 'Password'}
+              New Password (leave blank to keep current)
             </label>
             <input
               type="password"
               value={formPassword}
               onChange={(e) => setFormPassword(e.target.value)}
-              placeholder={editAccount ? 'Leave blank to keep current' : 'At least 12 characters'}
+              placeholder="Leave blank to keep current"
               autoComplete="new-password"
               className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
@@ -598,7 +934,7 @@ export default function RBACAccounts() {
               disabled={saving}
               className="flex-1 bg-blue-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50"
             >
-              {saving ? 'Saving...' : editAccount ? 'Update Account' : 'Create Account'}
+              {saving ? 'Saving...' : 'Update Account'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
This PR cleans up the People & Access control-plane flow and the related provisioning/invitation contracts.

  It does three main things:

  - merges Add User and Invite by Email into one Add Person provisioning flow
  - redesigns People & Access into a paginated table view with a tab switcher for Users and Invitations
  - tightens the backend and UI contracts around provisioning, invitation state, summary totals, and Docker-local defaults

  This PR is control-plane only. It does not change the AI gateway hot path.

  ## What Changed

  ### 1. Unified provisioning flow

  - Added a new backend provisioning path in src/api/admin/endpoints/rbac.py
  - Added src/services/access_provisioning_service.py
  - Added explicit manual account creation support in src/services/platform_identity_service.py
  - Added ui/src/components/admin/ProvisionPersonModal.tsx
  - Replaced separate Add User and invitation-create flows with one Add Person modal in ui/src/pages/RBACAccounts.tsx

  Provisioning modes:

  - Send invite email
  - Create account manually

  ### 2. People & Access list redesign

  - Refactored ui/src/pages/RBACAccounts.tsx into the same table/pagination pattern used by other list pages
  - Added a top-level switcher between:
      - Users
      - Invitations
  - Refactored ui/src/components/admin/InvitationPanel.tsx into a controlled invitation table with pagination and row actions
  - Kept edit-account, membership management, and runtime asset-access flows intact

  ### 3. Invitation list contract cleanup

  - Updated src/api/admin/endpoints/invitations.py so status=active is applied before pagination
  - Updated ui/src/lib/api.ts to model active as a supported invitation list filter
  - Renamed the People & Access invitation tab to Invitations so the label matches the lifecycle filters it exposes

  ### 4. Summary and refresh correctness

  - Added /ui/api/principals/summary in src/api/admin/endpoints/rbac.py
  - Switched the People & Access summary strip to backend-derived global totals instead of current-page counts
  - Clarified in the page description that the summary cards reflect all platform accounts
  - Updated ui/src/components/admin/ProvisionPersonModal.tsx so a successful provision closes cleanly even if the follow-up list
    refresh fails

  ### 5. Provisioning hardening

  - Manual account creation no longer depends on invitation/email services being available
  - Invite mode still fails cleanly when invitation service is unavailable
  - Manual account creation now verifies that the password write actually landed before reporting success
  - Added a focused regression in tests/services/test_platform_identity_service.py

  ### 6. Docker-local default alignment

  - Kept Docker Compose mapped to host port 4002 in docker-compose.yaml
  - Updated local helper scripts to default to 4002
  - Updated user-facing docs and starter config examples to match the Docker-local default:
      - README.md
      - docs/getting-started/docker.md
      - docs/getting-started/mcp-quickstart.md
      - docs/admin-ui/index.md
      - docs/deployment/docker.md
      - docs/configuration/general.md
      - config.example.yaml

  ## Why

  Before this PR:

  - People & Access had two overlapping create flows
  - invitations and users were rendered as stacked surfaces on one page
  - invitation active filtering was applied after pagination
  - summary cards in People & Access were based on only the current principals page
  - manual create could be blocked by invitation-service unavailability
  - successful provisioning could be surfaced as a failed modal submit if refresh failed
  - Docker-local defaults had drifted from scripts/docs

  This PR makes the page and its backend contract more coherent and maintainable without expanding scope into the gateway/runtime path.

  ## Verification

  Passed:

  - uv run ruff check src/api/admin/endpoints/rbac.py src/services/access_provisioning_service.py src/services/
    platform_identity_service.py tests/services/test_platform_identity_service.py tests/test_ui_access_provisioning.py tests/
    test_ui_invitations.py
  - uv run pytest tests/services/test_platform_identity_service.py tests/test_ui_access_provisioning.py tests/test_ui_invitations.py
  - cd ui && npm run build