### PR TITLE
fix: improve request log coverage for #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 # DeltaLLM
 
-<p align="center">
-  <a href="https://github.com/deltawi/deltallm/actions"><img src="https://img.shields.io/github/actions/workflow/status/deltawi/deltallm/ci.yml?label=tests" alt="Tests"></a>
-  <a href="https://deltallm.readthedocs.io"><img src="https://img.shields.io/badge/docs-readthedocs-blue" alt="Documentation"></a>
-  <a href="https://github.com/deltawi/deltallm/releases"><img src="https://img.shields.io/github/v/release/deltawi/deltallm?sort=semver" alt="Latest Release"></a>
-  <img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python">
-  <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-  <img src="https://img.shields.io/github/last-commit/deltawi/deltallm" alt="Last Commit">
-  <a href="https://github.com/deltawi/deltallm/stargazers"><img src="https://img.shields.io/github/stars/deltawi/deltallm?style=social" alt="Stars"></a>
-</p>
 
 
 ## What is DeltaLLM?
@@ -34,7 +25,7 @@ That's it. Your existing code works unchanged — now with routing, spend tracki
 
 Manage all your model deployments, API keys, teams, and usage from a clean web interface:
 
-![DeltaLLM Admin UI - Models List](docs/admin-ui/images/models-list.png)
+DeltaLLM Admin UI - Models List
 
 ## Key Features
 
@@ -49,7 +40,7 @@ Manage all your model deployments, API keys, teams, and usage from a clean web i
 - **Response Caching** — Memory, Redis, or S3 backends for lower latency and cost
 - **Observability** — Prometheus metrics, request logging, and spend analytics
 
