### PR TITLE
fix: publish runnable helm quickstart overlays

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -132,12 +132,39 @@ jobs:
 
       - name: Validate packaged chart
         run: |
+          VALID_MASTER_KEY=sk-release-validation-1234567890abcdeA1
+          VALID_SALT_KEY=release-validation-salt-0123456789abcdef0123456789abcdef
+          VALID_DATABASE_URL=postgresql://deltallm:deltallm@postgres:5432/deltallm
+          VALID_REDIS_URL=redis://redis:6379/0
+
           helm lint /tmp/deltallm-chart \
-            --set secret.values.masterKey=sk-release-validation-1234567890abcdeA1 \
-            --set secret.values.saltKey=release-validation-salt-0123456789abcdef0123456789abcdef
+            --set secret.values.masterKey="${VALID_MASTER_KEY}" \
+            --set secret.values.saltKey="${VALID_SALT_KEY}"
           helm template deltallm /tmp/deltallm-chart \
-            --set secret.values.masterKey=sk-release-validation-1234567890abcdeA1 \
-            --set secret.values.saltKey=release-validation-salt-0123456789abcdef0123456789abcdef \
+            --set secret.values.masterKey="${VALID_MASTER_KEY}" \
+            --set secret.values.saltKey="${VALID_SALT_KEY}" \
+            > /dev/null
+          helm lint /tmp/deltallm-chart \
+            -f helm/values-eval.yaml \
+            --set secret.values.masterKey="${VALID_MASTER_KEY}" \
+            --set secret.values.saltKey="${VALID_SALT_KEY}"
+          helm template deltallm /tmp/deltallm-chart \
+            -f helm/values-eval.yaml \
+            --set secret.values.masterKey="${VALID_MASTER_KEY}" \
+            --set secret.values.saltKey="${VALID_SALT_KEY}" \
+            > /dev/null
+          helm lint /tmp/deltallm-chart \
+            -f helm/values-production.yaml \
+            --set secret.values.masterKey="${VALID_MASTER_KEY}" \
+            --set secret.values.saltKey="${VALID_SALT_KEY}" \
+            --set runtime.database.url="${VALID_DATABASE_URL}" \
+            --set runtime.redis.url="${VALID_REDIS_URL}"
+          helm template deltallm /tmp/deltallm-chart \
+            -f helm/values-production.yaml \
+            --set secret.values.masterKey="${VALID_MASTER_KEY}" \
+            --set secret.values.saltKey="${VALID_SALT_KEY}" \
+            --set runtime.database.url="${VALID_DATABASE_URL}" \
+            --set runtime.redis.url="${VALID_REDIS_URL}" \
             > /dev/null
 
       - name: Package chart
@@ -165,6 +192,12 @@ jobs:
           fi
 
           cp "/tmp/deltallm-packages/deltallm-${CHART_VERSION}.tgz" .
+          cp helm/values.yaml .
+          cp helm/values-eval.yaml .
+          cp helm/values-production.yaml .
+          cp helm/values.yaml "values-${CHART_VERSION}.yaml"
+          cp helm/values-eval.yaml "values-eval-${CHART_VERSION}.yaml"
+          cp helm/values-production.yaml "values-production-${CHART_VERSION}.yaml"
 
           if [[ -f index.yaml ]]; then
             helm repo index . --url "${CHART_REPO_URL}" --merge index.yaml
@@ -185,6 +218,16 @@ jobs:
             <p>Add this repository with:</p>
             <pre><code>helm repo add deltallm ${CHART_REPO_URL}
           helm repo update</code></pre>
