### PR TITLE
Fix #53: add auto-refresh controls to the Usage page

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -614,22 +614,28 @@ export const health = {
 };
 
 export const spend = {
-  summary: (start_date?: string, end_date?: string) => {
+  summary: (start_date?: string, end_date?: string, opts?: RequestInit) => {
     const qs = new URLSearchParams();
     if (start_date) qs.set('start_date', start_date);
     if (end_date) qs.set('end_date', end_date);
     const suffix = qs.toString() ? `?${qs.toString()}` : '';
-    return apiFetch<SpendSummary>(`/ui/api/spend/summary${suffix}`);
+    return apiFetch<SpendSummary>(`/ui/api/spend/summary${suffix}`, opts);
   },
-  report: (group_by: 'model' | 'provider' | 'day' | 'user' | 'team', start_date?: string, end_date?: string) => {
+  report: (
+    group_by: 'model' | 'provider' | 'day' | 'user' | 'team',
+    start_date?: string,
+    end_date?: string,
+    opts?: RequestInit,
+  ) => {
     const qs = new URLSearchParams({ group_by });
     if (start_date) qs.set('start_date', start_date);
     if (end_date) qs.set('end_date', end_date);
-    return apiFetch<any>(`/ui/api/spend/report?${qs.toString()}`);
+    return apiFetch<any>(`/ui/api/spend/report?${qs.toString()}`, opts);
   },
   groupedReport: (
     group_by: SpendGroupBy,
-    params?: { start_date?: string; end_date?: string; search?: string; limit?: number; offset?: number }
+    params?: { start_date?: string; end_date?: string; search?: string; limit?: number; offset?: number },
+    opts?: RequestInit,
   ) => {
     const qs = new URLSearchParams({ group_by });
     if (params?.start_date) qs.set('start_date', params.start_date);
@@ -637,12 +643,12 @@ export const spend = {
     if (params?.search) qs.set('search', params.search);
     if (params?.limit != null) qs.set('limit', String(params.limit));
     if (params?.offset != null) qs.set('offset', String(params.offset));
-    return apiFetch<SpendGroupReport>(`/ui/api/spend/report?${qs.toString()}`);
+    return apiFetch<SpendGroupReport>(`/ui/api/spend/report?${qs.toString()}`, opts);
   },
-  logs: (params?: Record<string, string>) => {
+  logs: (params?: Record<string, string>, opts?: RequestInit) => {
     const qs = new URLSearchParams(params || {});
     const suffix = qs.toString() ? `?${qs.toString()}` : '';
-    return apiFetch<{ logs: SpendLog[]; pagination: Pagination }>(`/ui/api/logs${suffix}`);
+    return apiFetch<{ logs: SpendLog[]; pagination: Pagination }>(`/ui/api/logs${suffix}`, opts);
   },
 };
 

--- a/ui/src/pages/Usage.tsx
+++ b/ui/src/pages/Usage.tsx
@@ -1,12 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useEffectEvent, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { useApi } from '../lib/hooks';
-import { spend, type SpendGroupBy, type SpendGroupRow, type SpendLog } from '../lib/api';
+import {
+  spend,
+  type Pagination,
+  type SpendGroupBy,
+  type SpendGroupReport,
+  type SpendGroupRow,
+  type SpendLog,
+  type SpendSummary,
+} from '../lib/api';
 import Card from '../components/Card';
 import DataTable from '../components/DataTable';
 import StatCard from '../components/StatCard';
 import Modal from '../components/Modal';
-import { DollarSign, Zap, Hash, Calendar } from 'lucide-react';
+import { DollarSign, LoaderCircle, Zap, Hash, Calendar } from 'lucide-react';
 import { XAxis, YAxis, Tooltip, ResponsiveContainer, AreaChart, Area } from 'recharts';
 
 const SPEND_GROUP_OPTIONS: Array<{ value: SpendGroupBy; label: string }> = [
@@ -29,6 +36,29 @@ const SPEND_SEARCH_PLACEHOLDERS: Record<SpendGroupBy, string> = {
   team: 'Filter teams...',
   api_key: 'Filter API keys...',
 };
+
+const AUTO_REFRESH_OPTIONS = [
+  { value: 0, label: 'Off' },
+  { value: 5000, label: '5 seconds' },
+  { value: 10000, label: '10 seconds' },
+  { value: 30000, label: '30 seconds' },
+] as const;
+
+type AutoRefreshMs = (typeof AUTO_REFRESH_OPTIONS)[number]['value'];
+
+interface SpendDayReportRow {
+  group_key: string;
+  total_spend: number;
+}
+
+interface SpendDayReport {
+  breakdown: SpendDayReportRow[];
+}
+
+interface SpendLogsResponse {
+  logs: SpendLog[];
+  pagination: Pagination;
+}
 
 function fmt(n: number | null | undefined): string {
   if (n == null) return '$0.00';
@@ -112,8 +142,22 @@ export default function Usage() {
   const [spendSearch, setSpendSearch] = useState('');
   const [spendOffset, setSpendOffset] = useState(0);
   const [logsOffset, setLogsOffset] = useState(0);
+  const [summary, setSummary] = useState<SpendSummary | null>(null);
+  const [dailyReport, setDailyReport] = useState<SpendDayReport | null>(null);
+  const [spendGroupsData, setSpendGroupsData] = useState<SpendGroupReport | null>(null);
+  const [logsData, setLogsData] = useState<SpendLogsResponse | null>(null);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [backgroundRefreshing, setBackgroundRefreshing] = useState(false);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<number | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+  const [autoRefreshMs, setAutoRefreshMs] = useState<AutoRefreshMs>(0);
+  const [pageVisible, setPageVisible] = useState(() => (typeof document === 'undefined' ? true : document.visibilityState === 'visible'));
   const spendPageSize = 5;
   const logsPageSize = 25;
+  const refreshInFlightRef = useRef(false);
+  const pendingRefreshRef = useRef(false);
+  const pendingRefreshBackgroundRef = useRef(false);
+  const requestSequenceRef = useRef(0);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -131,37 +175,133 @@ export default function Usage() {
     setLogsOffset(0);
   }, [startDate, endDate]);
 
-  const { data: summary } = useApi(() => spend.summary(startDate, endDate), [startDate, endDate]);
-  const { data: dailyReport } = useApi(() => spend.report('day', startDate, endDate), [startDate, endDate]);
-  const { data: spendGroupsData, loading: spendGroupsLoading } = useApi(
-    () =>
-      spend.groupedReport(spendBy, {
-        start_date: startDate || undefined,
-        end_date: endDate || undefined,
-        search: spendSearch || undefined,
-        limit: spendPageSize,
-        offset: spendOffset,
-      }),
-    [spendBy, startDate, endDate, spendSearch, spendOffset]
-  );
-  const { data: logsData, loading: logsLoading } = useApi(
-    () => {
-      const params: Record<string, string> = {
+  const refreshUsageData = useEffectEvent(async (background: boolean) => {
+    if (refreshInFlightRef.current) {
+      pendingRefreshRef.current = true;
+      pendingRefreshBackgroundRef.current = pendingRefreshBackgroundRef.current || background;
+      return;
+    }
+
+    refreshInFlightRef.current = true;
+    const requestId = ++requestSequenceRef.current;
+    const hasData =
+      summary !== null || dailyReport !== null || spendGroupsData !== null || logsData !== null;
+
+    if (hasData) {
+      setBackgroundRefreshing(true);
+    } else {
+      setInitialLoading(true);
+    }
+    setRefreshError(null);
+
+    try {
+      const logsParams: Record<string, string> = {
         limit: String(logsPageSize),
         offset: String(logsOffset),
       };
-      if (startDate) params.start_date = startDate;
-      if (endDate) params.end_date = endDate;
-      return spend.logs(params);
-    },
-    [startDate, endDate, logsOffset]
-  );
+      if (startDate) logsParams.start_date = startDate;
+      if (endDate) logsParams.end_date = endDate;
 
-  const daily = (dailyReport?.breakdown || []).map((r: any) => ({ date: r.group_key, total_spend: r.total_spend }));
+      const [nextSummary, nextDailyReport, nextSpendGroupsData, nextLogsData] = await Promise.all([
+        spend.summary(startDate, endDate),
+        spend.report('day', startDate, endDate) as Promise<SpendDayReport>,
+        spend.groupedReport(spendBy, {
+          start_date: startDate || undefined,
+          end_date: endDate || undefined,
+          search: spendSearch || undefined,
+          limit: spendPageSize,
+          offset: spendOffset,
+        }),
+        spend.logs(logsParams),
+      ]);
+
+      if (requestId !== requestSequenceRef.current) {
+        return;
+      }
+
+      setSummary(nextSummary);
+      setDailyReport(nextDailyReport);
+      setSpendGroupsData(nextSpendGroupsData);
+      setLogsData(nextLogsData);
+      setLastRefreshedAt(Date.now());
+    } catch (error) {
+      if (requestId === requestSequenceRef.current) {
+        setRefreshError(error instanceof Error ? error.message : 'Refresh failed');
+      }
+    } finally {
+      if (requestId === requestSequenceRef.current) {
+        setInitialLoading(false);
+        setBackgroundRefreshing(false);
+      }
+
+      refreshInFlightRef.current = false;
+
+      if (pendingRefreshRef.current) {
+        const pendingBackground = pendingRefreshBackgroundRef.current;
+        pendingRefreshRef.current = false;
+        pendingRefreshBackgroundRef.current = false;
+        void refreshUsageData(pendingBackground);
+      }
+    }
+  });
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setPageVisible(document.visibilityState === 'visible');
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    void refreshUsageData(false);
+  }, [startDate, endDate, spendBy, spendSearch, spendOffset, logsOffset]);
+
+  useEffect(() => {
+    if (!pageVisible || autoRefreshMs === 0) {
+      return;
+    }
+    void refreshUsageData(true);
+  }, [pageVisible, autoRefreshMs]);
+
+  useEffect(() => {
+    if (!pageVisible || autoRefreshMs === 0) {
+      return;
+    }
+    const timer = window.setInterval(() => {
+      void refreshUsageData(true);
+    }, autoRefreshMs);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [pageVisible, autoRefreshMs]);
+
+  const spendGroupsLoading = initialLoading && spendGroupsData === null;
+  const logsLoading = initialLoading && logsData === null;
+  const refreshControlDisabled = initialLoading || backgroundRefreshing;
+  const daily = (dailyReport?.breakdown || []).map((row) => ({ date: row.group_key, total_spend: row.total_spend }));
   const spendGroups = spendGroupsData?.data || [];
   const spendGroupsPagination = spendGroupsData?.pagination;
   const logs = logsData?.logs || [];
   const logsPagination = logsData?.pagination;
+  const refreshStatusLabel = backgroundRefreshing
+    ? 'Refreshing now'
+    : refreshError
+      ? 'Refresh failed'
+      : autoRefreshMs > 0
+        ? pageVisible
+          ? `Every ${autoRefreshMs / 1000}s`
+          : 'Paused in background'
+        : 'Manual refresh';
+  const refreshStatusTone = backgroundRefreshing
+    ? 'bg-blue-50 text-blue-700 ring-blue-200'
+    : refreshError
+      ? 'bg-rose-50 text-rose-700 ring-rose-200'
+      : autoRefreshMs > 0
+        ? 'bg-emerald-50 text-emerald-700 ring-emerald-200'
+        : 'bg-gray-100 text-gray-600 ring-gray-200';
 
   const spendGroupColumns = [
     {
@@ -189,16 +329,9 @@ export default function Usage() {
 
   return (
     <div className="p-4 sm:p-6">
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Usage & Spend</h1>
-          <p className="text-sm text-gray-500 mt-1">Monitor costs, tokens, and request analytics</p>
-        </div>
-        <div className="flex items-center gap-2 w-full sm:w-auto">
-          <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className="flex-1 sm:flex-none px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
-          <span className="text-gray-400 shrink-0">to</span>
-          <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className="flex-1 sm:flex-none px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
-        </div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Usage & Spend</h1>
+        <p className="mt-1 text-sm text-gray-500">Monitor costs, tokens, and request analytics</p>
       </div>
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
@@ -208,9 +341,58 @@ export default function Usage() {
         <StatCard title="Unique Models" value={fmtNum(summary?.unique_models)} icon={<Calendar className="w-5 h-5" />} />
       </div>
 
-      <div className="flex gap-2 mb-6">
-        <button onClick={() => setTab('overview')} className={`px-4 py-2 text-sm rounded-lg transition-colors ${tab === 'overview' ? 'bg-blue-600 text-white' : 'bg-white border text-gray-700 hover:bg-gray-50'}`}>Overview</button>
-        <button onClick={() => setTab('logs')} className={`px-4 py-2 text-sm rounded-lg transition-colors ${tab === 'logs' ? 'bg-blue-600 text-white' : 'bg-white border text-gray-700 hover:bg-gray-50'}`}>Request Logs</button>
+      <div className="mb-6 flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+        <div className="flex gap-2">
+          <button onClick={() => setTab('overview')} className={`px-4 py-2 text-sm rounded-lg transition-colors ${tab === 'overview' ? 'bg-blue-600 text-white' : 'bg-white border text-gray-700 hover:bg-gray-50'}`}>Overview</button>
+          <button onClick={() => setTab('logs')} className={`px-4 py-2 text-sm rounded-lg transition-colors ${tab === 'logs' ? 'bg-blue-600 text-white' : 'bg-white border text-gray-700 hover:bg-gray-50'}`}>Request Logs</button>
+        </div>
+
+        <div className="flex flex-col gap-2 xl:items-end">
+          <div className="flex flex-wrap items-center gap-2 xl:justify-end">
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Start date"
+            />
+            <span className="text-sm text-gray-400">to</span>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="End date"
+            />
+            <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${refreshStatusTone}`}>
+              {backgroundRefreshing ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : <span className="h-1.5 w-1.5 rounded-full bg-current" />}
+              <span>{refreshStatusLabel}</span>
+            </span>
+            <select
+              value={String(autoRefreshMs)}
+              onChange={(e) => setAutoRefreshMs(Number(e.target.value) as AutoRefreshMs)}
+              disabled={refreshControlDisabled}
+              className="rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+              aria-label="Auto refresh interval"
+            >
+              {AUTO_REFRESH_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500 xl:justify-end">
+            {refreshError ? (
+              <span className="text-rose-600">{refreshError}</span>
+            ) : lastRefreshedAt !== null ? (
+              <span>Last updated {new Date(lastRefreshedAt).toLocaleTimeString()}</span>
+            ) : (
+              <span>Waiting for first refresh</span>
+            )}
+          </div>
+        </div>
       </div>
 
       {tab === 'overview' ? (

--- a/ui/src/pages/Usage.tsx
+++ b/ui/src/pages/Usage.tsx
@@ -60,6 +60,17 @@ interface SpendLogsResponse {
   pagination: Pagination;
 }
 
+interface UsageRefreshSnapshot {
+  startDate: string;
+  endDate: string;
+  spendBy: SpendGroupBy;
+  spendSearch: string;
+  spendOffset: number;
+  logsOffset: number;
+}
+
+type RefreshStrategy = 'replace' | 'skip_if_busy';
+
 function fmt(n: number | null | undefined): string {
   if (n == null) return '$0.00';
   return `$${Number(n).toFixed(4)}`;
@@ -72,6 +83,10 @@ function fmtNum(n: number | null | undefined): string {
 
 function fmtDateTime(value: string | null | undefined): string {
   return value ? new Date(value).toLocaleString() : '—';
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 function prettyJson(value: Record<string, unknown> | null | undefined): string {
@@ -154,10 +169,12 @@ export default function Usage() {
   const [pageVisible, setPageVisible] = useState(() => (typeof document === 'undefined' ? true : document.visibilityState === 'visible'));
   const spendPageSize = 5;
   const logsPageSize = 25;
-  const refreshInFlightRef = useRef(false);
-  const pendingRefreshRef = useRef(false);
-  const pendingRefreshBackgroundRef = useRef(false);
-  const requestSequenceRef = useRef(0);
+  const activeControllerRef = useRef<AbortController | null>(null);
+  const latestRequestIdRef = useRef(0);
+  const mountedRef = useRef(true);
+  const previousPageVisibleRef = useRef(pageVisible);
+  const hasUsageData =
+    summary !== null || dailyReport !== null || spendGroupsData !== null || logsData !== null;
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -168,26 +185,35 @@ export default function Usage() {
   }, [spendSearchInput]);
 
   useEffect(() => {
-    setSpendOffset(0);
-  }, [spendBy, startDate, endDate]);
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      activeControllerRef.current?.abort();
+      activeControllerRef.current = null;
+    };
+  }, []);
 
-  useEffect(() => {
-    setLogsOffset(0);
-  }, [startDate, endDate]);
+  const buildRefreshSnapshot = useEffectEvent((): UsageRefreshSnapshot => ({
+    startDate,
+    endDate,
+    spendBy,
+    spendSearch,
+    spendOffset,
+    logsOffset,
+  }));
 
-  const refreshUsageData = useEffectEvent(async (background: boolean) => {
-    if (refreshInFlightRef.current) {
-      pendingRefreshRef.current = true;
-      pendingRefreshBackgroundRef.current = pendingRefreshBackgroundRef.current || background;
+  const runRefresh = useEffectEvent(async (snapshot: UsageRefreshSnapshot, strategy: RefreshStrategy) => {
+    if (strategy === 'skip_if_busy' && activeControllerRef.current) {
       return;
     }
 
-    refreshInFlightRef.current = true;
-    const requestId = ++requestSequenceRef.current;
-    const hasData =
-      summary !== null || dailyReport !== null || spendGroupsData !== null || logsData !== null;
+    activeControllerRef.current?.abort();
+    const controller = new AbortController();
+    activeControllerRef.current = controller;
+    const requestId = latestRequestIdRef.current + 1;
+    latestRequestIdRef.current = requestId;
 
-    if (hasData) {
+    if (hasUsageData) {
       setBackgroundRefreshing(true);
     } else {
       setInitialLoading(true);
@@ -197,25 +223,25 @@ export default function Usage() {
     try {
       const logsParams: Record<string, string> = {
         limit: String(logsPageSize),
-        offset: String(logsOffset),
+        offset: String(snapshot.logsOffset),
       };
-      if (startDate) logsParams.start_date = startDate;
-      if (endDate) logsParams.end_date = endDate;
+      if (snapshot.startDate) logsParams.start_date = snapshot.startDate;
+      if (snapshot.endDate) logsParams.end_date = snapshot.endDate;
 
       const [nextSummary, nextDailyReport, nextSpendGroupsData, nextLogsData] = await Promise.all([
-        spend.summary(startDate, endDate),
-        spend.report('day', startDate, endDate) as Promise<SpendDayReport>,
-        spend.groupedReport(spendBy, {
-          start_date: startDate || undefined,
-          end_date: endDate || undefined,
-          search: spendSearch || undefined,
+        spend.summary(snapshot.startDate, snapshot.endDate, { signal: controller.signal }),
+        spend.report('day', snapshot.startDate, snapshot.endDate, { signal: controller.signal }) as Promise<SpendDayReport>,
+        spend.groupedReport(snapshot.spendBy, {
+          start_date: snapshot.startDate || undefined,
+          end_date: snapshot.endDate || undefined,
+          search: snapshot.spendSearch || undefined,
           limit: spendPageSize,
-          offset: spendOffset,
-        }),
-        spend.logs(logsParams),
+          offset: snapshot.spendOffset,
+        }, { signal: controller.signal }),
+        spend.logs(logsParams, { signal: controller.signal }),
       ]);
 
-      if (requestId !== requestSequenceRef.current) {
+      if (!mountedRef.current || controller.signal.aborted || requestId !== latestRequestIdRef.current) {
         return;
       }
 
@@ -225,25 +251,43 @@ export default function Usage() {
       setLogsData(nextLogsData);
       setLastRefreshedAt(Date.now());
     } catch (error) {
-      if (requestId === requestSequenceRef.current) {
+      if (controller.signal.aborted || isAbortError(error)) {
+        return;
+      }
+      if (mountedRef.current && requestId === latestRequestIdRef.current) {
         setRefreshError(error instanceof Error ? error.message : 'Refresh failed');
       }
     } finally {
-      if (requestId === requestSequenceRef.current) {
+      if (activeControllerRef.current === controller) {
+        activeControllerRef.current = null;
+      }
+      if (
+        mountedRef.current &&
+        requestId === latestRequestIdRef.current &&
+        activeControllerRef.current === null
+      ) {
         setInitialLoading(false);
         setBackgroundRefreshing(false);
       }
-
-      refreshInFlightRef.current = false;
-
-      if (pendingRefreshRef.current) {
-        const pendingBackground = pendingRefreshBackgroundRef.current;
-        pendingRefreshRef.current = false;
-        pendingRefreshBackgroundRef.current = false;
-        void refreshUsageData(pendingBackground);
-      }
     }
   });
+
+  const handleStartDateChange = (value: string) => {
+    setStartDate(value);
+    setSpendOffset(0);
+    setLogsOffset(0);
+  };
+
+  const handleEndDateChange = (value: string) => {
+    setEndDate(value);
+    setSpendOffset(0);
+    setLogsOffset(0);
+  };
+
+  const handleSpendByChange = (value: SpendGroupBy) => {
+    setSpendBy(value);
+    setSpendOffset(0);
+  };
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -256,22 +300,38 @@ export default function Usage() {
   }, []);
 
   useEffect(() => {
-    void refreshUsageData(false);
+    if (!pageVisible) {
+      return;
+    }
+    void runRefresh(buildRefreshSnapshot(), 'replace');
   }, [startDate, endDate, spendBy, spendSearch, spendOffset, logsOffset]);
+
+  useEffect(() => {
+    const wasVisible = previousPageVisibleRef.current;
+    previousPageVisibleRef.current = pageVisible;
+    if (!pageVisible) {
+      activeControllerRef.current?.abort();
+      return;
+    }
+    if (wasVisible || (autoRefreshMs === 0 && hasUsageData)) {
+      return;
+    }
+    void runRefresh(buildRefreshSnapshot(), 'replace');
+  }, [pageVisible, autoRefreshMs, hasUsageData]);
 
   useEffect(() => {
     if (!pageVisible || autoRefreshMs === 0) {
       return;
     }
-    void refreshUsageData(true);
-  }, [pageVisible, autoRefreshMs]);
+    void runRefresh(buildRefreshSnapshot(), 'replace');
+  }, [autoRefreshMs]);
 
   useEffect(() => {
     if (!pageVisible || autoRefreshMs === 0) {
       return;
     }
     const timer = window.setInterval(() => {
-      void refreshUsageData(true);
+      void runRefresh(buildRefreshSnapshot(), 'skip_if_busy');
     }, autoRefreshMs);
     return () => {
       window.clearInterval(timer);
@@ -352,7 +412,7 @@ export default function Usage() {
             <input
               type="date"
               value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
+              onChange={(e) => handleStartDateChange(e.target.value)}
               className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
               aria-label="Start date"
             />
@@ -360,7 +420,7 @@ export default function Usage() {
             <input
               type="date"
               value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
+              onChange={(e) => handleEndDateChange(e.target.value)}
               className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
               aria-label="End date"
             />
@@ -424,7 +484,7 @@ export default function Usage() {
                 {SPEND_GROUP_OPTIONS.map((option) => (
                   <button
                     key={option.value}
-                    onClick={() => setSpendBy(option.value)}
+                    onClick={() => handleSpendByChange(option.value)}
                     className={`rounded-md px-3 py-2 text-sm transition-colors ${
                       spendBy === option.value ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-600 hover:text-gray-900'
                     }`}


### PR DESCRIPTION
## Summary
Fixes #53

This adds auto-refresh controls to the Usage page so operators can keep usage, spend, grouped breakdowns, and request logs up to date without manually refreshing the page.

## What changed
- Added an auto-refresh control to the Usage page with `Off`, `5 seconds`, `10 seconds`, and `30 seconds`
- Added refresh status feedback and last-updated timestamp
- Coordinated Usage page data refreshes through a single page-level refresh path to avoid flicker while keeping current data visible
- Paused auto-refresh when the browser tab is hidden
- Stopped refresh automatically when the user leaves `/usage` by keeping polling scoped to the mounted page component
- Updated the controls layout so the date range and refresh controls sit on the same row as the `Overview` and `Request Logs` tabs, aligned to the right

## Why this fixes the issue
Issue #53 asked for selectable auto-refresh intervals on the Usage page and for all page data to refresh automatically. This PR adds that behavior while avoiding unnecessary background polling when the user is not actively viewing the page.

## Verification
- `npm run build`

## Notes
- This is a UI-only change
- No backend or AI gateway request-path logic was changed