### PR TITLE
Fix/issue 52 dashboard failed requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.so
 .deltallm/
 docs/internal/
+.codex/
 
 # Distribution / packaging
 .Python
@@ -208,3 +209,4 @@ attached_assets/
 scripts/run_backend_local.sh
 scripts/e2e_embeddings.sh
 scripts/ci-local.sh
+.omx/

--- a/artifacts/mockup-sandbox/package-lock.json
+++ b/artifacts/mockup-sandbox/package-lock.json
@@ -28,6 +28,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.13.1",
+        "recharts": "^3.8.1",
         "tailwind-merge": "^3.2.0"
       },
       "devDependencies": {
@@ -1521,6 +1522,42 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "dev": true,
@@ -1537,6 +1574,18 @@
       "os": [
         "linux"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
@@ -1639,6 +1688,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
@@ -1669,6 +1781,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -1812,6 +1930,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "dev": true,
@@ -1827,6 +2066,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1856,6 +2101,16 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -1904,6 +2159,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1969,6 +2230,25 @@
       "version": "4.2.11",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2228,6 +2508,36 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "dev": true,
@@ -2336,6 +2646,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -2461,6 +2822,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -2613,6 +2980,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/artifacts/mockup-sandbox/package.json
+++ b/artifacts/mockup-sandbox/package.json
@@ -29,6 +29,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.13.1",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^3.2.0"
   },
   "devDependencies": {

--- a/artifacts/mockup-sandbox/src/.generated/mockup-components.ts
+++ b/artifacts/mockup-sandbox/src/.generated/mockup-components.ts
@@ -14,16 +14,17 @@ import * as M11 from "../components/mockups/ai-gateway/RgTabSettings";
 import * as M12 from "../components/mockups/ai-gateway/RgTabTest";
 import * as M13 from "../components/mockups/ai-gateway/RouteGroupDetailV2";
 import * as M14 from "../components/mockups/ai-gateway/RouteGroupsList";
-import * as M15 from "../components/mockups/dashboard/DashboardRedesign";
-import * as M16 from "../components/mockups/guardrails/GuardrailsRedesign";
-import * as M17 from "../components/mockups/org-team/OrgCreateForm";
-import * as M18 from "../components/mockups/org-team/OrganizationDetail";
-import * as M19 from "../components/mockups/org-team/OrganizationsList";
-import * as M20 from "../components/mockups/org-team/TeamCreateForm";
-import * as M21 from "../components/mockups/org-team/TeamDetail";
-import * as M22 from "../components/mockups/org-team/TeamsList";
-import * as M23 from "../components/mockups/sidebar-redesign/CleanLight";
-import * as M24 from "../components/mockups/sidebar-redesign/IconRail";
+import * as M15 from "../components/mockups/dashboard/DashboardHealth";
+import * as M16 from "../components/mockups/dashboard/DashboardRedesign";
+import * as M17 from "../components/mockups/guardrails/GuardrailsRedesign";
+import * as M18 from "../components/mockups/org-team/OrgCreateForm";
+import * as M19 from "../components/mockups/org-team/OrganizationDetail";
+import * as M20 from "../components/mockups/org-team/OrganizationsList";
+import * as M21 from "../components/mockups/org-team/TeamCreateForm";
+import * as M22 from "../components/mockups/org-team/TeamDetail";
+import * as M23 from "../components/mockups/org-team/TeamsList";
+import * as M24 from "../components/mockups/sidebar-redesign/CleanLight";
+import * as M25 from "../components/mockups/sidebar-redesign/IconRail";
 
 export const mockupComponents = [
   { folder: "ai-gateway", name: "ModelDetailV2", previewPath: "/preview/ai-gateway/ModelDetailV2", module: M0 },
@@ -41,14 +42,15 @@ export const mockupComponents = [
   { folder: "ai-gateway", name: "RgTabTest", previewPath: "/preview/ai-gateway/RgTabTest", module: M12 },
   { folder: "ai-gateway", name: "RouteGroupDetailV2", previewPath: "/preview/ai-gateway/RouteGroupDetailV2", module: M13 },
   { folder: "ai-gateway", name: "RouteGroupsList", previewPath: "/preview/ai-gateway/RouteGroupsList", module: M14 },
-  { folder: "dashboard", name: "DashboardRedesign", previewPath: "/preview/dashboard/DashboardRedesign", module: M15 },
-  { folder: "guardrails", name: "GuardrailsRedesign", previewPath: "/preview/guardrails/GuardrailsRedesign", module: M16 },
-  { folder: "org-team", name: "OrgCreateForm", previewPath: "/preview/org-team/OrgCreateForm", module: M17 },
-  { folder: "org-team", name: "OrganizationDetail", previewPath: "/preview/org-team/OrganizationDetail", module: M18 },
-  { folder: "org-team", name: "OrganizationsList", previewPath: "/preview/org-team/OrganizationsList", module: M19 },
-  { folder: "org-team", name: "TeamCreateForm", previewPath: "/preview/org-team/TeamCreateForm", module: M20 },
-  { folder: "org-team", name: "TeamDetail", previewPath: "/preview/org-team/TeamDetail", module: M21 },
-  { folder: "org-team", name: "TeamsList", previewPath: "/preview/org-team/TeamsList", module: M22 },
-  { folder: "sidebar-redesign", name: "CleanLight", previewPath: "/preview/sidebar-redesign/CleanLight", module: M23 },
-  { folder: "sidebar-redesign", name: "IconRail", previewPath: "/preview/sidebar-redesign/IconRail", module: M24 },
+  { folder: "dashboard", name: "DashboardHealth", previewPath: "/preview/dashboard/DashboardHealth", module: M15 },
+  { folder: "dashboard", name: "DashboardRedesign", previewPath: "/preview/dashboard/DashboardRedesign", module: M16 },
+  { folder: "guardrails", name: "GuardrailsRedesign", previewPath: "/preview/guardrails/GuardrailsRedesign", module: M17 },
+  { folder: "org-team", name: "OrgCreateForm", previewPath: "/preview/org-team/OrgCreateForm", module: M18 },
+  { folder: "org-team", name: "OrganizationDetail", previewPath: "/preview/org-team/OrganizationDetail", module: M19 },
+  { folder: "org-team", name: "OrganizationsList", previewPath: "/preview/org-team/OrganizationsList", module: M20 },
+  { folder: "org-team", name: "TeamCreateForm", previewPath: "/preview/org-team/TeamCreateForm", module: M21 },
+  { folder: "org-team", name: "TeamDetail", previewPath: "/preview/org-team/TeamDetail", module: M22 },
+  { folder: "org-team", name: "TeamsList", previewPath: "/preview/org-team/TeamsList", module: M23 },
+  { folder: "sidebar-redesign", name: "CleanLight", previewPath: "/preview/sidebar-redesign/CleanLight", module: M24 },
+  { folder: "sidebar-redesign", name: "IconRail", previewPath: "/preview/sidebar-redesign/IconRail", module: M25 },
 ] as const;

--- a/artifacts/mockup-sandbox/src/.generated/mockup-components.ts
+++ b/artifacts/mockup-sandbox/src/.generated/mockup-components.ts
@@ -14,15 +14,16 @@ import * as M11 from "../components/mockups/ai-gateway/RgTabSettings";
 import * as M12 from "../components/mockups/ai-gateway/RgTabTest";
 import * as M13 from "../components/mockups/ai-gateway/RouteGroupDetailV2";
 import * as M14 from "../components/mockups/ai-gateway/RouteGroupsList";
-import * as M15 from "../components/mockups/guardrails/GuardrailsRedesign";
-import * as M16 from "../components/mockups/org-team/OrgCreateForm";
-import * as M17 from "../components/mockups/org-team/OrganizationDetail";
-import * as M18 from "../components/mockups/org-team/OrganizationsList";
-import * as M19 from "../components/mockups/org-team/TeamCreateForm";
-import * as M20 from "../components/mockups/org-team/TeamDetail";
-import * as M21 from "../components/mockups/org-team/TeamsList";
-import * as M22 from "../components/mockups/sidebar-redesign/CleanLight";
-import * as M23 from "../components/mockups/sidebar-redesign/IconRail";
+import * as M15 from "../components/mockups/dashboard/DashboardRedesign";
+import * as M16 from "../components/mockups/guardrails/GuardrailsRedesign";
+import * as M17 from "../components/mockups/org-team/OrgCreateForm";
+import * as M18 from "../components/mockups/org-team/OrganizationDetail";
+import * as M19 from "../components/mockups/org-team/OrganizationsList";
+import * as M20 from "../components/mockups/org-team/TeamCreateForm";
+import * as M21 from "../components/mockups/org-team/TeamDetail";
+import * as M22 from "../components/mockups/org-team/TeamsList";
+import * as M23 from "../components/mockups/sidebar-redesign/CleanLight";
+import * as M24 from "../components/mockups/sidebar-redesign/IconRail";
 
 export const mockupComponents = [
   { folder: "ai-gateway", name: "ModelDetailV2", previewPath: "/preview/ai-gateway/ModelDetailV2", module: M0 },
@@ -40,13 +41,14 @@ export const mockupComponents = [
   { folder: "ai-gateway", name: "RgTabTest", previewPath: "/preview/ai-gateway/RgTabTest", module: M12 },
   { folder: "ai-gateway", name: "RouteGroupDetailV2", previewPath: "/preview/ai-gateway/RouteGroupDetailV2", module: M13 },
   { folder: "ai-gateway", name: "RouteGroupsList", previewPath: "/preview/ai-gateway/RouteGroupsList", module: M14 },
-  { folder: "guardrails", name: "GuardrailsRedesign", previewPath: "/preview/guardrails/GuardrailsRedesign", module: M15 },
-  { folder: "org-team", name: "OrgCreateForm", previewPath: "/preview/org-team/OrgCreateForm", module: M16 },
-  { folder: "org-team", name: "OrganizationDetail", previewPath: "/preview/org-team/OrganizationDetail", module: M17 },
-  { folder: "org-team", name: "OrganizationsList", previewPath: "/preview/org-team/OrganizationsList", module: M18 },
-  { folder: "org-team", name: "TeamCreateForm", previewPath: "/preview/org-team/TeamCreateForm", module: M19 },
-  { folder: "org-team", name: "TeamDetail", previewPath: "/preview/org-team/TeamDetail", module: M20 },
-  { folder: "org-team", name: "TeamsList", previewPath: "/preview/org-team/TeamsList", module: M21 },
-  { folder: "sidebar-redesign", name: "CleanLight", previewPath: "/preview/sidebar-redesign/CleanLight", module: M22 },
-  { folder: "sidebar-redesign", name: "IconRail", previewPath: "/preview/sidebar-redesign/IconRail", module: M23 },
+  { folder: "dashboard", name: "DashboardRedesign", previewPath: "/preview/dashboard/DashboardRedesign", module: M15 },
+  { folder: "guardrails", name: "GuardrailsRedesign", previewPath: "/preview/guardrails/GuardrailsRedesign", module: M16 },
+  { folder: "org-team", name: "OrgCreateForm", previewPath: "/preview/org-team/OrgCreateForm", module: M17 },
+  { folder: "org-team", name: "OrganizationDetail", previewPath: "/preview/org-team/OrganizationDetail", module: M18 },
+  { folder: "org-team", name: "OrganizationsList", previewPath: "/preview/org-team/OrganizationsList", module: M19 },
+  { folder: "org-team", name: "TeamCreateForm", previewPath: "/preview/org-team/TeamCreateForm", module: M20 },
+  { folder: "org-team", name: "TeamDetail", previewPath: "/preview/org-team/TeamDetail", module: M21 },
+  { folder: "org-team", name: "TeamsList", previewPath: "/preview/org-team/TeamsList", module: M22 },
+  { folder: "sidebar-redesign", name: "CleanLight", previewPath: "/preview/sidebar-redesign/CleanLight", module: M23 },
+  { folder: "sidebar-redesign", name: "IconRail", previewPath: "/preview/sidebar-redesign/IconRail", module: M24 },
 ] as const;

--- a/artifacts/mockup-sandbox/src/components/mockups/dashboard/DashboardHealth.tsx
+++ b/artifacts/mockup-sandbox/src/components/mockups/dashboard/DashboardHealth.tsx
@@ -6,22 +6,23 @@ import {
   YAxis,
   Tooltip,
   ResponsiveContainer,
-  CartesianGrid
+  CartesianGrid,
+  PieChart,
+  Pie,
+  Cell
 } from 'recharts';
 import {
   DollarSign,
   Zap,
   Key,
   Box,
-  CheckCircle2,
   Server,
   Database,
   Clock,
-  TrendingUp,
-  AlertCircle,
-  AlertTriangle,
-  Activity
+  TrendingUp
 } from 'lucide-react';
+
+const COLORS = ['#8b5cf6', '#3b82f6', '#06b6d4', '#10b981', '#f59e0b'];
 
 const summaryStats = {
   total_spend: 47.23,
@@ -43,23 +44,20 @@ const dailyRequests = [
   { date: 'Mar 23', success: 2100, failed: 6 }
 ];
 
+const providerSpend = [
+  { provider: 'OpenAI', spend: 24.5 },
+  { provider: 'Anthropic', spend: 12.3 },
+  { provider: 'Google', spend: 6.8 },
+  { provider: 'Groq', spend: 2.1 },
+  { provider: 'Mistral', spend: 1.53 }
+];
+
 const providers = [
   { name: 'OpenAI', status: 'healthy', latency: 340, successRate: 99.9, requests: 5842, models: 4 },
   { name: 'Anthropic', status: 'healthy', latency: 480, successRate: 99.7, requests: 3210, models: 3 },
   { name: 'Google Gemini', status: 'degraded', latency: 1250, successRate: 97.2, requests: 1890, models: 2 },
   { name: 'Groq', status: 'healthy', latency: 120, successRate: 100, requests: 1205, models: 2 },
   { name: 'Mistral', status: 'healthy', latency: 390, successRate: 99.8, requests: 700, models: 1 }
-];
-
-const activityFeed = [
-  { id: 1, timestamp: 'Just now', model: 'gpt-4o', tokens: 452, latency: 340, status: 'success' as const },
-  { id: 2, timestamp: '1 min ago', model: 'claude-3.5-sonnet', tokens: 1205, latency: 890, status: 'success' as const },
-  { id: 3, timestamp: '3 mins ago', model: 'gemini-1.5-pro', tokens: 0, latency: 120, status: 'error' as const },
-  { id: 4, timestamp: '5 mins ago', model: 'gemini-1.5-pro', tokens: 0, latency: 5200, status: 'warning' as const },
-  { id: 5, timestamp: '8 mins ago', model: 'gpt-4o', tokens: 89, latency: 210, status: 'success' as const },
-  { id: 6, timestamp: '12 mins ago', model: 'mixtral-8x7b', tokens: 2048, latency: 1250, status: 'success' as const },
-  { id: 7, timestamp: '15 mins ago', model: 'llama-3-70b', tokens: 156, latency: 450, status: 'success' as const },
-  { id: 8, timestamp: '22 mins ago', model: 'gpt-4o', tokens: 310, latency: 280, status: 'success' as const }
 ];
 
 function fmtDollar(n: number) {
@@ -74,24 +72,6 @@ const statusConfig = {
   healthy: { dot: 'bg-emerald-500', text: 'text-emerald-700', bg: 'bg-emerald-50', label: 'Healthy' },
   degraded: { dot: 'bg-amber-500', text: 'text-amber-700', bg: 'bg-amber-50', label: 'Degraded' },
   down: { dot: 'bg-rose-500', text: 'text-rose-700', bg: 'bg-rose-50', label: 'Down' }
-};
-
-const feedBorder = {
-  success: 'border-l-emerald-400',
-  error: 'border-l-rose-400',
-  warning: 'border-l-amber-400'
-};
-
-const feedIcon = {
-  success: <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />,
-  error: <AlertCircle className="h-3.5 w-3.5 text-rose-500" />,
-  warning: <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
-};
-
-const feedLabel = {
-  success: { text: 'Success', cls: 'bg-emerald-50 text-emerald-700' },
-  error: { text: 'Error', cls: 'bg-rose-50 text-rose-700' },
-  warning: { text: 'Timeout', cls: 'bg-amber-50 text-amber-700' }
 };
 
 export function DashboardHealth() {
@@ -187,42 +167,43 @@ export function DashboardHealth() {
           </div>
 
           <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-base font-semibold text-gray-900">Provider Health</h2>
-              <span className="text-xs text-gray-400">Last checked 12s ago</span>
-            </div>
-            <div className="space-y-0 divide-y divide-gray-100">
-              {providers.map((p) => {
-                const cfg = statusConfig[p.status as keyof typeof statusConfig];
-                return (
-                  <div key={p.name} className="flex items-center justify-between py-3 first:pt-0 last:pb-0">
-                    <div className="flex items-center gap-3 min-w-0">
-                      <div className={`h-2.5 w-2.5 rounded-full shrink-0 ${cfg.dot}`} />
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium text-gray-900 truncate">{p.name}</p>
-                        <p className="text-xs text-gray-400">{p.models} model{p.models > 1 ? 's' : ''}</p>
+            <h2 className="text-base font-semibold text-gray-900 mb-4">Cost by Provider</h2>
+            <div className="h-64 flex items-center">
+              <ResponsiveContainer width="50%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={providerSpend}
+                    dataKey="spend"
+                    nameKey="provider"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={80}
+                    innerRadius={50}
+                    paddingAngle={2}
+                  >
+                    {providerSpend.map((_entry, index) => (
+                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    formatter={(value: number) => [fmtDollar(value), 'Spend']}
+                    contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)', fontSize: '13px' }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+              <div className="pl-4 pr-2 overflow-y-auto max-h-full w-full">
+                <div className="space-y-3">
+                  {providerSpend.map((p, idx) => (
+                    <div key={p.provider} className="flex items-center justify-between">
+                      <div className="flex items-center gap-2 overflow-hidden">
+                        <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: COLORS[idx % COLORS.length] }} />
+                        <span className="text-sm text-gray-600 truncate">{p.provider}</span>
                       </div>
+                      <span className="text-sm font-medium text-gray-900 tabular-nums shrink-0 ml-2">{fmtDollar(p.spend)}</span>
                     </div>
-                    <div className="flex items-center gap-5 shrink-0">
-                      <div className="text-right">
-                        <p className="text-sm tabular-nums text-gray-700">{p.latency}ms</p>
-                        <p className="text-[11px] text-gray-400">latency</p>
-                      </div>
-                      <div className="text-right">
-                        <p className={`text-sm tabular-nums ${p.successRate < 99 ? 'text-amber-600 font-medium' : 'text-gray-700'}`}>{p.successRate}%</p>
-                        <p className="text-[11px] text-gray-400">success</p>
-                      </div>
-                      <div className="text-right hidden sm:block">
-                        <p className="text-sm tabular-nums text-gray-700">{fmtNum(p.requests)}</p>
-                        <p className="text-[11px] text-gray-400">requests</p>
-                      </div>
-                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${cfg.bg} ${cfg.text}`}>
-                        {cfg.label}
-                      </span>
-                    </div>
-                  </div>
-                );
-              })}
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -260,32 +241,41 @@ export function DashboardHealth() {
 
         <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
           <div className="px-5 py-4 border-b border-gray-100 flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Activity className="h-4 w-4 text-gray-400" />
-              <h2 className="text-base font-semibold text-gray-900">Recent Activity</h2>
-            </div>
-            <button className="text-sm text-violet-600 hover:text-violet-700 font-medium">View all</button>
+            <h2 className="text-base font-semibold text-gray-900">Provider Health</h2>
+            <span className="text-xs text-gray-400">Last checked 12s ago</span>
           </div>
-          <div className="divide-y divide-gray-50">
-            {activityFeed.map((item) => (
-              <div
-                key={item.id}
-                className={`flex items-center gap-4 px-5 py-3 border-l-[3px] ${feedBorder[item.status]} hover:bg-gray-50/50 transition-colors`}
-              >
-                <div className="shrink-0">{feedIcon[item.status]}</div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-flex items-center py-0.5 px-1.5 rounded bg-gray-100 text-gray-700 text-xs font-medium">{item.model}</span>
-                    {item.tokens > 0 && <span className="text-xs text-gray-500">{fmtNum(item.tokens)} tokens</span>}
-                    <span className="text-xs text-gray-400">{item.latency}ms</span>
+          <div className="divide-y divide-gray-100">
+            {providers.map((p) => {
+              const cfg = statusConfig[p.status as keyof typeof statusConfig];
+              return (
+                <div key={p.name} className="flex items-center justify-between px-5 py-3.5">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className={`h-2.5 w-2.5 rounded-full shrink-0 ${cfg.dot}`} />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 truncate">{p.name}</p>
+                      <p className="text-xs text-gray-400">{p.models} model{p.models > 1 ? 's' : ''}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-5 shrink-0">
+                    <div className="text-right">
+                      <p className="text-sm tabular-nums text-gray-700">{p.latency}ms</p>
+                      <p className="text-[11px] text-gray-400">latency</p>
+                    </div>
+                    <div className="text-right">
+                      <p className={`text-sm tabular-nums ${p.successRate < 99 ? 'text-amber-600 font-medium' : 'text-gray-700'}`}>{p.successRate}%</p>
+                      <p className="text-[11px] text-gray-400">success</p>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-sm tabular-nums text-gray-700">{fmtNum(p.requests)}</p>
+                      <p className="text-[11px] text-gray-400">requests</p>
+                    </div>
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${cfg.bg} ${cfg.text}`}>
+                      {cfg.label}
+                    </span>
                   </div>
                 </div>
-                <span className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium shrink-0 ${feedLabel[item.status].cls}`}>
-                  {feedLabel[item.status].text}
-                </span>
-                <span className="text-xs text-gray-400 shrink-0 w-20 text-right">{item.timestamp}</span>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
 

--- a/artifacts/mockup-sandbox/src/components/mockups/dashboard/DashboardHealth.tsx
+++ b/artifacts/mockup-sandbox/src/components/mockups/dashboard/DashboardHealth.tsx
@@ -1,0 +1,295 @@
+import React from 'react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid
+} from 'recharts';
+import {
+  DollarSign,
+  Zap,
+  Key,
+  Box,
+  CheckCircle2,
+  Server,
+  Database,
+  Clock,
+  TrendingUp,
+  AlertCircle,
+  AlertTriangle,
+  Activity
+} from 'lucide-react';
+
+const summaryStats = {
+  total_spend: 47.23,
+  total_tokens: 1450200,
+  total_requests: 12847,
+  failed_requests: 23,
+  active_keys: 18,
+  models: 12,
+  avg_latency: 420
+};
+
+const dailyRequests = [
+  { date: 'Mar 17', success: 1200, failed: 5 },
+  { date: 'Mar 18', success: 1800, failed: 12 },
+  { date: 'Mar 19', success: 1400, failed: 2 },
+  { date: 'Mar 20', success: 2200, failed: 28 },
+  { date: 'Mar 21', success: 1900, failed: 4 },
+  { date: 'Mar 22', success: 2500, failed: 10 },
+  { date: 'Mar 23', success: 2100, failed: 6 }
+];
+
+const providers = [
+  { name: 'OpenAI', status: 'healthy', latency: 340, successRate: 99.9, requests: 5842, models: 4 },
+  { name: 'Anthropic', status: 'healthy', latency: 480, successRate: 99.7, requests: 3210, models: 3 },
+  { name: 'Google Gemini', status: 'degraded', latency: 1250, successRate: 97.2, requests: 1890, models: 2 },
+  { name: 'Groq', status: 'healthy', latency: 120, successRate: 100, requests: 1205, models: 2 },
+  { name: 'Mistral', status: 'healthy', latency: 390, successRate: 99.8, requests: 700, models: 1 }
+];
+
+const activityFeed = [
+  { id: 1, timestamp: 'Just now', model: 'gpt-4o', tokens: 452, latency: 340, status: 'success' as const },
+  { id: 2, timestamp: '1 min ago', model: 'claude-3.5-sonnet', tokens: 1205, latency: 890, status: 'success' as const },
+  { id: 3, timestamp: '3 mins ago', model: 'gemini-1.5-pro', tokens: 0, latency: 120, status: 'error' as const },
+  { id: 4, timestamp: '5 mins ago', model: 'gemini-1.5-pro', tokens: 0, latency: 5200, status: 'warning' as const },
+  { id: 5, timestamp: '8 mins ago', model: 'gpt-4o', tokens: 89, latency: 210, status: 'success' as const },
+  { id: 6, timestamp: '12 mins ago', model: 'mixtral-8x7b', tokens: 2048, latency: 1250, status: 'success' as const },
+  { id: 7, timestamp: '15 mins ago', model: 'llama-3-70b', tokens: 156, latency: 450, status: 'success' as const },
+  { id: 8, timestamp: '22 mins ago', model: 'gpt-4o', tokens: 310, latency: 280, status: 'success' as const }
+];
+
+function fmtDollar(n: number) {
+  return `$${n.toFixed(2)}`;
+}
+
+function fmtNum(n: number) {
+  return n.toLocaleString();
+}
+
+const statusConfig = {
+  healthy: { dot: 'bg-emerald-500', text: 'text-emerald-700', bg: 'bg-emerald-50', label: 'Healthy' },
+  degraded: { dot: 'bg-amber-500', text: 'text-amber-700', bg: 'bg-amber-50', label: 'Degraded' },
+  down: { dot: 'bg-rose-500', text: 'text-rose-700', bg: 'bg-rose-50', label: 'Down' }
+};
+
+const feedBorder = {
+  success: 'border-l-emerald-400',
+  error: 'border-l-rose-400',
+  warning: 'border-l-amber-400'
+};
+
+const feedIcon = {
+  success: <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />,
+  error: <AlertCircle className="h-3.5 w-3.5 text-rose-500" />,
+  warning: <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+};
+
+const feedLabel = {
+  success: { text: 'Success', cls: 'bg-emerald-50 text-emerald-700' },
+  error: { text: 'Error', cls: 'bg-rose-50 text-rose-700' },
+  warning: { text: 'Timeout', cls: 'bg-amber-50 text-amber-700' }
+};
+
+export function DashboardHealth() {
+  return (
+    <div className="min-h-screen bg-gray-50/50 p-6 font-sans">
+      <div className="max-w-7xl mx-auto space-y-6">
+
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Dashboard</h1>
+          <p className="text-sm text-gray-500 mt-1">Gateway overview</p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-50">
+              <DollarSign className="h-5 w-5 text-violet-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Total Spend</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtDollar(summaryStats.total_spend)}</p>
+              <p className="mt-1 text-xs text-gray-500">{fmtNum(summaryStats.total_tokens)} tokens used</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50">
+              <Zap className="h-5 w-5 text-blue-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Total Requests</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(summaryStats.total_requests)}</p>
+              <p className="mt-1 text-xs text-red-500 font-medium">{summaryStats.failed_requests} failed</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-50">
+              <Key className="h-5 w-5 text-emerald-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Active Keys</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{summaryStats.active_keys}</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-50">
+              <Box className="h-5 w-5 text-amber-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Models</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{summaryStats.models}</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-cyan-50">
+              <Clock className="h-5 w-5 text-cyan-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Avg Latency</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{summaryStats.avg_latency}<span className="text-sm font-medium text-gray-500 ml-1">ms</span></p>
+              <p className="mt-1 text-xs text-emerald-600 font-medium">99.8% Success Rate</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
+            <h2 className="text-base font-semibold text-gray-900 mb-4">Request Volume</h2>
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={dailyRequests} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="colorSuccessHealth" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#8b5cf6" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#8b5cf6" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
+                  <XAxis dataKey="date" axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#6b7280' }} dy={10} />
+                  <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#6b7280' }} />
+                  <Tooltip
+                    contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)' }}
+                    itemStyle={{ fontSize: '13px' }}
+                    labelStyle={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginBottom: '4px' }}
+                  />
+                  <Area type="monotone" dataKey="success" stackId="1" stroke="#8b5cf6" strokeWidth={2} fillOpacity={1} fill="url(#colorSuccessHealth)" name="Successful" />
+                  <Area type="monotone" dataKey="failed" stackId="1" stroke="#f43f5e" strokeWidth={2} fill="#fecdd3" name="Failed" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-base font-semibold text-gray-900">Provider Health</h2>
+              <span className="text-xs text-gray-400">Last checked 12s ago</span>
+            </div>
+            <div className="space-y-0 divide-y divide-gray-100">
+              {providers.map((p) => {
+                const cfg = statusConfig[p.status as keyof typeof statusConfig];
+                return (
+                  <div key={p.name} className="flex items-center justify-between py-3 first:pt-0 last:pb-0">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className={`h-2.5 w-2.5 rounded-full shrink-0 ${cfg.dot}`} />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-gray-900 truncate">{p.name}</p>
+                        <p className="text-xs text-gray-400">{p.models} model{p.models > 1 ? 's' : ''}</p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-5 shrink-0">
+                      <div className="text-right">
+                        <p className="text-sm tabular-nums text-gray-700">{p.latency}ms</p>
+                        <p className="text-[11px] text-gray-400">latency</p>
+                      </div>
+                      <div className="text-right">
+                        <p className={`text-sm tabular-nums ${p.successRate < 99 ? 'text-amber-600 font-medium' : 'text-gray-700'}`}>{p.successRate}%</p>
+                        <p className="text-[11px] text-gray-400">success</p>
+                      </div>
+                      <div className="text-right hidden sm:block">
+                        <p className="text-sm tabular-nums text-gray-700">{fmtNum(p.requests)}</p>
+                        <p className="text-[11px] text-gray-400">requests</p>
+                      </div>
+                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${cfg.bg} ${cfg.text}`}>
+                        {cfg.label}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-gray-100/80 border border-gray-200/80 rounded-xl p-3 flex flex-wrap items-center gap-6 text-sm">
+          <div className="flex items-center gap-2">
+            <div className="relative flex h-2.5 w-2.5">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-emerald-500"></span>
+            </div>
+            <span className="font-medium text-gray-700">Healthy</span>
+          </div>
+
+          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
+
+          <div className="flex items-center gap-1.5 text-gray-600">
+            <Server className="h-4 w-4 text-gray-400" />
+            <span>5 Providers Active</span>
+          </div>
+
+          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
+
+          <div className="flex items-center gap-1.5 text-gray-600">
+            <Database className="h-4 w-4 text-gray-400" />
+            <span>87% Cache Hit</span>
+          </div>
+
+          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
+
+          <div className="flex items-center gap-1.5 text-gray-600">
+            <TrendingUp className="h-4 w-4 text-gray-400" />
+            <span>99.9% Uptime</span>
+          </div>
+        </div>
+
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <div className="px-5 py-4 border-b border-gray-100 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Activity className="h-4 w-4 text-gray-400" />
+              <h2 className="text-base font-semibold text-gray-900">Recent Activity</h2>
+            </div>
+            <button className="text-sm text-violet-600 hover:text-violet-700 font-medium">View all</button>
+          </div>
+          <div className="divide-y divide-gray-50">
+            {activityFeed.map((item) => (
+              <div
+                key={item.id}
+                className={`flex items-center gap-4 px-5 py-3 border-l-[3px] ${feedBorder[item.status]} hover:bg-gray-50/50 transition-colors`}
+              >
+                <div className="shrink-0">{feedIcon[item.status]}</div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-flex items-center py-0.5 px-1.5 rounded bg-gray-100 text-gray-700 text-xs font-medium">{item.model}</span>
+                    {item.tokens > 0 && <span className="text-xs text-gray-500">{fmtNum(item.tokens)} tokens</span>}
+                    <span className="text-xs text-gray-400">{item.latency}ms</span>
+                  </div>
+                </div>
+                <span className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium shrink-0 ${feedLabel[item.status].cls}`}>
+                  {feedLabel[item.status].text}
+                </span>
+                <span className="text-xs text-gray-400 shrink-0 w-20 text-right">{item.timestamp}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/artifacts/mockup-sandbox/src/components/mockups/dashboard/DashboardRedesign.tsx
+++ b/artifacts/mockup-sandbox/src/components/mockups/dashboard/DashboardRedesign.tsx
@@ -1,0 +1,303 @@
+import React from 'react';
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  CartesianGrid
+} from 'recharts';
+import {
+  DollarSign,
+  Zap,
+  Key,
+  Box,
+  CheckCircle2,
+  Server,
+  Database,
+  Clock,
+  TrendingUp,
+  AlertCircle
+} from 'lucide-react';
+
+const COLORS = ['#8b5cf6', '#3b82f6', '#06b6d4', '#10b981', '#f59e0b'];
+
+// Mock Data
+const summaryStats = {
+  total_spend: 47.23,
+  total_tokens: 1450200,
+  total_requests: 12847,
+  failed_requests: 23,
+  active_keys: 18,
+  models: 12,
+  avg_latency: 420
+};
+
+const dailyRequests = [
+  { date: 'Mar 17', success: 1200, failed: 5 },
+  { date: 'Mar 18', success: 1800, failed: 12 },
+  { date: 'Mar 19', success: 1400, failed: 2 },
+  { date: 'Mar 20', success: 2200, failed: 28 },
+  { date: 'Mar 21', success: 1900, failed: 4 },
+  { date: 'Mar 22', success: 2500, failed: 10 },
+  { date: 'Mar 23', success: 2100, failed: 6 }
+];
+
+const modelSpend = [
+  { model: 'gpt-4o', spend: 24.5 },
+  { model: 'claude-3.5-sonnet', spend: 12.3 },
+  { model: 'gemini-1.5-pro', spend: 6.8 },
+  { model: 'mixtral-8x7b', spend: 2.1 },
+  { model: 'llama-3-70b', spend: 1.53 }
+];
+
+const recentRequests = [
+  { id: 'req_1', timestamp: 'Just now', model: 'gpt-4o', status: 'success', tokens: 452, latency: 340, cost: 0.0015 },
+  { id: 'req_2', timestamp: '2 mins ago', model: 'claude-3.5-sonnet', status: 'success', tokens: 1205, latency: 890, cost: 0.0036 },
+  { id: 'req_3', timestamp: '5 mins ago', model: 'gemini-1.5-pro', status: 'error', tokens: 0, latency: 120, cost: 0 },
+  { id: 'req_4', timestamp: '12 mins ago', model: 'gpt-4o', status: 'success', tokens: 89, latency: 210, cost: 0.0003 },
+  { id: 'req_5', timestamp: '15 mins ago', model: 'mixtral-8x7b', status: 'success', tokens: 2048, latency: 1250, cost: 0.0012 },
+  { id: 'req_6', timestamp: '22 mins ago', model: 'llama-3-70b', status: 'success', tokens: 156, latency: 450, cost: 0.0001 }
+];
+
+function fmtDollar(n: number) {
+  return `$${n.toFixed(2)}`;
+}
+
+function fmtNum(n: number) {
+  return n.toLocaleString();
+}
+
+export function DashboardRedesign() {
+  return (
+    <div className="min-h-screen bg-gray-50/50 p-6 font-sans">
+      <div className="max-w-7xl mx-auto space-y-6">
+        
+        {/* Header */}
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Dashboard</h1>
+          <p className="text-sm text-gray-500 mt-1">Gateway overview</p>
+        </div>
+
+        {/* Stats Section */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-50">
+              <DollarSign className="h-5 w-5 text-violet-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Total Spend</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtDollar(summaryStats.total_spend)}</p>
+              <p className="mt-1 text-xs text-gray-500">{fmtNum(summaryStats.total_tokens)} tokens used</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50">
+              <Zap className="h-5 w-5 text-blue-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Total Requests</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(summaryStats.total_requests)}</p>
+              <p className="mt-1 text-xs text-red-500 font-medium">{summaryStats.failed_requests} failed</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-50">
+              <Key className="h-5 w-5 text-emerald-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Active Keys</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{summaryStats.active_keys}</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-50">
+              <Box className="h-5 w-5 text-amber-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Models</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{summaryStats.models}</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-cyan-50">
+              <Clock className="h-5 w-5 text-cyan-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Avg Latency</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{summaryStats.avg_latency}<span className="text-sm font-medium text-gray-500 ml-1">ms</span></p>
+              <p className="mt-1 text-xs text-emerald-600 font-medium">99.8% Success Rate</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Charts Section */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
+            <h2 className="text-base font-semibold text-gray-900 mb-4">Request Volume</h2>
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={dailyRequests} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="colorSuccess" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#8b5cf6" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#8b5cf6" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
+                  <XAxis dataKey="date" axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#6b7280' }} dy={10} />
+                  <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#6b7280' }} />
+                  <Tooltip 
+                    contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)' }}
+                    itemStyle={{ fontSize: '13px' }}
+                    labelStyle={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginBottom: '4px' }}
+                  />
+                  <Area type="monotone" dataKey="success" stackId="1" stroke="#8b5cf6" strokeWidth={2} fillOpacity={1} fill="url(#colorSuccess)" name="Successful" />
+                  <Area type="monotone" dataKey="failed" stackId="1" stroke="#f43f5e" strokeWidth={2} fill="#fecdd3" name="Failed" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
+            <h2 className="text-base font-semibold text-gray-900 mb-4">Cost by Model</h2>
+            <div className="h-64 flex items-center">
+              <ResponsiveContainer width="50%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={modelSpend}
+                    dataKey="spend"
+                    nameKey="model"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={80}
+                    innerRadius={50}
+                    paddingAngle={2}
+                  >
+                    {modelSpend.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip 
+                    formatter={(value: number) => [fmtDollar(value), 'Spend']}
+                    contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)', fontSize: '13px' }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+              <div className="w-50% pl-4 pr-2 overflow-y-auto max-h-full w-full">
+                <div className="space-y-3">
+                  {modelSpend.map((model, idx) => (
+                    <div key={model.model} className="flex items-center justify-between">
+                      <div className="flex items-center gap-2 overflow-hidden">
+                        <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: COLORS[idx % COLORS.length] }} />
+                        <span className="text-sm text-gray-600 truncate">{model.model}</span>
+                      </div>
+                      <span className="text-sm font-medium text-gray-900 tabular-nums shrink-0 ml-2">{fmtDollar(model.spend)}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* System Status Strip */}
+        <div className="bg-gray-100/80 border border-gray-200/80 rounded-xl p-3 flex flex-wrap items-center gap-6 text-sm">
+          <div className="flex items-center gap-2">
+            <div className="relative flex h-2.5 w-2.5">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-emerald-500"></span>
+            </div>
+            <span className="font-medium text-gray-700">Healthy</span>
+          </div>
+          
+          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
+          
+          <div className="flex items-center gap-1.5 text-gray-600">
+            <Server className="h-4 w-4 text-gray-400" />
+            <span>5 Providers Active</span>
+          </div>
+
+          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
+
+          <div className="flex items-center gap-1.5 text-gray-600">
+            <Database className="h-4 w-4 text-gray-400" />
+            <span>87% Cache Hit</span>
+          </div>
+
+          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
+
+          <div className="flex items-center gap-1.5 text-gray-600">
+            <TrendingUp className="h-4 w-4 text-gray-400" />
+            <span>99.9% Uptime</span>
+          </div>
+        </div>
+
+        {/* Recent Activity */}
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <div className="px-5 py-4 border-b border-gray-100 flex items-center justify-between">
+            <h2 className="text-base font-semibold text-gray-900">Recent Requests</h2>
+            <button className="text-sm text-violet-600 hover:text-violet-700 font-medium">View all</button>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm whitespace-nowrap">
+              <thead className="bg-gray-50/50 text-gray-500">
+                <tr>
+                  <th className="px-5 py-3 font-medium">Time</th>
+                  <th className="px-5 py-3 font-medium">Model</th>
+                  <th className="px-5 py-3 font-medium">Status</th>
+                  <th className="px-5 py-3 font-medium text-right">Tokens</th>
+                  <th className="px-5 py-3 font-medium text-right">Latency</th>
+                  <th className="px-5 py-3 font-medium text-right">Cost</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {recentRequests.map((req) => (
+                  <tr key={req.id} className="hover:bg-gray-50/50 transition-colors">
+                    <td className="px-5 py-3.5 text-gray-500">{req.timestamp}</td>
+                    <td className="px-5 py-3.5">
+                      <span className="inline-flex items-center gap-1.5 py-1 px-2 rounded-md bg-gray-100 text-gray-700 text-xs font-medium">
+                        {req.model}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3.5">
+                      {req.status === 'success' ? (
+                        <span className="inline-flex items-center gap-1 text-emerald-600 text-xs font-medium bg-emerald-50 px-2 py-0.5 rounded-full">
+                          <CheckCircle2 className="h-3.5 w-3.5" /> Success
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 text-rose-600 text-xs font-medium bg-rose-50 px-2 py-0.5 rounded-full">
+                          <AlertCircle className="h-3.5 w-3.5" /> Error
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-5 py-3.5 text-right tabular-nums text-gray-600">
+                      {req.tokens > 0 ? req.tokens : '-'}
+                    </td>
+                    <td className="px-5 py-3.5 text-right tabular-nums text-gray-600">
+                      {req.latency}ms
+                    </td>
+                    <td className="px-5 py-3.5 text-right tabular-nums text-gray-900 font-medium">
+                      {req.cost > 0 ? `$${req.cost.toFixed(4)}` : '-'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/src/api/admin/endpoints/models.py
+++ b/src/api/admin/endpoints/models.py
@@ -37,6 +37,38 @@ def _to_int_or_none(value: Any) -> int | None:
         return None
 
 
+def _normalized_provider_key(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    return normalized or "unknown"
+
+
+def _provider_health_status(*, models: int, healthy_models: int) -> str:
+    if models <= 0:
+        return "healthy"
+    if healthy_models <= 0:
+        return "down"
+    if healthy_models < models:
+        return "degraded"
+    return "healthy"
+
+
+async def _deployment_health_flags(app: Any, deployment_ids: list[str]) -> dict[str, bool]:
+    if not deployment_ids:
+        return {}
+
+    health_backend = getattr(app.state, "router_state_backend", None)
+    if health_backend is None:
+        return {deployment_id: True for deployment_id in deployment_ids}
+
+    health_by_deployment = await health_backend.get_health_batch(deployment_ids)
+    cooldown_by_deployment = await health_backend.get_cooldown_batch(deployment_ids)
+    return {
+        deployment_id: str(health_by_deployment.get(deployment_id, {}).get("healthy", "true")) != "false"
+        and not cooldown_by_deployment.get(deployment_id, False)
+        for deployment_id in deployment_ids
+    }
+
+
 async def _serialize_deployment_health(app: Any, deployment_id: str) -> dict[str, Any]:
     health_backend = getattr(app.state, "router_state_backend", None)
     if health_backend is None:
@@ -181,6 +213,63 @@ async def list_models(
     return {
         "data": page,
         "pagination": {"total": total, "limit": limit, "offset": offset, "has_more": offset + limit < total},
+    }
+
+
+@router.get("/ui/api/models/provider-health-summary", dependencies=[Depends(require_authenticated)])
+async def provider_health_summary(request: Request) -> dict[str, Any]:
+    entries = model_entries(request.app)
+    deployment_ids = [str(entry["deployment_id"]) for entry in entries]
+    healthy_by_deployment = await _deployment_health_flags(request.app, deployment_ids)
+
+    provider_aggregates: dict[str, dict[str, int | str]] = {}
+    for entry in entries:
+        deployment_id = str(entry["deployment_id"])
+        provider = _normalized_provider_key(entry.get("provider"))
+        aggregate = provider_aggregates.setdefault(
+            provider,
+            {
+                "provider": provider,
+                "models": 0,
+                "healthy_models": 0,
+            },
+        )
+        aggregate["models"] = int(aggregate["models"]) + 1
+        if healthy_by_deployment.get(deployment_id, True):
+            aggregate["healthy_models"] = int(aggregate["healthy_models"]) + 1
+
+    providers: list[dict[str, Any]] = []
+    active_providers = 0
+    down_providers = 0
+    for aggregate in provider_aggregates.values():
+        models = int(aggregate["models"])
+        healthy_models = int(aggregate["healthy_models"])
+        unhealthy_models = models - healthy_models
+        status_name = _provider_health_status(models=models, healthy_models=healthy_models)
+        if status_name == "down":
+            down_providers += 1
+        else:
+            active_providers += 1
+        providers.append(
+            {
+                "provider": aggregate["provider"],
+                "models": models,
+                "healthy_models": healthy_models,
+                "unhealthy_models": unhealthy_models,
+                "status": status_name,
+            }
+        )
+
+    providers.sort(key=lambda item: (-int(item["models"]), str(item["provider"])))
+
+    return {
+        "total_models": len(entries),
+        "providers": providers,
+        "summary": {
+            "total_providers": len(providers),
+            "active_providers": active_providers,
+            "down_providers": down_providers,
+        },
     }
 
 

--- a/src/api/admin/endpoints/spend.py
+++ b/src/api/admin/endpoints/spend.py
@@ -120,7 +120,9 @@ async def spend_summary(
             COALESCE(SUM(total_tokens), 0) AS total_tokens,
             COALESCE(SUM({source.prompt_tokens_column}), 0) AS prompt_tokens,
             COALESCE(SUM({source.completion_tokens_column}), 0) AS completion_tokens,
-            COUNT(*) AS total_requests
+            COUNT(*) AS total_requests,
+            COUNT(*) FILTER (WHERE COALESCE(status, 'success') = 'success') AS successful_requests,
+            COUNT(*) FILTER (WHERE status = 'error') AS failed_requests
         FROM {source.table}
         {where_sql}
         """,
@@ -174,7 +176,9 @@ async def spend_report(
                 DATE(start_time) AS group_key,
                 COALESCE(SUM(spend), 0) AS total_spend,
                 COUNT(*) AS request_count,
-                COALESCE(SUM(total_tokens), 0) AS total_tokens
+                COALESCE(SUM(total_tokens), 0) AS total_tokens,
+                COUNT(*) FILTER (WHERE COALESCE(status, 'success') = 'success') AS successful_requests,
+                COUNT(*) FILTER (WHERE status = 'error') AS failed_requests
             FROM {source.table}
             {where_sql}
             GROUP BY DATE(start_time)

--- a/src/api/admin/endpoints/spend.py
+++ b/src/api/admin/endpoints/spend.py
@@ -10,6 +10,7 @@ from src.api.admin.endpoints.common import db_or_503, get_auth_scope, log_admin_
 from src.auth.roles import Permission
 from src.billing.spend_read import SpendReadSource, apply_org_scope, get_spend_read_source
 from src.middleware.admin import require_admin_permission
+from src.providers.resolution import provider_from_model, resolve_provider
 
 router = APIRouter(tags=["Spend"])
 
@@ -26,7 +27,141 @@ def _date_end(value: date | None) -> datetime | None:
     return datetime.combine(value, time.max, tzinfo=UTC)
 
 
-def _grouped_spend_config(group_by: str, source: SpendReadSource) -> dict[str, Any]:
+def _provider_from_api_base_expr(api_base_expr: str) -> str:
+    lowered_api_base = f"LOWER(COALESCE({api_base_expr}, ''))"
+    return f"""
+        CASE
+            WHEN {lowered_api_base} LIKE '%openai.azure.com%' THEN 'azure_openai'
+            WHEN {lowered_api_base} LIKE '%api.groq.com%' OR {lowered_api_base} LIKE '%groq%' THEN 'groq'
+            WHEN {lowered_api_base} LIKE '%openrouter.ai%' OR {lowered_api_base} LIKE '%openrouter%' THEN 'openrouter'
+            WHEN {lowered_api_base} LIKE '%fireworks%' THEN 'fireworks'
+            WHEN {lowered_api_base} LIKE '%together%' THEN 'together'
+            WHEN {lowered_api_base} LIKE '%deepinfra%' THEN 'deepinfra'
+            WHEN {lowered_api_base} LIKE '%perplexity%' THEN 'perplexity'
+            WHEN {lowered_api_base} LIKE '%anthropic%' THEN 'anthropic'
+            WHEN {lowered_api_base} LIKE '%googleapis.com%' OR {lowered_api_base} LIKE '%generativelanguage.googleapis.com%' THEN 'gemini'
+            WHEN {lowered_api_base} LIKE '%bedrock%' THEN 'bedrock'
+            WHEN {lowered_api_base} LIKE '%api.openai.com%' OR {lowered_api_base} LIKE '%openai.com%' THEN 'openai'
+            WHEN {lowered_api_base} LIKE '%azure%' THEN 'azure_openai'
+            ELSE NULL
+        END
+    """.strip()
+
+
+def _provider_from_model_expr(model_expr: str) -> str:
+    lowered_model = f"LOWER(COALESCE({model_expr}, ''))"
+    return f"""
+        CASE
+            WHEN {lowered_model} LIKE 'azure_openai/%' OR {lowered_model} LIKE 'azure/%' THEN 'azure_openai'
+            WHEN {lowered_model} LIKE 'anthropic/%' THEN 'anthropic'
+            WHEN {lowered_model} LIKE 'openrouter/%' THEN 'openrouter'
+            WHEN {lowered_model} LIKE 'groq/%' THEN 'groq'
+            WHEN {lowered_model} LIKE 'together/%' THEN 'together'
+            WHEN {lowered_model} LIKE 'fireworks/%' THEN 'fireworks'
+            WHEN {lowered_model} LIKE 'deepinfra/%' THEN 'deepinfra'
+            WHEN {lowered_model} LIKE 'perplexity/%' THEN 'perplexity'
+            WHEN {lowered_model} LIKE 'gemini/%' THEN 'gemini'
+            WHEN {lowered_model} LIKE 'bedrock/%' THEN 'bedrock'
+            WHEN {lowered_model} LIKE 'vllm/%' THEN 'vllm'
+            WHEN {lowered_model} LIKE 'lmstudio/%' THEN 'lmstudio'
+            WHEN {lowered_model} LIKE 'ollama/%' THEN 'ollama'
+            WHEN {lowered_model} LIKE 'openai/%' THEN 'openai'
+            ELSE NULL
+        END
+    """.strip()
+
+
+def _sql_string_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _legacy_cache_provider_override_expr(
+    *,
+    table_alias: str = "s",
+    model_provider_overrides: dict[str, str] | None = None,
+) -> str:
+    if not model_provider_overrides:
+        return "NULL"
+
+    lowered_api_base = f"LOWER(COALESCE({table_alias}.api_base, ''))"
+    cases = []
+    for model, provider in sorted(model_provider_overrides.items()):
+        model_literal = _sql_string_literal(model)
+        provider_literal = _sql_string_literal(provider)
+        cases.append(
+            f"""WHEN (
+                LOWER(COALESCE({table_alias}.deployment_model, '')) = {model_literal}
+                OR LOWER(COALESCE({table_alias}.model, '')) = {model_literal}
+            ) THEN {provider_literal}"""
+        )
+    case_sql = "\n            ".join(cases)
+    return f"""
+        CASE
+            WHEN {lowered_api_base} <> 'cache' THEN NULL
+            {case_sql}
+            ELSE NULL
+        END
+    """.strip()
+
+
+def _canonical_provider_expr(
+    *,
+    table_alias: str = "s",
+    model_provider_overrides: dict[str, str] | None = None,
+) -> str:
+    provider_column = f"{table_alias}.provider"
+    metadata_provider_column = f"{table_alias}.metadata->>'provider'"
+    api_base_column = f"{table_alias}.api_base"
+    api_base_provider_expr = _provider_from_api_base_expr(api_base_column)
+    legacy_cache_provider_expr = _legacy_cache_provider_override_expr(
+        table_alias=table_alias,
+        model_provider_overrides=model_provider_overrides,
+    )
+    deployment_model_provider_expr = _provider_from_model_expr(f"{table_alias}.deployment_model")
+    model_provider_expr = _provider_from_model_expr(f"{table_alias}.model")
+    return f"""
+        COALESCE(
+            {api_base_provider_expr},
+            NULLIF(LOWER(TRIM(COALESCE({metadata_provider_column}, ''))), ''),
+            NULLIF(LOWER(TRIM({provider_column})), ''),
+            {legacy_cache_provider_expr},
+            {deployment_model_provider_expr},
+            {model_provider_expr},
+            'unknown'
+        )
+    """.strip()
+
+
+def _legacy_cache_model_provider_overrides(request: Request) -> dict[str, str]:
+    registry = getattr(request.app.state, "model_registry", {}) or {}
+    provider_candidates: dict[str, set[str]] = {}
+    for deployments in registry.values():
+        if not isinstance(deployments, list):
+            continue
+        for deployment in deployments:
+            params = deployment.get("deltallm_params") if isinstance(deployment, dict) else None
+            if not isinstance(params, dict):
+                continue
+            deployment_model = str(params.get("model") or "").strip()
+            provider = resolve_provider(params)
+            if not deployment_model or provider == "unknown":
+                continue
+            if provider_from_model(deployment_model) == provider:
+                continue
+            provider_candidates.setdefault(deployment_model.lower(), set()).add(provider)
+    return {
+        deployment_model: next(iter(providers))
+        for deployment_model, providers in provider_candidates.items()
+        if len(providers) == 1
+    }
+
+
+def _grouped_spend_config(
+    group_by: str,
+    source: SpendReadSource,
+    *,
+    model_provider_overrides: dict[str, str] | None = None,
+) -> dict[str, Any]:
     if group_by == "model":
         return {
             "group_expr": "s.model",
@@ -71,11 +206,15 @@ def _grouped_spend_config(group_by: str, source: SpendReadSource) -> dict[str, A
             "search_clause": "(s.api_key ILIKE ${i} OR COALESCE(vt.key_name, '') ILIKE ${i})",
         }
     if group_by == "provider":
+        provider_expr = _canonical_provider_expr(
+            table_alias="s",
+            model_provider_overrides=model_provider_overrides,
+        )
         return {
-            "group_expr": "COALESCE(s.api_base, 'unknown')",
+            "group_expr": provider_expr,
             "display_expr": "NULL",
-            "group_by_exprs": ["COALESCE(s.api_base, 'unknown')"],
-            "search_clause": "COALESCE(s.api_base, 'unknown') ILIKE ${i}",
+            "group_by_exprs": [provider_expr],
+            "search_clause": f"({provider_expr} ILIKE ${{i}} OR COALESCE(s.api_base, '') ILIKE ${{i}})",
         }
     return {
         "group_expr": f"COALESCE({source.column('user_column', table_alias='s')}, 'anonymous')",
@@ -198,7 +337,11 @@ async def spend_report(
             "breakdown": [to_json_value(dict(row)) for row in rows],
         }
 
-    config = _grouped_spend_config(group_by, source)
+    config = _grouped_spend_config(
+        group_by,
+        source,
+        model_provider_overrides=_legacy_cache_model_provider_overrides(request) if group_by == "provider" else None,
+    )
     clauses: list[str] = []
     params: list[Any] = []
     joins = list(config.get("joins", []))

--- a/src/batch/worker.py
+++ b/src/batch/worker.py
@@ -13,8 +13,9 @@ from src.batch.models import BatchJobStatus
 from src.batch.repository import BatchRepository
 from src.batch.storage import BatchArtifactStorage
 from src.billing.cost import ModelPricing, completion_cost
-from src.metrics import increment_request, increment_spend, increment_usage, infer_provider
+from src.metrics import increment_request, increment_spend, increment_usage
 from src.models.requests import EmbeddingRequest
+from src.providers.resolution import resolve_provider
 from src.routers.routing_decision import route_failover_kwargs
 from src.routers.embeddings import _execute_embedding
 
@@ -114,7 +115,7 @@ class BatchExecutorWorker:
                 return_deployment=True,
                 **failover_kwargs,
             )
-            api_provider = infer_provider(served_deployment.deltallm_params.get("model"))
+            api_provider = resolve_provider(served_deployment.deltallm_params)
             usage = data.get("usage") or {}
             deployment_pricing = None
             if served_deployment.input_cost_per_token or served_deployment.output_cost_per_token:
@@ -159,6 +160,7 @@ class BatchExecutorWorker:
                 billed_cost=billed_cost,
                 provider_cost=provider_cost,
                 api_base=served_deployment.deltallm_params.get("api_base"),
+                deployment_model=str(served_deployment.deltallm_params.get("model") or "") or None,
                 batch_id=batch_id,
             )
             return
@@ -186,6 +188,7 @@ class BatchExecutorWorker:
         billed_cost: float,
         provider_cost: float,
         api_base: str | None,
+        deployment_model: str | None,
         batch_id: str,
     ) -> None:
         try:
@@ -232,6 +235,8 @@ class BatchExecutorWorker:
                     cost=billed_cost,
                     metadata={
                         "api_base": api_base,
+                        "provider": api_provider,
+                        "deployment_model": deployment_model,
                         "batch_id": batch_id,
                         "batch_item_id": item.item_id,
                         "execution_mode": job.execution_mode,

--- a/src/billing/spend_events.py
+++ b/src/billing/spend_events.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
+from src.providers.resolution import provider_from_model
+
 
 def build_spend_event(
     *,
@@ -63,7 +65,12 @@ def build_spend_event(
         "end_user_id": end_user_id,
         "model": model,
         "deployment_model": _str_or_none(meta.get("deployment_model")),
-        "provider": _str_or_none(meta.get("provider")) or _provider_from_api_base(meta.get("api_base")),
+        "provider": _resolve_provider(
+            explicit_provider=meta.get("provider"),
+            api_base=meta.get("api_base"),
+            deployment_model=meta.get("deployment_model"),
+            model=model,
+        ),
         "api_base": _str_or_none(meta.get("api_base")),
         "spend": float(cost),
         "provider_cost": _float_or_none(meta.get("provider_cost")),
@@ -95,6 +102,28 @@ def build_spend_event(
         "http_status_code": _int_or_none(http_status_code),
         "error_type": _str_or_none(error_type),
     }
+
+
+def _resolve_provider(
+    *,
+    explicit_provider: Any,
+    api_base: Any,
+    deployment_model: Any,
+    model: str,
+) -> str | None:
+    provider = _normalized_provider(explicit_provider)
+    if provider:
+        return provider
+
+    provider = _provider_from_api_base(api_base)
+    if provider:
+        return provider
+
+    provider = _provider_from_model(deployment_model)
+    if provider:
+        return provider
+
+    return _provider_from_model(model)
 
 
 def _int_value(*values: Any) -> int:
@@ -143,6 +172,18 @@ def _str_or_none(value: Any) -> str | None:
     return str(value)
 
 
+def _normalized_provider(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    return normalized or None
+
+
+def _provider_from_model(value: Any) -> str | None:
+    provider = provider_from_model(str(value or ""))
+    return None if provider == "unknown" else provider
+
+
 def _latency_ms(start_time: datetime, end_time: datetime) -> int | None:
     try:
         return max(int((end_time - start_time).total_seconds() * 1000), 0)
@@ -154,18 +195,28 @@ def _provider_from_api_base(value: Any) -> str | None:
     if value is None:
         return None
     lowered = str(value).lower()
-    if "openai" in lowered:
-        return "openai"
-    if "anthropic" in lowered:
-        return "anthropic"
-    if "azure" in lowered:
-        return "azure"
-    if "groq" in lowered:
+    if "openai.azure.com" in lowered:
+        return "azure_openai"
+    if "api.groq.com" in lowered or "groq" in lowered:
         return "groq"
+    if "openrouter.ai" in lowered or "openrouter" in lowered:
+        return "openrouter"
     if "fireworks" in lowered:
         return "fireworks"
     if "together" in lowered:
         return "together"
     if "deepinfra" in lowered:
         return "deepinfra"
+    if "perplexity" in lowered:
+        return "perplexity"
+    if "anthropic" in lowered:
+        return "anthropic"
+    if "googleapis.com" in lowered or "generativelanguage.googleapis.com" in lowered:
+        return "gemini"
+    if "bedrock" in lowered:
+        return "bedrock"
+    if "openai.com" in lowered or "openai" in lowered:
+        return "openai"
+    if "azure" in lowered:
+        return "azure_openai"
     return None

--- a/src/cache/backends/base.py
+++ b/src/cache/backends/base.py
@@ -14,6 +14,8 @@ class CacheEntry:
     token_count: int = 0
     pricing: dict[str, Any] | None = None
     deployment_id: str | None = None
+    provider: str | None = None
+    deployment_model: str | None = None
 
 
 class CacheBackend(ABC):

--- a/src/cache/backends/memory.py
+++ b/src/cache/backends/memory.py
@@ -37,6 +37,8 @@ class InMemoryBackend(CacheBackend):
                     token_count=entry.token_count,
                     pricing=entry.pricing,
                     deployment_id=entry.deployment_id,
+                    provider=entry.provider,
+                    deployment_model=entry.deployment_model,
                 )
 
             if key in self._cache:

--- a/src/cache/backends/redis.py
+++ b/src/cache/backends/redis.py
@@ -42,6 +42,8 @@ class RedisBackend(CacheBackend):
             token_count=int(payload.get("token_count", 0)),
             pricing=payload.get("pricing"),
             deployment_id=payload.get("deployment_id"),
+            provider=payload.get("provider"),
+            deployment_model=payload.get("deployment_model"),
         )
 
     async def set(self, key: str, entry: CacheEntry, ttl: int | None = None) -> None:

--- a/src/cache/middleware.py
+++ b/src/cache/middleware.py
@@ -15,7 +15,8 @@ from src.billing.cost import completion_cost
 from src.billing.pricing import normalize_gateway_cache_hit_usage, pricing_from_model_info
 from src.middleware.auth import authenticate_request
 from src.middleware.rate_limit import _check_and_acquire_rate_limits, _release_rate_limits
-from src.metrics import increment_request, increment_spend, increment_usage, infer_provider
+from src.metrics import increment_request, increment_spend, increment_usage
+from src.providers.resolution import provider_from_model, resolve_provider
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
 
 from .backends.base import CacheBackend, CacheEntry
@@ -254,7 +255,16 @@ class CacheMiddleware(BaseHTTPMiddleware):
         payload = entry.response if isinstance(entry.response, dict) else {}
         usage = payload.get("usage") if isinstance(payload, dict) else None
         usage = normalize_gateway_cache_hit_usage(usage if isinstance(usage, dict) else {})
-        api_provider = infer_provider(model)
+        deployment_model = _normalized_text(entry.deployment_model)
+        api_provider = _normalized_provider(entry.provider)
+        deployment = None
+        if api_provider is None or deployment_model is None:
+            deployment = _find_runtime_deployment(request, entry.deployment_id)
+        if deployment is not None:
+            deployment_model = deployment_model or _normalized_text(deployment.deltallm_params.get("model"))
+            api_provider = api_provider or _normalized_provider(resolve_provider(deployment.deltallm_params))
+        if api_provider is None:
+            api_provider = _provider_from_model_value(deployment_model) or _provider_from_model_value(model) or "unknown"
         custom_pricing = pricing_from_model_info(entry.pricing)
         if custom_pricing is None:
             custom_pricing = await self._resolve_cache_hit_pricing(request, model, entry)
@@ -301,7 +311,12 @@ class CacheMiddleware(BaseHTTPMiddleware):
                 call_type=call_type,
                 usage=usage,
                 cost=request_cost,
-                metadata={"api_base": "cache", "cache_key": cache_key},
+                metadata={
+                    "api_base": "cache",
+                    "cache_key": cache_key,
+                    "provider": api_provider,
+                    "deployment_model": deployment_model,
+                },
                 cache_hit=True,
             )
         )
@@ -354,6 +369,8 @@ class CacheMiddleware(BaseHTTPMiddleware):
             token_count=int((response_data.get("usage") or {}).get("total_tokens") or 0),
             pricing=_pricing_for_cache_entry(request),
             deployment_id=_deployment_id_for_cache_entry(request),
+            provider=_provider_for_cache_entry(request),
+            deployment_model=_deployment_model_for_cache_entry(request),
         )
 
         try:
@@ -405,6 +422,14 @@ def _deployment_id_for_cache_entry(request: Request) -> str | None:
     return str(deployment_id) if deployment_id else None
 
 
+def _provider_for_cache_entry(request: Request) -> str | None:
+    return _normalized_provider(getattr(request.state, "cache_store_provider", None))
+
+
+def _deployment_model_for_cache_entry(request: Request) -> str | None:
+    return _normalized_text(getattr(request.state, "cache_store_deployment_model", None))
+
+
 def _find_runtime_deployment(request: Request, deployment_id: str | None):
     if not deployment_id:
         return None
@@ -426,3 +451,22 @@ async def _select_runtime_deployment_for_pricing(request: Request, model: str):
     request_context = {"metadata": metadata or {}, "user_id": auth.user_id or auth.api_key}
     model_group = router.resolve_model_group(model)
     return await router.select_deployment(model_group, request_context)
+
+
+def _normalized_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalized_provider(value: Any) -> str | None:
+    normalized = _normalized_text(value)
+    if normalized is None:
+        return None
+    return normalized.lower()
+
+
+def _provider_from_model_value(value: Any) -> str | None:
+    provider = provider_from_model(_normalized_text(value))
+    return None if provider == "unknown" else provider

--- a/src/cache/streaming.py
+++ b/src/cache/streaming.py
@@ -19,6 +19,8 @@ class StreamWriteContext:
     model: str
     pricing: dict[str, Any] | None = None
     deployment_id: str | None = None
+    provider: str | None = None
+    deployment_model: str | None = None
 
 
 @dataclass(slots=True)
@@ -208,6 +210,8 @@ class StreamingCacheHandler:
             token_count=token_count,
             pricing=ctx.pricing,
             deployment_id=ctx.deployment_id,
+            provider=ctx.provider,
+            deployment_model=ctx.deployment_model,
         )
         try:
             await self.backend.set(ctx.cache_key, entry, ctx.ttl)

--- a/src/chat/telemetry.py
+++ b/src/chat/telemetry.py
@@ -318,7 +318,14 @@ async def emit_nonstream_success(
             call_type="completion",
             usage=usage,
             cost=request_cost,
-            metadata=_append_route_decision_metadata(request, {"api_base": api_base}),
+            metadata=_append_route_decision_metadata(
+                request,
+                {
+                    "api_base": api_base,
+                    "provider": api_provider,
+                    "deployment_model": served_deployment.deltallm_params.get("model"),
+                },
+            ),
             cache_hit=cache_hit,
             start_time=callback_start,
             end_time=datetime.now(tz=UTC),

--- a/src/router/state.py
+++ b/src/router/state.py
@@ -51,6 +51,8 @@ class DeploymentStateBackend(Protocol):
 
     async def is_cooled_down(self, deployment_id: str) -> bool: ...
 
+    async def get_cooldown_batch(self, deployment_ids: list[str]) -> dict[str, bool]: ...
+
     async def record_success(self, deployment_id: str) -> None: ...
 
     async def record_failure(self, deployment_id: str, error: str) -> int: ...
@@ -432,6 +434,36 @@ class RedisStateBackend:
                 return False
             self._touch_local_state(deployment_id, now=time.time())
             return True
+
+    async def get_cooldown_batch(self, deployment_ids: list[str]) -> dict[str, bool]:
+        if not deployment_ids:
+            return {}
+
+        keys = [f"cooldown:{deployment_id}" for deployment_id in deployment_ids]
+        try:
+            values = await self._redis_call("mget", keys)
+            return {
+                deployment_id: value not in (None, "", b"")
+                for deployment_id, value in zip(deployment_ids, values, strict=False)
+            }
+        except Exception as exc:
+            self._handle_backend_failure(exc)
+            self._prune_local_state()
+            now = time.time()
+            statuses: dict[str, bool] = {}
+            for deployment_id in deployment_ids:
+                until = self._cooldown_until.get(deployment_id)
+                if not until:
+                    statuses[deployment_id] = False
+                    continue
+                if until <= now:
+                    self._cooldown_until.pop(deployment_id, None)
+                    self._drop_local_state_if_unused(deployment_id)
+                    statuses[deployment_id] = False
+                    continue
+                self._touch_local_state(deployment_id, now=now)
+                statuses[deployment_id] = True
+            return statuses
 
     async def record_success(self, deployment_id: str) -> None:
         failures_key = f"failures:{deployment_id}"

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -209,7 +209,12 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
         billing = compute_billing_result(mode="audio_speech", usage=usage, model_info=model_info)
         request_cost = billing.cost
         spend_metadata = attach_route_decision(
-            {"api_base": api_base, "billing": billing_metadata(billing)},
+            {
+                "api_base": api_base,
+                "provider": api_provider,
+                "deployment_model": deployment_model,
+                "billing": billing_metadata(billing),
+            },
             request,
         )
         increment_request(

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -220,7 +220,12 @@ async def audio_transcriptions(
         billing = compute_billing_result(mode="audio_transcription", usage=usage, model_info=model_info)
         request_cost = billing.cost
         spend_metadata = attach_route_decision(
-            {"api_base": api_base, "billing": billing_metadata(billing)},
+            {
+                "api_base": api_base,
+                "provider": api_provider,
+                "deployment_model": deployment_model,
+                "billing": billing_metadata(billing),
+            },
             request,
         )
         increment_request(

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -172,6 +172,8 @@ async def handle_chat_like_request(
                             model=payload.model,
                             pricing=dict(served_deployment.model_info or {}),
                             deployment_id=served_deployment.deployment_id,
+                            provider=resolve_provider(served_deployment.deltallm_params),
+                            deployment_model=str(served_deployment.deltallm_params.get("model") or "") or None,
                         )
                         stream_handler.start_stream(stream_id)
 
@@ -291,6 +293,8 @@ async def handle_chat_like_request(
         )
         request.state.cache_store_pricing = dict(served_deployment.model_info or {})
         request.state.cache_store_deployment_id = served_deployment.deployment_id
+        request.state.cache_store_provider = resolve_provider(served_deployment.deltallm_params)
+        request.state.cache_store_deployment_model = str(served_deployment.deltallm_params.get("model") or "") or None
         response_payload = response_transform(payload_data) if response_transform is not None else payload_data
         api_provider = resolve_provider(served_deployment.deltallm_params)
         await emit_nonstream_success(

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -217,6 +217,8 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
         )
         request.state.cache_store_pricing = dict(served_deployment.model_info or {})
         request.state.cache_store_deployment_id = served_deployment.deployment_id
+        request.state.cache_store_provider = resolve_provider(served_deployment.deltallm_params)
+        request.state.cache_store_deployment_model = str(served_deployment.deltallm_params.get("model") or "") or None
         route_meta = route_decision_metadata(request)
         await request.app.state.passive_health_tracker.record_request_outcome(served_deployment.deployment_id, success=True)
         api_provider = resolve_provider(served_deployment.deltallm_params)
@@ -268,7 +270,11 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
             team=auth.team_id,
             spend=request_cost,
         )
-        spend_metadata: dict[str, Any] = {"api_base": api_base}
+        spend_metadata: dict[str, Any] = {
+            "api_base": api_base,
+            "provider": api_provider,
+            "deployment_model": deployment_model,
+        }
         if route_meta is not None:
             spend_metadata["routing_decision"] = route_meta
         fire_and_forget(

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -185,7 +185,14 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
                 call_type="image_generation",
                 usage=usage,
                 cost=request_cost,
-                metadata=attach_route_decision({"api_base": api_base}, request),
+                metadata=attach_route_decision(
+                    {
+                        "api_base": api_base,
+                        "provider": api_provider,
+                        "deployment_model": deployment_model,
+                    },
+                    request,
+                ),
                 cache_hit=False,
                 start_time=callback_start,
                 end_time=datetime.now(tz=UTC),

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -176,7 +176,14 @@ async def rerank(request: Request, payload: RerankRequest):
                 call_type="rerank",
                 usage=usage,
                 cost=request_cost,
-                metadata=attach_route_decision({"api_base": api_base}, request),
+                metadata=attach_route_decision(
+                    {
+                        "api_base": api_base,
+                        "provider": api_provider,
+                        "deployment_model": deployment_model,
+                    },
+                    request,
+                ),
                 cache_hit=False,
                 start_time=callback_start,
                 end_time=datetime.now(tz=UTC),

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -158,6 +158,7 @@ async def test_batch_worker_logs_batch_pricing_and_spend(monkeypatch):
     logged = spend.events[0]
     assert logged["call_type"] == "embedding_batch"
     assert logged["cost"] == 0.0025
+    assert logged["metadata"]["deployment_model"] == "vllm/sentence-transformers/all-MiniLM-L6-v2"
     assert logged["metadata"]["pricing_tier"] == "batch"
     assert logged["metadata"]["provider_cost"] == 0.005
 

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
 
 from src.billing.budget import BudgetEnforcementService, BudgetExceeded
 from src.billing.spend import SpendTrackingService
+from src.billing.spend_events import build_spend_event
 
 
 class RecordingDB:
@@ -258,6 +260,61 @@ async def test_spend_tracking_persists_cached_token_counts():
     insert_call = next(args for query, args in db.calls if "insert into deltallm_spendlog_events" in query.lower())
     assert insert_call[19] == 6
     assert insert_call[20] == 0
+
+
+def test_build_spend_event_infers_groq_from_openai_compatible_api_base() -> None:
+    event = build_spend_event(
+        request_id="req_groq",
+        api_key="key_hash",
+        user_id=None,
+        team_id=None,
+        organization_id=None,
+        end_user_id=None,
+        model="openai/gpt-oss-20b",
+        call_type="completion",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        cost=0.01,
+        metadata={"api_base": "https://api.groq.com/openai/v1"},
+        cache_hit=False,
+        start_time=datetime.now(tz=UTC),
+        end_time=datetime.now(tz=UTC),
+    )
+
+    assert event["provider"] == "groq"
+
+
+@pytest.mark.asyncio
+async def test_spend_tracking_preserves_explicit_provider_for_cache_rows():
+    db = RecordingDB()
+    service = SpendTrackingService(db_client=db)
+
+    await service.log_spend(
+        request_id="req_cached_groq",
+        api_key="key_hash",
+        user_id="user_1",
+        team_id="team_1",
+        organization_id="org_1",
+        end_user_id=None,
+        model="openai/gpt-oss-20b",
+        call_type="completion",
+        usage={
+            "total_tokens": 10,
+            "prompt_tokens": 6,
+            "completion_tokens": 4,
+            "prompt_tokens_cached": 6,
+            "completion_tokens_cached": 0,
+        },
+        cost=0.01,
+        metadata={
+            "api_base": "cache",
+            "provider": "groq",
+            "deployment_model": "openai/gpt-oss-20b",
+        },
+        cache_hit=True,
+    )
+
+    insert_call = next(args for query, args in db.calls if "insert into deltallm_spendlog_events" in query.lower())
+    assert insert_call[10] == "groq"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -100,6 +100,20 @@ def _refresh_runtime_registry(test_app) -> None:
     test_app.state.router_health_handler.registry.update(rebuilt)
 
 
+def _configure_groq_openai_compatible_chat_model(test_app) -> None:
+    test_app.state.model_registry["gpt-4o-mini"] = [
+        {
+            "deltallm_params": {
+                "provider": "groq",
+                "model": "openai/gpt-oss-20b",
+                "api_key": "provider-key",
+                "api_base": "https://api.groq.com/openai/v1",
+            }
+        }
+    ]
+    _refresh_runtime_registry(test_app)
+
+
 @pytest.mark.asyncio
 async def test_chat_cache_hit(client, test_app):
     _enable_cache(test_app)
@@ -204,6 +218,68 @@ async def test_streaming_cache_miss_populates_cache_entry(client, test_app):
     assert len(backend._cache) == 1
     stored = next(iter(backend._cache.values()))
     assert stored.response.get("object") == "chat.completion"
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_uses_persisted_provider_metadata_when_runtime_deployment_missing(client, test_app):
+    _enable_cache(test_app)
+    _configure_groq_openai_compatible_chat_model(test_app)
+    recorder = _SpendRecorder()
+    test_app.state.spend_tracking_service = recorder
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "cache provider"}],
+        "stream": False,
+    }
+
+    warm = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert warm.status_code == 200
+
+    cached_entry = next(iter(test_app.state.cache_backend._cache.values()))
+    assert cached_entry.provider == "groq"
+    assert cached_entry.deployment_model == "openai/gpt-oss-20b"
+    cached_entry.deployment_id = None
+
+    hit = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert hit.status_code == 200
+    assert hit.headers["x-deltallm-cache-hit"] == "true"
+
+    await asyncio.sleep(0.05)
+    assert recorder.events[-1]["cache_hit"] is True
+    assert recorder.events[-1]["metadata"]["provider"] == "groq"
+    assert recorder.events[-1]["metadata"]["deployment_model"] == "openai/gpt-oss-20b"
+
+
+@pytest.mark.asyncio
+async def test_streaming_cache_hit_uses_persisted_provider_metadata_when_runtime_deployment_missing(client, test_app):
+    _enable_stream_cache(test_app)
+    _configure_groq_openai_compatible_chat_model(test_app)
+    recorder = _SpendRecorder()
+    test_app.state.spend_tracking_service = recorder
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "stream provider"}],
+        "stream": True,
+    }
+
+    warm = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert warm.status_code == 200
+
+    cached_entry = next(iter(test_app.state.cache_backend._cache.values()))
+    assert cached_entry.provider == "groq"
+    assert cached_entry.deployment_model == "openai/gpt-oss-20b"
+    cached_entry.deployment_id = None
+
+    hit = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert hit.status_code == 200
+    assert hit.headers["x-deltallm-cache-hit"] == "true"
+
+    await asyncio.sleep(0.05)
+    assert recorder.events[-1]["cache_hit"] is True
+    assert recorder.events[-1]["metadata"]["provider"] == "groq"
+    assert recorder.events[-1]["metadata"]["deployment_model"] == "openai/gpt-oss-20b"
 
 
 @pytest.mark.asyncio

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -255,6 +255,17 @@ async def test_usage_based_strategy_uses_router_state_usage():
 
 
 @pytest.mark.asyncio
+async def test_cooldown_batch_uses_local_fallback_state():
+    state = RedisStateBackend(redis=None)
+
+    await state.set_cooldown("dep-a", 30, "manual")
+
+    cooldowns = await state.get_cooldown_batch(["dep-a", "dep-b"])
+
+    assert cooldowns == {"dep-a": True, "dep-b": False}
+
+
+@pytest.mark.asyncio
 async def test_usage_based_strategy_uses_image_limits_when_configured():
     state = RedisStateBackend(redis=None)
     registry = build_deployment_registry(

--- a/tests/test_ui_models.py
+++ b/tests/test_ui_models.py
@@ -46,3 +46,103 @@ async def test_model_health_check_uses_runtime_checker_when_available(client, te
     assert payload["deployment_id"] == "gpt-4o-mini-0"
     assert payload["status_code"] == 200
     assert payload["checked_at"] == 123
+
+
+@pytest.mark.asyncio
+async def test_provider_health_summary_aggregates_provider_statuses(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.model_registry = {
+        "gpt-4o-mini": [
+            {
+                "deployment_id": "dep-openai-1",
+                "deltallm_params": {
+                    "provider": "openai",
+                    "model": "openai/gpt-4o-mini",
+                    "api_base": "https://api.openai.com/v1",
+                    "api_key": "provider-key",
+                },
+            },
+            {
+                "deployment_id": "dep-openai-2",
+                "deltallm_params": {
+                    "provider": "openai",
+                    "model": "openai/gpt-4o-mini",
+                    "api_base": "https://api.openai.com/v1",
+                    "api_key": "provider-key",
+                },
+            },
+        ],
+        "claude-sonnet": [
+            {
+                "deployment_id": "dep-anthropic-1",
+                "deltallm_params": {
+                    "provider": "anthropic",
+                    "model": "anthropic/claude-sonnet-4-20250514",
+                    "api_base": "https://api.anthropic.com/v1",
+                    "api_key": "provider-key",
+                },
+            },
+        ],
+        "azure-gpt": [
+            {
+                "deployment_id": "dep-azure-1",
+                "deltallm_params": {
+                    "provider": "azure_openai",
+                    "model": "azure_openai/gpt-4o-mini",
+                    "api_base": "https://resource.openai.azure.com/openai/v1",
+                    "api_key": "provider-key",
+                },
+            },
+        ],
+    }
+
+    await test_app.state.router_state_backend.set_health("dep-openai-2", False)
+    await test_app.state.router_state_backend.set_cooldown("dep-anthropic-1", 60, "test-cooldown")
+
+    response = await client.get("/ui/api/models/provider-health-summary", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_models"] == 4
+    assert payload["summary"] == {
+        "total_providers": 3,
+        "active_providers": 2,
+        "down_providers": 1,
+    }
+
+    providers = {item["provider"]: item for item in payload["providers"]}
+    assert providers["openai"]["models"] == 2
+    assert providers["openai"]["healthy_models"] == 1
+    assert providers["openai"]["unhealthy_models"] == 1
+    assert providers["openai"]["status"] == "degraded"
+    assert providers["anthropic"]["status"] == "down"
+    assert providers["azure_openai"]["status"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_provider_health_summary_counts_models_beyond_paginated_limit(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.model_registry = {
+        "gpt-4o-mini": [
+            {
+                "deployment_id": f"dep-openai-{index}",
+                "deltallm_params": {
+                    "provider": "openai",
+                    "model": "openai/gpt-4o-mini",
+                    "api_base": "https://api.openai.com/v1",
+                    "api_key": "provider-key",
+                },
+            }
+            for index in range(501)
+        ]
+    }
+
+    response = await client.get("/ui/api/models/provider-health-summary", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_models"] == 501
+    assert payload["summary"]["total_providers"] == 1
+    assert payload["providers"][0]["provider"] == "openai"
+    assert payload["providers"][0]["models"] == 501
+    assert payload["providers"][0]["healthy_models"] == 501

--- a/tests/test_ui_rbac_scoping.py
+++ b/tests/test_ui_rbac_scoping.py
@@ -236,6 +236,49 @@ async def test_grouped_spend_report_for_model_does_not_group_by_null_constant(cl
 
 
 @pytest.mark.asyncio
+async def test_grouped_spend_report_for_provider_uses_canonical_provider_grouping(client, test_app, monkeypatch):
+    fake_db = FakeSpendDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.model_registry["gpt-oss-20b"] = [
+        {
+            "deltallm_params": {
+                "provider": "groq",
+                "model": "openai/gpt-oss-20b",
+                "api_key": "provider-key",
+                "api_base": "https://api.groq.com/openai/v1",
+            }
+        }
+    ]
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.spend.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=True,
+            org_ids=[],
+            team_ids=[],
+        ),
+    )
+
+    response = await client.get(
+        "/ui/api/spend/report?group_by=provider&limit=5&offset=0",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+    assert response.status_code == 200
+
+    query, _ = fake_db.calls[0]
+    assert "LOWER(TRIM(s.provider))" in query
+    assert "metadata->>'provider'" in query
+    assert "s.deployment_model" in query
+    assert "openai.azure.com" in query
+    assert "api.groq.com" in query
+    assert "openai/gpt-oss-20b" in query
+    assert "THEN 'groq'" in query
+    assert "<> 'cache'" in query
+    assert "COALESCE(s.api_base, 'unknown')" not in query
+
+
+@pytest.mark.asyncio
 async def test_spend_endpoints_cast_date_filters_to_timestamp(client, test_app, monkeypatch):
     fake_db = FakeSpendDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -122,6 +122,17 @@ export interface SpendLog {
 
 export type SpendGroupBy = 'model' | 'organization' | 'team' | 'api_key';
 
+export interface SpendSummary {
+  total_spend: number;
+  total_tokens: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_requests: number;
+  unique_models?: number;
+  successful_requests?: number;
+  failed_requests?: number;
+}
+
 export interface SpendGroupRow {
   group_key: string;
   display_name?: string | null;
@@ -134,6 +145,26 @@ export interface SpendGroupReport {
   group_by: SpendGroupBy | 'provider' | 'user';
   data: SpendGroupRow[];
   pagination: Pagination;
+}
+
+export type ProviderHealthStatus = 'healthy' | 'degraded' | 'down';
+
+export interface ProviderHealthSummaryRow {
+  provider: string;
+  models: number;
+  healthy_models: number;
+  unhealthy_models: number;
+  status: ProviderHealthStatus;
+}
+
+export interface ProviderHealthSummary {
+  total_models: number;
+  providers: ProviderHealthSummaryRow[];
+  summary: {
+    total_providers: number;
+    active_providers: number;
+    down_providers: number;
+  };
 }
 
 export interface ServiceAccount {
@@ -565,7 +596,7 @@ export const spend = {
     if (start_date) qs.set('start_date', start_date);
     if (end_date) qs.set('end_date', end_date);
     const suffix = qs.toString() ? `?${qs.toString()}` : '';
-    return apiFetch<any>(`/ui/api/spend/summary${suffix}`);
+    return apiFetch<SpendSummary>(`/ui/api/spend/summary${suffix}`);
   },
   report: (group_by: 'model' | 'provider' | 'day' | 'user' | 'team', start_date?: string, end_date?: string) => {
     const qs = new URLSearchParams({ group_by });
@@ -605,6 +636,7 @@ export const audit = {
 export const models = {
   list: (params?: { search?: string; provider?: string; mode?: string; limit?: number; offset?: number }) =>
     apiFetch<Paginated<any>>(withQuery('/ui/api/models', params as any)),
+  providerHealthSummary: () => apiFetch<ProviderHealthSummary>('/ui/api/models/provider-health-summary'),
   providerPresets: () => apiFetch<{ data: ProviderPreset[] }>('/ui/api/provider-presets'),
   get: (deploymentId: string) => apiFetch<ModelDeploymentDetail>(`/ui/api/models/${encodeURIComponent(deploymentId)}`),
   checkHealth: (deploymentId: string) =>

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -65,9 +65,10 @@ export default function Dashboard() {
   const { data: keysResult } = useApi(() => keysApi.list(), []);
   const { data: healthData } = useApi(() => health.check(), []);
 
-  const daily = (dailyReport?.breakdown || dailyReport?.data || []).map((r: SpendReportRow) => ({
+  const daily = (dailyReport?.breakdown || dailyReport?.data || []).map((r: any) => ({
     date: r.group_key,
-    requests: r.request_count ?? 0,
+    success: r.successful_requests ?? r.request_count ?? 0,
+    failed: r.failed_requests ?? 0,
   }));
 
   const providerSpend = (providerReport?.breakdown || providerReport?.data || []).map((r: SpendReportRow) => {
@@ -112,6 +113,7 @@ export default function Dashboard() {
   const activeProviders = providerList.filter(p => p.status !== 'down').length;
 
   const totalRequests = summary?.total_requests ?? 0;
+  const failedRequests = summary?.failed_requests ?? 0;
 
   return (
     <div className="p-4 sm:p-6">
@@ -141,6 +143,9 @@ export default function Dashboard() {
             <div>
               <p className="text-sm font-medium text-gray-500">Total Requests</p>
               <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(totalRequests)}</p>
+              {failedRequests > 0 && (
+                <p className="mt-1 text-xs text-red-500 font-medium">{fmtNum(failedRequests)} failed</p>
+              )}
             </div>
           </div>
 
@@ -199,7 +204,8 @@ export default function Dashboard() {
                       itemStyle={{ fontSize: '13px' }}
                       labelStyle={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginBottom: '4px' }}
                     />
-                    <Area type="monotone" dataKey="requests" stroke="#8b5cf6" strokeWidth={2} fillOpacity={1} fill="url(#colorRequests)" name="Requests" />
+                    <Area type="monotone" dataKey="success" stackId="1" stroke="#8b5cf6" strokeWidth={2} fillOpacity={1} fill="url(#colorRequests)" name="Successful" />
+                    <Area type="monotone" dataKey="failed" stackId="1" stroke="#f43f5e" strokeWidth={2} fill="#fecdd3" name="Failed" />
                   </AreaChart>
                 </ResponsiveContainer>
               ) : (

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,16 +1,41 @@
+import { useMemo } from 'react';
 import { useApi } from '../lib/hooks';
 import { spend, models as modelsApi, keys as keysApi, health } from '../lib/api';
-import StatCard from '../components/StatCard';
-import Card from '../components/Card';
-import { DollarSign, Zap, Key, Box, Activity } from 'lucide-react';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
+import {
+  DollarSign,
+  Zap,
+  Key,
+  Box,
+  Clock,
+  Server,
+  Database,
+  TrendingUp,
+  Activity,
+} from 'lucide-react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  PieChart,
+  Pie,
+  Cell,
+} from 'recharts';
 
-const COLORS = ['#3b82f6', '#8b5cf6', '#06b6d4', '#10b981', '#f59e0b', '#ef4444', '#ec4899', '#6366f1'];
+const COLORS = ['#8b5cf6', '#3b82f6', '#06b6d4', '#10b981', '#f59e0b'];
 
-type SpendReportRow = { group_key: string; total_spend: number };
+type SpendReportRow = { group_key: string; total_spend: number; request_count?: number; total_tokens?: number; display_name?: string | null };
 
-function fmt(n: number | null | undefined): string {
+function fmtDollar(n: number | null | undefined): string {
   if (n == null) return '$0.00';
+  return `$${Number(n).toFixed(2)}`;
+}
+
+function fmtDollarPrecise(n: number | null | undefined): string {
+  if (n == null) return '$0.0000';
   return `$${Number(n).toFixed(4)}`;
 }
 
@@ -19,112 +44,299 @@ function fmtNum(n: number | null | undefined): string {
   return Number(n).toLocaleString();
 }
 
+interface ProviderAgg {
+  name: string;
+  status: 'healthy' | 'degraded' | 'down';
+  models: number;
+  healthyModels: number;
+}
+
+const statusConfig = {
+  healthy: { dot: 'bg-emerald-500', text: 'text-emerald-700', bg: 'bg-emerald-50', label: 'Healthy' },
+  degraded: { dot: 'bg-amber-500', text: 'text-amber-700', bg: 'bg-amber-50', label: 'Degraded' },
+  down: { dot: 'bg-rose-500', text: 'text-rose-700', bg: 'bg-rose-50', label: 'Down' },
+};
+
 export default function Dashboard() {
   const { data: summary } = useApi(() => spend.summary(), []);
   const { data: dailyReport } = useApi(() => spend.report('day'), []);
-  const { data: modelReport } = useApi(() => spend.report('model'), []);
-  const { data: modelsResult } = useApi(() => modelsApi.list(), []);
+  const { data: providerReport } = useApi(() => spend.report('provider'), []);
+  const { data: modelsResult } = useApi(() => modelsApi.list({ limit: 500 }), []);
   const { data: keysResult } = useApi(() => keysApi.list(), []);
   const { data: healthData } = useApi(() => health.check(), []);
 
-  const daily = (dailyReport?.breakdown || []).map((r: SpendReportRow) => ({ date: r.group_key, total_spend: r.total_spend }));
-  const perModel = (modelReport?.breakdown || []).map((r: SpendReportRow) => ({ model: r.group_key, total_spend: r.total_spend }));
+  const daily = (dailyReport?.breakdown || dailyReport?.data || []).map((r: SpendReportRow) => ({
+    date: r.group_key,
+    requests: r.request_count ?? 0,
+  }));
+
+  const providerSpend = (providerReport?.breakdown || providerReport?.data || []).map((r: SpendReportRow) => {
+    const raw = r.display_name || r.group_key || 'Unknown';
+    const parts = raw.replace(/^https?:\/\//, '').split('/');
+    const host = parts[0];
+    let label = host;
+    if (host.includes('openai.com')) label = 'OpenAI';
+    else if (host.includes('anthropic.com') || host.includes('anthropic')) label = 'Anthropic';
+    else if (host.includes('googleapis.com') || host.includes('google')) label = 'Google';
+    else if (host.includes('groq.com') || host.includes('groq')) label = 'Groq';
+    else if (host.includes('mistral.ai') || host.includes('mistral')) label = 'Mistral';
+    else if (host.includes('cohere') || host.includes('cohere')) label = 'Cohere';
+    return { provider: label, spend: r.total_spend };
+  });
+
+  const allModels = modelsResult?.data || [];
+  const totalModels = modelsResult?.pagination?.total ?? allModels.length;
+
+  const providerHealthMap = useMemo(() => {
+    const map: Record<string, ProviderAgg> = {};
+    for (const m of allModels) {
+      const p = m.provider || 'unknown';
+      if (!map[p]) {
+        map[p] = { name: p, status: 'healthy', models: 0, healthyModels: 0 };
+      }
+      map[p].models++;
+      if (m.healthy) map[p].healthyModels++;
+    }
+    for (const agg of Object.values(map)) {
+      if (agg.healthyModels === 0 && agg.models > 0) agg.status = 'down';
+      else if (agg.healthyModels < agg.models) agg.status = 'degraded';
+      else agg.status = 'healthy';
+    }
+    return map;
+  }, [allModels]);
+
+  const providerList = Object.values(providerHealthMap).sort((a, b) => b.models - a.models);
 
   const healthStatus = healthData?.readiness?.status || healthData?.liveliness || 'unknown';
+  const isHealthy = healthStatus === 'ok' || healthStatus === 'healthy';
+  const activeProviders = providerList.filter(p => p.status !== 'down').length;
+
+  const totalRequests = summary?.total_requests ?? 0;
 
   return (
     <div className="p-4 sm:p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-        <p className="text-sm text-gray-500 mt-1">Overview of your LLM proxy</p>
-      </div>
+      <div className="max-w-7xl mx-auto space-y-6">
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-        <StatCard
-          title="Total Spend"
-          value={fmt(summary?.total_spend)}
-          icon={<DollarSign className="w-5 h-5" />}
-          subtitle={`${fmtNum(summary?.total_tokens)} tokens used`}
-        />
-        <StatCard
-          title="Total Requests"
-          value={fmtNum(summary?.total_requests)}
-          icon={<Zap className="w-5 h-5" />}
-        />
-        <StatCard
-          title="Active Keys"
-          value={fmtNum(keysResult?.pagination?.total ?? keysResult?.data?.length)}
-          icon={<Key className="w-5 h-5" />}
-        />
-        <StatCard
-          title="Models"
-          value={fmtNum(modelsResult?.pagination?.total ?? modelsResult?.data?.length)}
-          icon={<Box className="w-5 h-5" />}
-          subtitle={healthStatus === 'ok' ? 'System healthy' : `Status: ${healthStatus}`}
-        />
-      </div>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Dashboard</h1>
+          <p className="text-sm text-gray-500 mt-1">Gateway overview</p>
+        </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card title="Daily Spend">
-          {daily && daily.length > 0 ? (
-            <ResponsiveContainer width="100%" height={250}>
-              <BarChart data={daily}>
-                <XAxis dataKey="date" tick={{ fontSize: 12 }} />
-                <YAxis tick={{ fontSize: 12 }} tickFormatter={(v) => `$${v}`} />
-                <Tooltip formatter={(v: any) => [`$${Number(v).toFixed(4)}`, 'Spend']} />
-                <Bar dataKey="total_spend" fill="#3b82f6" radius={[4, 4, 0, 0]} />
-              </BarChart>
-            </ResponsiveContainer>
-          ) : (
-            <div className="flex items-center justify-center h-[250px] text-gray-400 text-sm">
-              <div className="text-center">
-                <Activity className="w-8 h-8 mx-auto mb-2 opacity-50" />
-                <p>No spend data yet</p>
-              </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-50">
+              <DollarSign className="h-5 w-5 text-violet-600" />
             </div>
-          )}
-        </Card>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Total Spend</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtDollar(summary?.total_spend)}</p>
+              <p className="mt-1 text-xs text-gray-500">{fmtNum(summary?.total_tokens)} tokens used</p>
+            </div>
+          </div>
 
-        <Card title="Spend by Model">
-          {perModel && perModel.length > 0 ? (
-            <div className="flex flex-col sm:flex-row items-center gap-4">
-              <ResponsiveContainer width="50%" height={250}>
-                <PieChart>
-                  <Pie
-                    data={perModel}
-                    dataKey="total_spend"
-                    nameKey="model"
-                    cx="50%"
-                    cy="50%"
-                    outerRadius={90}
-                    innerRadius={50}
-                  >
-                    {perModel.map((_m: { model: string; total_spend: number }, i: number) => (
-                      <Cell key={i} fill={COLORS[i % COLORS.length]} />
-                    ))}
-                  </Pie>
-                  <Tooltip formatter={(v: any) => `$${Number(v).toFixed(4)}`} />
-                </PieChart>
-              </ResponsiveContainer>
-              <div className="flex-1 space-y-2">
-                {perModel.slice(0, 6).map((m: any, i: number) => (
-                  <div key={m.model} className="flex items-center gap-2 text-sm">
-                    <div className="w-3 h-3 rounded-full" style={{ background: COLORS[i % COLORS.length] }} />
-                    <span className="text-gray-600 truncate flex-1">{m.model}</span>
-                    <span className="font-medium text-gray-900">{fmt(m.total_spend)}</span>
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50">
+              <Zap className="h-5 w-5 text-blue-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Total Requests</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(totalRequests)}</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-50">
+              <Key className="h-5 w-5 text-emerald-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Active Keys</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(keysResult?.pagination?.total ?? keysResult?.data?.length)}</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-50">
+              <Box className="h-5 w-5 text-amber-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Models</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(totalModels)}</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-cyan-50">
+              <Clock className="h-5 w-5 text-cyan-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Providers</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{providerList.length}</p>
+              <p className={`mt-1 text-xs font-medium ${activeProviders === providerList.length ? 'text-emerald-600' : 'text-amber-600'}`}>
+                {activeProviders} active
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
+            <h2 className="text-base font-semibold text-gray-900 mb-4">Request Volume</h2>
+            <div className="h-64">
+              {daily.length > 0 ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={daily} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+                    <defs>
+                      <linearGradient id="colorRequests" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#8b5cf6" stopOpacity={0.3} />
+                        <stop offset="95%" stopColor="#8b5cf6" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
+                    <XAxis dataKey="date" axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#6b7280' }} dy={10} />
+                    <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#6b7280' }} />
+                    <Tooltip
+                      contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)' }}
+                      itemStyle={{ fontSize: '13px' }}
+                      labelStyle={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginBottom: '4px' }}
+                    />
+                    <Area type="monotone" dataKey="requests" stroke="#8b5cf6" strokeWidth={2} fillOpacity={1} fill="url(#colorRequests)" name="Requests" />
+                  </AreaChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex items-center justify-center h-full text-gray-400 text-sm">
+                  <div className="text-center">
+                    <Activity className="w-8 h-8 mx-auto mb-2 opacity-50" />
+                    <p>No request data yet</p>
                   </div>
-                ))}
-              </div>
+                </div>
+              )}
             </div>
-          ) : (
-            <div className="flex items-center justify-center h-[250px] text-gray-400 text-sm">
-              <div className="text-center">
-                <Box className="w-8 h-8 mx-auto mb-2 opacity-50" />
-                <p>No model data yet</p>
-              </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
+            <h2 className="text-base font-semibold text-gray-900 mb-4">Cost by Provider</h2>
+            <div className="h-64 flex items-center">
+              {providerSpend.length > 0 ? (
+                <>
+                  <ResponsiveContainer width="50%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={providerSpend}
+                        dataKey="spend"
+                        nameKey="provider"
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={80}
+                        innerRadius={50}
+                        paddingAngle={2}
+                      >
+                        {providerSpend.map((_: any, index: number) => (
+                          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <Tooltip
+                        formatter={(value: any) => [fmtDollarPrecise(value), 'Spend']}
+                        contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)', fontSize: '13px' }}
+                      />
+                    </PieChart>
+                  </ResponsiveContainer>
+                  <div className="pl-4 pr-2 overflow-y-auto max-h-full w-full">
+                    <div className="space-y-3">
+                      {providerSpend.map((p: any, idx: number) => (
+                        <div key={p.provider} className="flex items-center justify-between">
+                          <div className="flex items-center gap-2 overflow-hidden">
+                            <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: COLORS[idx % COLORS.length] }} />
+                            <span className="text-sm text-gray-600 truncate">{p.provider}</span>
+                          </div>
+                          <span className="text-sm font-medium text-gray-900 tabular-nums shrink-0 ml-2">{fmtDollarPrecise(p.spend)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="flex items-center justify-center w-full h-full text-gray-400 text-sm">
+                  <div className="text-center">
+                    <Box className="w-8 h-8 mx-auto mb-2 opacity-50" />
+                    <p>No provider data yet</p>
+                  </div>
+                </div>
+              )}
             </div>
-          )}
-        </Card>
+          </div>
+        </div>
+
+        <div className="bg-gray-100/80 border border-gray-200/80 rounded-xl p-3 flex flex-wrap items-center gap-6 text-sm">
+          <div className="flex items-center gap-2">
+            <div className="relative flex h-2.5 w-2.5">
+              {isHealthy ? (
+                <>
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+                  <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-emerald-500"></span>
+                </>
+              ) : (
+                <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-amber-500"></span>
+              )}
+            </div>
+            <span className="font-medium text-gray-700">{isHealthy ? 'Healthy' : healthStatus}</span>
+          </div>
+
+          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
+
+          <div className="flex items-center gap-1.5 text-gray-600">
+            <Server className="h-4 w-4 text-gray-400" />
+            <span>{activeProviders} Provider{activeProviders !== 1 ? 's' : ''} Active</span>
+          </div>
+
+          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
+
+          <div className="flex items-center gap-1.5 text-gray-600">
+            <Database className="h-4 w-4 text-gray-400" />
+            <span>{fmtNum(totalModels)} Model{totalModels !== 1 ? 's' : ''} Deployed</span>
+          </div>
+
+          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
+
+          <div className="flex items-center gap-1.5 text-gray-600">
+            <TrendingUp className="h-4 w-4 text-gray-400" />
+            <span>{fmtNum(totalRequests)} Total Requests</span>
+          </div>
+        </div>
+
+        {providerList.length > 0 && (
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+            <div className="px-5 py-4 border-b border-gray-100 flex items-center justify-between">
+              <h2 className="text-base font-semibold text-gray-900">Provider Health</h2>
+              <span className="text-xs text-gray-400">{providerList.length} provider{providerList.length !== 1 ? 's' : ''} configured</span>
+            </div>
+            <div className="divide-y divide-gray-100">
+              {providerList.map((p) => {
+                const cfg = statusConfig[p.status];
+                return (
+                  <div key={p.name} className="flex items-center justify-between px-5 py-3.5">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className={`h-2.5 w-2.5 rounded-full shrink-0 ${cfg.dot}`} />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-gray-900 truncate capitalize">{p.name}</p>
+                        <p className="text-xs text-gray-400">{p.models} model{p.models > 1 ? 's' : ''}</p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-5 shrink-0">
+                      <div className="text-right">
+                        <p className="text-sm tabular-nums text-gray-700">{p.healthyModels}/{p.models}</p>
+                        <p className="text-[11px] text-gray-400">healthy</p>
+                      </div>
+                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${cfg.bg} ${cfg.text}`}>
+                        {cfg.label}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
       </div>
     </div>
   );

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -215,32 +215,34 @@ export default function Dashboard() {
 
           <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
             <h2 className="text-base font-semibold text-gray-900 mb-4">Cost by Provider</h2>
-            <div className="h-64 flex items-center">
+            <div className="min-h-[256px]">
               {providerSpend.length > 0 ? (
-                <>
-                  <ResponsiveContainer width="50%" height="100%">
-                    <PieChart>
-                      <Pie
-                        data={providerSpend}
-                        dataKey="spend"
-                        nameKey="provider"
-                        cx="50%"
-                        cy="50%"
-                        outerRadius={80}
-                        innerRadius={50}
-                        paddingAngle={2}
-                      >
-                        {providerSpend.map((_: any, index: number) => (
-                          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                        ))}
-                      </Pie>
-                      <Tooltip
-                        formatter={(value: any) => [fmtDollarPrecise(value), 'Spend']}
-                        contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)', fontSize: '13px' }}
-                      />
-                    </PieChart>
-                  </ResponsiveContainer>
-                  <div className="pl-4 pr-2 overflow-y-auto max-h-full w-full">
+                <div className="flex flex-col sm:flex-row items-center gap-4">
+                  <div className="w-full sm:w-1/2 h-48 sm:h-64">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie
+                          data={providerSpend}
+                          dataKey="spend"
+                          nameKey="provider"
+                          cx="50%"
+                          cy="50%"
+                          outerRadius="70%"
+                          innerRadius="45%"
+                          paddingAngle={2}
+                        >
+                          {providerSpend.map((_: any, index: number) => (
+                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                          ))}
+                        </Pie>
+                        <Tooltip
+                          formatter={(value: any) => [fmtDollarPrecise(value), 'Spend']}
+                          contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)', fontSize: '13px' }}
+                        />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  </div>
+                  <div className="w-full sm:w-1/2 sm:pl-2 overflow-y-auto max-h-48 sm:max-h-64">
                     <div className="space-y-3">
                       {providerSpend.map((p: any, idx: number) => (
                         <div key={p.provider} className="flex items-center justify-between">
@@ -253,9 +255,9 @@ export default function Dashboard() {
                       ))}
                     </div>
                   </div>
-                </>
+                </div>
               ) : (
-                <div className="flex items-center justify-center w-full h-full text-gray-400 text-sm">
+                <div className="flex items-center justify-center w-full h-64 text-gray-400 text-sm">
                   <div className="text-center">
                     <Box className="w-8 h-8 mx-auto mb-2 opacity-50" />
                     <p>No provider data yet</p>

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -143,9 +143,7 @@ export default function Dashboard() {
             <div>
               <p className="text-sm font-medium text-gray-500">Total Requests</p>
               <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(totalRequests)}</p>
-              {failedRequests > 0 && (
-                <p className="mt-1 text-xs text-red-500 font-medium">{fmtNum(failedRequests)} failed</p>
-              )}
+              <p className={`mt-1 text-xs font-medium ${failedRequests > 0 ? 'text-red-500' : 'text-gray-400'}`}>{fmtNum(failedRequests)} failed</p>
             </div>
           </div>
 

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
 import { useApi } from '../lib/hooks';
-import { spend, models as modelsApi, keys as keysApi, health } from '../lib/api';
+import { spend, models as modelsApi, keys as keysApi, health, type ProviderHealthStatus } from '../lib/api';
+import { providerDisplayName } from '../lib/providers';
 import {
   DollarSign,
   Zap,
@@ -28,10 +28,11 @@ import {
 const COLORS = ['#8b5cf6', '#3b82f6', '#06b6d4', '#10b981', '#f59e0b'];
 
 type SpendReportRow = { group_key: string; total_spend: number; request_count?: number; total_tokens?: number; display_name?: string | null };
+type ProviderSpendDatum = { provider: string; label: string; spend: number };
 
 function fmtDollar(n: number | null | undefined): string {
-  if (n == null) return '$0.00';
-  return `$${Number(n).toFixed(2)}`;
+  if (n == null) return '$0.0000';
+  return `$${Number(n).toFixed(4)}`;
 }
 
 function fmtDollarPrecise(n: number | null | undefined): string {
@@ -45,13 +46,14 @@ function fmtNum(n: number | null | undefined): string {
 }
 
 interface ProviderAgg {
-  name: string;
-  status: 'healthy' | 'degraded' | 'down';
+  provider: string;
+  status: ProviderHealthStatus;
   models: number;
-  healthyModels: number;
+  healthy_models: number;
+  unhealthy_models: number;
 }
 
-const statusConfig = {
+const statusConfig: Record<ProviderHealthStatus, { dot: string; text: string; bg: string; label: string }> = {
   healthy: { dot: 'bg-emerald-500', text: 'text-emerald-700', bg: 'bg-emerald-50', label: 'Healthy' },
   degraded: { dot: 'bg-amber-500', text: 'text-amber-700', bg: 'bg-amber-50', label: 'Degraded' },
   down: { dot: 'bg-rose-500', text: 'text-rose-700', bg: 'bg-rose-50', label: 'Down' },
@@ -61,7 +63,7 @@ export default function Dashboard() {
   const { data: summary } = useApi(() => spend.summary(), []);
   const { data: dailyReport } = useApi(() => spend.report('day'), []);
   const { data: providerReport } = useApi(() => spend.report('provider'), []);
-  const { data: modelsResult } = useApi(() => modelsApi.list({ limit: 500 }), []);
+  const { data: providerHealthSummary } = useApi(() => modelsApi.providerHealthSummary(), []);
   const { data: keysResult } = useApi(() => keysApi.list(), []);
   const { data: healthData } = useApi(() => health.check(), []);
 
@@ -71,46 +73,23 @@ export default function Dashboard() {
     failed: r.failed_requests ?? 0,
   }));
 
-  const providerSpend = (providerReport?.breakdown || providerReport?.data || []).map((r: SpendReportRow) => {
-    const raw = r.display_name || r.group_key || 'Unknown';
-    const parts = raw.replace(/^https?:\/\//, '').split('/');
-    const host = parts[0];
-    let label = host;
-    if (host.includes('openai.com')) label = 'OpenAI';
-    else if (host.includes('anthropic.com') || host.includes('anthropic')) label = 'Anthropic';
-    else if (host.includes('googleapis.com') || host.includes('google')) label = 'Google';
-    else if (host.includes('groq.com') || host.includes('groq')) label = 'Groq';
-    else if (host.includes('mistral.ai') || host.includes('mistral')) label = 'Mistral';
-    else if (host.includes('cohere') || host.includes('cohere')) label = 'Cohere';
-    return { provider: label, spend: r.total_spend };
+  const providerSpend: ProviderSpendDatum[] = ((providerReport?.breakdown || providerReport?.data || []) as SpendReportRow[]).map((r) => {
+    const provider = (r.group_key || 'unknown').trim().toLowerCase() || 'unknown';
+    return {
+      provider,
+      label: providerDisplayName(provider),
+      spend: r.total_spend,
+    };
   });
 
-  const allModels = modelsResult?.data || [];
-  const totalModels = modelsResult?.pagination?.total ?? allModels.length;
-
-  const providerHealthMap = useMemo(() => {
-    const map: Record<string, ProviderAgg> = {};
-    for (const m of allModels) {
-      const p = m.provider || 'unknown';
-      if (!map[p]) {
-        map[p] = { name: p, status: 'healthy', models: 0, healthyModels: 0 };
-      }
-      map[p].models++;
-      if (m.healthy) map[p].healthyModels++;
-    }
-    for (const agg of Object.values(map)) {
-      if (agg.healthyModels === 0 && agg.models > 0) agg.status = 'down';
-      else if (agg.healthyModels < agg.models) agg.status = 'degraded';
-      else agg.status = 'healthy';
-    }
-    return map;
-  }, [allModels]);
-
-  const providerList = Object.values(providerHealthMap).sort((a, b) => b.models - a.models);
+  const providerList = (providerHealthSummary?.providers || []) as ProviderAgg[];
+  const totalModels = providerHealthSummary?.total_models ?? 0;
+  const totalProviders = providerHealthSummary?.summary.total_providers ?? providerList.length;
 
   const healthStatus = healthData?.readiness?.status || healthData?.liveliness || 'unknown';
   const isHealthy = healthStatus === 'ok' || healthStatus === 'healthy';
-  const activeProviders = providerList.filter(p => p.status !== 'down').length;
+  const activeProviders =
+    providerHealthSummary?.summary.active_providers ?? providerList.filter((p) => p.status !== 'down').length;
 
   const totalRequests = summary?.total_requests ?? 0;
   const failedRequests = summary?.failed_requests ?? 0;
@@ -173,8 +152,8 @@ export default function Dashboard() {
             </div>
             <div>
               <p className="text-sm font-medium text-gray-500">Providers</p>
-              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{providerList.length}</p>
-              <p className={`mt-1 text-xs font-medium ${activeProviders === providerList.length ? 'text-emerald-600' : 'text-amber-600'}`}>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{totalProviders}</p>
+              <p className={`mt-1 text-xs font-medium ${activeProviders === totalProviders ? 'text-emerald-600' : 'text-amber-600'}`}>
                 {activeProviders} active
               </p>
             </div>
@@ -228,14 +207,14 @@ export default function Dashboard() {
                         <Pie
                           data={providerSpend}
                           dataKey="spend"
-                          nameKey="provider"
+                          nameKey="label"
                           cx="50%"
                           cy="50%"
                           outerRadius="70%"
                           innerRadius="45%"
                           paddingAngle={2}
                         >
-                          {providerSpend.map((_: any, index: number) => (
+                          {providerSpend.map((_, index) => (
                             <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                           ))}
                         </Pie>
@@ -248,11 +227,11 @@ export default function Dashboard() {
                   </div>
                   <div className="w-full sm:w-1/2 sm:pl-2 overflow-y-auto max-h-48 sm:max-h-64">
                     <div className="space-y-3">
-                      {providerSpend.map((p: any, idx: number) => (
+                      {providerSpend.map((p, idx) => (
                         <div key={p.provider} className="flex items-center justify-between">
                           <div className="flex items-center gap-2 overflow-hidden">
                             <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: COLORS[idx % COLORS.length] }} />
-                            <span className="text-sm text-gray-600 truncate">{p.provider}</span>
+                            <span className="text-sm text-gray-600 truncate">{p.label}</span>
                           </div>
                           <span className="text-sm font-medium text-gray-900 tabular-nums shrink-0 ml-2">{fmtDollarPrecise(p.spend)}</span>
                         </div>
@@ -313,23 +292,23 @@ export default function Dashboard() {
           <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
             <div className="px-5 py-4 border-b border-gray-100 flex items-center justify-between">
               <h2 className="text-base font-semibold text-gray-900">Provider Health</h2>
-              <span className="text-xs text-gray-400">{providerList.length} provider{providerList.length !== 1 ? 's' : ''} configured</span>
+              <span className="text-xs text-gray-400">{totalProviders} provider{totalProviders !== 1 ? 's' : ''} configured</span>
             </div>
             <div className="divide-y divide-gray-100">
               {providerList.map((p) => {
                 const cfg = statusConfig[p.status];
                 return (
-                  <div key={p.name} className="flex items-center justify-between px-5 py-3.5">
+                  <div key={p.provider} className="flex items-center justify-between px-5 py-3.5">
                     <div className="flex items-center gap-3 min-w-0">
                       <div className={`h-2.5 w-2.5 rounded-full shrink-0 ${cfg.dot}`} />
                       <div className="min-w-0">
-                        <p className="text-sm font-medium text-gray-900 truncate capitalize">{p.name}</p>
+                        <p className="text-sm font-medium text-gray-900 truncate">{providerDisplayName(p.provider)}</p>
                         <p className="text-xs text-gray-400">{p.models} model{p.models > 1 ? 's' : ''}</p>
                       </div>
                     </div>
                     <div className="flex items-center gap-5 shrink-0">
                       <div className="text-right">
-                        <p className="text-sm tabular-nums text-gray-700">{p.healthyModels}/{p.models}</p>
+                        <p className="text-sm tabular-nums text-gray-700">{p.healthy_models}/{p.models}</p>
                         <p className="text-[11px] text-gray-400">healthy</p>
                       </div>
                       <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${cfg.bg} ${cfg.text}`}>


### PR DESCRIPTION
**Summary**
Redesigns the admin Dashboard to focus on operational health and eliminates redundancy with the Usage page. Adds failed request tracking to the spend summary and daily report endpoints, closing #52.

**Changes**

**Backend**
Migration applied: Adds status, http_status_code, and error_type columns to deltallm_spendlog_events (from PR #56 migration file)
Spend summary endpoint (/ui/api/spend/summary): Now returns successful_requests and failed_requests counts alongside total_requests
Daily report endpoint (/ui/api/spend/report?group_by=day): Now returns successful_requests and failed_requests per day

**Frontend — Dashboard**
5 stat cards with colored icon containers: Total Spend, Total Requests (with failed count always visible), Active Keys, Models, Providers
Request Volume stacked area chart showing successful (violet) and failed (rose) requests over time
Cost by Provider responsive donut pie chart with color-coded legend — stacks vertically on mobile, uses percentage-based radii for proper scaling
System Status strip showing gateway health, active providers, deployed models, total requests
Provider Health full-width table with per-provider status (healthy/degraded/down) derived from model health data
**Removed (moved to Usage page)**
Daily Spend bar chart (duplicated Usage)
Spend by Model donut chart (duplicated Usage)
Old 4-column stat card layout
**Closes**
Closes #52 — Dashboard "Total Requests" now properly distinguishes successful vs. failed requests across all views (stat card, area chart, and API responses).