-**Docs:** https://deltallm.readthedocs.io/en/latest
+**Docs:** [https://deltallm.readthedocs.io/en/latest](https://deltallm.readthedocs.io/en/latest)
 
 ## Choose Your Install Path
 

--- a/prisma/migrations/20260328153000_request_log_failures/migration.sql
+++ b/prisma/migrations/20260328153000_request_log_failures/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE deltallm_spendlog_events
+    ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'success',
+    ADD COLUMN IF NOT EXISTS http_status_code INTEGER,
+    ADD COLUMN IF NOT EXISTS error_type TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,9 @@ model DeltaLLM_SpendLogEvents {
   pricing_fields_used    Json?
   usage_snapshot         Json?
   metadata               Json?
+  status                 String   @default("success")
+  http_status_code       Int?
+  error_type             String?
 
   @@index([organization_id, start_time], map: "deltallm_spendlog_events_org_time_idx")
   @@index([team_id, start_time], map: "deltallm_spendlog_events_team_time_idx")

--- a/src/api/admin/endpoints/spend.py
+++ b/src/api/admin/endpoints/spend.py
@@ -329,7 +329,7 @@ async def request_logs(
                {source.cached_prompt_tokens_column} AS prompt_tokens_cached,
                {source.cached_completion_tokens_column} AS completion_tokens_cached,
                start_time, end_time, {source.user_column} AS "user", team_id, {source.end_user_column} AS end_user,
-               metadata, cache_hit, cache_key, request_tags
+               metadata, cache_hit, cache_key, request_tags, status, http_status_code, error_type
         FROM {source.table}
         {where_sql}
         ORDER BY start_time DESC

--- a/src/billing/spend.py
+++ b/src/billing/spend.py
@@ -36,6 +36,90 @@ class SpendTrackingService:
         start_time: datetime | None = None,
         end_time: datetime | None = None,
     ) -> None:
+        await self._log_request_event(
+            request_id=request_id,
+            api_key=api_key,
+            user_id=user_id,
+            team_id=team_id,
+            organization_id=organization_id,
+            end_user_id=end_user_id,
+            model=model,
+            call_type=call_type,
+            usage=usage,
+            cost=cost,
+            metadata=metadata,
+            cache_hit=cache_hit,
+            start_time=start_time,
+            end_time=end_time,
+            update_ledger=True,
+        )
+
+    async def log_request_failure(
+        self,
+        *,
+        request_id: str,
+        api_key: str,
+        user_id: str | None,
+        team_id: str | None,
+        organization_id: str | None,
+        end_user_id: str | None,
+        model: str,
+        call_type: str,
+        metadata: dict[str, Any] | None = None,
+        cache_hit: bool = False,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        http_status_code: int | None = None,
+        exc: Exception | None = None,
+        error_type: str | None = None,
+    ) -> None:
+        await self._log_request_event(
+            request_id=request_id,
+            api_key=api_key,
+            user_id=user_id,
+            team_id=team_id,
+            organization_id=organization_id,
+            end_user_id=end_user_id,
+            model=model,
+            call_type=call_type,
+            usage=None,
+            cost=0.0,
+            metadata=_failure_metadata(
+                metadata=metadata,
+                exc=exc,
+                http_status_code=http_status_code,
+            ),
+            cache_hit=cache_hit,
+            start_time=start_time,
+            end_time=end_time,
+            status="error",
+            http_status_code=http_status_code,
+            error_type=error_type or getattr(exc, "error_type", None) or (exc.__class__.__name__ if exc is not None else None),
+            update_ledger=False,
+        )
+
+    async def _log_request_event(
+        self,
+        *,
+        request_id: str,
+        api_key: str,
+        user_id: str | None,
+        team_id: str | None,
+        organization_id: str | None,
+        end_user_id: str | None,
+        model: str,
+        call_type: str,
+        usage: dict[str, int] | None,
+        cost: float,
+        metadata: dict[str, Any] | None,
+        cache_hit: bool,
+        start_time: datetime | None,
+        end_time: datetime | None,
+        status: str = "success",
+        http_status_code: int | None = None,
+        error_type: str | None = None,
+        update_ledger: bool,
+    ) -> None:
         if self.db is None:
             return
 
@@ -60,8 +144,25 @@ class SpendTrackingService:
             cache_hit=cache_hit,
             start_time=log_start,
             end_time=log_end,
+            status=status,
+            http_status_code=http_status_code,
+            error_type=error_type,
         )
 
+        await self._write_event(event_entry)
+        if not update_ledger:
+            return
+
+        await self.ledger.increment_spend(
+            api_key=api_key,
+            user_id=user_id,
+            team_id=team_id,
+            organization_id=organization_id,
+            model=model,
+            cost=float(cost),
+        )
+
+    async def _write_event(self, event_entry: dict[str, Any]) -> None:
         try:
             import uuid as _uuid
 
@@ -110,9 +211,12 @@ class SpendTrackingService:
                     unpriced_reason,
                     pricing_fields_used,
                     usage_snapshot,
-                    metadata
+                    metadata,
+                    status,
+                    http_status_code,
+                    error_type
                 ) VALUES (
-                    $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29::timestamp,$30::timestamp,$31,$32,$33,$34,$35,$36::jsonb,$37::jsonb,$38::jsonb
+                    $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29::timestamp,$30::timestamp,$31,$32,$33,$34,$35,$36::jsonb,$37::jsonb,$38::jsonb,$39,$40,$41
                 )
                 """,
                 row_id,
@@ -153,15 +257,29 @@ class SpendTrackingService:
                 json.dumps(event_entry["pricing_fields_used"], default=str),
                 json.dumps(event_entry["usage_snapshot"], default=str),
                 json.dumps(event_entry["metadata"], default=str),
+                event_entry["status"],
+                event_entry["http_status_code"],
+                event_entry["error_type"],
             )
         except Exception as exc:  # pragma: no cover - defensive logging
             logger.warning("failed to write normalized spend event: %s", exc)
 
-        await self.ledger.increment_spend(
-            api_key=api_key,
-            user_id=user_id,
-            team_id=team_id,
-            organization_id=organization_id,
-            model=model,
-            cost=float(cost),
-        )
+
+def _failure_metadata(
+    *,
+    metadata: dict[str, Any] | None,
+    exc: Exception | None,
+    http_status_code: int | None,
+) -> dict[str, Any]:
+    base = dict(metadata or {})
+    error_payload = dict(base.get("error") or {}) if isinstance(base.get("error"), dict) else {}
+    if exc is not None:
+        error_payload.setdefault("type", getattr(exc, "error_type", None) or exc.__class__.__name__)
+        error_payload.setdefault("message", str(exc))
+        if getattr(exc, "code", None):
+            error_payload.setdefault("code", getattr(exc, "code"))
+    if http_status_code is not None:
+        error_payload.setdefault("http_status_code", int(http_status_code))
+    if error_payload:
+        base["error"] = error_payload
+    return base

--- a/src/billing/spend_events.py
+++ b/src/billing/spend_events.py
@@ -20,6 +20,9 @@ def build_spend_event(
     cache_hit: bool,
     start_time: datetime,
     end_time: datetime,
+    status: str = "success",
+    http_status_code: int | None = None,
+    error_type: str | None = None,
 ) -> dict[str, Any]:
     usage_data = usage or {}
     meta = metadata if isinstance(metadata, dict) else {}
@@ -88,6 +91,9 @@ def build_spend_event(
         "pricing_fields_used": billing.get("pricing_fields_used") if isinstance(billing.get("pricing_fields_used"), list) else None,
         "usage_snapshot": usage_snapshot or None,
         "metadata": meta,
+        "status": str(status or "success"),
+        "http_status_code": _int_or_none(http_status_code),
+        "error_type": _str_or_none(error_type),
     }
 
 
@@ -100,6 +106,15 @@ def _int_value(*values: Any) -> int:
         except Exception:
             continue
     return 0
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except Exception:
+        return None
 
 
 def _float_value(*values: Any) -> float:

--- a/src/chat/telemetry.py
+++ b/src/chat/telemetry.py
@@ -19,11 +19,43 @@ from src.metrics import (
     observe_request_latency,
 )
 from src.providers.resolution import resolve_provider
-from src.routers.routing_decision import attach_route_decision
+from src.telemetry.request_failures import enqueue_request_log_write
+from src.routers.routing_decision import attach_route_decision, resolve_failure_target
+from src.routers.utils import fire_and_forget
 
 
 def _append_route_decision_metadata(request: Request, metadata: dict[str, Any]) -> dict[str, Any]:
     return attach_route_decision(metadata, request)
+
+
+def _exception_status_code(exc: Exception) -> int | None:
+    response = getattr(exc, "response", None)
+    raw_status = getattr(exc, "status_code", None)
+    if raw_status is None and response is not None:
+        raw_status = getattr(response, "status_code", None)
+    try:
+        return int(raw_status) if raw_status is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_failure_fields(
+    request: Request,
+    *,
+    fallback_deployment: Any,
+    default_provider: str | None = None,
+    default_api_base: str | None = None,
+    default_deployment_model: str | None = None,
+) -> dict[str, str | None]:
+    target = resolve_failure_target(request, fallback_deployment=fallback_deployment)
+    fallback_params = getattr(fallback_deployment, "deltallm_params", {})
+    fallback_model = fallback_params.get("model") if isinstance(fallback_params, dict) else None
+    return {
+        "deployment_id": target.deployment_id or getattr(fallback_deployment, "deployment_id", None),
+        "provider": target.provider or default_provider,
+        "api_base": target.api_base or default_api_base,
+        "deployment_model": target.deployment_model or default_deployment_model or fallback_model,
+    }
 
 
 async def emit_stream_success(
@@ -41,9 +73,11 @@ async def emit_stream_success(
     cache_hit: bool,
     cache_key: str | None,
     audit_action: str,
+    served_deployment: Any,
     api_base: str,
     params: dict[str, Any],
 ) -> None:
+    await request.app.state.passive_health_tracker.record_request_outcome(served_deployment.deployment_id, success=True)
     callback_payload = build_standard_logging_payload(
         call_type="completion",
         request_id=request_id,
@@ -109,36 +143,83 @@ async def emit_stream_failure(
     cache_hit: bool,
     cache_key: str | None,
     audit_action: str,
+    primary_deployment: Any,
     api_base: str,
     params: dict[str, Any],
+    exc: Exception,
 ) -> None:
+    failure_fields = _resolve_failure_fields(
+        request,
+        fallback_deployment=primary_deployment,
+        default_provider=resolve_provider(params),
+        default_api_base=api_base,
+        default_deployment_model=params.get("model"),
+    )
+    enqueue_request_log_write(
+        request,
+        request.app.state.spend_tracking_service.log_request_failure(
+            request_id=request_id or "",
+            api_key=auth.api_key,
+            user_id=auth.user_id,
+            team_id=auth.team_id,
+            organization_id=getattr(auth, "organization_id", None),
+            end_user_id=None,
+            model=payload.model,
+            call_type="completion",
+            metadata=_append_route_decision_metadata(
+                request,
+                {
+                    "route": request.url.path,
+                    "stream": True,
+                    "cache_hit": cache_hit,
+                    "cache_key": cache_key,
+                    "api_base": failure_fields["api_base"],
+                    "provider": failure_fields["provider"],
+                    "deployment_model": failure_fields["deployment_model"],
+                },
+            ),
+            cache_hit=cache_hit,
+            start_time=callback_start,
+            end_time=datetime.now(tz=UTC),
+            http_status_code=_exception_status_code(exc),
+            exc=exc,
+        )
+    )
+    if failure_fields["deployment_id"]:
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            str(failure_fields["deployment_id"]),
+            success=False,
+            error=str(exc),
+        )
     callback_payload = build_standard_logging_payload(
         call_type="completion",
         request_id=request_id,
         model=payload.model,
-        deployment_model=params.get("model"),
+        deployment_model=failure_fields["deployment_model"],
         request_payload=request_data,
         response_obj=None,
         user_api_key_dict=auth.model_dump(mode="json"),
         start_time=callback_start,
         end_time=datetime.now(tz=UTC),
-        api_base=api_base,
+        api_base=failure_fields["api_base"],
         cache_hit=cache_hit,
         cache_key=cache_key,
-        error_info={"error_type": "stream_error"},
+        error_info={
+            "error_type": getattr(exc, "error_type", None) or exc.__class__.__name__,
+            "message": str(exc),
+        },
         turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
     )
-    stream_exc = Exception("stream interrupted")
-    callback_manager.dispatch_failure_callbacks(callback_payload, stream_exc)
+    callback_manager.dispatch_failure_callbacks(callback_payload, exc)
     await callback_manager.execute_post_call_failure_hooks(
         request_data=request_data,
-        original_exception=stream_exc,
+        original_exception=exc,
         user_api_key_dict=auth.model_dump(mode="json"),
     )
     await guardrail_middleware.run_post_call_failure(
         request_data=request_data,
         user_api_key_dict=auth.model_dump(mode="python"),
-        original_exception=stream_exc,
+        original_exception=exc,
         call_type="completion",
     )
     emit_text_audit_event(
@@ -150,7 +231,7 @@ async def emit_stream_failure(
         request_start=request_start,
         request_data=request_data,
         response_data=None,
-        error=stream_exc,
+        error=exc,
         metadata=_append_route_decision_metadata(
             request,
             {
@@ -158,9 +239,9 @@ async def emit_stream_failure(
                 "stream": True,
                 "cache_hit": cache_hit,
                 "cache_key": cache_key,
-                "api_base": api_base,
-                "provider": resolve_provider(params),
-                "deployment_model": params.get("model"),
+                "api_base": failure_fields["api_base"],
+                "provider": failure_fields["provider"],
+                "deployment_model": failure_fields["deployment_model"],
             },
         ),
     )
@@ -225,8 +306,6 @@ async def emit_nonstream_success(
         team=auth.team_id,
         spend=request_cost,
     )
-    from src.routers.utils import fire_and_forget
-
     fire_and_forget(
         request.app.state.spend_tracking_service.log_spend(
             request_id=request_id or "",
@@ -329,6 +408,43 @@ async def emit_nonstream_failure(
     exc: Exception,
     status_code: int,
 ) -> None:
+    failure_fields = _resolve_failure_fields(
+        request,
+        fallback_deployment=primary_deployment,
+        default_provider=api_provider,
+        default_api_base=api_base,
+        default_deployment_model=primary_deployment.deltallm_params.get("model"),
+    )
+    enqueue_request_log_write(
+        request,
+        request.app.state.spend_tracking_service.log_request_failure(
+            request_id=request_id or "",
+            api_key=auth.api_key,
+            user_id=auth.user_id,
+            team_id=auth.team_id,
+            organization_id=getattr(auth, "organization_id", None),
+            end_user_id=None,
+            model=payload.model,
+            call_type="completion",
+            metadata=_append_route_decision_metadata(
+                request,
+                {
+                    "route": request.url.path,
+                    "stream": False,
+                    "cache_hit": cache_hit,
+                    "cache_key": cache_key,
+                    "api_base": failure_fields["api_base"],
+                    "provider": failure_fields["provider"],
+                    "deployment_model": failure_fields["deployment_model"],
+                },
+            ),
+            cache_hit=cache_hit,
+            start_time=callback_start,
+            end_time=datetime.now(tz=UTC),
+            http_status_code=status_code,
+            exc=exc,
+        )
+    )
     await guardrail_middleware.run_post_call_failure(
         request_data=request_data,
         user_api_key_dict=auth.model_dump(mode="python"),
@@ -336,13 +452,13 @@ async def emit_nonstream_failure(
         call_type="completion",
     )
     await request.app.state.passive_health_tracker.record_request_outcome(
-        primary_deployment.deployment_id,
+        str(failure_fields["deployment_id"] or primary_deployment.deployment_id),
         success=False,
         error=str(exc),
     )
     increment_request(
         model=payload.model,
-        api_provider=api_provider,
+        api_provider=str(failure_fields["provider"] or api_provider),
         api_key=auth.api_key,
         user=auth.user_id,
         team=auth.team_id,
@@ -350,12 +466,12 @@ async def emit_nonstream_failure(
     )
     increment_request_failure(
         model=payload.model,
-        api_provider=api_provider,
+        api_provider=str(failure_fields["provider"] or api_provider),
         error_type=exc.__class__.__name__,
     )
     observe_request_latency(
         model=payload.model,
-        api_provider=api_provider,
+        api_provider=str(failure_fields["provider"] or api_provider),
         status_code=status_code,
         latency_seconds=perf_counter() - request_start,
     )
@@ -363,13 +479,13 @@ async def emit_nonstream_failure(
         call_type="completion",
         request_id=request_id,
         model=payload.model,
-        deployment_model=primary_deployment.deltallm_params.get("model"),
+        deployment_model=failure_fields["deployment_model"],
         request_payload=request_data,
         response_obj=None,
         user_api_key_dict=auth.model_dump(mode="json"),
         start_time=callback_start,
         end_time=datetime.now(tz=UTC),
-        api_base=api_base,
+        api_base=failure_fields["api_base"],
         cache_hit=cache_hit,
         cache_key=cache_key,
         error_info={"error_type": exc.__class__.__name__, "message": str(exc)},
@@ -398,9 +514,9 @@ async def emit_nonstream_failure(
                 "stream": False,
                 "cache_hit": cache_hit,
                 "cache_key": cache_key,
-                "api_base": api_base,
-                "provider": api_provider,
-                "deployment_model": primary_deployment.deltallm_params.get("model"),
+                "api_base": failure_fields["api_base"],
+                "provider": failure_fields["provider"],
+                "deployment_model": failure_fields["deployment_model"],
             },
         ),
     )

--- a/src/middleware/errors.py
+++ b/src/middleware/errors.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import logging
 
 from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from src.guardrails.exceptions import GuardrailViolationError
 from src.models.errors import ApprovalRequiredError, ProxyError, RateLimitError
+from src.telemetry.request_failures import maybe_log_proxy_error, maybe_log_request_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +32,17 @@ def _serialize_error(exc: ProxyError) -> dict[str, object]:
 
 def register_exception_handlers(app: FastAPI) -> None:
     @app.exception_handler(ProxyError)
-    async def proxy_error_handler(_: Request, exc: ProxyError) -> JSONResponse:
+    async def proxy_error_handler(request: Request, exc: ProxyError) -> JSONResponse:
+        maybe_log_proxy_error(request, exc)
         headers = {}
         if isinstance(exc, RateLimitError) and getattr(exc, "retry_after", None):
             headers["Retry-After"] = str(exc.retry_after)
         return JSONResponse(status_code=exc.status_code, content=_serialize_error(exc), headers=headers)
+
+    @app.exception_handler(RequestValidationError)
+    async def request_validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        await maybe_log_request_validation_failure(request, exc)
+        return JSONResponse(status_code=422, content={"detail": jsonable_encoder(exc.errors())})
 
     @app.exception_handler(Exception)
     async def unhandled_error_handler(_: Request, exc: Exception) -> JSONResponse:

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -219,6 +219,15 @@ class FailoverManager:
             delay = delay * (0.5 + random.random() * 0.5)
         return delay
 
+    @staticmethod
+    def _notify_attempt(on_attempt: Callable[[Deployment], None] | None, deployment: Deployment) -> None:
+        if on_attempt is None:
+            return
+        try:
+            on_attempt(deployment)
+        except Exception:
+            logger.warning("failover attempt callback failed", exc_info=True)
+
     async def execute_with_failover(
         self,
         primary_deployment: Deployment,
@@ -227,6 +236,7 @@ class FailoverManager:
         request_tokens: int = 0,
         *,
         return_deployment: bool = False,
+        on_attempt: Callable[[Deployment], None] | None = None,
         timeout_seconds: float | None = None,
         retry_max_attempts: int | None = None,
         retryable_error_classes: list[str] | set[str] | None = None,
@@ -248,6 +258,7 @@ class FailoverManager:
             for attempt in range(effective_retries + 1):
                 started = time.monotonic()
                 try:
+                    self._notify_attempt(on_attempt, deployment)
                     await self.state.increment_active(deployment.deployment_id)
                     result = await asyncio.wait_for(
                         execute(deployment),
@@ -314,6 +325,7 @@ class FailoverManager:
                             execute,
                             deployment.deployment_id,
                             classification,
+                            on_attempt=on_attempt,
                             timeout_seconds=effective_timeout,
                         )
                         if extra_result is not None:
@@ -350,6 +362,7 @@ class FailoverManager:
                             execute,
                             deployment.deployment_id,
                             classification,
+                            on_attempt=on_attempt,
                             timeout_seconds=effective_timeout,
                         )
                         if extra_result is not None:
@@ -386,6 +399,7 @@ class FailoverManager:
                             execute,
                             deployment.deployment_id,
                             classification,
+                            on_attempt=on_attempt,
                             timeout_seconds=effective_timeout,
                         )
                         if extra_result is not None:
@@ -442,6 +456,7 @@ class FailoverManager:
         from_deployment_id: str,
         classification: str,
         *,
+        on_attempt: Callable[[Deployment], None] | None = None,
         timeout_seconds: float,
     ) -> tuple[Any, Deployment] | None:
         for deployment in chain:
@@ -452,6 +467,7 @@ class FailoverManager:
                 continue
 
             try:
+                self._notify_attempt(on_attempt, deployment)
                 await self.state.increment_active(deployment.deployment_id)
                 started = time.monotonic()
                 result = await asyncio.wait_for(

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -30,12 +30,15 @@ from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
+from src.telemetry.request_failures import enqueue_request_log_write, seed_request_failure_context
 from src.routers.audit_helpers import emit_audit_event
 from src.routers.routing_decision import (
     attach_route_decision,
+    capture_attempted_deployment,
     capture_initial_route_decision,
     route_failover_kwargs,
     route_decision_headers,
+    resolve_failure_target,
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
@@ -131,6 +134,13 @@ async def _execute_tts(
 async def audio_speech(request: Request, payload: AudioSpeechRequest):
     request_start = perf_counter()
     callback_start = datetime.now(tz=UTC)
+    seed_request_failure_context(
+        request,
+        call_type="audio_speech",
+        model=payload.model,
+        request_start=request_start,
+        audit_action=AuditAction.AUDIO_SPEECH_REQUEST,
+    )
     auth = request.state.user_api_key
     ensure_model_allowed(
         auth,
@@ -155,6 +165,10 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
     capture_initial_route_decision(request, request_context)
     api_provider = resolve_provider(primary.deltallm_params)
     request_id = request.headers.get("x-request-id")
+    primary_api_base = str(primary.deltallm_params.get("api_base", request.app.state.settings.openai_base_url)).rstrip("/")
+
+    def track_attempt(deployment):  # noqa: ANN001
+        capture_attempted_deployment(request, deployment)
 
     try:
         result, served_deployment = await request.app.state.failover_manager.execute_with_failover(
@@ -162,6 +176,7 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
             model_group=model_group,
             execute=lambda dep: _execute_tts(request, payload, dep),
             return_deployment=True,
+            on_attempt=track_attempt,
             **failover_kwargs,
         )
         update_served_route_decision(
@@ -260,11 +275,43 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
         content_type = AUDIO_CONTENT_TYPES.get(effective_format, "audio/mpeg")
         return Response(content=audio_bytes, media_type=content_type, headers=route_decision_headers(request))
     except httpx.HTTPError as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
-        increment_request(model=payload.model, api_provider=api_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
-        increment_request_failure(model=payload.model, api_provider=api_provider, error_type=exc.__class__.__name__)
-        observe_request_latency(model=payload.model, api_provider=api_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
+        increment_request(model=payload.model, api_provider=failure_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
+        increment_request_failure(model=payload.model, api_provider=failure_provider, error_type=exc.__class__.__name__)
+        observe_request_latency(model=payload.model, api_provider=failure_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=payload.model,
+                call_type="audio_speech",
+                metadata=attach_route_decision(
+                    {
+                        "route": request.url.path,
+                        "provider": failure_provider,
+                        "api_base": failure_api_base,
+                        "deployment_model": failure_deployment_model,
+                    },
+                    request,
+                ),
+                cache_hit=False,
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         emit_audit_event(
             request=request,
             request_start=request_start,
@@ -278,11 +325,52 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
             resource_id=payload.model,
             request_payload=request_data,
             error=exc,
-            metadata=attach_route_decision({"route": request.url.path, "provider": api_provider}, request),
+            metadata=attach_route_decision(
+                {
+                    "route": request.url.path,
+                    "provider": failure_provider,
+                    "api_base": failure_api_base,
+                    "deployment_model": failure_deployment_model,
+                },
+                request,
+            ),
         )
         raise InvalidRequestError(message=f"Audio speech request failed: {exc}") from exc
     except Exception as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        status_code = int(getattr(exc, "status_code", 500) or 500)
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=payload.model,
+                call_type="audio_speech",
+                metadata=attach_route_decision(
+                    {
+                        "route": request.url.path,
+                        "provider": failure_provider,
+                        "api_base": failure_api_base,
+                        "deployment_model": failure_deployment_model,
+                    },
+                    request,
+                ),
+                cache_hit=False,
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         emit_audit_event(
             request=request,
             request_start=request_start,
@@ -296,7 +384,15 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
             resource_id=payload.model,
             request_payload=request_data,
             error=exc,
-            metadata=attach_route_decision({"route": request.url.path, "provider": api_provider}, request),
+            metadata=attach_route_decision(
+                {
+                    "route": request.url.path,
+                    "provider": failure_provider,
+                    "api_base": failure_api_base,
+                    "deployment_model": failure_deployment_model,
+                },
+                request,
+            ),
         )
         raise
 

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -29,12 +29,15 @@ from src.providers.resolution import (
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
+from src.telemetry.request_failures import enqueue_request_log_write, seed_request_failure_context
 from src.routers.audit_helpers import emit_audit_event
 from src.routers.routing_decision import (
     attach_route_decision,
+    capture_attempted_deployment,
     capture_initial_route_decision,
     route_failover_kwargs,
     route_decision_headers,
+    resolve_failure_target,
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
@@ -137,6 +140,13 @@ async def audio_transcriptions(
 ):
     request_start = perf_counter()
     callback_start = datetime.now(tz=UTC)
+    seed_request_failure_context(
+        request,
+        call_type="audio_transcription",
+        model=model,
+        request_start=request_start,
+        audit_action=AuditAction.AUDIO_TRANSCRIPTION_REQUEST,
+    )
     auth = request.state.user_api_key
     ensure_model_allowed(
         auth,
@@ -165,6 +175,10 @@ async def audio_transcriptions(
     capture_initial_route_decision(request, request_context)
     api_provider = resolve_provider(primary.deltallm_params)
     request_id = request.headers.get("x-request-id")
+    primary_api_base = str(primary.deltallm_params.get("api_base", request.app.state.settings.openai_base_url)).rstrip("/")
+
+    def track_attempt(deployment):  # noqa: ANN001
+        capture_attempted_deployment(request, deployment)
 
     try:
         data, served_deployment = await request.app.state.failover_manager.execute_with_failover(
@@ -175,6 +189,7 @@ async def audio_transcriptions(
                 model, language, prompt, response_format, temperature, dep,
             ),
             return_deployment=True,
+            on_attempt=track_attempt,
             **failover_kwargs,
         )
         update_served_route_decision(
@@ -270,11 +285,44 @@ async def audio_transcriptions(
         )
         return JSONResponse(status_code=200, content=data, headers=route_decision_headers(request))
     except httpx.HTTPError as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
-        increment_request(model=model, api_provider=api_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
-        increment_request_failure(model=model, api_provider=api_provider, error_type=exc.__class__.__name__)
-        observe_request_latency(model=model, api_provider=api_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
+        increment_request(model=model, api_provider=failure_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
+        increment_request_failure(model=model, api_provider=failure_provider, error_type=exc.__class__.__name__)
+        observe_request_latency(model=model, api_provider=failure_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=model,
+                call_type="audio_transcription",
+                metadata=attach_route_decision(
+                    {
+                        "route": request.url.path,
+                        "provider": failure_provider,
+                        "api_base": failure_api_base,
+                        "deployment_model": failure_deployment_model,
+                        "file_size_bytes": len(file_content),
+                    },
+                    request,
+                ),
+                cache_hit=False,
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         emit_audit_event(
             request=request,
             request_start=request_start,
@@ -289,13 +337,53 @@ async def audio_transcriptions(
             request_payload=request_data,
             error=exc,
             metadata=attach_route_decision(
-                {"route": request.url.path, "provider": api_provider, "file_size_bytes": len(file_content)},
+                {
+                    "route": request.url.path,
+                    "provider": failure_provider,
+                    "api_base": failure_api_base,
+                    "deployment_model": failure_deployment_model,
+                    "file_size_bytes": len(file_content),
+                },
                 request,
             ),
         )
         raise InvalidRequestError(message=f"Audio transcription request failed: {exc}") from exc
     except Exception as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        status_code = int(getattr(exc, "status_code", 500) or 500)
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=model,
+                call_type="audio_transcription",
+                metadata=attach_route_decision(
+                    {
+                        "route": request.url.path,
+                        "provider": failure_provider,
+                        "api_base": failure_api_base,
+                        "deployment_model": failure_deployment_model,
+                        "file_size_bytes": len(file_content),
+                    },
+                    request,
+                ),
+                cache_hit=False,
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         emit_audit_event(
             request=request,
             request_start=request_start,
@@ -310,7 +398,13 @@ async def audio_transcriptions(
             request_payload=request_data,
             error=exc,
             metadata=attach_route_decision(
-                {"route": request.url.path, "provider": api_provider, "file_size_bytes": len(file_content)},
+                {
+                    "route": request.url.path,
+                    "provider": failure_provider,
+                    "api_base": failure_api_base,
+                    "deployment_model": failure_deployment_model,
+                    "file_size_bytes": len(file_content),
+                },
                 request,
             ),
         )

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -28,7 +28,9 @@ from src.models.requests import ChatCompletionRequest
 from src.providers.registry import resolve_chat_upstream
 from src.providers.resolution import resolve_provider
 from src.router.usage import record_router_usage
+from src.telemetry.request_failures import seed_request_failure_context
 from src.routers.routing_decision import (
+    capture_attempted_deployment,
     capture_initial_route_decision,
     route_failover_kwargs,
     route_decision_headers,
@@ -80,6 +82,14 @@ async def handle_chat_like_request(
 ):
     request_start = perf_counter()
     callback_start = datetime.now(tz=UTC)
+    audit_action = audit_action_for_path(request.url.path)
+    seed_request_failure_context(
+        request,
+        call_type="completion",
+        model=payload.model,
+        request_start=request_start,
+        audit_action=audit_action,
+    )
     auth, payload, request_data, callback_manager, guardrail_middleware = await run_text_preflight(
         request=request,
         payload=payload,
@@ -99,11 +109,13 @@ async def handle_chat_like_request(
     api_provider = resolve_provider(primary.deltallm_params)
     request_id = request.headers.get("x-request-id")
     api_base = primary.deltallm_params.get("api_base", request.app.state.settings.openai_base_url).rstrip("/")
+
+    def track_attempt(deployment):  # noqa: ANN001
+        capture_attempted_deployment(request, deployment)
+
     cache_context = getattr(request.state, "cache_context", None)
     cache_hit = bool(getattr(cache_context, "hit", False)) if cache_context is not None else False
     cache_key = getattr(cache_context, "cache_key", None) if cache_context is not None else None
-    audit_action = audit_action_for_path(request.url.path)
-
     try:
         if payload.stream:
             if has_mcp_tools:
@@ -118,116 +130,125 @@ async def handle_chat_like_request(
                 stream_id = None
                 stream_write_context: StreamWriteContext | None = None
                 stream_usage = _StreamUsageTracker()
-                opened_stream = await request.app.state.failover_manager.execute_with_failover(
-                    primary_deployment=primary,
-                    model_group=model_group,
-                    execute=lambda dep: open_stream_with_first_chunk(request, payload, dep),
-                    return_deployment=True,
-                    **failover_kwargs,
-                )
-                opened_stream, served_deployment = opened_stream
-                update_served_route_decision(
-                    request,
-                    primary_deployment_id=primary.deployment_id,
-                    served_deployment_id=served_deployment.deployment_id,
-                )
-                params = opened_stream.params
-                api_base_local = opened_stream.api_base
-                if (
-                    enable_stream_cache
-                    and request.url.path == "/v1/chat/completions"
-                    and
-                    cache_context is not None
-                    and stream_handler is not None
-                    and cache_context.options.control.value != "no-store"
-                ):
-                    cache_ttl = int(
-                        cache_context.options.ttl
-                        or getattr(
-                            getattr(getattr(request.app.state, "app_config", None), "general_settings", None),
-                            "cache_ttl",
-                            3600,
-                        )
-                    )
-                    stream_id = cache_context.cache_key
-                    stream_write_context = StreamWriteContext(
-                        cache_key=cache_context.cache_key,
-                        ttl=cache_ttl,
-                        model=payload.model,
-                        pricing=dict(served_deployment.model_info or {}),
-                        deployment_id=served_deployment.deployment_id,
-                    )
-                    stream_handler.start_stream(stream_id)
-
+                opened_stream = None
+                served_deployment = None
+                failure_exc: Exception | None = None
                 try:
-                    try:
-                        initial = opened_stream.first_line
-                        if initial:
-                            stream_usage.add_line(initial)
-                            if stream_id is not None and stream_handler is not None:
-                                stream_handler.add_chunk_from_line(stream_id, initial)
-                            out_line = stream_line_transform(initial) if stream_line_transform is not None else initial
-                            if out_line is not None:
-                                yield f"{out_line}\n\n"
-                        async for line in opened_stream.translated_stream:
-                            if not line:
-                                continue
-
-                            stream_usage.add_line(line)
-                            if stream_id is not None and stream_handler is not None:
-                                stream_handler.add_chunk_from_line(stream_id, line)
-                                if line.strip() == "data: [DONE]" and stream_write_context is not None:
-                                    await stream_handler.finalize_and_store(stream_id, stream_write_context)
-
-                            out_line = stream_line_transform(line) if stream_line_transform is not None else line
-                            if out_line is None:
-                                continue
-                            yield f"{out_line}\n\n"
-                        await record_router_usage(
-                            request.app.state.router_state_backend,
-                            served_deployment.deployment_id,
-                            mode="chat",
-                            usage=stream_usage.usage,
+                    opened_stream, served_deployment = await request.app.state.failover_manager.execute_with_failover(
+                        primary_deployment=primary,
+                        model_group=model_group,
+                        execute=lambda dep: open_stream_with_first_chunk(request, payload, dep),
+                        return_deployment=True,
+                        on_attempt=track_attempt,
+                        **failover_kwargs,
+                    )
+                    update_served_route_decision(
+                        request,
+                        primary_deployment_id=primary.deployment_id,
+                        served_deployment_id=served_deployment.deployment_id,
+                    )
+                    params = opened_stream.params
+                    api_base_local = opened_stream.api_base
+                    if (
+                        enable_stream_cache
+                        and request.url.path == "/v1/chat/completions"
+                        and
+                        cache_context is not None
+                        and stream_handler is not None
+                        and cache_context.options.control.value != "no-store"
+                    ):
+                        cache_ttl = int(
+                            cache_context.options.ttl
+                            or getattr(
+                                getattr(getattr(request.app.state, "app_config", None), "general_settings", None),
+                                "cache_ttl",
+                                3600,
+                            )
                         )
-                        await emit_stream_success(
-                            request=request,
-                            auth=auth,
-                            payload=payload,
-                            request_data=request_data,
-                            callback_manager=callback_manager,
-                            guardrail_middleware=guardrail_middleware,
-                            callback_start=callback_start,
-                            request_start=request_start,
-                            request_id=request_id,
-                            stream_response_object=stream_response_object,
-                            cache_hit=cache_hit,
-                            cache_key=cache_key,
-                            audit_action=audit_action,
-                            api_base=api_base_local,
-                            params=params,
+                        stream_id = cache_context.cache_key
+                        stream_write_context = StreamWriteContext(
+                            cache_key=cache_context.cache_key,
+                            ttl=cache_ttl,
+                            model=payload.model,
+                            pricing=dict(served_deployment.model_info or {}),
+                            deployment_id=served_deployment.deployment_id,
                         )
-                    except Exception:
+                        stream_handler.start_stream(stream_id)
+
+                    initial = opened_stream.first_line
+                    if initial:
+                        stream_usage.add_line(initial)
                         if stream_id is not None and stream_handler is not None:
-                            stream_handler.discard_stream(stream_id)
-                        await emit_stream_failure(
-                            request=request,
-                            auth=auth,
-                            payload=payload,
-                            request_data=request_data,
-                            callback_manager=callback_manager,
-                            guardrail_middleware=guardrail_middleware,
-                            callback_start=callback_start,
-                            request_start=request_start,
-                            request_id=request_id,
-                            cache_hit=cache_hit,
-                            cache_key=cache_key,
-                            audit_action=audit_action,
-                            api_base=api_base_local,
-                            params=params,
-                        )
-                        raise
+                            stream_handler.add_chunk_from_line(stream_id, initial)
+                        out_line = stream_line_transform(initial) if stream_line_transform is not None else initial
+                        if out_line is not None:
+                            yield f"{out_line}\n\n"
+                    async for line in opened_stream.translated_stream:
+                        if not line:
+                            continue
+
+                        stream_usage.add_line(line)
+                        if stream_id is not None and stream_handler is not None:
+                            stream_handler.add_chunk_from_line(stream_id, line)
+                            if line.strip() == "data: [DONE]" and stream_write_context is not None:
+                                await stream_handler.finalize_and_store(stream_id, stream_write_context)
+
+                        out_line = stream_line_transform(line) if stream_line_transform is not None else line
+                        if out_line is None:
+                            continue
+                        yield f"{out_line}\n\n"
+                    await record_router_usage(
+                        request.app.state.router_state_backend,
+                        served_deployment.deployment_id,
+                        mode="chat",
+                        usage=stream_usage.usage,
+                    )
+                    await emit_stream_success(
+                        request=request,
+                        auth=auth,
+                        payload=payload,
+                        request_data=request_data,
+                        callback_manager=callback_manager,
+                        guardrail_middleware=guardrail_middleware,
+                        callback_start=callback_start,
+                        request_start=request_start,
+                        request_id=request_id,
+                        stream_response_object=stream_response_object,
+                        cache_hit=cache_hit,
+                        cache_key=cache_key,
+                        audit_action=audit_action,
+                        served_deployment=served_deployment,
+                        api_base=api_base_local,
+                        params=params,
+                    )
+                except Exception as exc:
+                    failure_exc = exc
+                    if stream_id is not None and stream_handler is not None:
+                        stream_handler.discard_stream(stream_id)
+                    failure_params = opened_stream.params if opened_stream is not None else primary.deltallm_params
+                    failure_api_base = opened_stream.api_base if opened_stream is not None else api_base
+                    await emit_stream_failure(
+                        request=request,
+                        auth=auth,
+                        payload=payload,
+                        request_data=request_data,
+                        callback_manager=callback_manager,
+                        guardrail_middleware=guardrail_middleware,
+                        callback_start=callback_start,
+                        request_start=request_start,
+                        request_id=request_id,
+                        cache_hit=cache_hit,
+                        cache_key=cache_key,
+                        audit_action=audit_action,
+                        primary_deployment=primary,
+                        api_base=failure_api_base,
+                        params=failure_params,
+                        exc=exc,
+                    )
+                    raise
                 finally:
-                    await opened_stream.close()
+                    if opened_stream is not None:
+                        await opened_stream.close(failure_exc)
 
             return StreamingResponse(
                 stream_sse(),
@@ -260,6 +281,7 @@ async def handle_chat_like_request(
             model_group=model_group,
             execute=_execute_for_deployment,
             return_deployment=True,
+            on_attempt=track_attempt,
             **failover_kwargs,
         )
         update_served_route_decision(
@@ -314,6 +336,7 @@ async def handle_chat_like_request(
         adapter = request.app.state.openai_adapter
         raise adapter.map_error(exc) from exc
     except Exception as exc:
+        status_code = int(getattr(exc, "status_code", 500) or 500)
         await emit_nonstream_failure(
             request=request,
             auth=auth,
@@ -331,6 +354,6 @@ async def handle_chat_like_request(
             api_provider=api_provider,
             api_base=api_base,
             exc=exc,
-            status_code=500,
+            status_code=status_code,
         )
         raise

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -26,11 +26,14 @@ from src.models.requests import EmbeddingRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
+from src.telemetry.request_failures import enqueue_request_log_write, seed_request_failure_context
 from src.routers.routing_decision import (
+    capture_attempted_deployment,
     capture_initial_route_decision,
     route_failover_kwargs,
     route_decision_headers,
     route_decision_metadata,
+    resolve_failure_target,
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
@@ -150,6 +153,13 @@ async def _execute_embedding(
 async def embeddings(request: Request, payload: EmbeddingRequest):
     request_start = perf_counter()
     callback_start = datetime.now(tz=UTC)
+    seed_request_failure_context(
+        request,
+        call_type="embedding",
+        model=payload.model,
+        request_start=request_start,
+        audit_action=AuditAction.EMBEDDING_REQUEST.value,
+    )
     auth = request.state.user_api_key
     ensure_model_allowed(
         auth,
@@ -186,6 +196,10 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
     capture_initial_route_decision(request, request_context)
     api_provider = resolve_provider(primary.deltallm_params)
     request_id = request.headers.get("x-request-id")
+    primary_api_base = str(primary.deltallm_params.get("api_base", request.app.state.settings.openai_base_url)).rstrip("/")
+
+    def track_attempt(deployment):  # noqa: ANN001
+        capture_attempted_deployment(request, deployment)
 
     try:
         data, served_deployment = await request.app.state.failover_manager.execute_with_failover(
@@ -193,6 +207,7 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
             model_group=model_group,
             execute=lambda dep: _execute_embedding(request, payload, dep),
             return_deployment=True,
+            on_attempt=track_attempt,
             **failover_kwargs,
         )
         update_served_route_decision(
@@ -334,19 +349,24 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
         )
         return JSONResponse(status_code=200, content=data, headers=route_decision_headers(request))
     except httpx.HTTPError as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
         increment_request(
-            model=payload.model, api_provider=api_provider,
+            model=payload.model, api_provider=failure_provider,
             api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code,
         )
-        increment_request_failure(model=payload.model, api_provider=api_provider, error_type=exc.__class__.__name__)
-        observe_request_latency(model=payload.model, api_provider=api_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
+        increment_request_failure(model=payload.model, api_provider=failure_provider, error_type=exc.__class__.__name__)
+        observe_request_latency(model=payload.model, api_provider=failure_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
         callback_payload = build_standard_logging_payload(
             call_type="embedding", request_id=request_id, model=payload.model,
-            deployment_model=None, request_payload=request_data, response_obj=None,
+            deployment_model=failure_deployment_model, request_payload=request_data, response_obj=None,
             user_api_key_dict=auth.model_dump(mode="json"), start_time=callback_start, end_time=datetime.now(tz=UTC),
-            api_base=None,
+            api_base=failure_api_base,
             error_info={"error_type": exc.__class__.__name__, "message": str(exc)},
             turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
         )
@@ -358,11 +378,31 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
         error_route_meta = route_decision_metadata(request)
         error_metadata: dict[str, Any] = {
             "route": request.url.path,
-            "provider": api_provider,
-            "deployment_model": primary.deltallm_params.get("model"),
+            "api_base": failure_api_base,
+            "provider": failure_provider,
+            "deployment_model": failure_deployment_model,
         }
         if error_route_meta is not None:
             error_metadata["routing_decision"] = error_route_meta
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=payload.model,
+                call_type="embedding",
+                metadata=error_metadata,
+                cache_hit=bool(getattr(request.state, "cache_hit", False)),
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         _emit_embedding_audit_event(
             request=request,
             auth=auth,
@@ -376,12 +416,18 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
         )
         raise InvalidRequestError(message=f"Embedding request failed: {exc}") from exc
     except Exception as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        status_code = int(getattr(exc, "status_code", 500) or 500)
         callback_payload = build_standard_logging_payload(
             call_type="embedding", request_id=request_id, model=payload.model,
-            deployment_model=None, request_payload=request_data, response_obj=None,
+            deployment_model=failure_deployment_model, request_payload=request_data, response_obj=None,
             user_api_key_dict=auth.model_dump(mode="json"), start_time=callback_start, end_time=datetime.now(tz=UTC),
-            api_base=None,
+            api_base=failure_api_base,
             error_info={"error_type": exc.__class__.__name__, "message": str(exc)},
             turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
         )
@@ -393,11 +439,31 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
         error_route_meta = route_decision_metadata(request)
         error_metadata: dict[str, Any] = {
             "route": request.url.path,
-            "provider": api_provider,
-            "deployment_model": primary.deltallm_params.get("model"),
+            "api_base": failure_api_base,
+            "provider": failure_provider,
+            "deployment_model": failure_deployment_model,
         }
         if error_route_meta is not None:
             error_metadata["routing_decision"] = error_route_meta
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=payload.model,
+                call_type="embedding",
+                metadata=error_metadata,
+                cache_hit=bool(getattr(request.state, "cache_hit", False)),
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         _emit_embedding_audit_event(
             request=request,
             auth=auth,

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -28,13 +28,16 @@ from src.providers.resolution import (
 )
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
+from src.telemetry.request_failures import enqueue_request_log_write, seed_request_failure_context
 from src.audit.actions import AuditAction
 from src.routers.audit_helpers import emit_audit_event
 from src.routers.routing_decision import (
     attach_route_decision,
+    capture_attempted_deployment,
     capture_initial_route_decision,
     route_failover_kwargs,
     route_decision_headers,
+    resolve_failure_target,
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
@@ -95,6 +98,13 @@ async def _execute_image_generation(
 async def image_generations(request: Request, payload: ImageGenerationRequest):
     request_start = perf_counter()
     callback_start = datetime.now(tz=UTC)
+    seed_request_failure_context(
+        request,
+        call_type="image_generation",
+        model=payload.model,
+        request_start=request_start,
+        audit_action=AuditAction.IMAGE_GENERATION_REQUEST,
+    )
     auth = request.state.user_api_key
     ensure_model_allowed(
         auth,
@@ -119,6 +129,10 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
     capture_initial_route_decision(request, request_context)
     api_provider = resolve_provider(primary.deltallm_params)
     request_id = request.headers.get("x-request-id")
+    primary_api_base = str(primary.deltallm_params.get("api_base", request.app.state.settings.openai_base_url)).rstrip("/")
+
+    def track_attempt(deployment):  # noqa: ANN001
+        capture_attempted_deployment(request, deployment)
 
     try:
         data, served_deployment = await request.app.state.failover_manager.execute_with_failover(
@@ -126,6 +140,7 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
             model_group=model_group,
             execute=lambda dep: _execute_image_generation(request, payload, dep),
             return_deployment=True,
+            on_attempt=track_attempt,
             **failover_kwargs,
         )
         update_served_route_decision(
@@ -212,11 +227,43 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
         )
         return JSONResponse(status_code=200, content=data, headers=route_decision_headers(request))
     except httpx.HTTPError as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
-        increment_request(model=payload.model, api_provider=api_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
-        increment_request_failure(model=payload.model, api_provider=api_provider, error_type=exc.__class__.__name__)
-        observe_request_latency(model=payload.model, api_provider=api_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
+        increment_request(model=payload.model, api_provider=failure_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
+        increment_request_failure(model=payload.model, api_provider=failure_provider, error_type=exc.__class__.__name__)
+        observe_request_latency(model=payload.model, api_provider=failure_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=payload.model,
+                call_type="image_generation",
+                metadata=attach_route_decision(
+                    {
+                        "route": request.url.path,
+                        "provider": failure_provider,
+                        "api_base": failure_api_base,
+                        "deployment_model": failure_deployment_model,
+                    },
+                    request,
+                ),
+                cache_hit=False,
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         emit_audit_event(
             request=request,
             request_start=request_start,
@@ -230,11 +277,52 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
             resource_id=payload.model,
             request_payload=request_data,
             error=exc,
-            metadata=attach_route_decision({"route": request.url.path, "provider": api_provider}, request),
+            metadata=attach_route_decision(
+                {
+                    "route": request.url.path,
+                    "provider": failure_provider,
+                    "api_base": failure_api_base,
+                    "deployment_model": failure_deployment_model,
+                },
+                request,
+            ),
         )
         raise InvalidRequestError(message=f"Image generation request failed: {exc}") from exc
     except Exception as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        status_code = int(getattr(exc, "status_code", 500) or 500)
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=payload.model,
+                call_type="image_generation",
+                metadata=attach_route_decision(
+                    {
+                        "route": request.url.path,
+                        "provider": failure_provider,
+                        "api_base": failure_api_base,
+                        "deployment_model": failure_deployment_model,
+                    },
+                    request,
+                ),
+                cache_hit=False,
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         emit_audit_event(
             request=request,
             request_start=request_start,
@@ -248,6 +336,14 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
             resource_id=payload.model,
             request_payload=request_data,
             error=exc,
-            metadata=attach_route_decision({"route": request.url.path, "provider": api_provider}, request),
+            metadata=attach_route_decision(
+                {
+                    "route": request.url.path,
+                    "provider": failure_provider,
+                    "api_base": failure_api_base,
+                    "deployment_model": failure_deployment_model,
+                },
+                request,
+            ),
         )
         raise

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -25,12 +25,15 @@ from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
+from src.telemetry.request_failures import enqueue_request_log_write, seed_request_failure_context
 from src.routers.audit_helpers import emit_audit_event
 from src.routers.routing_decision import (
     attach_route_decision,
+    capture_attempted_deployment,
     capture_initial_route_decision,
     route_failover_kwargs,
     route_decision_headers,
+    resolve_failure_target,
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
@@ -85,6 +88,13 @@ async def _execute_rerank(
 async def rerank(request: Request, payload: RerankRequest):
     request_start = perf_counter()
     callback_start = datetime.now(tz=UTC)
+    seed_request_failure_context(
+        request,
+        call_type="rerank",
+        model=payload.model,
+        request_start=request_start,
+        audit_action=AuditAction.RERANK_REQUEST,
+    )
     auth = request.state.user_api_key
     ensure_model_allowed(
         auth,
@@ -109,6 +119,10 @@ async def rerank(request: Request, payload: RerankRequest):
     capture_initial_route_decision(request, request_context)
     api_provider = resolve_provider(primary.deltallm_params)
     request_id = request.headers.get("x-request-id")
+    primary_api_base = str(primary.deltallm_params.get("api_base", request.app.state.settings.openai_base_url)).rstrip("/")
+
+    def track_attempt(deployment):  # noqa: ANN001
+        capture_attempted_deployment(request, deployment)
 
     try:
         data, served_deployment = await request.app.state.failover_manager.execute_with_failover(
@@ -116,6 +130,7 @@ async def rerank(request: Request, payload: RerankRequest):
             model_group=model_group,
             execute=lambda dep: _execute_rerank(request, payload, dep),
             return_deployment=True,
+            on_attempt=track_attempt,
             **failover_kwargs,
         )
         update_served_route_decision(
@@ -204,11 +219,44 @@ async def rerank(request: Request, payload: RerankRequest):
         )
         return JSONResponse(status_code=200, content=data, headers=route_decision_headers(request))
     except httpx.HTTPError as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
-        increment_request(model=payload.model, api_provider=api_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
-        increment_request_failure(model=payload.model, api_provider=api_provider, error_type=exc.__class__.__name__)
-        observe_request_latency(model=payload.model, api_provider=api_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
+        increment_request(model=payload.model, api_provider=failure_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
+        increment_request_failure(model=payload.model, api_provider=failure_provider, error_type=exc.__class__.__name__)
+        observe_request_latency(model=payload.model, api_provider=failure_provider, status_code=status_code, latency_seconds=perf_counter() - request_start)
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=payload.model,
+                call_type="rerank",
+                metadata=attach_route_decision(
+                    {
+                        "route": request.url.path,
+                        "provider": failure_provider,
+                        "api_base": failure_api_base,
+                        "deployment_model": failure_deployment_model,
+                        "document_count": len(payload.documents),
+                    },
+                    request,
+                ),
+                cache_hit=False,
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         emit_audit_event(
             request=request,
             request_start=request_start,
@@ -223,13 +271,53 @@ async def rerank(request: Request, payload: RerankRequest):
             request_payload=request_data,
             error=exc,
             metadata=attach_route_decision(
-                {"route": request.url.path, "provider": api_provider, "document_count": len(payload.documents)},
+                {
+                    "route": request.url.path,
+                    "provider": failure_provider,
+                    "api_base": failure_api_base,
+                    "deployment_model": failure_deployment_model,
+                    "document_count": len(payload.documents),
+                },
                 request,
             ),
         )
         raise InvalidRequestError(message=f"Rerank request failed: {exc}") from exc
     except Exception as exc:
-        await request.app.state.passive_health_tracker.record_request_outcome(primary.deployment_id, success=False, error=str(exc))
+        failure_target = resolve_failure_target(request, fallback_deployment=primary)
+        failure_deployment_id = str(failure_target.deployment_id or primary.deployment_id)
+        failure_provider = str(failure_target.provider or api_provider)
+        failure_api_base = failure_target.api_base or primary_api_base
+        failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
+        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        status_code = int(getattr(exc, "status_code", 500) or 500)
+        enqueue_request_log_write(
+            request,
+            request.app.state.spend_tracking_service.log_request_failure(
+                request_id=request_id or "",
+                api_key=auth.api_key,
+                user_id=auth.user_id,
+                team_id=auth.team_id,
+                organization_id=getattr(auth, "organization_id", None),
+                end_user_id=None,
+                model=payload.model,
+                call_type="rerank",
+                metadata=attach_route_decision(
+                    {
+                        "route": request.url.path,
+                        "provider": failure_provider,
+                        "api_base": failure_api_base,
+                        "deployment_model": failure_deployment_model,
+                        "document_count": len(payload.documents),
+                    },
+                    request,
+                ),
+                cache_hit=False,
+                start_time=callback_start,
+                end_time=datetime.now(tz=UTC),
+                http_status_code=status_code,
+                exc=exc,
+            )
+        )
         emit_audit_event(
             request=request,
             request_start=request_start,
@@ -244,7 +332,13 @@ async def rerank(request: Request, payload: RerankRequest):
             request_payload=request_data,
             error=exc,
             metadata=attach_route_decision(
-                {"route": request.url.path, "provider": api_provider, "document_count": len(payload.documents)},
+                {
+                    "route": request.url.path,
+                    "provider": failure_provider,
+                    "api_base": failure_api_base,
+                    "deployment_model": failure_deployment_model,
+                    "document_count": len(payload.documents),
+                },
                 request,
             ),
         )

--- a/src/routers/routing_decision.py
+++ b/src/routers/routing_decision.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any
 
 from fastapi import Request
+
+from src.providers.resolution import resolve_provider
+
+_FAILURE_TARGET_ATTR = "_failure_target"
+
+
+@dataclass(frozen=True, slots=True)
+class FailureTarget:
+    deployment_id: str | None = None
+    provider: str | None = None
+    api_base: str | None = None
+    deployment_model: str | None = None
 
 
 def _refresh_request_resolution(request: Request) -> dict[str, Any] | None:
@@ -16,6 +29,54 @@ def _refresh_request_resolution(request: Request) -> dict[str, Any] | None:
         resolution["prompt"] = deepcopy(prompt)
     request.state.request_resolution = deepcopy(resolution) if resolution else None
     return deepcopy(resolution) if resolution else None
+
+
+def _build_failure_target(request: Request, deployment: Any) -> FailureTarget:
+    if deployment is None:
+        return FailureTarget()
+
+    deployment_id = getattr(deployment, "deployment_id", None)
+    params = getattr(deployment, "deltallm_params", None)
+    if not isinstance(params, dict):
+        return FailureTarget(deployment_id=deployment_id)
+
+    provider: str | None = None
+    try:
+        provider = resolve_provider(params)
+    except Exception:
+        raw_provider = str(params.get("provider") or "").strip()
+        provider = raw_provider or None
+
+    default_api_base = getattr(getattr(request.app.state, "settings", None), "openai_base_url", None)
+    raw_api_base = params.get("api_base", default_api_base)
+    api_base = str(raw_api_base).rstrip("/") if raw_api_base else None
+    deployment_model = params.get("model")
+
+    return FailureTarget(
+        deployment_id=deployment_id,
+        provider=provider,
+        api_base=api_base,
+        deployment_model=str(deployment_model) if deployment_model is not None else None,
+    )
+
+
+def capture_attempted_deployment(request: Request, deployment: Any) -> FailureTarget:
+    target = _build_failure_target(request, deployment)
+    setattr(request.state, _FAILURE_TARGET_ATTR, target)
+    return target
+
+
+def resolve_failure_target(
+    request: Request,
+    *,
+    fallback_deployment: Any | None = None,
+) -> FailureTarget:
+    target = getattr(request.state, _FAILURE_TARGET_ATTR, None)
+    if isinstance(target, FailureTarget):
+        return target
+    if fallback_deployment is not None:
+        return _build_failure_target(request, fallback_deployment)
+    return FailureTarget()
 
 
 def capture_initial_route_decision(request: Request, request_context: dict[str, Any]) -> dict[str, Any] | None:

--- a/src/routers/spend.py
+++ b/src/routers/spend.py
@@ -169,7 +169,10 @@ async def get_spend_logs(
             {source.user_column} AS "user",
             team_id,
             cache_hit,
-            request_tags
+            request_tags,
+            status,
+            http_status_code,
+            error_type
         FROM {source.table}
         {where_sql}
         ORDER BY start_time DESC

--- a/src/telemetry/request_failures.py
+++ b/src/telemetry/request_failures.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Request
+from fastapi.exceptions import RequestValidationError
+
+from src.audit.actions import AuditAction
+from src.models.errors import ApprovalRequiredError, BudgetExceededError, PermissionDeniedError, ProxyError
+from src.routers.audit_helpers import emit_audit_event
+from src.routers.utils import fire_and_forget
+
+_REQUEST_LOG_EMITTED_ATTR = "_request_log_emitted"
+_REQUEST_FAILURE_CONTEXT_ATTR = "_request_failure_context"
+
+
+@dataclass(slots=True)
+class RequestFailureContext:
+    call_type: str
+    model: str | None = None
+    request_start: float | None = None
+    audit_action: str | AuditAction | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _GatewayRouteDefinition:
+    call_type: str
+    audit_action: str | AuditAction | None = None
+
+
+_GATEWAY_ROUTE_DEFINITIONS: dict[str, _GatewayRouteDefinition] = {
+    "/v1/chat/completions": _GatewayRouteDefinition(call_type="completion", audit_action="CHAT_COMPLETION_REQUEST"),
+    "/v1/completions": _GatewayRouteDefinition(call_type="completion", audit_action="COMPLETION_REQUEST"),
+    "/v1/responses": _GatewayRouteDefinition(call_type="completion", audit_action="RESPONSES_REQUEST"),
+    "/v1/embeddings": _GatewayRouteDefinition(call_type="embedding", audit_action=AuditAction.EMBEDDING_REQUEST),
+    "/v1/images/generations": _GatewayRouteDefinition(call_type="image_generation", audit_action=AuditAction.IMAGE_GENERATION_REQUEST),
+    "/v1/audio/speech": _GatewayRouteDefinition(call_type="audio_speech", audit_action=AuditAction.AUDIO_SPEECH_REQUEST),
+    "/v1/audio/transcriptions": _GatewayRouteDefinition(call_type="audio_transcription", audit_action=AuditAction.AUDIO_TRANSCRIPTION_REQUEST),
+    "/v1/rerank": _GatewayRouteDefinition(call_type="rerank", audit_action=AuditAction.RERANK_REQUEST),
+}
+
+
+def seed_request_failure_context(
+    request: Request,
+    *,
+    call_type: str,
+    model: str | None = None,
+    request_start: float | None = None,
+    audit_action: str | AuditAction | None = None,
+) -> None:
+    setattr(
+        request.state,
+        _REQUEST_FAILURE_CONTEXT_ATTR,
+        RequestFailureContext(
+            call_type=call_type,
+            model=model,
+            request_start=request_start,
+            audit_action=audit_action,
+        ),
+    )
+
+
+def mark_request_log_emitted(request: Request) -> None:
+    setattr(request.state, _REQUEST_LOG_EMITTED_ATTR, True)
+
+
+def enqueue_request_log_write(request: Request, coro: Any) -> None:
+    mark_request_log_emitted(request)
+    fire_and_forget(coro)
+
+
+def maybe_log_proxy_error(request: Request, exc: ProxyError) -> None:
+    if _request_log_already_emitted(request):
+        return
+    route = _route_definition(request)
+    auth = getattr(request.state, "user_api_key", None)
+    spend_tracking_service = getattr(request.app.state, "spend_tracking_service", None)
+    if route is None or auth is None or spend_tracking_service is None:
+        return
+
+    context = _request_failure_context(request)
+    metadata = {
+        "route": request.url.path,
+        "request_method": request.method,
+        "failure_stage": "preflight",
+    }
+    enqueue_request_log_write(
+        request,
+        spend_tracking_service.log_request_failure(
+            request_id=request.headers.get("x-request-id") or "",
+            api_key=getattr(auth, "api_key", None) or "anonymous",
+            user_id=getattr(auth, "user_id", None),
+            team_id=getattr(auth, "team_id", None),
+            organization_id=getattr(auth, "organization_id", None),
+            end_user_id=None,
+            model=(context.model if context is not None and context.model else None) or "(unknown)",
+            call_type=(context.call_type if context is not None else route.call_type),
+            metadata=metadata,
+            cache_hit=False,
+            http_status_code=int(getattr(exc, "status_code", 500) or 500),
+            exc=exc,
+        ),
+    )
+
+    if not _should_emit_preflight_audit(exc):
+        return
+    if context is None or context.request_start is None:
+        return
+    emit_audit_event(
+        request=request,
+        request_start=context.request_start,
+        action=context.audit_action or route.audit_action or "GATEWAY_REQUEST",
+        status="error",
+        actor_type="api_key",
+        actor_id=getattr(auth, "user_id", None) or getattr(auth, "api_key", None),
+        organization_id=getattr(auth, "organization_id", None),
+        api_key=getattr(auth, "api_key", None),
+        resource_type="model",
+        resource_id=context.model,
+        error=exc,
+        metadata=metadata,
+    )
+
+
+async def maybe_log_request_validation_failure(request: Request, exc: RequestValidationError) -> None:
+    if _request_log_already_emitted(request):
+        return
+    route = _route_definition(request)
+    spend_tracking_service = getattr(request.app.state, "spend_tracking_service", None)
+    if route is None or spend_tracking_service is None:
+        return
+
+    auth = await _resolve_request_auth(request)
+    if auth is None:
+        return
+
+    context = _request_failure_context(request)
+    errors = exc.errors()
+    first_error_type = _first_validation_error_type(errors)
+    metadata = {
+        "route": request.url.path,
+        "request_method": request.method,
+        "failure_stage": "request_validation",
+        "content_type": request.headers.get("content-type"),
+        "error": {
+            "code": first_error_type,
+            "message": "Request validation failed",
+        },
+        "validation": _validation_metadata(errors),
+    }
+    enqueue_request_log_write(
+        request,
+        spend_tracking_service.log_request_failure(
+            request_id=request.headers.get("x-request-id") or "",
+            api_key=getattr(auth, "api_key", None) or "anonymous",
+            user_id=getattr(auth, "user_id", None),
+            team_id=getattr(auth, "team_id", None),
+            organization_id=getattr(auth, "organization_id", None),
+            end_user_id=None,
+            model=(context.model if context is not None and context.model else None) or "(unknown)",
+            call_type=(context.call_type if context is not None else route.call_type),
+            metadata=metadata,
+            cache_hit=False,
+            http_status_code=422,
+            exc=None,
+            error_type="request_validation_error",
+        ),
+    )
+
+
+def _request_log_already_emitted(request: Request) -> bool:
+    return bool(getattr(request.state, _REQUEST_LOG_EMITTED_ATTR, False))
+
+
+async def _resolve_request_auth(request: Request) -> Any | None:
+    auth = getattr(request.state, "user_api_key", None)
+    if auth is not None:
+        return auth
+
+    authorization = request.headers.get("authorization")
+    if not authorization:
+        return None
+
+    try:
+        from src.middleware.auth import authenticate_request
+
+        return await authenticate_request(request, authorization=authorization)
+    except Exception:
+        return None
+
+
+def _request_failure_context(request: Request) -> RequestFailureContext | None:
+    context = getattr(request.state, _REQUEST_FAILURE_CONTEXT_ATTR, None)
+    if isinstance(context, RequestFailureContext):
+        return context
+    return None
+
+
+def _route_definition(request: Request) -> _GatewayRouteDefinition | None:
+    return _GATEWAY_ROUTE_DEFINITIONS.get(request.url.path)
+
+
+def _should_emit_preflight_audit(exc: ProxyError) -> bool:
+    return isinstance(exc, (ApprovalRequiredError, BudgetExceededError, PermissionDeniedError))
+
+
+def _first_validation_error_type(errors: list[dict[str, Any]]) -> str:
+    for error in errors:
+        value = str(error.get("type") or "").strip()
+        if value:
+            return value
+    return "validation_error"
+
+
+def _validation_metadata(errors: list[dict[str, Any]]) -> dict[str, Any]:
+    summarized: list[dict[str, Any]] = []
+    for error in errors[:5]:
+        summarized.append(
+            {
+                "type": str(error.get("type") or "validation_error"),
+                "loc": [str(item) for item in error.get("loc") or []],
+                "msg": str(error.get("msg") or ""),
+            }
+        )
+    return {
+        "error_count": len(errors),
+        "errors": summarized,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,9 @@ class NoopSpendTrackingService:
     async def log_spend(self, **kwargs):
         return None
 
+    async def log_request_failure(self, **kwargs):
+        return None
+
 
 class FakeRedis:
     def __init__(self) -> None:

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -16,7 +16,10 @@ class _SpendRecorder:
         self.events: list[dict] = []
 
     async def log_spend(self, **kwargs):
-        self.events.append(kwargs)
+        self.events.append({"status": "success", **kwargs})
+
+    async def log_request_failure(self, **kwargs):
+        self.events.append({"status": "error", "cost": 0.0, **kwargs})
 
 
 class _FakeRepository:

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -116,7 +116,11 @@ class SpendQueryDB:
                     "end_time": "2026-02-13T00:00:01+00:00",
                     "user": "u1",
                     "team_id": "t1",
+                    "metadata": {"error": {"message": "upstream unavailable"}},
                     "cache_hit": False,
+                    "status": "error",
+                    "http_status_code": 503,
+                    "error_type": "HTTPStatusError",
                     "request_tags": ["tag-a"],
                 }
             ]
@@ -257,6 +261,37 @@ async def test_spend_tracking_persists_cached_token_counts():
 
 
 @pytest.mark.asyncio
+async def test_request_failure_logging_writes_error_event_without_ledger_updates():
+    db = RecordingDB()
+    service = SpendTrackingService(db_client=db)
+
+    await service.log_request_failure(
+        request_id="req_failure",
+        api_key="key_hash",
+        user_id="user_1",
+        team_id="team_1",
+        organization_id="org_1",
+        end_user_id=None,
+        model="gpt-4o-mini",
+        call_type="completion",
+        metadata={"api_base": "https://api.openai.com/v1"},
+        http_status_code=503,
+        exc=RuntimeError("upstream unavailable"),
+    )
+
+    event_call = next(args for query, args in db.calls if "insert into deltallm_spendlog_events" in query.lower())
+    assert event_call[12] == 0.0
+    assert event_call[16] == 0
+    assert event_call[38] == "error"
+    assert event_call[39] == 503
+    assert event_call[40] == "RuntimeError"
+    assert not any("update deltallm_verificationtoken" in q.lower() for q, _ in db.calls)
+    assert not any("update deltallm_usertable" in q.lower() for q, _ in db.calls)
+    assert not any("update deltallm_teamtable" in q.lower() for q, _ in db.calls)
+    assert not any("update deltallm_organizationtable" in q.lower() for q, _ in db.calls)
+
+
+@pytest.mark.asyncio
 async def test_budget_enforcement_raises_when_hard_budget_exceeded():
     service = BudgetEnforcementService(db_client=BudgetDB())
 
@@ -342,6 +377,9 @@ async def test_spend_logs_endpoint_returns_paginated_data(client, test_app):
     payload = response.json()
     assert payload["pagination"]["total"] == 1
     assert payload["logs"][0]["request_id"] == "req_1"
+    assert payload["logs"][0]["status"] == "error"
+    assert payload["logs"][0]["http_status_code"] == 503
+    assert payload["logs"][0]["error_type"] == "HTTPStatusError"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -18,7 +18,10 @@ class _SpendRecorder:
         self.events: list[dict] = []
 
     async def log_spend(self, **kwargs):
-        self.events.append(kwargs)
+        self.events.append({"status": "success", **kwargs})
+
+    async def log_request_failure(self, **kwargs):
+        self.events.append({"status": "error", "cost": 0.0, **kwargs})
 
 
 def _enable_cache(test_app):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -58,6 +58,21 @@ class _RecordingAuditService:
         self.records.append((event, list(payloads or []), critical))
 
 
+class _SpendRecorder:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def log_spend(self, **kwargs):
+        self.events.append({"status": "success", **kwargs})
+
+    async def log_request_failure(self, **kwargs):
+        error_type = kwargs.get("error_type")
+        if error_type is None:
+            exc = kwargs.get("exc")
+            error_type = getattr(exc, "error_type", None) or (exc.__class__.__name__ if exc is not None else None)
+        self.events.append({"status": "error", "cost": 0.0, "error_type": error_type, **kwargs})
+
+
 class _ExplodingMCPGateway:
     async def list_visible_tools(self, auth):  # noqa: ANN001, ANN201
         del auth
@@ -610,9 +625,10 @@ async def test_chat_completion_runs_failure_callback(client, test_app):
 
 
 class _StreamContext:
-    def __init__(self, status_code: int, lines: list[str]) -> None:
+    def __init__(self, status_code: int, lines: list[str], *, line_error: Exception | None = None) -> None:
         self.status_code = status_code
         self._lines = lines
+        self._line_error = line_error
 
     async def __aenter__(self):
         return self
@@ -623,6 +639,8 @@ class _StreamContext:
     async def aiter_lines(self):
         for line in self._lines:
             yield line
+        if self._line_error is not None:
+            raise self._line_error
 
 
 @pytest.mark.asyncio
@@ -667,6 +685,67 @@ async def test_stream_retries_before_first_token_with_failover(client, test_app)
     assert response.status_code == 200
     assert "data: [DONE]" in response.text
     assert calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_failure_after_failover_uses_last_attempted_deployment(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+
+    registry = test_app.state.router.deployment_registry["gpt-4o-mini"]
+    registry[0].deltallm_params["api_base"] = "https://primary.example/v1"
+    registry[0].deltallm_params["api_key"] = "provider-key"
+    fallback = type(registry[0])(
+        deployment_id="gpt-4o-mini-fallback",
+        model_name="gpt-4o-mini",
+        deltallm_params={
+            "model": "openai/gpt-4o-mini",
+            "api_key": "provider-key-fallback",
+            "api_base": "https://fallback.example/v1",
+        },
+        model_info={},
+    )
+    registry.append(fallback)
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del request_context
+        return test_app.state.router.deployment_registry[model_group][0]
+
+    test_app.state.router.select_deployment = choose_primary
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
+        del method, url, json, timeout
+        auth = headers.get("Authorization", "")
+        if auth.endswith("provider-key"):
+            return _StreamContext(status_code=503, lines=[])
+        return _StreamContext(
+            status_code=200,
+            lines=[
+                'data: {"id":"chatcmpl-fb","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}',
+            ],
+            line_error=httpx.ReadError("fallback stream broke"),
+        )
+
+    test_app.state.http_client.stream = stream
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-stream-fallback-failure"}
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": True}
+
+    with pytest.raises(httpx.ReadError, match="fallback stream broke"):
+        await client.post("/v1/chat/completions", headers=headers, json=body)
+
+    await asyncio.sleep(0.05)
+    assert len(test_app.state.spend_tracking_service.events) == 1
+    last = test_app.state.spend_tracking_service.events[-1]
+    metadata = last.get("metadata") or {}
+    assert last["status"] == "error"
+    assert last["call_type"] == "completion"
+    assert last["error_type"] == "ReadError"
+    assert metadata.get("api_base") == "https://fallback.example/v1"
+    assert metadata.get("deployment_model") == "openai/gpt-4o-mini"
+
+    primary_health = await test_app.state.router_state_backend.get_health(registry[0].deployment_id)
+    fallback_health = await test_app.state.router_state_backend.get_health("gpt-4o-mini-fallback")
+    assert primary_health.get("last_error") == "Provider error: 503"
+    assert fallback_health.get("last_error") == "fallback stream broke"
 
 
 @pytest.mark.asyncio

--- a/tests/test_prompt_preflight.py
+++ b/tests/test_prompt_preflight.py
@@ -31,7 +31,10 @@ class _SpendRecorder:
         self.events: list[dict[str, object]] = []
 
     async def log_spend(self, **kwargs):  # noqa: ANN003, ANN201
-        self.events.append(kwargs)
+        self.events.append({"status": "success", **kwargs})
+
+    async def log_request_failure(self, **kwargs):  # noqa: ANN003, ANN201
+        self.events.append({"status": "error", "cost": 0.0, **kwargs})
 
 
 class _PromptRepoForDefaults:

--- a/tests/test_ui_rbac_scoping.py
+++ b/tests/test_ui_rbac_scoping.py
@@ -121,6 +121,9 @@ async def test_spend_logs_use_normalized_event_columns(client, test_app, monkeyp
     assert "FROM deltallm_spendlog_events" in logs_query[0]
     assert "input_tokens AS prompt_tokens" in logs_query[0]
     assert 'user_id AS "user"' in logs_query[0]
+    assert "status" in logs_query[0]
+    assert "http_status_code" in logs_query[0]
+    assert "error_type" in logs_query[0]
     assert "FROM deltallm_spendlog_events" in count_query[0]
 
 

--- a/tests/test_uniformity_hardening.py
+++ b/tests/test_uniformity_hardening.py
@@ -22,7 +22,22 @@ class _SpendRecorder:
         self.events: list[dict] = []
 
     async def log_spend(self, **kwargs):
-        self.events.append(kwargs)
+        self.events.append({"status": "success", **kwargs})
+
+    async def log_request_failure(self, **kwargs):
+        error_type = kwargs.get("error_type")
+        if error_type is None:
+            exc = kwargs.get("exc")
+            error_type = getattr(exc, "error_type", None) or (exc.__class__.__name__ if exc is not None else None)
+        self.events.append({"status": "error", "cost": 0.0, "error_type": error_type, **kwargs})
+
+
+class _RecordingAuditService:
+    def __init__(self) -> None:
+        self.events: list[tuple[object, list[object], bool]] = []
+
+    def record_event(self, event, *, payloads=None, critical=False):  # noqa: ANN001, ANN201
+        self.events.append((event, list(payloads or []), critical))
 
 
 @pytest.mark.asyncio
@@ -139,6 +154,194 @@ async def test_explicit_provider_keeps_spend_logging_intact(client, test_app, pa
     assert last.get("model") == body["model"]
     assert (last.get("metadata") or {}).get("api_base") == "https://openrouter.ai/api/v1"
     assert "cost" in last
+
+
+@pytest.mark.asyncio
+async def test_chat_failure_writes_error_request_log(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+
+    async def failing_post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        return httpx.Response(503, json={"error": "upstream unavailable"}, request=httpx.Request("POST", url))
+
+    test_app.state.http_client.post = failing_post
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-chat-error"},
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False},
+    )
+    assert response.status_code == 503
+
+    await asyncio.sleep(0.05)
+    assert len(test_app.state.spend_tracking_service.events) == 1
+    last = test_app.state.spend_tracking_service.events[-1]
+    assert last["status"] == "error"
+    assert last["call_type"] == "completion"
+    assert last["cost"] == 0.0
+    assert last["http_status_code"] == 503
+    assert (last.get("metadata") or {}).get("route") == "/v1/chat/completions"
+
+
+@pytest.mark.asyncio
+async def test_embedding_failure_writes_error_request_log(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+
+    async def failing_post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        return httpx.Response(503, json={"error": "upstream unavailable"}, request=httpx.Request("POST", url))
+
+    test_app.state.http_client.post = failing_post
+
+    response = await client.post(
+        "/v1/embeddings",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-embedding-error"},
+        json={"model": "text-embedding-3-small", "input": "hello"},
+    )
+    assert response.status_code == 503
+
+    await asyncio.sleep(0.05)
+    assert len(test_app.state.spend_tracking_service.events) == 1
+    last = test_app.state.spend_tracking_service.events[-1]
+    assert last["status"] == "error"
+    assert last["call_type"] == "embedding"
+    assert last["cost"] == 0.0
+    assert last["http_status_code"] == 503
+    assert (last.get("metadata") or {}).get("route") == "/v1/embeddings"
+
+
+@pytest.mark.asyncio
+async def test_embedding_failover_failure_uses_last_attempted_deployment_metadata(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    audit = _RecordingAuditService()
+    test_app.state.audit_service = audit
+
+    registry = test_app.state.router.deployment_registry["text-embedding-3-small"]
+    registry[0].deltallm_params["api_base"] = "https://primary.example/v1"
+    registry[0].deltallm_params["api_key"] = "primary-key"
+    fallback = type(registry[0])(
+        deployment_id="text-embedding-3-small-fallback",
+        model_name="text-embedding-3-small",
+        deltallm_params={
+            "model": "openai/text-embedding-3-small",
+            "api_key": "fallback-key",
+            "api_base": "https://fallback.example/v1",
+        },
+        model_info={},
+    )
+    registry.append(fallback)
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del request_context
+        return test_app.state.router.deployment_registry[model_group][0]
+
+    test_app.state.router.select_deployment = choose_primary
+
+    async def failing_post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del json, timeout
+        request = httpx.Request("POST", url)
+        if headers.get("Authorization") == "Bearer primary-key":
+            return httpx.Response(503, json={"error": "primary unavailable"}, request=request)
+        return httpx.Response(502, json={"error": "fallback unavailable"}, request=request)
+
+    test_app.state.http_client.post = failing_post
+
+    response = await client.post(
+        "/v1/embeddings",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-embedding-failover-failure"},
+        json={"model": "text-embedding-3-small", "input": "hello"},
+    )
+    assert response.status_code == 503
+
+    await asyncio.sleep(0.05)
+    assert len(test_app.state.spend_tracking_service.events) == 1
+    last = test_app.state.spend_tracking_service.events[-1]
+    metadata = last.get("metadata") or {}
+    assert last["status"] == "error"
+    assert metadata.get("api_base") == "https://fallback.example/v1"
+    assert metadata.get("provider") == "openai"
+    assert metadata.get("deployment_model") == "openai/text-embedding-3-small"
+
+    assert len(audit.events) == 1
+    event, payloads, critical = audit.events[0]
+    assert event.status == "error"
+    assert event.metadata["api_base"] == "https://fallback.example/v1"
+    assert event.metadata["deployment_model"] == "openai/text-embedding-3-small"
+    assert critical is True
+    assert payloads
+
+    primary_health = await test_app.state.router_state_backend.get_health(registry[0].deployment_id)
+    fallback_health = await test_app.state.router_state_backend.get_health(fallback.deployment_id)
+    assert primary_health.get("last_error") == "Upstream embedding call failed with status 503"
+    assert fallback_health.get("last_error") == "Upstream embedding call failed with status 502"
+
+
+@pytest.mark.asyncio
+async def test_denied_model_preflight_writes_request_log_and_audit_event(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    audit = _RecordingAuditService()
+    test_app.state.audit_service = audit
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-chat-denied"},
+        json={"model": "gpts-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False},
+    )
+    assert response.status_code == 403
+    payload = response.json()["error"]
+    assert payload["type"] == "permission_denied"
+
+    await asyncio.sleep(0.05)
+    assert len(test_app.state.spend_tracking_service.events) == 1
+    last = test_app.state.spend_tracking_service.events[-1]
+    assert last["status"] == "error"
+    assert last["call_type"] == "completion"
+    assert last["model"] == "gpts-4o-mini"
+    assert last["http_status_code"] == 403
+    assert last["error_type"] == "permission_denied"
+    assert (last.get("metadata") or {}).get("failure_stage") == "preflight"
+
+    assert len(audit.events) == 1
+    event, payloads, critical = audit.events[0]
+    assert event.action == "CHAT_COMPLETION_REQUEST"
+    assert event.status == "error"
+    assert event.resource_id == "gpts-4o-mini"
+    assert event.error_type == "PermissionDeniedError"
+    assert critical is True
+    assert payloads == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_writes_request_log_without_audit_event(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    audit = _RecordingAuditService()
+    test_app.state.audit_service = audit
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {test_app.state._test_key}",
+            "Content-Type": "application/json",
+            "x-request-id": "req-chat-json-invalid",
+        },
+        content='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}',
+    )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail[0]["type"] == "json_invalid"
+
+    await asyncio.sleep(0.05)
+    assert len(test_app.state.spend_tracking_service.events) == 1
+    last = test_app.state.spend_tracking_service.events[-1]
+    assert last["status"] == "error"
+    assert last["call_type"] == "completion"
+    assert last["model"] == "(unknown)"
+    assert last["http_status_code"] == 422
+    assert last["error_type"] == "request_validation_error"
+    assert (last.get("metadata") or {}).get("failure_stage") == "request_validation"
+    assert ((last.get("metadata") or {}).get("error") or {}).get("code") == "json_invalid"
+
+    assert audit.events == []
 
 
 @pytest.mark.asyncio

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -115,6 +115,9 @@ export interface SpendLog {
   cache_hit: boolean;
   cache_key?: string | null;
   request_tags?: string[];
+  status?: string | null;
+  http_status_code?: number | null;
+  error_type?: string | null;
 }
 
 export type SpendGroupBy = 'model' | 'organization' | 'team' | 'api_key';

--- a/ui/src/pages/Usage.tsx
+++ b/ui/src/pages/Usage.tsx
@@ -49,6 +49,28 @@ function prettyJson(value: Record<string, unknown> | null | undefined): string {
   return JSON.stringify(value, null, 2);
 }
 
+function logStatus(value: SpendLog): 'success' | 'error' {
+  return value.status === 'error' ? 'error' : 'success';
+}
+
+function errorMessage(value: SpendLog): string {
+  const metadataError = value.metadata?.['error'];
+  const errorValue = metadataError && typeof metadataError === 'object' ? metadataError as Record<string, unknown> : null;
+  const message = typeof errorValue?.['message'] === 'string' ? errorValue['message'] : null;
+  if (message && message.trim()) {
+    return message;
+  }
+  return '—';
+}
+
+function StatusBadge({ status }: { status: 'success' | 'error' }) {
+  const classes =
+    status === 'error'
+      ? 'bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-200'
+      : 'bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200';
+  return <span className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${classes}`}>{status}</span>;
+}
+
 function DetailItem({ label, value, mono = false }: { label: string; value: ReactNode; mono?: boolean }) {
   return (
     <div>
@@ -156,6 +178,7 @@ export default function Usage() {
     { key: 'start_time', header: 'Time', render: (r: SpendLog) => <span className="text-xs text-gray-500 whitespace-nowrap">{fmtDateTime(r.start_time)}</span> },
     { key: 'model', header: 'Model', render: (r: SpendLog) => <span className="font-medium text-xs">{r.model}</span> },
     { key: 'call_type', header: 'Type', render: (r: SpendLog) => <span className="text-xs capitalize">{r.call_type}</span> },
+    { key: 'status', header: 'Status', render: (r: SpendLog) => <StatusBadge status={logStatus(r)} /> },
     { key: 'spend', header: 'Cost', render: (r: SpendLog) => fmt(r.spend) },
     { key: 'prompt_tokens', header: 'Prompt', render: (r: SpendLog) => fmtNum(r.prompt_tokens) },
     { key: 'completion_tokens', header: 'Completion', render: (r: SpendLog) => fmtNum(r.completion_tokens) },
@@ -262,13 +285,16 @@ export default function Usage() {
         </Card>
       )}
 
-      <Modal open={selectedLog !== null} onClose={() => setSelectedLog(null)} title="Spend Log Details" wide>
+      <Modal open={selectedLog !== null} onClose={() => setSelectedLog(null)} title="Request Log Details" wide>
         {selectedLog && (
           <div className="space-y-6">
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               <DetailItem label="Time" value={fmtDateTime(selectedLog.start_time)} />
               <DetailItem label="Model" value={selectedLog.model} />
               <DetailItem label="Type" value={selectedLog.call_type} />
+              <DetailItem label="Status" value={<StatusBadge status={logStatus(selectedLog)} />} />
+              <DetailItem label="HTTP Status" value={selectedLog.http_status_code ?? '—'} />
+              <DetailItem label="Error Type" value={selectedLog.error_type || '—'} />
               <DetailItem label="Cost" value={fmt(selectedLog.spend)} />
               <DetailItem label="Total Tokens" value={fmtNum(selectedLog.total_tokens)} />
               <DetailItem label="Cache" value={selectedLog.cache_hit ? 'Hit' : 'Miss'} />
@@ -282,6 +308,7 @@ export default function Usage() {
               <DetailItem label="API Base" value={selectedLog.api_base || '—'} mono />
               <DetailItem label="Request ID" value={selectedLog.request_id} mono />
               <DetailItem label="API Key" value={selectedLog.api_key} mono />
+              <DetailItem label="Error Message" value={errorMessage(selectedLog)} />
               <DetailItem label="Cache Key" value={selectedLog.cache_key || '—'} mono />
               <DetailItem label="Tags" value={selectedLog.request_tags && selectedLog.request_tags.length > 0 ? selectedLog.request_tags.join(', ') : '—'} />
               <DetailItem label="End Time" value={fmtDateTime(selectedLog.end_time)} />


### PR DESCRIPTION
This PR fixes request-log visibility for failed gateway requests and closes the main observability gaps behind issue #51.

  Before this change, Usage -> Request Logs only showed a partial view of failures:

  - successful routed requests were logged
  - many failed requests were missing entirely
  - streamed failures lost the real upstream error
  - failures after failover could be attributed to the wrong deployment

  This PR makes request logs behave like request-outcome logs instead of success-only spend logs.

  Fixes #51

  ## What changed

  ### 1. Failed requests are now persisted in Request Logs

  The request-log pipeline now writes explicit failure rows into deltallm_spendlog_events, including:

  - status
  - http_status_code
  - error_type
  - zero spend / zero tokens for failures

  This covers routed failures across:

  - chat / completions / responses
  - embeddings
  - image generation
  - audio speech
  - audio transcription
  - rerank

  ### 2. Preflight denials and request validation failures now show up

  Added a shared fallback failure logger in:

  - src/telemetry/request_failures.py

  This fills the gaps for failures that happened before existing route telemetry, including:

  - preflight denials like model not allowed
  - malformed JSON / request validation failures

  Behavior:

  - these now appear in Usage -> Request Logs
  - governance-significant preflight denials also emit Audit Log events
  - malformed JSON is kept out of Audit Logs to avoid noise

  ### 3. Streamed failures now preserve the real exception

  Updated:

  - src/routers/chat.py
  - src/chat/telemetry.py

  Before:

  - stream failures were logged as a synthetic stream interrupted error

  Now:

  - the real exception is preserved
  - request logs, callbacks, guardrail failure hooks, passive health, and audit metadata use the real stream error
  - stream-open failures before the first chunk are also covered

  ### 4. Post-failover failures are now attributed to the actual failing deployment

  Added request-scoped attempted-deployment tracking in:

  - src/routers/routing_decision.py

  Wired failover attempt tracking through:

  - src/router/failover.py

  Applied the resolved failure target in:

  - src/chat/telemetry.py
  - src/routers/embeddings.py
  - src/routers/images.py
  - src/routers/audio_speech.py
  - src/routers/audio_transcription.py
  - src/routers/rerank.py

  This fixes attribution for:

  - Request Logs
  - Audit Logs
  - passive health tracking
  - error metrics labels

  ### 5. Usage UI now shows failed requests explicitly

  Updated:

  - src/api/admin/endpoints/spend.py
  - ui/src/lib/api.ts
  - ui/src/pages/Usage.tsx

  The Request Logs view now includes:

  - request status
  - HTTP status code
  - error type
  - improved request detail modal for failed rows

  ### 6. Schema/migration support

  Added an additive migration:

  - prisma/migrations/20260328153000_request_log_failures/migration.sql

  And updated:

  - prisma/schema.prisma

  This extends the request-log backing table without changing the overall storage model.

  ## Why this approach

  This PR keeps the current request-log source intact instead of introducing a new table.

  That gives us:

  - minimal migration churn
  - no new query path for the Usage page
  - no extra network calls
  - no synchronous success-path latency regression

  The only new runtime overhead on healthy requests is lightweight in-memory tracking of the last attempted deployment during failover.

  ## Verification

  Passed locally:

  - uv run pytest tests/test_chat.py tests/test_uniformity_hardening.py -q
  - 45 passed
  - uv run ruff check ...
  - git diff --check