+            <p>Quick-start evaluation install with bundled PostgreSQL and Redis:</p>
+            <pre><code>helm install deltallm deltallm/deltallm \\
+          --version ${CHART_VERSION} \\
+          -f ${CHART_REPO_URL}/values-eval-${CHART_VERSION}.yaml</code></pre>
+            <p>Release-matched values overlays:</p>
+            <ul>
+              <li><a href="values-eval-${CHART_VERSION}.yaml">values-eval-${CHART_VERSION}.yaml</a></li>
+              <li><a href="values-production-${CHART_VERSION}.yaml">values-production-${CHART_VERSION}.yaml</a></li>
+              <li><a href="values-${CHART_VERSION}.yaml">values-${CHART_VERSION}.yaml</a></li>
+            </ul>
             <p>See the main project docs for deployment examples.</p>
           </body>
           </html>
@@ -194,7 +237,17 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .nojekyll index.html index.yaml "deltallm-${CHART_VERSION}.tgz"
+          git add \
+            .nojekyll \
+            index.html \
+            index.yaml \
+            "deltallm-${CHART_VERSION}.tgz" \
+            values.yaml \
+            values-eval.yaml \
+            values-production.yaml \
+            "values-${CHART_VERSION}.yaml" \
+            "values-eval-${CHART_VERSION}.yaml" \
+            "values-production-${CHART_VERSION}.yaml"
           if git diff --cached --quiet; then
             echo "No chart repo changes to publish"
             exit 0

--- a/README.md
+++ b/README.md
@@ -165,15 +165,34 @@ If you set `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` and `PLATFORM_BOOTSTRAP_ADMIN_PASSWO
 
 ## Option 2: Kubernetes From a Released Chart
 
-Released Helm charts are published to the public Helm repository at `https://deltawi.github.io/deltallm`.
+Released Helm charts and matching values overlays are published to the public Helm repository at `https://deltawi.github.io/deltallm`.
 
 ```bash
 helm repo add deltallm https://deltawi.github.io/deltallm
 helm repo update
 ```
 
+Generate the required secrets first:
+
 ```bash
-helm install deltallm deltallm/deltallm --version <chart-version>
+export DELTALLM_MASTER_KEY="$(python3 -c 'import secrets; print(\"sk-\" + secrets.token_hex(20) + \"A1\")')"
+export DELTALLM_SALT_KEY="$(openssl rand -hex 32)"
+```
+
+Quick-start install with bundled PostgreSQL and Redis:
+
+```bash
+helm install deltallm deltallm/deltallm \
+  --version <chart-version> \
+  --namespace deltallm \
+  --create-namespace \
+  -f https://deltawi.github.io/deltallm/values-eval-<chart-version>.yaml \
+  --set secret.values.masterKey="$DELTALLM_MASTER_KEY" \
+  --set secret.values.saltKey="$DELTALLM_SALT_KEY" \
+  --set-string env[0].name=PLATFORM_BOOTSTRAP_ADMIN_EMAIL \
+  --set-string env[0].value=admin@example.com \
+  --set-string env[1].name=PLATFORM_BOOTSTRAP_ADMIN_PASSWORD \
+  --set-string env[1].value='ChangeMe123!'
 ```
 
 If you want the Presidio-enabled image variant from the same chart release:
@@ -181,8 +200,19 @@ If you want the Presidio-enabled image variant from the same chart release:
 ```bash
 helm install deltallm deltallm/deltallm \
   --version <chart-version> \
+  --namespace deltallm \
+  --create-namespace \
+  -f https://deltawi.github.io/deltallm/values-eval-<chart-version>.yaml \
+  --set secret.values.masterKey="$DELTALLM_MASTER_KEY" \
+  --set secret.values.saltKey="$DELTALLM_SALT_KEY" \
+  --set-string env[0].name=PLATFORM_BOOTSTRAP_ADMIN_EMAIL \
+  --set-string env[0].value=admin@example.com \
+  --set-string env[1].name=PLATFORM_BOOTSTRAP_ADMIN_PASSWORD \
+  --set-string env[1].value='ChangeMe123!' \
   --set image.tag=v<chart-version>-presidio
 ```
