### PR TITLE
Fix #59: auto-follow org callable target catalog updates

### DIFF
--- a/src/api/admin/endpoints/callable_targets.py
+++ b/src/api/admin/endpoints/callable_targets.py
@@ -27,6 +27,7 @@ from src.services.callable_target_migration import (
     apply_callable_target_migration_backfill,
     build_callable_target_migration_report,
 )
+from src.services.organization_callable_target_sync import maybe_disable_organization_auto_follow_for_scope_mutation
 from src.services.callable_targets import CallableTarget
 
 router = APIRouter(tags=["Admin Callable Targets"])
@@ -239,6 +240,11 @@ async def upsert_callable_target_binding(request: Request, payload: dict[str, An
             enabled=binding.enabled,
             metadata=binding.metadata,
         )
+    await maybe_disable_organization_auto_follow_for_scope_mutation(
+        db_or_503(request),
+        scope_type=binding.scope_type,
+        scope_id=binding.scope_id,
+    )
     await reload_callable_target_grants(request)
     response = _binding_payload(binding)
     await emit_admin_mutation_audit(
@@ -359,6 +365,11 @@ async def delete_callable_target_binding(request: Request, binding_id: str) -> d
             scope_type=binding.scope_type,
             scope_id=binding.scope_id,
         )
+    await maybe_disable_organization_auto_follow_for_scope_mutation(
+        db_or_503(request),
+        scope_type=binding.scope_type,
+        scope_id=binding.scope_id,
+    )
     await reload_callable_target_grants(request)
     response = {"deleted": True, "callable_target_binding_id": binding_id}
     await emit_admin_mutation_audit(

--- a/src/api/admin/endpoints/models.py
+++ b/src/api/admin/endpoints/models.py
@@ -17,7 +17,10 @@ from src.providers.healthcheck import probe_provider_health
 from src.providers.model_discovery import discover_provider_models
 from src.providers.resolution import provider_presets, validate_provider_mode_compatibility
 from src.router import build_deployment_registry
+from src.services.asset_binding_mirror import reload_callable_target_grants_for_app
+from src.services.callable_targets import build_callable_target_catalog
 from src.services.model_deployments import DuplicateModelNameError, ensure_model_name_available
+from src.services.organization_callable_target_sync import sync_auto_follow_organization_bindings
 
 router = APIRouter(tags=["Models"])
 
@@ -108,6 +111,10 @@ async def _serialize_deployment_health(app: Any, deployment_id: str) -> dict[str
 def _rebuild_runtime_registry(app: Any) -> None:
     model_registry = getattr(app.state, "model_registry", {})
     route_groups = list(getattr(app.state, "route_groups", []))
+    app.state.callable_target_catalog = build_callable_target_catalog(
+        model_registry,
+        route_groups,
+    )
     rebuilt = build_deployment_registry(model_registry, route_groups=route_groups)
 
     runtime_registry = getattr(getattr(app.state, "router", None), "deployment_registry", None)
@@ -128,6 +135,17 @@ async def _invalidate_route_group_runtime_cache(app: Any) -> None:
     invalidate = getattr(cache, "invalidate", None)
     if callable(invalidate):
         await invalidate()
+
+
+async def _sync_auto_follow_org_bindings(app: Any) -> None:
+    changed = await sync_auto_follow_organization_bindings(
+        db=getattr(getattr(app.state, "prisma_manager", None), "client", None),
+        callable_target_binding_repository=getattr(app.state, "callable_target_binding_repository", None),
+        route_group_repository=getattr(app.state, "route_group_repository", None),
+        callable_target_catalog=getattr(app.state, "callable_target_catalog", None),
+    )
+    if changed > 0:
+        await reload_callable_target_grants_for_app(app)
 
 
 def _validate_model_config_or_400(model_config: dict[str, Any]) -> None:
@@ -367,6 +385,7 @@ async def create_model(request: Request, payload: dict[str, Any]) -> dict[str, A
         )
         await _invalidate_route_group_runtime_cache(request.app)
         _rebuild_runtime_registry(request.app)
+        await _sync_auto_follow_org_bindings(request.app)
 
     response = {
         "deployment_id": deployment_id,
@@ -452,6 +471,7 @@ async def update_model(request: Request, deployment_id: str, payload: dict[str, 
         )
         await _invalidate_route_group_runtime_cache(request.app)
         _rebuild_runtime_registry(request.app)
+        await _sync_auto_follow_org_bindings(request.app)
 
     response = {
         "deployment_id": deployment_id,
@@ -513,6 +533,7 @@ async def delete_model(request: Request, deployment_id: str) -> dict[str, bool]:
                 registry.pop(model_name, None)
             await _invalidate_route_group_runtime_cache(request.app)
             _rebuild_runtime_registry(request.app)
+            await _sync_auto_follow_org_bindings(request.app)
             response = {"deleted": True}
             await emit_control_audit_event(
                 request=request,

--- a/src/api/admin/endpoints/organizations.py
+++ b/src/api/admin/endpoints/organizations.py
@@ -34,7 +34,13 @@ from src.services.asset_visibility_preview import (
     build_asset_visibility_preview,
     list_scope_route_group_bindings,
 )
-from src.services.scoped_asset_access import apply_scope_asset_access, build_scope_asset_access
+from src.services.organization_callable_target_sync import (
+    get_organization_auto_follow_catalog,
+    organization_auto_follow_catalog,
+    set_organization_auto_follow_catalog,
+    with_organization_auto_follow_catalog,
+)
+from src.services.scoped_asset_access import build_scope_asset_access, sync_scope_asset_access_state
 from src.services.ui_authorization import build_organization_capabilities
 
 router = APIRouter(tags=["Admin Organizations"])
@@ -559,13 +565,15 @@ async def get_organization_asset_access(
     )
     if not rows:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
-    return await build_scope_asset_access(
+    response = await build_scope_asset_access(
         request,
         scope_type="organization",
         scope_id=organization_id,
         organization_id=organization_id,
         include_targets=include_targets,
     )
+    response["auto_follow_catalog"] = await get_organization_auto_follow_catalog(db, organization_id)
+    return response
 
 
 @router.put("/ui/api/organizations/{organization_id}/asset-access", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
@@ -587,15 +595,47 @@ async def update_organization_asset_access(
     )
     if not rows:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
-    response = await apply_scope_asset_access(
+    auto_follow_catalog = bool(payload.get("select_all_selectable", False))
+    async def _apply_asset_access(db_client: Any, *, callable_repository, route_repository) -> None:  # noqa: ANN001, ANN202
+        await sync_scope_asset_access_state(
+            request,
+            scope_type="organization",
+            scope_id=organization_id,
+            organization_id=organization_id,
+            mode=payload.get("mode"),
+            selected_callable_keys=payload.get("selected_callable_keys", []),
+            select_all_selectable=auto_follow_catalog,
+            binding_repository=callable_repository,
+            route_group_repository=route_repository,
+            reload_after_write=False,
+        )
+        await set_organization_auto_follow_catalog(
+            db_client,
+            organization_id,
+            enabled=auto_follow_catalog,
+        )
+
+    if hasattr(db, "tx"):
+        async with db.tx() as tx:
+            await _apply_asset_access(
+                tx,
+                callable_repository=_callable_target_binding_repository_for_request(request, db_client=tx),
+                route_repository=_route_group_repository_for_request(request, db_client=tx),
+            )
+    else:
+        await _apply_asset_access(
+            db,
+            callable_repository=_callable_target_binding_repository_for_request(request),
+            route_repository=_route_group_repository_for_request(request),
+        )
+    await reload_callable_target_grants(request)
+    response = await build_scope_asset_access(
         request,
         scope_type="organization",
         scope_id=organization_id,
         organization_id=organization_id,
-        mode=payload.get("mode"),
-        selected_callable_keys=payload.get("selected_callable_keys", []),
-        select_all_selectable=bool(payload.get("select_all_selectable", False)),
     )
+    response["auto_follow_catalog"] = auto_follow_catalog
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -629,7 +669,10 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
         payload.get("audit_content_storage_enabled"),
         "audit_content_storage_enabled",
     )
-    metadata = _audit_retention_metadata(payload)
+    metadata = with_organization_auto_follow_catalog(
+        _audit_retention_metadata(payload),
+        enabled=False,
+    )
     route_group_bindings = _normalize_route_group_binding_payloads(payload.get("route_group_bindings"))
     callable_target_bindings = _normalize_callable_target_binding_payloads(payload.get("callable_target_bindings"))
     _validate_route_group_callable_target_overlap(route_group_bindings, callable_target_bindings)
@@ -809,7 +852,8 @@ async def update_organization(
         payload.get("audit_content_storage_enabled", existing.get("audit_content_storage_enabled")),
         "audit_content_storage_enabled",
     )
-    metadata = _audit_retention_metadata(payload, existing.get("metadata") if isinstance(existing.get("metadata"), dict) else None)
+    existing_metadata = existing.get("metadata") if isinstance(existing.get("metadata"), dict) else None
+    metadata = _audit_retention_metadata(payload, existing_metadata)
     route_group_bindings = (
         _normalize_route_group_binding_payloads(payload.get("route_group_bindings"))
         if "route_group_bindings" in payload
@@ -836,6 +880,14 @@ async def update_organization(
             binding_payloads=callable_target_bindings,
             catalog=catalog,
         )
+    metadata = with_organization_auto_follow_catalog(
+        metadata if metadata is not None else existing_metadata,
+        enabled=(
+            organization_auto_follow_catalog(existing_metadata)
+            and route_group_bindings is None
+            and callable_target_bindings is None
+        ),
+    )
 
     async def _apply_update(db_client: Any, *, route_repository, callable_repository):  # noqa: ANN001, ANN202
         await db_client.execute_raw(
@@ -852,7 +904,7 @@ async def update_organization(
                 model_rpm_limit = $9::jsonb,
                 model_tpm_limit = $10::jsonb,
                 audit_content_storage_enabled = $11,
-                metadata = COALESCE($12::jsonb, metadata),
+                metadata = $12::jsonb,
                 updated_at = NOW()
             WHERE organization_id = $13
             """,

--- a/src/api/admin/endpoints/route_groups.py
+++ b/src/api/admin/endpoints/route_groups.py
@@ -14,7 +14,7 @@ from src.services.asset_binding_mirror import (
     mirror_route_group_binding_to_callable_target,
     reload_callable_target_grants,
 )
-from src.api.admin.endpoints.common import emit_admin_mutation_audit, model_entries, to_json_value
+from src.api.admin.endpoints.common import db_or_503, emit_admin_mutation_audit, model_entries, to_json_value
 from src.db.prompt_registry import PromptRegistryRepository
 from src.db.route_groups import RouteGroupRepository
 from src.middleware.admin import require_admin_permission
@@ -27,6 +27,7 @@ from src.services.asset_ownership import (
     public_metadata_without_owner_scope,
 )
 from src.services.asset_scopes import normalize_scope_type
+from src.services.organization_callable_target_sync import maybe_disable_organization_auto_follow_for_scope_mutation
 from src.services.prompt_registry import apply_route_preferences_to_metadata, parse_prompt_reference
 from src.services.route_groups import RouteGroupRuntimeCache
 
@@ -564,6 +565,12 @@ async def upsert_route_group_binding(request: Request, payload: dict[str, Any]) 
         enabled=enabled,
         metadata=metadata,
     )
+    if normalized_scope_type == "organization":
+        await maybe_disable_organization_auto_follow_for_scope_mutation(
+            db_or_503(request),
+            scope_type=normalized_scope_type,
+            scope_id=scope_id,
+        )
     await reload_callable_target_grants(request)
     response = _binding_response_payload(binding)
     await emit_admin_mutation_audit(
@@ -596,6 +603,12 @@ async def delete_route_group_binding(request: Request, binding_id: str) -> dict[
         scope_type=binding.scope_type,
         scope_id=binding.scope_id,
     )
+    if binding.scope_type == "organization":
+        await maybe_disable_organization_auto_follow_for_scope_mutation(
+            db_or_503(request),
+            scope_type=binding.scope_type,
+            scope_id=binding.scope_id,
+        )
     await reload_callable_target_grants(request)
     response = {"deleted": True, "route_group_binding_id": binding_id}
     await emit_admin_mutation_audit(

--- a/src/config_runtime/models.py
+++ b/src/config_runtime/models.py
@@ -10,8 +10,10 @@ from src.db.repositories import ModelDeploymentRecord, ModelDeploymentRepository
 from src.db.route_groups import RouteGroupRepository
 from src.providers.resolution import validate_provider_mode_compatibility
 from src.router import RouterConfig, RoutingStrategy, build_deployment_registry, build_route_group_policies
+from src.services.asset_binding_mirror import reload_callable_target_grants_for_app
 from src.services.callable_targets import build_callable_target_catalog
 from src.services.model_deployments import ensure_model_name_available, load_model_registry
+from src.services.organization_callable_target_sync import sync_auto_follow_organization_bindings
 from src.services.route_groups import RouteGroupRuntimeCache, load_route_groups
 
 
@@ -197,6 +199,14 @@ class ModelHotReloadManager:
     async def _reload_runtime(self) -> None:
         app_config = self.dynamic_config.get_app_config()
         await self._apply_runtime_config(app_config)
+        changed = await sync_auto_follow_organization_bindings(
+            db=getattr(getattr(self.app.state, "prisma_manager", None), "client", None),
+            callable_target_binding_repository=getattr(self.app.state, "callable_target_binding_repository", None),
+            route_group_repository=getattr(self.app.state, "route_group_repository", None),
+            callable_target_catalog=getattr(self.app.state, "callable_target_catalog", None),
+        )
+        if changed > 0:
+            await reload_callable_target_grants_for_app(self.app)
         await self.dynamic_config.publish_model_updated()
 
     async def reload_runtime(self) -> None:

--- a/src/services/asset_binding_mirror.py
+++ b/src/services/asset_binding_mirror.py
@@ -31,13 +31,17 @@ def callable_catalog(request: Request) -> dict[str, CallableTarget]:
 
 
 async def reload_callable_target_grants(request: Request) -> None:
-    invalidation = getattr(request.app.state, "governance_invalidation_service", None)
+    await reload_callable_target_grants_for_app(request.app)
+
+
+async def reload_callable_target_grants_for_app(app: Any) -> None:
+    invalidation = getattr(app.state, "governance_invalidation_service", None)
     if invalidation is not None and callable(getattr(invalidation, "invalidate_local", None)):
         await invalidation.invalidate_local("callable_target")
         if callable(getattr(invalidation, "notify", None)):
             await invalidation.notify("callable_target")
         return
-    service = getattr(request.app.state, "callable_target_grant_service", None)
+    service = getattr(app.state, "callable_target_grant_service", None)
     if service is None or not callable(getattr(service, "reload", None)):
         return
     await service.reload()

--- a/src/services/organization_callable_target_sync.py
+++ b/src/services/organization_callable_target_sync.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.services.asset_binding_mirror import (
+    list_all_callable_target_bindings,
+    list_all_route_group_bindings,
+)
+from src.services.callable_targets import CallableTarget
+
+_CALLABLE_TARGET_ACCESS_METADATA_KEY = "_callable_target_access"
+_AUTO_FOLLOW_CATALOG_METADATA_KEY = "auto_follow_catalog"
+
+
+def organization_auto_follow_catalog(metadata: dict[str, Any] | None) -> bool:
+    if not isinstance(metadata, dict):
+        return False
+    settings = metadata.get(_CALLABLE_TARGET_ACCESS_METADATA_KEY)
+    if not isinstance(settings, dict):
+        return False
+    value = settings.get(_AUTO_FOLLOW_CATALOG_METADATA_KEY, False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    return False
+
+
+def _organization_scope_id(scope_type: str | None, scope_id: str | None) -> str | None:
+    normalized_scope_type = str(scope_type or "").strip().lower()
+    if normalized_scope_type not in {"organization", "org"}:
+        return None
+    normalized_scope_id = str(scope_id or "").strip()
+    return normalized_scope_id or None
+
+
+def with_organization_auto_follow_catalog(
+    metadata: dict[str, Any] | None,
+    *,
+    enabled: bool,
+) -> dict[str, Any] | None:
+    next_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    raw_settings = next_metadata.get(_CALLABLE_TARGET_ACCESS_METADATA_KEY)
+    settings = dict(raw_settings) if isinstance(raw_settings, dict) else {}
+
+    if enabled:
+        settings[_AUTO_FOLLOW_CATALOG_METADATA_KEY] = True
+        next_metadata[_CALLABLE_TARGET_ACCESS_METADATA_KEY] = settings
+        return next_metadata
+
+    settings.pop(_AUTO_FOLLOW_CATALOG_METADATA_KEY, None)
+    if settings:
+        next_metadata[_CALLABLE_TARGET_ACCESS_METADATA_KEY] = settings
+    else:
+        next_metadata.pop(_CALLABLE_TARGET_ACCESS_METADATA_KEY, None)
+    return next_metadata or None
+
+
+async def get_organization_auto_follow_catalog(db: Any, organization_id: str) -> bool:
+    rows = await db.query_raw(
+        """
+        SELECT metadata
+        FROM deltallm_organizationtable
+        WHERE organization_id = $1
+        LIMIT 1
+        """,
+        organization_id,
+    )
+    if not rows:
+        return False
+    return organization_auto_follow_catalog(rows[0].get("metadata") if isinstance(rows[0], dict) else None)
+
+
+async def set_organization_auto_follow_catalog(
+    db: Any,
+    organization_id: str,
+    *,
+    enabled: bool,
+) -> None:
+    rows = await db.query_raw(
+        """
+        SELECT metadata
+        FROM deltallm_organizationtable
+        WHERE organization_id = $1
+        LIMIT 1
+        """,
+        organization_id,
+    )
+    if not rows:
+        return
+
+    current_metadata = rows[0].get("metadata") if isinstance(rows[0], dict) else None
+    next_metadata = with_organization_auto_follow_catalog(
+        current_metadata if isinstance(current_metadata, dict) else None,
+        enabled=enabled,
+    )
+    await db.execute_raw(
+        """
+        UPDATE deltallm_organizationtable
+        SET metadata = $2::jsonb,
+            updated_at = NOW()
+        WHERE organization_id = $1
+        """,
+        organization_id,
+        next_metadata,
+    )
+
+
+async def disable_organization_auto_follow_catalog(db: Any, organization_id: str) -> bool:
+    if not await get_organization_auto_follow_catalog(db, organization_id):
+        return False
+    await set_organization_auto_follow_catalog(
+        db,
+        organization_id,
+        enabled=False,
+    )
+    return True
+
+
+async def maybe_disable_organization_auto_follow_for_scope_mutation(
+    db: Any,
+    *,
+    scope_type: str | None,
+    scope_id: str | None,
+) -> bool:
+    organization_id = _organization_scope_id(scope_type, scope_id)
+    if organization_id is None:
+        return False
+    return await disable_organization_auto_follow_catalog(db, organization_id)
+
+
+async def list_organization_ids_with_auto_follow_catalog(db: Any) -> list[str]:
+    rows = await db.query_raw(
+        """
+        SELECT organization_id, metadata
+        FROM deltallm_organizationtable
+        """
+    )
+    organization_ids: list[str] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        organization_id = str(row.get("organization_id") or "").strip()
+        if not organization_id:
+            continue
+        if not organization_auto_follow_catalog(row.get("metadata") if isinstance(row.get("metadata"), dict) else None):
+            continue
+        organization_ids.append(organization_id)
+    return organization_ids
+
+
+async def sync_auto_follow_organization_bindings(
+    *,
+    db: Any | None,
+    callable_target_binding_repository: Any | None,
+    route_group_repository: Any | None,
+    callable_target_catalog: dict[str, CallableTarget] | None,
+) -> int:
+    if db is None or callable_target_binding_repository is None or callable_target_catalog is None:
+        return 0
+
+    organization_ids = await list_organization_ids_with_auto_follow_catalog(db)
+    if not organization_ids:
+        return 0
+
+    desired_keys = set(callable_target_catalog.keys())
+    route_group_keys = {
+        callable_key
+        for callable_key, target in callable_target_catalog.items()
+        if isinstance(target, CallableTarget) and target.target_type == "route_group"
+    }
+    changed = 0
+    for organization_id in organization_ids:
+        bindings = await list_all_callable_target_bindings(
+            callable_target_binding_repository,
+            scope_type="organization",
+            scope_id=organization_id,
+        )
+        current_bindings_by_key = {
+            str(binding.callable_key or "").strip(): binding
+            for binding in bindings
+            if str(binding.callable_key or "").strip()
+        }
+        current_keys = set(current_bindings_by_key.keys())
+
+        for callable_key in sorted(current_keys - desired_keys):
+            binding = current_bindings_by_key.get(callable_key)
+            if binding is None:
+                continue
+            await callable_target_binding_repository.delete_binding(binding.callable_target_binding_id)
+            changed += 1
+
+        for callable_key in sorted(desired_keys):
+            binding = current_bindings_by_key.get(callable_key)
+            if binding is not None and binding.enabled:
+                continue
+            metadata = (
+                dict(binding.metadata)
+                if binding is not None and isinstance(binding.metadata, dict)
+                else {"source": "auto_follow_catalog"}
+            )
+            await callable_target_binding_repository.upsert_binding(
+                callable_key=callable_key,
+                scope_type="organization",
+                scope_id=organization_id,
+                enabled=True,
+                metadata=metadata,
+            )
+            changed += 1
+
+        if route_group_repository is None:
+            continue
+
+        route_group_bindings = await list_all_route_group_bindings(
+            route_group_repository,
+            scope_type="organization",
+            scope_id=organization_id,
+        )
+        route_group_bindings_by_key = {
+            str(binding.group_key or "").strip(): binding
+            for binding in route_group_bindings
+            if str(binding.group_key or "").strip()
+        }
+        current_route_group_keys = set(route_group_bindings_by_key.keys())
+
+        for callable_key in sorted(current_route_group_keys - route_group_keys):
+            binding = route_group_bindings_by_key.get(callable_key)
+            if binding is None:
+                continue
+            await route_group_repository.delete_binding(binding.route_group_binding_id)
+            changed += 1
+
+        for callable_key in sorted(route_group_keys):
+            binding = route_group_bindings_by_key.get(callable_key)
+            if binding is not None and binding.enabled:
+                continue
+            metadata = (
+                dict(binding.metadata)
+                if binding is not None and isinstance(binding.metadata, dict)
+                else {"source": "auto_follow_catalog"}
+            )
+            await route_group_repository.upsert_binding(
+                callable_key,
+                scope_type="organization",
+                scope_id=organization_id,
+                enabled=True,
+                metadata=metadata,
+            )
+            changed += 1
+    return changed

--- a/src/services/scoped_asset_access.py
+++ b/src/services/scoped_asset_access.py
@@ -11,6 +11,7 @@ from src.services.asset_binding_mirror import (
     callable_target_binding_repository,
     delete_route_group_binding_mirror,
     list_all_callable_target_bindings,
+    list_all_route_group_bindings,
     mirror_callable_target_binding_to_route_group,
     reload_callable_target_grants,
 )
@@ -205,6 +206,47 @@ async def apply_scope_asset_access(
     user_id: str | None = None,
     select_all_selectable: bool = False,
 ) -> dict[str, Any]:
+    await sync_scope_asset_access_state(
+        request,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        organization_id=organization_id,
+        mode=mode,
+        selected_callable_keys=selected_callable_keys,
+        team_id=team_id,
+        api_key_id=api_key_id,
+        user_id=user_id,
+        select_all_selectable=select_all_selectable,
+    )
+
+    return await build_scope_asset_access(
+        request,
+        scope_type=_normalize_scope_type(scope_type),
+        scope_id=scope_id,
+        organization_id=organization_id,
+        team_id=team_id,
+        api_key_id=api_key_id,
+        user_id=user_id,
+    )
+
+
+async def sync_scope_asset_access_state(
+    request: Request,
+    *,
+    scope_type: str,
+    scope_id: str,
+    organization_id: str,
+    mode: str | None,
+    selected_callable_keys: list[str],
+    team_id: str | None = None,
+    api_key_id: str | None = None,
+    user_id: str | None = None,
+    select_all_selectable: bool = False,
+    binding_repository: CallableTargetBindingRepository | None = None,
+    policy_repository: CallableTargetScopePolicyRepository | None = None,
+    route_group_repository: Any | None = None,
+    reload_after_write: bool = True,
+) -> None:
     normalized_scope_type = _normalize_scope_type(scope_type)
     normalized_mode = _normalize_mode(normalized_scope_type, mode)
     normalized_selected = _normalize_selected_callable_keys(selected_callable_keys)
@@ -245,7 +287,7 @@ async def apply_scope_asset_access(
             detail="selected_callable_keys must be empty when mode is inherit",
         )
 
-    repository = _binding_repository_or_503(request)
+    repository = binding_repository or _binding_repository_or_503(request)
     await _sync_scope_bindings(
         request,
         repository=repository,
@@ -253,24 +295,17 @@ async def apply_scope_asset_access(
         scope_id=scope_id,
         selected_callable_keys=normalized_selected if normalized_mode != "inherit" else [],
         catalog=catalog,
+        route_group_repository=route_group_repository,
     )
     await _sync_scope_policy(
         request,
         scope_type=normalized_scope_type,
         scope_id=scope_id,
         mode=normalized_mode,
+        policy_repository=policy_repository,
     )
-    await reload_callable_target_grants(request)
-
-    return await build_scope_asset_access(
-        request,
-        scope_type=normalized_scope_type,
-        scope_id=scope_id,
-        organization_id=organization_id,
-        team_id=team_id,
-        api_key_id=api_key_id,
-        user_id=user_id,
-    )
+    if reload_after_write:
+        await reload_callable_target_grants(request)
 
 
 async def _resolved_mode(request: Request, *, scope_type: str, scope_id: str) -> str:
@@ -419,6 +454,7 @@ async def _sync_scope_bindings(
     scope_id: str,
     selected_callable_keys: list[str],
     catalog: dict[str, CallableTarget],
+    route_group_repository: Any | None = None,
 ) -> None:
     selected_set = set(selected_callable_keys)
     existing = await list_all_callable_target_bindings(
@@ -440,14 +476,24 @@ async def _sync_scope_bindings(
         )
         target = catalog.get(callable_key)
         if target is not None and target.target_type == "route_group":
-            await mirror_callable_target_binding_to_route_group(
-                request,
-                callable_key=callable_key,
-                scope_type=scope_type,
-                scope_id=scope_id,
-                enabled=True,
-                metadata=metadata,
-            )
+            if route_group_repository is not None:
+                if await route_group_repository.get_group(callable_key) is not None:
+                    await route_group_repository.upsert_binding(
+                        callable_key,
+                        scope_type=scope_type,
+                        scope_id=scope_id,
+                        enabled=True,
+                        metadata=metadata,
+                    )
+            else:
+                await mirror_callable_target_binding_to_route_group(
+                    request,
+                    callable_key=callable_key,
+                    scope_type=scope_type,
+                    scope_id=scope_id,
+                    enabled=True,
+                    metadata=metadata,
+                )
 
     for callable_key, binding in existing_by_key.items():
         if callable_key in selected_set:
@@ -455,12 +501,22 @@ async def _sync_scope_bindings(
         await repository.delete_binding(binding.callable_target_binding_id)
         target = catalog.get(callable_key)
         if target is not None and target.target_type == "route_group":
-            await delete_route_group_binding_mirror(
-                request,
-                group_key=callable_key,
-                scope_type=scope_type,
-                scope_id=scope_id,
-            )
+            if route_group_repository is not None:
+                bindings = await list_all_route_group_bindings(
+                    route_group_repository,
+                    group_key=callable_key,
+                    scope_type=scope_type,
+                    scope_id=scope_id,
+                )
+                for route_group_binding in bindings:
+                    await route_group_repository.delete_binding(route_group_binding.route_group_binding_id)
+            else:
+                await delete_route_group_binding_mirror(
+                    request,
+                    group_key=callable_key,
+                    scope_type=scope_type,
+                    scope_id=scope_id,
+                )
 
 
 async def _sync_scope_policy(
@@ -469,10 +525,11 @@ async def _sync_scope_policy(
     scope_type: str,
     scope_id: str,
     mode: str,
+    policy_repository: CallableTargetScopePolicyRepository | None = None,
 ) -> None:
     if scope_type not in _SCOPES_WITH_POLICY:
         return
-    repository = _policy_repository_or_503(request)
+    repository = policy_repository or _policy_repository_or_503(request)
     if mode == "restrict":
         await repository.upsert_policy(
             scope_type=scope_type,

--- a/tests/test_ui_asset_access.py
+++ b/tests/test_ui_asset_access.py
@@ -6,13 +6,14 @@ import pytest
 
 from src.db.callable_target_policies import CallableTargetScopePolicyRecord
 from src.db.callable_targets import CallableTargetBindingRecord
+from src.db.route_groups import RouteGroupBindingRecord, RouteGroupRecord
 from src.services.callable_targets import CallableTarget
 
 
 class _FakeScopeDB:
     def __init__(self) -> None:
         self.organizations = {
-            "org-1": {"organization_id": "org-1"},
+            "org-1": {"organization_id": "org-1", "metadata": None},
         }
         self.teams = {
             "team-1": {
@@ -41,6 +42,8 @@ class _FakeScopeDB:
         if "FROM deltallm_organizationtable" in query and "WHERE organization_id = $1" in query:
             row = self.organizations.get(str(params[0]))
             return [row] if row else []
+        if "FROM deltallm_organizationtable" in query:
+            return list(self.organizations.values())
         if "FROM deltallm_teamtable" in query and "WHERE team_id = $1" in query:
             row = self.teams.get(str(params[0]))
             return [row] if row else []
@@ -48,6 +51,27 @@ class _FakeScopeDB:
             row = self.keys.get(str(params[0]))
             return [row] if row else []
         return []
+
+    async def execute_raw(self, query: str, *params):  # noqa: ANN201
+        if "UPDATE deltallm_organizationtable" in query and "metadata = $2::jsonb" in query:
+            row = self.organizations.get(str(params[0]))
+            if row is None:
+                return 0
+            row["metadata"] = params[1]
+            return 1
+        return 0
+
+    def tx(self):  # noqa: ANN201
+        db = self
+
+        class _TxContext:
+            async def __aenter__(self_inner):  # noqa: ANN202
+                return db
+
+            async def __aexit__(self_inner, exc_type, exc, tb):  # noqa: ANN202
+                return False
+
+        return _TxContext()
 
 
 class _FakeCallableTargetBindingRepository:
@@ -139,6 +163,76 @@ class _FakeGrantService:
         self.reloads += 1
 
 
+class _SharedRouteGroupState:
+    def __init__(self) -> None:
+        self.groups = {
+            "support-chat": RouteGroupRecord(
+                route_group_id="rg-1",
+                group_key="support-chat",
+                name="Support Chat",
+                mode="chat",
+                routing_strategy="weighted",
+                enabled=True,
+                metadata=None,
+                owner_scope_type="global",
+                owner_scope_id=None,
+            )
+        }
+        self.bindings: list[RouteGroupBindingRecord] = []
+
+
+class _CountingRouteGroupRepository:
+    def __init__(self, shared: _SharedRouteGroupState) -> None:
+        self.shared = shared
+        self.upsert_calls = 0
+        self.delete_calls = 0
+
+    async def get_group(self, group_key: str):  # noqa: ANN201
+        return self.shared.groups.get(group_key)
+
+    async def list_groups(self, *, limit=100, offset=0):  # noqa: ANN001, ANN201
+        items = list(self.shared.groups.values())[offset : offset + limit]
+        return items, len(self.shared.groups)
+
+    async def list_bindings(self, *, group_key=None, scope_type=None, scope_id=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+        items = list(self.shared.bindings)
+        if group_key:
+            items = [item for item in items if item.group_key == group_key]
+        if scope_type:
+            items = [item for item in items if item.scope_type == scope_type]
+        if scope_id:
+            items = [item for item in items if item.scope_id == scope_id]
+        page = items[offset : offset + limit]
+        return page, len(items)
+
+    async def upsert_binding(self, group_key: str, *, scope_type, scope_id, enabled, metadata):  # noqa: ANN001, ANN201
+        self.upsert_calls += 1
+        for index, item in enumerate(self.shared.bindings):
+            if item.group_key == group_key and item.scope_type == scope_type and item.scope_id == scope_id:
+                self.shared.bindings[index] = replace(item, enabled=enabled, metadata=metadata)
+                return self.shared.bindings[index]
+        group = self.shared.groups[group_key]
+        record = RouteGroupBindingRecord(
+            route_group_binding_id=f"rgb-{len(self.shared.bindings) + 1}",
+            route_group_id=group.route_group_id,
+            group_key=group_key,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            enabled=enabled,
+            metadata=metadata,
+        )
+        self.shared.bindings.append(record)
+        return record
+
+    async def delete_binding(self, binding_id: str) -> bool:
+        self.delete_calls += 1
+        kept = [item for item in self.shared.bindings if item.route_group_binding_id != binding_id]
+        if len(kept) == len(self.shared.bindings):
+            return False
+        self.shared.bindings = kept
+        return True
+
+
 @pytest.mark.asyncio
 async def test_get_organization_asset_access_returns_selected_targets(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
@@ -167,9 +261,85 @@ async def test_get_organization_asset_access_returns_selected_targets(client, te
     assert response.status_code == 200
     payload = response.json()
     assert payload["mode"] == "grant"
+    assert payload["auto_follow_catalog"] is False
     assert payload["selected_callable_keys"] == ["gpt-4o-mini"]
     assert payload["summary"]["selectable_total"] == 2
     assert payload["summary"]["effective_total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_update_organization_asset_access_select_all_enables_auto_follow(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    scope_db = _FakeScopeDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": scope_db})()
+    binding_repository = _FakeCallableTargetBindingRepository()
+    grant_service = _FakeGrantService()
+    test_app.state.callable_target_binding_repository = binding_repository
+    test_app.state.callable_target_scope_policy_repository = _FakeCallableTargetScopePolicyRepository()
+    test_app.state.callable_target_grant_service = grant_service
+    test_app.state.callable_target_catalog = {
+        "gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model"),
+        "support-chat": CallableTarget(key="support-chat", target_type="route_group"),
+    }
+
+    response = await client.put(
+        "/ui/api/organizations/org-1/asset-access",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"mode": "grant", "selected_callable_keys": [], "select_all_selectable": True},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["auto_follow_catalog"] is True
+    assert payload["selected_callable_keys"] == ["gpt-4o-mini", "support-chat"]
+    assert scope_db.organizations["org-1"]["metadata"] == {
+        "_callable_target_access": {"auto_follow_catalog": True}
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_organization_asset_access_uses_transaction_route_group_repository(client, test_app, monkeypatch) -> None:
+    from src.api.admin.endpoints import organizations as organizations_endpoints
+
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    scope_db = _FakeScopeDB()
+    shared_route_groups = _SharedRouteGroupState()
+    request_route_repo = _CountingRouteGroupRepository(shared_route_groups)
+    tx_route_repo = _CountingRouteGroupRepository(shared_route_groups)
+    binding_repository = _FakeCallableTargetBindingRepository()
+    grant_service = _FakeGrantService()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": scope_db})()
+    test_app.state.callable_target_binding_repository = binding_repository
+    test_app.state.callable_target_scope_policy_repository = _FakeCallableTargetScopePolicyRepository()
+    test_app.state.callable_target_grant_service = grant_service
+    test_app.state.route_group_repository = request_route_repo
+    test_app.state.callable_target_catalog = {
+        "support-chat": CallableTarget(key="support-chat", target_type="route_group"),
+    }
+
+    def _route_group_repository_for_request(request, *, db_client=None):  # noqa: ANN001, ANN202
+        del request
+        return tx_route_repo if db_client is not None else request_route_repo
+
+    monkeypatch.setattr(
+        organizations_endpoints,
+        "_route_group_repository_for_request",
+        _route_group_repository_for_request,
+    )
+
+    response = await client.put(
+        "/ui/api/organizations/org-1/asset-access",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"mode": "grant", "selected_callable_keys": ["support-chat"]},
+    )
+
+    assert response.status_code == 200
+    assert tx_route_repo.upsert_calls == 1
+    assert request_route_repo.upsert_calls == 0
+    assert {
+        (binding.group_key, binding.scope_type, binding.scope_id)
+        for binding in shared_route_groups.bindings
+    } == {("support-chat", "organization", "org-1")}
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_callable_targets.py
+++ b/tests/test_ui_callable_targets.py
@@ -97,7 +97,7 @@ class _FakeMigrationDB:
 
 class _FakeScopeValidationDB:
     def __init__(self) -> None:
-        self.organizations = [{"organization_id": "org-1"}]
+        self.organizations = [{"organization_id": "org-1", "metadata": {"_callable_target_access": {"auto_follow_catalog": True}}}]
         self.teams = [{"team_id": "team-1", "organization_id": "org-1"}]
         self.keys = [{"token": "key-1", "team_id": "team-1", "organization_id": "org-1"}]
         self.users = [{"user_id": "user-1", "team_id": "team-1", "organization_id": "org-1"}]
@@ -115,7 +115,19 @@ class _FakeScopeValidationDB:
         if "FROM deltallm_usertable u" in query and "WHERE u.user_id = $1" in query:
             user_id = str(params[0])
             return [row for row in self.users if row["user_id"] == user_id]
+        if "FROM deltallm_organizationtable" in query:
+            return list(self.organizations)
         return []
+
+    async def execute_raw(self, query: str, *params):  # noqa: ANN201
+        if "UPDATE deltallm_organizationtable" in query and "metadata = $2::jsonb" in query:
+            organization_id = str(params[0])
+            for row in self.organizations:
+                if row["organization_id"] == organization_id:
+                    row["metadata"] = params[1]
+                    return 1
+            return 0
+        return 0
 
 
 class _FakeReadyMigrationDB(_FakeMigrationDB):
@@ -346,7 +358,8 @@ async def test_callable_target_binding_admin_lifecycle(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
     repo = _FakeCallableTargetBindingRepository()
     policy_repo = _FakeCallableTargetScopePolicyRepository()
-    test_app.state.prisma_manager = type("Prisma", (), {"client": _FakeScopeValidationDB()})()
+    scope_db = _FakeScopeValidationDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": scope_db})()
     test_app.state.callable_target_binding_repository = repo
     test_app.state.callable_target_scope_policy_repository = policy_repo
     test_app.state.callable_target_catalog = {
@@ -370,6 +383,7 @@ async def test_callable_target_binding_admin_lifecycle(client, test_app):
     payload = upsert.json()
     assert payload["callable_key"] == "support-fast"
     assert payload["scope_type"] == "organization"
+    assert scope_db.organizations[0]["metadata"] is None
 
     detail = await client.get("/ui/api/callable-targets/support-fast", headers=headers)
     assert detail.status_code == 200
@@ -384,12 +398,14 @@ async def test_callable_target_binding_admin_lifecycle(client, test_app):
     assert listing.status_code == 200
     assert listing.json()["pagination"]["total"] == 1
 
+    scope_db.organizations[0]["metadata"] = {"_callable_target_access": {"auto_follow_catalog": True}}
     delete = await client.delete(
         f"/ui/api/callable-target-bindings/{payload['callable_target_binding_id']}",
         headers=headers,
     )
     assert delete.status_code == 200
     assert delete.json()["deleted"] is True
+    assert scope_db.organizations[0]["metadata"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_models.py
+++ b/tests/test_ui_models.py
@@ -1,8 +1,159 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
+
+from src.db.callable_targets import CallableTargetBindingRecord
+from src.db.route_groups import RouteGroupBindingRecord, RouteGroupRecord
+from src.services.callable_target_grants import CallableTargetGrantService
+from src.services.callable_targets import CallableTarget
+from src.services.organization_callable_target_sync import sync_auto_follow_organization_bindings
+
+
+class _FakeOrganizationMetadataDB:
+    def __init__(self) -> None:
+        self.organizations = {
+            "org-default": {
+                "organization_id": "org-default",
+                "metadata": {
+                    "_callable_target_access": {"auto_follow_catalog": True},
+                },
+            }
+        }
+
+    async def query_raw(self, query: str, *params):  # noqa: ANN201
+        if "FROM deltallm_organizationtable" in query and "WHERE organization_id = $1" in query:
+            row = self.organizations.get(str(params[0]))
+            return [row] if row else []
+        if "FROM deltallm_organizationtable" in query:
+            return list(self.organizations.values())
+        return []
+
+    async def execute_raw(self, query: str, *params):  # noqa: ANN201
+        if "UPDATE deltallm_organizationtable" in query and "metadata = $2::jsonb" in query:
+            row = self.organizations.get(str(params[0]))
+            if row is None:
+                return 0
+            row["metadata"] = params[1]
+            return 1
+        return 0
+
+
+class _MalformedOrganizationMetadataDB(_FakeOrganizationMetadataDB):
+    def __init__(self) -> None:
+        super().__init__()
+        self.organizations["org-default"]["metadata"] = {
+            "_callable_target_access": {"auto_follow_catalog": "yes"},
+        }
+
+
+class _MutableCallableTargetBindingRepository:
+    def __init__(self, bindings: list[CallableTargetBindingRecord]) -> None:
+        self.bindings = list(bindings)
+        self._counter = len(bindings)
+
+    async def list_bindings(self, *, callable_key=None, scope_type=None, scope_id=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+        items = list(self.bindings)
+        if callable_key:
+            items = [item for item in items if item.callable_key == callable_key]
+        if scope_type:
+            items = [item for item in items if item.scope_type == scope_type]
+        if scope_id:
+            items = [item for item in items if item.scope_id == scope_id]
+        page = items[offset : offset + limit]
+        return page, len(items)
+
+    async def upsert_binding(self, *, callable_key, scope_type, scope_id, enabled, metadata):  # noqa: ANN001, ANN201
+        for index, item in enumerate(self.bindings):
+            if item.callable_key == callable_key and item.scope_type == scope_type and item.scope_id == scope_id:
+                updated = replace(item, enabled=enabled, metadata=metadata)
+                self.bindings[index] = updated
+                return updated
+        self._counter += 1
+        record = CallableTargetBindingRecord(
+            callable_target_binding_id=f"ctb-{self._counter}",
+            callable_key=callable_key,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            enabled=enabled,
+            metadata=metadata,
+        )
+        self.bindings.append(record)
+        return record
+
+    async def delete_binding(self, binding_id: str) -> bool:
+        kept = [item for item in self.bindings if item.callable_target_binding_id != binding_id]
+        if len(kept) == len(self.bindings):
+            return False
+        self.bindings = kept
+        return True
+
+
+class _MutableRouteGroupRepository:
+    def __init__(self) -> None:
+        self.groups = {
+            "support-fast": RouteGroupRecord(
+                route_group_id="rg-1",
+                group_key="support-fast",
+                name="Support Fast",
+                mode="chat",
+                routing_strategy="weighted",
+                enabled=True,
+                metadata=None,
+                owner_scope_type="global",
+                owner_scope_id=None,
+            )
+        }
+        self.bindings: list[RouteGroupBindingRecord] = [
+            RouteGroupBindingRecord(
+                route_group_binding_id="rgb-1",
+                route_group_id="rg-1",
+                group_key="support-fast",
+                scope_type="organization",
+                scope_id="org-default",
+                enabled=True,
+                metadata=None,
+            )
+        ]
+
+    async def list_bindings(self, *, group_key=None, scope_type=None, scope_id=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+        items = list(self.bindings)
+        if group_key:
+            items = [item for item in items if item.group_key == group_key]
+        if scope_type:
+            items = [item for item in items if item.scope_type == scope_type]
+        if scope_id:
+            items = [item for item in items if item.scope_id == scope_id]
+        page = items[offset : offset + limit]
+        return page, len(items)
+
+    async def upsert_binding(self, group_key: str, *, scope_type, scope_id, enabled, metadata):  # noqa: ANN001, ANN201
+        for index, item in enumerate(self.bindings):
+            if item.group_key == group_key and item.scope_type == scope_type and item.scope_id == scope_id:
+                updated = replace(item, enabled=enabled, metadata=metadata)
+                self.bindings[index] = updated
+                return updated
+        group = self.groups[group_key]
+        record = RouteGroupBindingRecord(
+            route_group_binding_id=f"rgb-{len(self.bindings) + 1}",
+            route_group_id=group.route_group_id,
+            group_key=group_key,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            enabled=enabled,
+            metadata=metadata,
+        )
+        self.bindings.append(record)
+        return record
+
+    async def delete_binding(self, binding_id: str) -> bool:
+        kept = [item for item in self.bindings if item.route_group_binding_id != binding_id]
+        if len(kept) == len(self.bindings):
+            return False
+        self.bindings = kept
+        return True
 
 
 @pytest.mark.asyncio
@@ -146,3 +297,124 @@ async def test_provider_health_summary_counts_models_beyond_paginated_limit(clie
     assert payload["providers"][0]["provider"] == "openai"
     assert payload["providers"][0]["models"] == 501
     assert payload["providers"][0]["healthy_models"] == 501
+
+
+@pytest.mark.asyncio
+async def test_create_model_syncs_auto_follow_org_bindings(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    binding_repository = _MutableCallableTargetBindingRepository(
+        [
+            CallableTargetBindingRecord(
+                callable_target_binding_id="ctb-org-1",
+                callable_key="gpt-4o-mini",
+                scope_type="organization",
+                scope_id="org-default",
+                enabled=True,
+                metadata=None,
+            ),
+            CallableTargetBindingRecord(
+                callable_target_binding_id="ctb-org-2",
+                callable_key="text-embedding-3-small",
+                scope_type="organization",
+                scope_id="org-default",
+                enabled=True,
+                metadata=None,
+            ),
+        ]
+    )
+    test_app.state.prisma_manager = type("Prisma", (), {"client": _FakeOrganizationMetadataDB()})()
+    test_app.state.callable_target_binding_repository = binding_repository
+    test_app.state.callable_target_grant_service = CallableTargetGrantService(
+        repository=binding_repository,
+        policy_repository=None,
+    )
+    await test_app.state.callable_target_grant_service.reload()
+
+    create_response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": "gpt-5-mini",
+            "deltallm_params": {
+                "provider": "openai",
+                "model": "openai/gpt-5-mini",
+                "api_base": "https://api.openai.com/v1",
+                "api_key": "provider-key",
+            },
+            "model_info": {"mode": "chat"},
+        },
+    )
+
+    assert create_response.status_code == 200
+    assert any(
+        binding.scope_type == "organization"
+        and binding.scope_id == "org-default"
+        and binding.callable_key == "gpt-5-mini"
+        for binding in binding_repository.bindings
+    )
+
+    models_response = await client.get(
+        "/v1/models",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+    )
+
+    assert models_response.status_code == 200
+    model_ids = {item["id"] for item in models_response.json()["data"]}
+    assert "gpt-5-mini" in model_ids
+
+
+@pytest.mark.asyncio
+async def test_auto_follow_sync_prunes_stale_org_bindings() -> None:
+    binding_repository = _MutableCallableTargetBindingRepository(
+        [
+            CallableTargetBindingRecord(
+                callable_target_binding_id="ctb-org-1",
+                callable_key="gpt-4o-mini",
+                scope_type="organization",
+                scope_id="org-default",
+                enabled=True,
+                metadata=None,
+            ),
+            CallableTargetBindingRecord(
+                callable_target_binding_id="ctb-org-2",
+                callable_key="support-fast",
+                scope_type="organization",
+                scope_id="org-default",
+                enabled=True,
+                metadata=None,
+            ),
+        ]
+    )
+    route_group_repository = _MutableRouteGroupRepository()
+
+    changed = await sync_auto_follow_organization_bindings(
+        db=_FakeOrganizationMetadataDB(),
+        callable_target_binding_repository=binding_repository,
+        route_group_repository=route_group_repository,
+        callable_target_catalog={
+            "gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model"),
+        },
+    )
+
+    assert changed == 2
+    assert {(item.scope_type, item.scope_id, item.callable_key) for item in binding_repository.bindings} == {
+        ("organization", "org-default", "gpt-4o-mini")
+    }
+    assert route_group_repository.bindings == []
+
+
+@pytest.mark.asyncio
+async def test_auto_follow_sync_ignores_malformed_metadata() -> None:
+    binding_repository = _MutableCallableTargetBindingRepository([])
+
+    changed = await sync_auto_follow_organization_bindings(
+        db=_MalformedOrganizationMetadataDB(),
+        callable_target_binding_repository=binding_repository,
+        route_group_repository=None,
+        callable_target_catalog={
+            "gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model"),
+        },
+    )
+
+    assert changed == 0
+    assert binding_repository.bindings == []

--- a/tests/test_ui_route_groups.py
+++ b/tests/test_ui_route_groups.py
@@ -272,6 +272,33 @@ class _FakeRouteGroupRepository:
         return rolled
 
 
+class _FakeOrganizationMetadataDB:
+    def __init__(self) -> None:
+        self.organizations = {
+            "org-1": {
+                "organization_id": "org-1",
+                "metadata": {"_callable_target_access": {"auto_follow_catalog": True}},
+            }
+        }
+
+    async def query_raw(self, query: str, *params):  # noqa: ANN201
+        if "FROM deltallm_organizationtable" in query and "WHERE organization_id = $1" in query:
+            row = self.organizations.get(str(params[0]))
+            return [row] if row else []
+        if "FROM deltallm_organizationtable" in query:
+            return list(self.organizations.values())
+        return []
+
+    async def execute_raw(self, query: str, *params):  # noqa: ANN201
+        if "UPDATE deltallm_organizationtable" in query and "metadata = $2::jsonb" in query:
+            row = self.organizations.get(str(params[0]))
+            if row is None:
+                return 0
+            row["metadata"] = params[1]
+            return 1
+        return 0
+
+
 class _FakeCallableTargetBindingRepository:
     def __init__(self) -> None:
         self.bindings: list[CallableTargetBindingRecord] = []
@@ -728,11 +755,13 @@ async def test_route_group_binding_admin_lifecycle(client, test_app):
     repo = _FakeRouteGroupRepository()
     callable_repo = _FakeCallableTargetBindingRepository()
     grant_reload = _FakeGrantReload()
+    scope_db = _FakeOrganizationMetadataDB()
     test_app.state.route_group_repository = repo
     test_app.state.callable_target_binding_repository = callable_repo
     test_app.state.callable_target_grant_service = grant_reload
     test_app.state.model_hot_reload_manager = _FakeHotReload()
     test_app.state.route_group_runtime_cache = _FakeRouteGroupRuntimeCache()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": scope_db})()
     headers = {"Authorization": "Bearer mk-test"}
 
     await client.post(
@@ -760,6 +789,7 @@ async def test_route_group_binding_admin_lifecycle(client, test_app):
     assert {(binding.callable_key, binding.scope_type, binding.scope_id) for binding in callable_repo.bindings} == {
         ("bound-route", "organization", "org-1")
     }
+    assert scope_db.organizations["org-1"]["metadata"] is None
     assert grant_reload.reload_count == 1
 
     list_response = await client.get(
@@ -775,6 +805,7 @@ async def test_route_group_binding_admin_lifecycle(client, test_app):
     assert detail_response.status_code == 200
     assert detail_response.json()["bindings"][0]["scope_id"] == "org-1"
 
+    scope_db.organizations["org-1"]["metadata"] = {"_callable_target_access": {"auto_follow_catalog": True}}
     delete_response = await client.delete(
         f"/ui/api/route-group-bindings/{payload['route_group_binding_id']}",
         headers=headers,
@@ -782,6 +813,7 @@ async def test_route_group_binding_admin_lifecycle(client, test_app):
     assert delete_response.status_code == 200
     assert delete_response.json()["deleted"] is True
     assert callable_repo.bindings == []
+    assert scope_db.organizations["org-1"]["metadata"] is None
     assert grant_reload.reload_count == 2
 
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -470,6 +470,7 @@ export interface ScopedAssetAccess {
   api_key_id?: string | null;
   user_id?: string | null;
   mode: 'grant' | 'inherit' | 'restrict';
+  auto_follow_catalog?: boolean;
   selected_callable_keys: string[];
   selectable_targets: AssetAccessTarget[];
   effective_targets: AssetAccessTarget[];

--- a/ui/src/pages/OrganizationCreate.tsx
+++ b/ui/src/pages/OrganizationCreate.tsx
@@ -531,9 +531,9 @@ export default function OrganizationCreate() {
                         />
                         <span>
                           <span className="block font-medium text-gray-900 text-xs">
-                            <Shield className="w-3 h-3 text-blue-600 inline mr-1" />Allow all
+                            <Shield className="w-3 h-3 text-blue-600 inline mr-1" />Allow all, including future additions
                           </span>
-                          <span className="block text-xs text-gray-500 mt-0.5">Grant every current model and route group.</span>
+                          <span className="block text-xs text-gray-500 mt-0.5">Grant every current asset now and automatically include newly added models and route groups.</span>
                         </span>
                       </div>
                     </label>
@@ -557,7 +557,7 @@ export default function OrganizationCreate() {
 
                   {selectAll ? (
                     <div className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-3 text-xs text-blue-800">
-                      Saving will grant every currently available model and route group to this organization.
+                      Saving will grant every currently available model and route group to this organization and automatically include future additions.
                     </div>
                   ) : (
                     <AssetAccessEditor
@@ -575,7 +575,7 @@ export default function OrganizationCreate() {
                       onTargetTypeFilterChange={(next) => { setAssetTargetType(next); setAssetPageOffset(0); }}
                       pagination={assetPagePagination}
                       onPageChange={setAssetPageOffset}
-                      primaryActionLabel="Allow all current assets"
+                      primaryActionLabel="Allow all assets"
                       onPrimaryAction={() => { setSelectAll(true); setSelectedKeys([]); }}
                       secondaryActionLabel={selectedKeys.length > 0 ? 'Clear selection' : undefined}
                       onSecondaryAction={selectedKeys.length > 0 ? () => setSelectedKeys([]) : undefined}

--- a/ui/src/pages/OrganizationDetail.tsx
+++ b/ui/src/pages/OrganizationDetail.tsx
@@ -151,9 +151,7 @@ export default function OrganizationDetail() {
     if (!isEditingAssets || !orgAssetAccess) return;
     setForm((c) => ({
       ...c,
-      select_all_current_assets:
-        orgAssetAccess.summary.selectable_total > 0 &&
-        orgAssetAccess.summary.selected_total === orgAssetAccess.summary.selectable_total,
+      select_all_current_assets: !!orgAssetAccess.auto_follow_catalog,
       selected_callable_keys: orgAssetAccess.selected_callable_keys || [],
     }));
   }, [isEditingAssets, orgAssetAccess]);
@@ -1092,8 +1090,8 @@ export default function OrganizationDetail() {
                           className="mt-0.5"
                         />
                         <span>
-                          <span className="block font-medium text-gray-900">Allow all current assets</span>
-                          <span className="block text-xs text-gray-500">Grant every current model and route group without loading the full catalog.</span>
+                          <span className="block font-medium text-gray-900">Allow all assets, including future additions</span>
+                          <span className="block text-xs text-gray-500">Grant every current asset now and automatically include newly added models and route groups.</span>
                         </span>
                       </div>
                     </label>
@@ -1117,8 +1115,8 @@ export default function OrganizationDetail() {
                   {form.select_all_current_assets ? (
                     <div className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-3 text-xs text-blue-800">
                       {orgAssetAccess
-                        ? `This organization currently has ${orgAssetAccess.summary.selected_total} of ${orgAssetAccess.summary.selectable_total} assets granted. Saving will align it to all current assets.`
-                        : 'Saving will grant every currently available model and route group to this organization.'}
+                        ? `This organization currently has ${orgAssetAccess.summary.selected_total} of ${orgAssetAccess.summary.selectable_total} assets granted. Saving will align it to all current assets and automatically include future additions.`
+                        : 'Saving will grant every currently available model and route group to this organization and automatically include future additions.'}
                     </div>
                   ) : (
                     <AssetAccessEditor
@@ -1136,7 +1134,7 @@ export default function OrganizationDetail() {
                       onTargetTypeFilterChange={(next) => { setAssetTargetType(next); setAssetPageOffset(0); }}
                       pagination={orgAssetPagination}
                       onPageChange={setAssetPageOffset}
-                      primaryActionLabel="Allow all current assets"
+                      primaryActionLabel="Allow all assets"
                       onPrimaryAction={() => setForm((c) => ({ ...c, select_all_current_assets: true, selected_callable_keys: [] }))}
                       secondaryActionLabel={form.selected_callable_keys.length > 0 ? 'Clear selection' : undefined}
                       onSecondaryAction={form.selected_callable_keys.length > 0 ? () => setForm((c) => ({ ...c, selected_callable_keys: [] })) : undefined}

--- a/ui/src/pages/Organizations.tsx
+++ b/ui/src/pages/Organizations.tsx
@@ -185,9 +185,7 @@ export default function Organizations() {
     if (!editItem || !editAssetAccess) return;
     setForm((c) => ({
       ...c,
-      select_all_current_assets:
-        editAssetAccess.summary.selectable_total > 0 &&
-        editAssetAccess.summary.selected_total === editAssetAccess.summary.selectable_total,
+      select_all_current_assets: !!editAssetAccess.auto_follow_catalog,
       selected_callable_keys: editAssetAccess.selected_callable_keys || [],
     }));
   }, [editItem, editAssetAccess]);
@@ -612,8 +610,8 @@ export default function Organizations() {
                       className="mt-0.5"
                     />
                     <span>
-                      <span className="block font-medium text-gray-900">Allow all current assets</span>
-                      <span className="block text-xs text-gray-500">Grant every model and route group that exists right now.</span>
+                      <span className="block font-medium text-gray-900">Allow all assets, including future additions</span>
+                      <span className="block text-xs text-gray-500">Grant every asset now and automatically include newly added models and route groups.</span>
                     </span>
                   </div>
                 </label>
@@ -637,8 +635,8 @@ export default function Organizations() {
               {form.select_all_current_assets ? (
                 <div className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-3 text-xs text-blue-800">
                   {editItem && editAssetAccess
-                    ? `This organization currently has ${editAssetAccess.summary.selected_total} of ${editAssetAccess.summary.selectable_total} assets granted. Saving will align it to all current callable assets.`
-                    : 'Saving will grant every currently available model and route group to this organization.'}
+                    ? `This organization currently has ${editAssetAccess.summary.selected_total} of ${editAssetAccess.summary.selectable_total} assets granted. Saving will align it to all current assets and automatically include future additions.`
+                    : 'Saving will grant every currently available model and route group to this organization and automatically include future additions.'}
                 </div>
               ) : (
                 <AssetAccessEditor
@@ -656,7 +654,7 @@ export default function Organizations() {
                   onTargetTypeFilterChange={(next) => { setAssetTargetType(next); setAssetPageOffset(0); }}
                   pagination={assetPagePagination}
                   onPageChange={setAssetPageOffset}
-                  primaryActionLabel="Allow all current assets"
+                  primaryActionLabel="Allow all assets"
                   onPrimaryAction={() => setForm((c) => ({ ...c, select_all_current_assets: true, selected_callable_keys: [] }))}
                   secondaryActionLabel={form.selected_callable_keys.length > 0 ? 'Clear selection' : undefined}
                   onSecondaryAction={form.selected_callable_keys.length > 0 ? () => setForm((c) => ({ ...c, selected_callable_keys: [] })) : undefined}


### PR DESCRIPTION
## Summary
Fixes #59

This PR implements explicit org-level auto-follow for callable target access so organizations configured to allow all assets continue to receive newly added models and route groups.

## Problem
Issue #59 reported that when an organization was configured to allow all models, models added later were not accessible to inheriting teams/keys.

The root cause was that org access was stored as a snapshot of explicit org bindings at save time. When the callable target catalog changed later, existing org bindings were not reconciled, so newly added models were blocked by policy enforcement.

## What changed
- Added explicit org auto-follow intent storage in organization metadata.
- Synced missing org bindings when the callable target catalog changes.
- Made the sync an exact mirror for opted-in orgs so stale bindings are pruned when assets disappear.
- Disabled org auto-follow when organization-scoped bindings are manually edited through the generic callable-target or route-group binding admin endpoints.
- Made org asset-access updates consistent with transaction-bound route-group mirror writes.
- Updated org UI/API responses to expose the explicit `auto_follow_catalog` state and clarified the UX copy.

## Why this fixes #59
When an org is saved with the “allow all assets, including future additions” behavior, newly introduced callable targets are now reconciled into org bindings on catalog changes. Inheriting teams, keys, and users continue to narrow from the org ceiling as before, but they no longer lose access to newly added models simply because the org bindings were created earlier.

## Notes
- Existing orgs that were configured before this flag existed are not auto-backfilled. Re-saving org asset access opts them into auto-follow.
- The gateway request path was not changed; the new logic runs on admin/catalog mutation and runtime reload flows only.

## Verification
- `uv run pytest tests/test_ui_asset_access.py tests/test_ui_models.py tests/test_ui_callable_targets.py tests/test_ui_route_groups.py tests/test_model_visibility.py`
- `uv run ruff check src/services/organization_callable_target_sync.py src/services/scoped_asset_access.py src/api/admin/endpoints/organizations.py tests/test_ui_asset_access.py tests/test_ui_models.py`
- `npm run build` in `ui`
