### PR TITLE
fix: new models not accessible when org policy is 'all models' (inherit)

### DIFF
--- a/src/services/callable_target_grants.py
+++ b/src/services/callable_target_grants.py
@@ -159,8 +159,12 @@ class CallableTargetGrantService:
         scope_context = resolve_runtime_scope_context(auth)
         if scope_context.organization_id is not None:
             organization_scope = ("organization", scope_context.organization_id)
-            if snapshot.binding_counts_by_scope.get(organization_scope, 0) == 0:
-                return set()
+            org_mode = snapshot.scope_modes_by_scope.get(organization_scope)
+            # If org policy is "inherit" (all models allowed), return None so
+            # models added after the policy was set are accessible automatically.
+            # See: https://github.com/deltawi/deltallm/issues/59
+            if org_mode != "restrict":
+                return None
             return set(snapshot.enabled_by_scope.get(organization_scope, ()))
 
         direct_scopes = self._applicable_scopes(auth)


### PR DESCRIPTION
## Summary
Fixes #59

## Problem
When an organization is set to "all models" access (`mode=inherit`), models added **after** the policy was configured are not accessible. This causes:
```json
{"error": {"message": "Model 'X' is not allowed for this key", "type": "permission_denied"}}
```

## Root cause
In `_resolve_base_allowlist`, the org check used `binding_counts_by_scope == 0` as the signal for "no restrictions", returning an empty set otherwise. But new models aren't in `enabled_by_scope`, so they get blocked.

## Fix
Check the org's **policy mode** instead of binding count. If the mode is not `restrict`, return `None` (allow all) so newly-added models are automatically accessible.

```python
# Before: used binding count as proxy (broken for new models)
if snapshot.binding_counts_by_scope.get(organization_scope, 0) == 0:
    return set()

# After: check actual policy mode
org_mode = snapshot.scope_modes_by_scope.get(organization_scope)
if org_mode != "restrict":
    return None  # allow all models
```