+
+`values-eval-<chart-version>.yaml` is the self-contained quick-start profile. Use `values-production-<chart-version>.yaml` with external PostgreSQL and Redis for production.
 
 Use the latest GitHub Release version for `<chart-version>`. The exact copy-paste install commands for each release live in the release notes.
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -23,6 +23,14 @@ The rewritten chart supports three concrete deployment shapes:
 
 Published releases are available from the public Helm repository at `https://deltawi.github.io/deltallm`.
 
+Each release publishes three matching values files:
+
+- `values-eval-<chart-version>.yaml`: self-contained quick-start with bundled PostgreSQL and Redis
+- `values-production-<chart-version>.yaml`: HA-oriented production baseline for external PostgreSQL and Redis
+- `values-<chart-version>.yaml`: raw base chart values
+
+The bare chart does not provision PostgreSQL or Redis by default. For a first install, use the eval values file.
+
 ```bash
 helm repo add deltallm https://deltawi.github.io/deltallm
 helm repo update
@@ -35,11 +43,14 @@ export DELTALLM_MASTER_KEY="$(python3 -c 'import secrets; print(\"sk-\" + secret
 export DELTALLM_SALT_KEY="$(openssl rand -hex 32)"
 ```
 
-Quick-start install:
+Quick-start evaluation install:
 
 ```bash
 helm install deltallm deltallm/deltallm \
   --version <chart-version> \
+  --namespace deltallm \
+  --create-namespace \
+  -f https://deltawi.github.io/deltallm/values-eval-<chart-version>.yaml \
   --set secret.values.masterKey="$DELTALLM_MASTER_KEY" \
   --set secret.values.saltKey="$DELTALLM_SALT_KEY" \
   --set-string env[0].name=PLATFORM_BOOTSTRAP_ADMIN_EMAIL \
@@ -53,6 +64,9 @@ To use the Presidio-enabled image variant from the same release:
 ```bash
 helm install deltallm deltallm/deltallm \
   --version <chart-version> \
+  --namespace deltallm \
+  --create-namespace \
+  -f https://deltawi.github.io/deltallm/values-eval-<chart-version>.yaml \
   --set secret.values.masterKey="$DELTALLM_MASTER_KEY" \
   --set secret.values.saltKey="$DELTALLM_SALT_KEY" \
   --set-string env[0].name=PLATFORM_BOOTSTRAP_ADMIN_EMAIL \
@@ -66,12 +80,34 @@ Use the latest GitHub Release version for `<chart-version>`. The exact pinned in
 
 After install:
 
+- `kubectl get pods -n deltallm` should show DeltaLLM plus bundled PostgreSQL and Redis pods
 - use `admin@example.com` and the bootstrap password to sign in to the Admin UI
 - use `DELTALLM_MASTER_KEY` for gateway and API requests
 
-For production, prefer a values file or secret-backed `envFrom` instead of passing credentials with `--set`.
+For production, do not use the eval overlay. Start from the released production overlay instead:
 
-This is the recommended path if you just want to deploy DeltaLLM.
+```bash
+curl -fsSLo values-production.yaml \
+  https://deltawi.github.io/deltallm/values-production-<chart-version>.yaml
+```
+
+Edit `values-production.yaml` to point at your external PostgreSQL and Redis secrets, then install:
+
+- set `secret.existingSecret` to the secret that contains `master-key` and `salt-key`
+- set `runtime.database.existingSecret.name` and `runtime.database.existingSecret.urlKey`
+- set `runtime.redis.existingSecret.name` and `runtime.redis.existingSecret.urlKey`
+- add any provider keys or platform credentials under `envFrom` or `env`
+
+```bash
+helm install deltallm deltallm/deltallm \
+  --version <chart-version> \
+  --namespace deltallm \
+  --create-namespace \
+  -f values-production.yaml \
+  --set secret.existingSecret=deltallm-app-secrets
+```
+
+Use the eval overlay for the simplest first working install. Use the production overlay once you have external stateful services and secret-backed runtime configuration.
 
 ## Option 2: Install From the Repo
 


### PR DESCRIPTION
This PR fixes the public Helm install path so a released-chart quickstart actually starts DeltaLLM with the required stateful services.

  Before this change:

  - the public docs told users to install the bare released chart
  - but the base chart disables bundled PostgreSQL and Redis
  - so a first-time released-chart install was incomplete unless the user already knew how to provide external services

  This PR fixes that by:

  - publishing release-matched Helm values overlays alongside the chart
  - updating the public quickstart docs to use the eval overlay for a self-contained install
  - keeping production guidance aligned with the production overlay and external PostgreSQL/Redis

  ## Root cause

  The runnable self-contained setup already existed in:

  - helm/values-eval.yaml

  But the released-chart docs in:

  - README.md
  - docs/deployment/kubernetes.md

  were installing:

  - deltallm/deltallm
    without:
  - -f values-eval.yaml

  Since the base chart in helm/values.yaml has:

  - postgresql.enabled: false
  - redis.enabled: false

  the released quickstart installed only DeltaLLM, not PostgreSQL and Redis.

  ## What changed

  ### 1. Release workflow now publishes runnable values overlays

  Updated .github/workflows/release-images.yml:

  - continues publishing the chart to the public GitHub Pages Helm repo
  - now also publishes:
      - values.yaml
      - values-eval.yaml
      - values-production.yaml
  - and versioned release-matched copies:
      - values-<chart-version>.yaml
      - values-eval-<chart-version>.yaml
      - values-production-<chart-version>.yaml

  This gives the released chart a matching public values surface.

  ### 2. Release workflow now validates the actual install profiles

  The workflow now validates:

  - base chart
  - eval overlay
  - production overlay with external DB/Redis URLs

  This catches broken release packaging for the two real install modes.

  ### 3. README released-chart install is now runnable

  Updated README.md:

  - released-chart quickstart now uses:
      - -f https://deltawi.github.io/deltallm/values-eval-<chart-version>.yaml
  - includes:
      - generated master/salt keys
      - bootstrap admin email/password
  - Presidio released install now uses the same eval overlay pattern

  ### 4. Kubernetes docs now distinguish eval vs production released installs

  Updated docs/deployment/kubernetes.md:

  - explicitly states that the bare chart does not provision PostgreSQL or Redis
  - explains the three published values files
  - uses values-eval-<chart-version>.yaml for the released quickstart
  - adds a post-install expectation that PostgreSQL and Redis pods should appear
  - adds a production path based on:
      - values-production-<chart-version>.yaml
      - external PostgreSQL/Redis
      - secret-backed runtime configuration

  ## Why this is the right fix

  This follows the same pattern used by mature Helm-based projects:

  - baseline chart stays clean
  - evaluation installs use an explicit quickstart overlay
  - production installs use a stricter overlay and external dependencies
  - public docs point users to the runnable profile, not the raw baseline

  It keeps:

  - the chart design clean
  - the public install path simple
  - production guidance honest

  ## Verification

  Validated locally:

  - helm lint ./helm --set secret.values.masterKey=... --set secret.values.saltKey=...
  - helm lint ./helm -f helm/values-eval.yaml --set secret.values.masterKey=... --set secret.values.saltKey=...
  - helm lint ./helm -f helm/values-production.yaml --set secret.values.masterKey=... --set secret.values.saltKey=... --set runtime.database.url=... --set runtime.redis.url=...

  Also verified:

  - eval overlay renders PostgreSQL and Redis resources
  - production overlay does not render bundled PostgreSQL or Redis
  - git diff --check passes

  ## Resulting public install flow

  Quickstart with bundled PostgreSQL and Redis:

  helm repo add deltallm https://deltawi.github.io/deltallm
  helm repo update

  helm install deltallm deltallm/deltallm \
    --version <chart-version> \
    -f https://deltawi.github.io/deltallm/values-eval-<chart-version>.yaml \
    ...

  Production:

  - start from values-production-<chart-version>.yaml
  - wire external PostgreSQL/Redis
  - keep secrets out of inline Helm flags where possible