### PR TITLE
Fix embedding batch reliability foundations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dev = [
   "pytest-asyncio>=0.23,<1.0",
   "ruff>=0.2,<1.0",
 ]
+batch-s3 = [
+  "boto3>=1.35,<2.0",
+]
 guardrails-presidio = [
   "presidio-analyzer>=2.2,<3.0",
   "presidio-anonymizer>=2.2,<3.0",

--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -140,7 +140,7 @@ async def batch_summary(
         SELECT
             COUNT(*) AS total,
             COUNT(*) FILTER (WHERE status = 'queued') AS queued,
-            COUNT(*) FILTER (WHERE status = 'in_progress') AS in_progress,
+            COUNT(*) FILTER (WHERE status IN ('in_progress', 'finalizing')) AS in_progress,
             COUNT(*) FILTER (WHERE status = 'completed') AS completed,
             COUNT(*) FILTER (WHERE status = 'failed') AS failed,
             COUNT(*) FILTER (WHERE status = 'cancelled') AS cancelled

--- a/src/batch/cleanup.py
+++ b/src/batch/cleanup.py
@@ -23,12 +23,28 @@ class BatchRetentionCleanupWorker:
         *,
         repository: BatchRepository,
         storage: BatchArtifactStorage,
+        storage_registry: dict[str, BatchArtifactStorage] | None = None,
         config: BatchCleanupConfig,
     ) -> None:
         self.repository = repository
         self.storage = storage
+        active_backend = str(getattr(storage, "backend_name", "local") or "local").strip().lower()
+        self.storage_registry = {
+            str(key).strip().lower(): value
+            for key, value in (storage_registry or {}).items()
+        }
+        self.storage_registry.setdefault(active_backend, storage)
         self.config = config
         self._running = False
+
+    def _storage_for_backend(self, backend: str | None) -> BatchArtifactStorage:
+        normalized = str(backend or getattr(self.storage, "backend_name", "local") or "local").strip().lower()
+        storage = self.storage_registry.get(normalized)
+        if storage is None:
+            raise RuntimeError(
+                f"Storage backend '{normalized}' is unavailable; keep legacy batch storage configured until referenced files expire"
+            )
+        return storage
 
     async def run(self) -> None:
         self._running = True
@@ -58,7 +74,7 @@ class BatchRetentionCleanupWorker:
         )
         for file_record in expired_files:
             try:
-                await self.storage.delete(file_record.storage_key)
+                await self._storage_for_backend(file_record.storage_backend).delete(file_record.storage_key)
             except Exception as exc:
                 logger.warning("batch artifact delete failed file_id=%s error=%s", file_record.file_id, exc)
                 continue
@@ -68,4 +84,3 @@ class BatchRetentionCleanupWorker:
         if deleted_jobs or deleted_files:
             logger.info("batch GC deleted jobs=%s files=%s", deleted_jobs, deleted_files)
         return deleted_jobs, deleted_files
-

--- a/src/batch/repositories/item_repository.py
+++ b/src/batch/repositories/item_repository.py
@@ -51,8 +51,10 @@ class BatchItemRepository:
                 SELECT item_id
                 FROM deltallm_batch_item
                 WHERE batch_id = $1
-                  AND status = 'pending'
-                  AND (lease_expires_at IS NULL OR lease_expires_at < NOW())
+                  AND (
+                        (status = 'pending' AND (lease_expires_at IS NULL OR lease_expires_at < NOW()))
+                     OR (status = 'in_progress' AND lease_expires_at < NOW())
+                  )
                 ORDER BY line_number ASC
                 FOR UPDATE SKIP LOCKED
                 LIMIT $2
@@ -78,46 +80,95 @@ class BatchItemRepository:
         self,
         *,
         item_id: str,
+        worker_id: str | None,
         response_body: dict[str, Any],
         usage: dict[str, Any] | None,
         provider_cost: float,
         billed_cost: float,
-    ) -> None:
+    ) -> bool:
         if self.prisma is None:
-            return
-        await self.prisma.execute_raw(
+            return False
+        if worker_id is None:
+            rows = await self.prisma.query_raw(
+                """
+                UPDATE deltallm_batch_item
+                SET status = 'completed',
+                    response_body = $2::jsonb,
+                    usage = $3::jsonb,
+                    provider_cost = $4,
+                    billed_cost = $5,
+                    lease_expires_at = NULL,
+                    locked_by = NULL,
+                    completed_at = NOW()
+                WHERE item_id = $1
+                  AND status = 'in_progress'
+                RETURNING item_id
+                """,
+                item_id,
+                json.dumps(response_body),
+                json.dumps(usage or {}),
+                provider_cost,
+                billed_cost,
+            )
+            return bool(rows)
+        rows = await self.prisma.query_raw(
             """
             UPDATE deltallm_batch_item
             SET status = 'completed',
-                response_body = $2::jsonb,
-                usage = $3::jsonb,
-                provider_cost = $4,
-                billed_cost = $5,
+                response_body = $3::jsonb,
+                usage = $4::jsonb,
+                provider_cost = $5,
+                billed_cost = $6,
                 lease_expires_at = NULL,
                 locked_by = NULL,
                 completed_at = NOW()
             WHERE item_id = $1
+              AND locked_by = $2
+              AND status = 'in_progress'
+            RETURNING item_id
             """,
             item_id,
+            worker_id,
             json.dumps(response_body),
             json.dumps(usage or {}),
             provider_cost,
             billed_cost,
         )
+        return bool(rows)
 
     async def mark_item_failed(
         self,
         *,
         item_id: str,
+        worker_id: str | None,
         error_body: dict[str, Any],
         last_error: str,
         retryable: bool,
         retry_delay_seconds: int = 0,
-    ) -> None:
+    ) -> bool:
         if self.prisma is None:
-            return
+            return False
         if retryable:
-            await self.prisma.execute_raw(
+            if worker_id is None:
+                rows = await self.prisma.query_raw(
+                    """
+                    UPDATE deltallm_batch_item
+                    SET status = 'pending',
+                        error_body = $2::jsonb,
+                        last_error = $3,
+                        lease_expires_at = NOW() + ($4 || ' seconds')::interval,
+                        locked_by = NULL
+                    WHERE item_id = $1
+                      AND status = 'in_progress'
+                    RETURNING item_id
+                    """,
+                    item_id,
+                    json.dumps(error_body),
+                    last_error,
+                    max(0, retry_delay_seconds),
+                )
+                return bool(rows)
+            rows = await self.prisma.query_raw(
                 """
                 UPDATE deltallm_batch_item
                 SET status = 'pending',
@@ -126,28 +177,74 @@ class BatchItemRepository:
                     lease_expires_at = NOW() + ($4 || ' seconds')::interval,
                     locked_by = NULL
                 WHERE item_id = $1
+                  AND locked_by = $5
+                  AND status = 'in_progress'
+                RETURNING item_id
                 """,
                 item_id,
                 json.dumps(error_body),
                 last_error,
                 max(0, retry_delay_seconds),
+                worker_id,
             )
-            return
-        await self.prisma.execute_raw(
+            return bool(rows)
+        if worker_id is None:
+            rows = await self.prisma.query_raw(
+                """
+                UPDATE deltallm_batch_item
+                SET status = 'failed',
+                    error_body = $2::jsonb,
+                    last_error = $3,
+                    lease_expires_at = NULL,
+                    locked_by = NULL,
+                    completed_at = NOW()
+                WHERE item_id = $1
+                  AND status = 'in_progress'
+                RETURNING item_id
+                """,
+                item_id,
+                json.dumps(error_body),
+                last_error,
+            )
+            return bool(rows)
+        rows = await self.prisma.query_raw(
             """
             UPDATE deltallm_batch_item
             SET status = 'failed',
-                error_body = $2::jsonb,
-                last_error = $3,
+                error_body = $3::jsonb,
+                last_error = $4,
                 lease_expires_at = NULL,
                 locked_by = NULL,
                 completed_at = NOW()
             WHERE item_id = $1
+              AND locked_by = $2
+              AND status = 'in_progress'
+            RETURNING item_id
             """,
             item_id,
+            worker_id,
             json.dumps(error_body),
             last_error,
         )
+        return bool(rows)
+
+    async def renew_item_lease(self, *, item_id: str, worker_id: str, lease_seconds: int) -> bool:
+        if self.prisma is None:
+            return False
+        rows = await self.prisma.query_raw(
+            """
+            UPDATE deltallm_batch_item
+            SET lease_expires_at = NOW() + ($3 || ' seconds')::interval
+            WHERE item_id = $1
+              AND locked_by = $2
+              AND status = 'in_progress'
+            RETURNING item_id
+            """,
+            item_id,
+            worker_id,
+            lease_seconds,
+        )
+        return bool(rows)
 
     async def mark_pending_items_cancelled(self, batch_id: str) -> None:
         if self.prisma is None:

--- a/src/batch/repositories/job_repository.py
+++ b/src/batch/repositories/job_repository.py
@@ -140,6 +140,7 @@ class BatchJobRepository:
             SET cancel_requested_at = NOW(),
                 status = CASE
                     WHEN status IN ('completed', 'failed', 'cancelled', 'expired') THEN status
+                    WHEN status = 'finalizing' THEN status
                     ELSE 'in_progress'
                 END,
                 status_last_updated_at = NOW()
@@ -160,9 +161,9 @@ class BatchJobRepository:
             WITH candidate AS (
                 SELECT batch_id
                 FROM deltallm_batch_job
-                WHERE status IN ('queued', 'in_progress')
+                WHERE status IN ('queued', 'in_progress', 'finalizing')
                   AND (lease_expires_at IS NULL OR lease_expires_at < NOW())
-                ORDER BY created_at ASC
+                ORDER BY CASE WHEN status = 'finalizing' THEN 1 ELSE 0 END, created_at ASC
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
             )
@@ -185,6 +186,50 @@ class BatchJobRepository:
         if not rows:
             return None
         return job_from_row(rows[0])
+
+    async def renew_job_lease(self, *, batch_id: str, worker_id: str, lease_seconds: int) -> bool:
+        if self.prisma is None:
+            return False
+        rows = await self.prisma.query_raw(
+            """
+            UPDATE deltallm_batch_job
+            SET lease_expires_at = NOW() + ($3 || ' seconds')::interval
+            WHERE batch_id = $1
+              AND locked_by = $2
+              AND status IN ('in_progress', 'finalizing')
+            RETURNING batch_id
+            """,
+            batch_id,
+            worker_id,
+            lease_seconds,
+        )
+        return bool(rows)
+
+    async def reschedule_finalization(
+        self,
+        *,
+        batch_id: str,
+        worker_id: str,
+        retry_delay_seconds: int,
+    ) -> bool:
+        if self.prisma is None:
+            return False
+        rows = await self.prisma.query_raw(
+            """
+            UPDATE deltallm_batch_job
+            SET lease_expires_at = NOW() + ($3 || ' seconds')::interval,
+                locked_by = NULL,
+                status_last_updated_at = NOW()
+            WHERE batch_id = $1
+              AND locked_by = $2
+              AND status = 'finalizing'
+            RETURNING batch_id
+            """,
+            batch_id,
+            worker_id,
+            max(1, retry_delay_seconds),
+        )
+        return bool(rows)
 
     async def refresh_job_progress(self, batch_id: str) -> BatchJobRecord | None:
         if self.prisma is None:
@@ -210,19 +255,11 @@ class BatchJobRepository:
                 cancelled_items = s.cancelled_items,
                 status = CASE
                     WHEN j.status IN ('completed', 'failed', 'cancelled', 'expired') THEN j.status
-                    WHEN j.cancel_requested_at IS NOT NULL AND s.pending_items = 0 AND s.in_progress_items = 0 THEN 'cancelled'
-                    WHEN s.pending_items = 0 AND s.in_progress_items = 0 THEN 'completed'
-                    WHEN s.in_progress_items > 0 OR s.completed_items > 0 OR s.failed_items > 0 THEN 'in_progress'
+                    WHEN s.pending_items = 0 AND s.in_progress_items = 0 THEN 'finalizing'
+                    WHEN s.in_progress_items > 0 OR s.completed_items > 0 OR s.failed_items > 0 OR s.cancelled_items > 0 THEN 'in_progress'
                     ELSE j.status
                 END,
-                completed_at = CASE
-                    WHEN j.completed_at IS NOT NULL THEN j.completed_at
-                    WHEN (
-                        j.cancel_requested_at IS NOT NULL AND s.pending_items = 0 AND s.in_progress_items = 0
-                    ) OR (s.pending_items = 0 AND s.in_progress_items = 0)
-                    THEN NOW()
-                    ELSE NULL
-                END,
+                completed_at = CASE WHEN j.status IN ('completed', 'failed', 'cancelled', 'expired') THEN COALESCE(j.completed_at, NOW()) ELSE NULL END,
                 status_last_updated_at = NOW()
             FROM stats s
             WHERE j.batch_id = $1
@@ -256,27 +293,51 @@ class BatchJobRepository:
         output_file_id: str | None,
         error_file_id: str | None,
         final_status: str,
+        worker_id: str | None = None,
     ) -> BatchJobRecord | None:
         if self.prisma is None:
             return None
-        rows = await self.prisma.query_raw(
-            """
-            UPDATE deltallm_batch_job
-            SET output_file_id = $2,
-                error_file_id = $3,
-                status = $4,
-                completed_at = COALESCE(completed_at, NOW()),
-                lease_expires_at = NULL,
-                locked_by = NULL,
-                status_last_updated_at = NOW()
-            WHERE batch_id = $1
-            RETURNING *
-            """,
-            batch_id,
-            output_file_id,
-            error_file_id,
-            final_status,
-        )
+        if worker_id is None:
+            rows = await self.prisma.query_raw(
+                """
+                UPDATE deltallm_batch_job
+                SET output_file_id = $2,
+                    error_file_id = $3,
+                    status = $4,
+                    completed_at = COALESCE(completed_at, NOW()),
+                    lease_expires_at = NULL,
+                    locked_by = NULL,
+                    status_last_updated_at = NOW()
+                WHERE batch_id = $1
+                RETURNING *
+                """,
+                batch_id,
+                output_file_id,
+                error_file_id,
+                final_status,
+            )
+        else:
+            rows = await self.prisma.query_raw(
+                """
+                UPDATE deltallm_batch_job
+                SET output_file_id = $3,
+                    error_file_id = $4,
+                    status = $5,
+                    completed_at = COALESCE(completed_at, NOW()),
+                    lease_expires_at = NULL,
+                    locked_by = NULL,
+                    status_last_updated_at = NOW()
+                WHERE batch_id = $1
+                  AND locked_by = $2
+                  AND status = 'finalizing'
+                RETURNING *
+                """,
+                batch_id,
+                worker_id,
+                output_file_id,
+                error_file_id,
+                final_status,
+            )
         if not rows:
             return None
         return job_from_row(rows[0])

--- a/src/batch/repository.py
+++ b/src/batch/repository.py
@@ -126,13 +126,15 @@ class BatchRepository:
         self,
         *,
         item_id: str,
+        worker_id: str | None,
         response_body: dict[str, Any],
         usage: dict[str, Any] | None,
         provider_cost: float,
         billed_cost: float,
-    ) -> None:
-        await self.items.mark_item_completed(
+    ) -> bool:
+        return await self.items.mark_item_completed(
             item_id=item_id,
+            worker_id=worker_id,
             response_body=response_body,
             usage=usage,
             provider_cost=provider_cost,
@@ -143,13 +145,15 @@ class BatchRepository:
         self,
         *,
         item_id: str,
+        worker_id: str | None,
         error_body: dict[str, Any],
         last_error: str,
         retryable: bool,
         retry_delay_seconds: int = 0,
-    ) -> None:
-        await self.items.mark_item_failed(
+    ) -> bool:
+        return await self.items.mark_item_failed(
             item_id=item_id,
+            worker_id=worker_id,
             error_body=error_body,
             last_error=last_error,
             retryable=retryable,
@@ -159,8 +163,27 @@ class BatchRepository:
     async def refresh_job_progress(self, batch_id: str) -> BatchJobRecord | None:
         return await self.jobs.refresh_job_progress(batch_id)
 
+    async def renew_job_lease(self, *, batch_id: str, worker_id: str, lease_seconds: int) -> bool:
+        return await self.jobs.renew_job_lease(batch_id=batch_id, worker_id=worker_id, lease_seconds=lease_seconds)
+
+    async def reschedule_finalization(
+        self,
+        *,
+        batch_id: str,
+        worker_id: str,
+        retry_delay_seconds: int,
+    ) -> bool:
+        return await self.jobs.reschedule_finalization(
+            batch_id=batch_id,
+            worker_id=worker_id,
+            retry_delay_seconds=retry_delay_seconds,
+        )
+
     async def release_job_lease(self, *, batch_id: str, worker_id: str) -> None:
         await self.jobs.release_job_lease(batch_id=batch_id, worker_id=worker_id)
+
+    async def renew_item_lease(self, *, item_id: str, worker_id: str, lease_seconds: int) -> bool:
+        return await self.items.renew_item_lease(item_id=item_id, worker_id=worker_id, lease_seconds=lease_seconds)
 
     async def mark_pending_items_cancelled(self, batch_id: str) -> None:
         await self.items.mark_pending_items_cancelled(batch_id)
@@ -175,12 +198,14 @@ class BatchRepository:
         output_file_id: str | None,
         error_file_id: str | None,
         final_status: str,
+        worker_id: str | None = None,
     ) -> BatchJobRecord | None:
         return await self.jobs.attach_artifacts_and_finalize(
             batch_id=batch_id,
             output_file_id=output_file_id,
             error_file_id=error_file_id,
             final_status=final_status,
+            worker_id=worker_id,
         )
 
     async def list_expired_terminal_job_ids(self, *, now: datetime, limit: int = 100) -> list[str]:

--- a/src/batch/service.py
+++ b/src/batch/service.py
@@ -22,15 +22,32 @@ class BatchService:
         *,
         repository: BatchRepository,
         storage: BatchArtifactStorage,
+        storage_registry: dict[str, BatchArtifactStorage] | None = None,
         metadata_retention_days: int = 30,
         callable_target_grant_service: CallableTargetGrantService | None = None,
         callable_target_scope_policy_mode: CallableTargetPolicyMode | str = "enforce",
     ) -> None:
         self.repository = repository
         self.storage = storage
+        active_backend = str(getattr(storage, "backend_name", "local") or "local").strip().lower()
+        self.storage_registry = {
+            str(key).strip().lower(): value
+            for key, value in (storage_registry or {}).items()
+        }
+        self.storage_registry.setdefault(active_backend, storage)
         self.metadata_retention_days = metadata_retention_days
         self.callable_target_grant_service = callable_target_grant_service
         self.callable_target_scope_policy_mode = callable_target_scope_policy_mode
+
+    def _storage_for_backend(self, backend: str | None) -> BatchArtifactStorage:
+        normalized = str(backend or getattr(self.storage, "backend_name", "local") or "local").strip().lower()
+        storage = self.storage_registry.get(normalized)
+        if storage is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"Storage backend '{normalized}' is unavailable; keep legacy batch storage configured until referenced files expire",
+            )
+        return storage
 
     async def create_file(self, *, auth: UserAPIKeyAuth, upload: UploadFile, purpose: str) -> dict[str, Any]:
         body = await upload.read()
@@ -46,7 +63,7 @@ class BatchService:
             purpose=purpose,
             filename=filename,
             bytes_size=bytes_size,
-            storage_backend="local",
+            storage_backend=getattr(self.storage, "backend_name", "local"),
             storage_key=storage_key,
             checksum=checksum,
             created_by_api_key=auth.api_key,
@@ -68,7 +85,7 @@ class BatchService:
             auth=auth,
         ):
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="File access denied")
-        return await self.storage.read_bytes(file_record.storage_key)
+        return await self._storage_for_backend(file_record.storage_backend).read_bytes(file_record.storage_key)
 
     async def create_embeddings_batch(
         self,
@@ -92,7 +109,7 @@ class BatchService:
         ):
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Input file access denied")
 
-        raw = await self.storage.read_bytes(file_record.storage_key)
+        raw = await self._storage_for_backend(file_record.storage_backend).read_bytes(file_record.storage_key)
         items, inferred_model = self._parse_input_jsonl(raw, endpoint=endpoint, auth=auth)
         if not items:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid batch items found in file")

--- a/src/batch/storage.py
+++ b/src/batch/storage.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from pathlib import Path
 from typing import Iterable
 from uuid import uuid4
 
+try:
+    import boto3
+
+    BOTO3_AVAILABLE = True
+except ImportError:
+    BOTO3_AVAILABLE = False
+    boto3 = None  # type: ignore[assignment]
+
 
 class BatchArtifactStorage:
+    backend_name = "unknown"
+
     async def write_bytes(self, *, purpose: str, filename: str, content: bytes) -> tuple[str, int, str]:
         raise NotImplementedError
 
@@ -22,6 +33,8 @@ class BatchArtifactStorage:
 
 
 class LocalBatchArtifactStorage(BatchArtifactStorage):
+    backend_name = "local"
+
     def __init__(self, base_dir: str) -> None:
         self.base_dir = Path(base_dir).resolve()
         self.base_dir.mkdir(parents=True, exist_ok=True)
@@ -43,3 +56,70 @@ class LocalBatchArtifactStorage(BatchArtifactStorage):
         target = self.base_dir / storage_key
         if target.exists():
             target.unlink()
+
+
+class S3BatchArtifactStorage(BatchArtifactStorage):
+    backend_name = "s3"
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        region: str = "us-east-1",
+        prefix: str = "deltallm/batch-artifacts",
+        endpoint_url: str | None = None,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        client: object | None = None,
+    ) -> None:
+        if not bucket:
+            raise ValueError("S3 batch storage bucket is required")
+        if client is None and not BOTO3_AVAILABLE:
+            raise ImportError("boto3 package required for S3 batch storage. Install the 'batch-s3' extra.")
+        self.bucket = bucket
+        self.region = region
+        self.prefix = prefix.strip("/")
+        self.endpoint_url = endpoint_url
+        self.access_key_id = access_key_id
+        self.secret_access_key = secret_access_key
+        self._client = client
+
+    @property
+    def s3(self):
+        if self._client is None:
+            kwargs: dict[str, str] = {"region_name": self.region}
+            if self.endpoint_url:
+                kwargs["endpoint_url"] = self.endpoint_url
+            if self.access_key_id:
+                kwargs["aws_access_key_id"] = self.access_key_id
+            if self.secret_access_key:
+                kwargs["aws_secret_access_key"] = self.secret_access_key
+            self._client = boto3.client("s3", **kwargs)
+        return self._client
+
+    def _storage_key(self, *, purpose: str, filename: str) -> str:
+        safe_name = filename.replace("/", "_")
+        relative = f"{purpose}/{uuid4().hex}-{safe_name}"
+        return f"{self.prefix}/{relative}" if self.prefix else relative
+
+    async def write_bytes(self, *, purpose: str, filename: str, content: bytes) -> tuple[str, int, str]:
+        storage_key = self._storage_key(purpose=purpose, filename=filename)
+        checksum = hashlib.sha256(content).hexdigest()
+        await asyncio.to_thread(
+            self.s3.put_object,
+            Bucket=self.bucket,
+            Key=storage_key,
+            Body=content,
+            Metadata={"sha256": checksum, "purpose": purpose, "filename": filename},
+        )
+        return storage_key, len(content), checksum
+
+    async def read_bytes(self, storage_key: str) -> bytes:
+        def _read() -> bytes:
+            response = self.s3.get_object(Bucket=self.bucket, Key=storage_key)
+            return response["Body"].read()
+
+        return await asyncio.to_thread(_read)
+
+    async def delete(self, storage_key: str) -> None:
+        await asyncio.to_thread(self.s3.delete_object, Bucket=self.bucket, Key=storage_key)

--- a/src/batch/worker.py
+++ b/src/batch/worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from dataclasses import dataclass
@@ -26,8 +27,10 @@ logger = logging.getLogger(__name__)
 class BatchWorkerConfig:
     worker_id: str
     poll_interval_seconds: float = 1.0
-    job_lease_seconds: int = 30
-    item_lease_seconds: int = 120
+    heartbeat_interval_seconds: float = 15.0
+    job_lease_seconds: int = 120
+    item_lease_seconds: int = 360
+    finalization_retry_delay_seconds: int = 60
     item_claim_limit: int = 20
     max_attempts: int = 3
     completed_artifact_retention_days: int = 7
@@ -57,7 +60,12 @@ class BatchExecutorWorker:
     async def run(self) -> None:
         self._running = True
         while self._running:
-            did_work = await self.process_once()
+            try:
+                did_work = await self.process_once()
+            except Exception:
+                logger.exception("batch worker iteration failed")
+                await asyncio.sleep(self.config.poll_interval_seconds)
+                continue
             if not did_work:
                 await asyncio.sleep(self.config.poll_interval_seconds)
 
@@ -71,7 +79,19 @@ class BatchExecutorWorker:
         )
         if job is None:
             return False
+        job_heartbeat = self._start_heartbeat(
+            renew=lambda: self.repository.renew_job_lease(
+                batch_id=job.batch_id,
+                worker_id=self.config.worker_id,
+                lease_seconds=self.config.job_lease_seconds,
+            ),
+            label=f"job:{job.batch_id}",
+        )
         try:
+            if job.status == BatchJobStatus.FINALIZING:
+                await self._finalize_with_retry(job)
+                return True
+
             if job.cancel_requested_at is not None:
                 await self.repository.mark_pending_items_cancelled(job.batch_id)
 
@@ -85,14 +105,11 @@ class BatchExecutorWorker:
                 await self._process_item(job, item)
 
             refreshed = await self.repository.refresh_job_progress(job.batch_id)
-            if refreshed and refreshed.status in {
-                BatchJobStatus.COMPLETED,
-                BatchJobStatus.CANCELLED,
-                BatchJobStatus.FAILED,
-            }:
-                await self._finalize_artifacts(refreshed)
+            if refreshed and refreshed.status == BatchJobStatus.FINALIZING:
+                await self._finalize_with_retry(refreshed)
             return True
         finally:
+            await self._stop_heartbeat(job_heartbeat)
             await self.repository.release_job_lease(batch_id=job.batch_id, worker_id=self.config.worker_id)
 
     async def _process_item(self, job, item) -> None:
@@ -107,6 +124,14 @@ class BatchExecutorWorker:
             deployment=await app_router.select_deployment(model_group, request_context),
         )
         failover_kwargs = route_failover_kwargs(request_context)
+        item_heartbeat = self._start_heartbeat(
+            renew=lambda: self.repository.renew_item_lease(
+                item_id=item.item_id,
+                worker_id=self.config.worker_id,
+                lease_seconds=self.config.item_lease_seconds,
+            ),
+            label=f"item:{item.item_id}",
+        )
         try:
             data, served_deployment = await self.app.state.failover_manager.execute_with_failover(
                 primary_deployment=primary,
@@ -144,13 +169,17 @@ class BatchExecutorWorker:
             data.pop("_api_base", None)
             data.pop("_deployment_model", None)
             data["_provider"] = api_provider
-            await self.repository.mark_item_completed(
+            updated = await self.repository.mark_item_completed(
                 item_id=item.item_id,
+                worker_id=self.config.worker_id,
                 response_body=data,
                 usage=usage,
                 provider_cost=provider_cost,
                 billed_cost=billed_cost,
             )
+            if not updated:
+                logger.warning("batch item completion skipped after lease loss batch_id=%s item_id=%s", batch_id, item.item_id)
+                return
             await self._record_success_side_effects(
                 job=job,
                 item=item,
@@ -168,14 +197,20 @@ class BatchExecutorWorker:
             retryable = self._is_retryable(exc) and item.attempts < self.config.max_attempts
             error_payload = {"message": str(exc), "type": exc.__class__.__name__}
             retry_delay = min(30, max(1, item.attempts * 2))
-            await self.repository.mark_item_failed(
+            updated = await self.repository.mark_item_failed(
                 item_id=item.item_id,
+                worker_id=self.config.worker_id,
                 error_body=error_payload,
                 last_error=str(exc),
                 retryable=retryable,
                 retry_delay_seconds=retry_delay,
             )
+            if not updated:
+                logger.warning("batch item failure update skipped after lease loss batch_id=%s item_id=%s", batch_id, item.item_id)
+                return
             await self.repository.refresh_job_progress(batch_id)
+        finally:
+            await self._stop_heartbeat(item_heartbeat)
 
     async def _record_success_side_effects(
         self,
@@ -263,6 +298,53 @@ class BatchExecutorWorker:
             return status_code == 429 or status_code >= 500
         return False
 
+    def _start_heartbeat(self, *, renew, label: str) -> asyncio.Task[None]:
+        return asyncio.create_task(self._run_heartbeat(renew=renew, label=label))
+
+    async def _run_heartbeat(self, *, renew, label: str) -> None:
+        while self._running:
+            await asyncio.sleep(self.config.heartbeat_interval_seconds)
+            try:
+                renewed = await renew()
+            except Exception:
+                logger.warning("batch lease heartbeat failed target=%s", label, exc_info=True)
+                continue
+            if not renewed:
+                logger.warning("batch lease heartbeat lost ownership target=%s", label)
+                return
+
+    async def _stop_heartbeat(self, task: asyncio.Task[None]) -> None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    def _resolve_final_status(self, job) -> str:
+        if job.cancel_requested_at is not None:
+            return BatchJobStatus.CANCELLED
+        if job.completed_items == 0 and job.failed_items > 0:
+            return BatchJobStatus.FAILED
+        return BatchJobStatus.COMPLETED
+
+    async def _finalize_with_retry(self, job) -> None:
+        try:
+            await self._finalize_artifacts(job)
+        except Exception as exc:
+            logger.warning("batch finalization failed batch_id=%s error=%s", job.batch_id, exc, exc_info=True)
+            rescheduled = await self.repository.reschedule_finalization(
+                batch_id=job.batch_id,
+                worker_id=self.config.worker_id,
+                retry_delay_seconds=self.config.finalization_retry_delay_seconds,
+            )
+            if not rescheduled:
+                logger.warning("batch finalization retry skipped after lease loss batch_id=%s", job.batch_id)
+
+    async def _cleanup_unattached_artifacts(self, artifacts: list[tuple[str, str]]) -> None:
+        for file_id, storage_key in artifacts:
+            with contextlib.suppress(Exception):
+                await self.storage.delete(storage_key)
+            with contextlib.suppress(Exception):
+                await self.repository.delete_file(file_id)
+
     async def _finalize_artifacts(self, job) -> None:
         items = await self.repository.list_items(job.batch_id)
         output_lines: list[str] = []
@@ -273,62 +355,75 @@ class BatchExecutorWorker:
             elif item.status in {"failed", "cancelled"}:
                 error_lines.append(json.dumps({"custom_id": item.custom_id, "error": item.error_body or {}}))
 
+        storage_backend = getattr(self.storage, "backend_name", "local")
+        created_artifacts: list[tuple[str, str]] = []
         output_file_id: str | None = None
         error_file_id: str | None = None
-        if output_lines:
-            key, size, checksum = await self.storage.write_lines(
-                purpose="batch_output",
-                filename=f"{job.batch_id}-output.jsonl",
-                lines=output_lines,
-            )
-            file_record = await self.repository.create_file(
-                purpose="batch_output",
-                filename=f"{job.batch_id}-output.jsonl",
-                bytes_size=size,
-                storage_backend="local",
-                storage_key=key,
-                checksum=checksum,
-                created_by_api_key=job.created_by_api_key,
-                created_by_user_id=job.created_by_user_id,
-                created_by_team_id=job.created_by_team_id,
-                expires_at=datetime.now(tz=UTC) + timedelta(days=self.config.completed_artifact_retention_days),
-            )
-            output_file_id = file_record.file_id if file_record is not None else None
+        final_status = self._resolve_final_status(job)
+        try:
+            if output_lines:
+                key, size, checksum = await self.storage.write_lines(
+                    purpose="batch_output",
+                    filename=f"{job.batch_id}-output.jsonl",
+                    lines=output_lines,
+                )
+                file_record = await self.repository.create_file(
+                    purpose="batch_output",
+                    filename=f"{job.batch_id}-output.jsonl",
+                    bytes_size=size,
+                    storage_backend=storage_backend,
+                    storage_key=key,
+                    checksum=checksum,
+                    created_by_api_key=job.created_by_api_key,
+                    created_by_user_id=job.created_by_user_id,
+                    created_by_team_id=job.created_by_team_id,
+                    expires_at=datetime.now(tz=UTC) + timedelta(days=self.config.completed_artifact_retention_days),
+                )
+                if file_record is None:
+                    raise RuntimeError(f"Failed to create output artifact record for batch {job.batch_id}")
+                created_artifacts.append((file_record.file_id, key))
+                output_file_id = file_record.file_id
 
-        if error_lines:
-            key, size, checksum = await self.storage.write_lines(
-                purpose="batch_error",
-                filename=f"{job.batch_id}-error.jsonl",
-                lines=error_lines,
-            )
-            retention_days = (
-                self.config.failed_artifact_retention_days
-                if job.status in {BatchJobStatus.FAILED, BatchJobStatus.CANCELLED}
-                else self.config.completed_artifact_retention_days
-            )
-            file_record = await self.repository.create_file(
-                purpose="batch_error",
-                filename=f"{job.batch_id}-error.jsonl",
-                bytes_size=size,
-                storage_backend="local",
-                storage_key=key,
-                checksum=checksum,
-                created_by_api_key=job.created_by_api_key,
-                created_by_user_id=job.created_by_user_id,
-                created_by_team_id=job.created_by_team_id,
-                expires_at=datetime.now(tz=UTC) + timedelta(days=retention_days),
-            )
-            error_file_id = file_record.file_id if file_record is not None else None
+            if error_lines:
+                key, size, checksum = await self.storage.write_lines(
+                    purpose="batch_error",
+                    filename=f"{job.batch_id}-error.jsonl",
+                    lines=error_lines,
+                )
+                retention_days = (
+                    self.config.failed_artifact_retention_days
+                    if final_status in {BatchJobStatus.FAILED, BatchJobStatus.CANCELLED}
+                    else self.config.completed_artifact_retention_days
+                )
+                file_record = await self.repository.create_file(
+                    purpose="batch_error",
+                    filename=f"{job.batch_id}-error.jsonl",
+                    bytes_size=size,
+                    storage_backend=storage_backend,
+                    storage_key=key,
+                    checksum=checksum,
+                    created_by_api_key=job.created_by_api_key,
+                    created_by_user_id=job.created_by_user_id,
+                    created_by_team_id=job.created_by_team_id,
+                    expires_at=datetime.now(tz=UTC) + timedelta(days=retention_days),
+                )
+                if file_record is None:
+                    raise RuntimeError(f"Failed to create error artifact record for batch {job.batch_id}")
+                created_artifacts.append((file_record.file_id, key))
+                error_file_id = file_record.file_id
 
-        final_status = job.status
-        if final_status == BatchJobStatus.COMPLETED and job.completed_items == 0 and job.failed_items > 0:
-            final_status = BatchJobStatus.FAILED
-        await self.repository.attach_artifacts_and_finalize(
-            batch_id=job.batch_id,
-            output_file_id=output_file_id,
-            error_file_id=error_file_id,
-            final_status=final_status,
-        )
+            finalized = await self.repository.attach_artifacts_and_finalize(
+                batch_id=job.batch_id,
+                output_file_id=output_file_id,
+                error_file_id=error_file_id,
+                final_status=final_status,
+                worker_id=self.config.worker_id,
+            )
+            if finalized is None:
+                raise RuntimeError(f"Failed to finalize batch {job.batch_id}")
+        except Exception:
+            await self._cleanup_unattached_artifacts(created_artifacts)
+            raise
         logger.info(
             "batch finalized id=%s status=%s completed=%s failed=%s",
             job.batch_id,

--- a/src/bootstrap/batch.py
+++ b/src/bootstrap/batch.py
@@ -9,7 +9,7 @@ from typing import Any
 from src.bootstrap.status import BootstrapStatus
 from src.batch import BatchCleanupConfig, BatchRetentionCleanupWorker, BatchRepository
 from src.batch.service import BatchService
-from src.batch.storage import LocalBatchArtifactStorage
+from src.batch.storage import LocalBatchArtifactStorage, S3BatchArtifactStorage
 from src.batch.worker import BatchExecutorWorker, BatchWorkerConfig
 from src.services.model_visibility import normalize_callable_target_policy_mode
 
@@ -23,20 +23,71 @@ class BatchRuntime:
     statuses: tuple[BootstrapStatus, ...] = ()
 
 
+def _build_s3_batch_storage(cfg: Any) -> S3BatchArtifactStorage:
+    general = cfg.general_settings
+    bucket = str(getattr(general, "embeddings_batch_s3_bucket", "") or "").strip()
+    if not bucket:
+        raise RuntimeError("embeddings_batch_s3_bucket must be configured when embeddings_batch_storage_backend='s3'")
+    try:
+        return S3BatchArtifactStorage(
+            bucket=bucket,
+            region=str(getattr(general, "embeddings_batch_s3_region", "us-east-1") or "us-east-1"),
+            prefix=str(getattr(general, "embeddings_batch_s3_prefix", "deltallm/batch-artifacts") or ""),
+            endpoint_url=getattr(general, "embeddings_batch_s3_endpoint_url", None),
+            access_key_id=getattr(general, "embeddings_batch_s3_access_key_id", None),
+            secret_access_key=getattr(general, "embeddings_batch_s3_secret_access_key", None),
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "S3 batch storage requires the 'batch-s3' optional dependency; install with `pip install .[batch-s3]`"
+        ) from exc
+
+
+def _build_batch_storage_registry(cfg: Any) -> dict[str, Any]:
+    general = cfg.general_settings
+    registry: dict[str, Any] = {
+        "local": LocalBatchArtifactStorage(general.embeddings_batch_storage_dir),
+    }
+    bucket = str(getattr(general, "embeddings_batch_s3_bucket", "") or "").strip()
+    if bucket:
+        try:
+            registry["s3"] = _build_s3_batch_storage(cfg)
+        except RuntimeError:
+            backend = str(getattr(general, "embeddings_batch_storage_backend", "local") or "local").strip().lower()
+            if backend == "s3":
+                raise
+    return registry
+
+
+def _build_batch_storage(cfg: Any, storage_registry: dict[str, Any]):
+    general = cfg.general_settings
+    backend = str(getattr(general, "embeddings_batch_storage_backend", "local") or "local").strip().lower()
+    storage = storage_registry.get(backend)
+    if storage is None:
+        if backend == "s3":
+            return _build_s3_batch_storage(cfg)
+        raise RuntimeError(f"Unsupported embeddings batch storage backend: {backend}")
+    return storage
+
+
 async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) -> BatchRuntime:
     runtime = BatchRuntime()
 
     if not cfg.general_settings.embeddings_batch_enabled:
         app.state.batch_storage = None
+        app.state.batch_storage_registry = None
         app.state.batch_service = None
         runtime.statuses = (BootstrapStatus("embeddings_batch", "disabled"),)
         return runtime
 
-    batch_storage = LocalBatchArtifactStorage(cfg.general_settings.embeddings_batch_storage_dir)
+    batch_storage_registry = _build_batch_storage_registry(cfg)
+    batch_storage = _build_batch_storage(cfg, batch_storage_registry)
     app.state.batch_storage = batch_storage
+    app.state.batch_storage_registry = batch_storage_registry
     app.state.batch_service = BatchService(
         repository=repository,
         storage=batch_storage,
+        storage_registry=batch_storage_registry,
         metadata_retention_days=cfg.general_settings.batch_metadata_retention_days,
         callable_target_grant_service=getattr(app.state, "callable_target_grant_service", None),
         callable_target_scope_policy_mode=normalize_callable_target_policy_mode(
@@ -52,6 +103,10 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
             config=BatchWorkerConfig(
                 worker_id=f"worker-{id(app)}",
                 poll_interval_seconds=cfg.general_settings.embeddings_batch_poll_interval_seconds,
+                heartbeat_interval_seconds=cfg.general_settings.embeddings_batch_heartbeat_interval_seconds,
+                job_lease_seconds=cfg.general_settings.embeddings_batch_job_lease_seconds,
+                item_lease_seconds=cfg.general_settings.embeddings_batch_item_lease_seconds,
+                finalization_retry_delay_seconds=cfg.general_settings.embeddings_batch_finalization_retry_delay_seconds,
                 item_claim_limit=cfg.general_settings.embeddings_batch_item_claim_limit,
                 max_attempts=cfg.general_settings.embeddings_batch_max_attempts,
                 completed_artifact_retention_days=cfg.general_settings.batch_completed_artifact_retention_days,
@@ -64,6 +119,7 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
         runtime.gc_worker = BatchRetentionCleanupWorker(
             repository=repository,
             storage=batch_storage,
+            storage_registry=batch_storage_registry,
             config=BatchCleanupConfig(
                 interval_seconds=cfg.general_settings.embeddings_batch_gc_interval_seconds,
                 scan_limit=cfg.general_settings.embeddings_batch_gc_scan_limit,

--- a/src/config.py
+++ b/src/config.py
@@ -248,8 +248,19 @@ class GeneralSettings(BaseModel):
     model_deployment_bootstrap_from_config: bool = True
     embeddings_batch_enabled: bool = False
     embeddings_batch_worker_enabled: bool = True
+    embeddings_batch_storage_backend: Literal["local", "s3"] = "local"
     embeddings_batch_storage_dir: str = ".deltallm/batch-artifacts"
+    embeddings_batch_s3_bucket: str | None = None
+    embeddings_batch_s3_region: str = "us-east-1"
+    embeddings_batch_s3_prefix: str = "deltallm/batch-artifacts"
+    embeddings_batch_s3_endpoint_url: str | None = None
+    embeddings_batch_s3_access_key_id: str | None = None
+    embeddings_batch_s3_secret_access_key: str | None = None
     embeddings_batch_poll_interval_seconds: float = 1.0
+    embeddings_batch_heartbeat_interval_seconds: float = Field(default=15.0, gt=0)
+    embeddings_batch_job_lease_seconds: int = Field(default=120, ge=5)
+    embeddings_batch_item_lease_seconds: int = Field(default=360, ge=30)
+    embeddings_batch_finalization_retry_delay_seconds: int = Field(default=60, ge=1)
     embeddings_batch_item_claim_limit: int = 20
     embeddings_batch_max_attempts: int = 3
     batch_completed_artifact_retention_days: int = 7

--- a/tests/bootstrap/test_optional_bootstrap.py
+++ b/tests/bootstrap/test_optional_bootstrap.py
@@ -23,15 +23,33 @@ def _audit_config(*, enabled: bool, retention_enabled: bool) -> SimpleNamespace:
     )
 
 
-def _batch_config(*, enabled: bool, worker_enabled: bool, gc_enabled: bool) -> SimpleNamespace:
+def _batch_config(
+    *,
+    enabled: bool,
+    worker_enabled: bool,
+    gc_enabled: bool,
+    storage_backend: str = "local",
+    s3_bucket: str | None = None,
+) -> SimpleNamespace:
     return SimpleNamespace(
         general_settings=SimpleNamespace(
             embeddings_batch_enabled=enabled,
             embeddings_batch_worker_enabled=worker_enabled,
             embeddings_batch_gc_enabled=gc_enabled,
+            embeddings_batch_storage_backend=storage_backend,
             embeddings_batch_storage_dir="/tmp/batch-artifacts",
+            embeddings_batch_s3_bucket=s3_bucket,
+            embeddings_batch_s3_region="us-east-1",
+            embeddings_batch_s3_prefix="deltallm/batch-artifacts",
+            embeddings_batch_s3_endpoint_url=None,
+            embeddings_batch_s3_access_key_id=None,
+            embeddings_batch_s3_secret_access_key=None,
             batch_metadata_retention_days=14,
             embeddings_batch_poll_interval_seconds=5,
+            embeddings_batch_heartbeat_interval_seconds=15,
+            embeddings_batch_job_lease_seconds=120,
+            embeddings_batch_item_lease_seconds=360,
+            embeddings_batch_finalization_retry_delay_seconds=60,
             embeddings_batch_item_claim_limit=10,
             embeddings_batch_max_attempts=3,
             batch_completed_artifact_retention_days=7,
@@ -116,6 +134,7 @@ async def test_init_batch_runtime_disabled_sets_batch_state_to_none() -> None:
     runtime = await init_batch_runtime(app, _batch_config(enabled=False, worker_enabled=False, gc_enabled=False), repository=object())
 
     assert app.state.batch_storage is None
+    assert app.state.batch_storage_registry is None
     assert app.state.batch_service is None
     assert runtime.worker is None
     assert runtime.gc_worker is None
@@ -132,11 +151,13 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
             repository,  # noqa: ANN001
             storage,  # noqa: ANN001
             metadata_retention_days,  # noqa: ANN001
+            storage_registry=None,  # noqa: ANN001
             callable_target_grant_service=None,  # noqa: ANN001
             callable_target_scope_policy_mode="enforce",  # noqa: ANN001
         ) -> None:
             self.repository = repository
             self.storage = storage
+            self.storage_registry = storage_registry
             self.metadata_retention_days = metadata_retention_days
             self.callable_target_grant_service = callable_target_grant_service
             self.callable_target_scope_policy_mode = callable_target_scope_policy_mode
@@ -158,9 +179,10 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
             self.stopped = True
 
     class FakeGCWorker:
-        def __init__(self, repository, storage, config) -> None:  # noqa: ANN001
+        def __init__(self, repository, storage, storage_registry=None, config=None) -> None:  # noqa: ANN001
             self.repository = repository
             self.storage = storage
+            self.storage_registry = storage_registry
             self.config = config
             self.stopped = False
             created["gc_worker"] = self
@@ -186,12 +208,15 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
     )
 
     assert app.state.batch_storage == {"path": "/tmp/batch-artifacts"}
+    assert app.state.batch_storage_registry == {"local": {"path": "/tmp/batch-artifacts"}}
     assert isinstance(app.state.batch_service, FakeBatchService)
     assert created["service"].repository is repository
+    assert created["service"].storage_registry == {"local": {"path": "/tmp/batch-artifacts"}}
     assert runtime.worker is created["worker"]
     assert runtime.worker_task is not None
     assert runtime.gc_worker is created["gc_worker"]
     assert runtime.gc_task is not None
+    assert created["gc_worker"].storage_registry == {"local": {"path": "/tmp/batch-artifacts"}}
     assert runtime.statuses == (
         BootstrapStatus("embeddings_batch", "ready"),
         BootstrapStatus("embeddings_batch_worker", "ready"),
@@ -202,3 +227,53 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
 
     assert created["worker"].stopped is True
     assert created["gc_worker"].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_init_batch_runtime_selects_s3_storage(monkeypatch: pytest.MonkeyPatch) -> None:
+    created: dict[str, object] = {}
+
+    class FakeBatchService:
+        def __init__(self, repository, storage, storage_registry=None, metadata_retention_days=30, callable_target_grant_service=None, callable_target_scope_policy_mode="enforce") -> None:  # noqa: ANN001
+            del metadata_retention_days, callable_target_grant_service, callable_target_scope_policy_mode
+            self.repository = repository
+            self.storage = storage
+            self.storage_registry = storage_registry
+            created["service"] = self
+
+    monkeypatch.setattr(
+        "src.bootstrap.batch.S3BatchArtifactStorage",
+        lambda **kwargs: {"backend": "s3", **kwargs},
+    )
+    monkeypatch.setattr("src.bootstrap.batch.LocalBatchArtifactStorage", lambda path: {"backend": "local", "path": path})
+    monkeypatch.setattr("src.bootstrap.batch.BatchService", FakeBatchService)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    repository = object()
+
+    runtime = await init_batch_runtime(
+        app,
+        _batch_config(enabled=True, worker_enabled=False, gc_enabled=False, storage_backend="s3", s3_bucket="batch-bucket"),
+        repository=repository,
+    )
+
+    assert app.state.batch_storage["backend"] == "s3"
+    assert app.state.batch_storage["bucket"] == "batch-bucket"
+    assert app.state.batch_storage_registry["local"]["path"] == "/tmp/batch-artifacts"
+    assert app.state.batch_storage_registry["s3"]["backend"] == "s3"
+    assert created["service"].storage == app.state.batch_storage
+    assert created["service"].storage_registry == app.state.batch_storage_registry
+    assert runtime.worker is None
+    assert runtime.gc_worker is None
+
+
+@pytest.mark.asyncio
+async def test_init_batch_runtime_rejects_s3_without_bucket() -> None:
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    with pytest.raises(RuntimeError, match="embeddings_batch_s3_bucket"):
+        await init_batch_runtime(
+            app,
+            _batch_config(enabled=True, worker_enabled=False, gc_enabled=False, storage_backend="s3", s3_bucket=None),
+            repository=object(),
+        )

--- a/tests/test_batch_cleanup.py
+++ b/tests/test_batch_cleanup.py
@@ -47,6 +47,8 @@ class _RepoStub:
 
 
 class _StorageStub:
+    backend_name = "local"
+
     def __init__(self) -> None:
         self.deleted: list[str] = []
 
@@ -70,3 +72,38 @@ async def test_batch_cleanup_worker_deletes_expired_jobs_and_files():
     assert repo.deleted_files == ["f-1"]
     assert storage.deleted == ["batch_output/f-1"]
 
+
+@pytest.mark.asyncio
+async def test_batch_cleanup_worker_routes_delete_by_file_backend():
+    repo = _RepoStub()
+    repo.files[0] = BatchFileRecord(
+        file_id="f-2",
+        purpose="batch_output",
+        filename="out.jsonl",
+        bytes=10,
+        status="processed",
+        storage_backend="local",
+        storage_key="batch_output/f-2",
+        checksum=None,
+        created_by_api_key=None,
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_at=repo.files[0].created_at,
+        expires_at=repo.files[0].expires_at,
+    )
+    active_storage = _StorageStub()
+    active_storage.backend_name = "s3"
+    local_storage = _StorageStub()
+    worker = BatchRetentionCleanupWorker(
+        repository=repo,  # type: ignore[arg-type]
+        storage=active_storage,  # type: ignore[arg-type]
+        storage_registry={"local": local_storage, "s3": active_storage},  # type: ignore[arg-type]
+        config=BatchCleanupConfig(interval_seconds=0.01, scan_limit=10),
+    )
+
+    deleted_jobs, deleted_files = await worker.process_once()
+
+    assert deleted_jobs == 2
+    assert deleted_files == 1
+    assert local_storage.deleted == ["batch_output/f-2"]
+    assert active_storage.deleted == []

--- a/tests/test_batch_repository.py
+++ b/tests/test_batch_repository.py
@@ -9,10 +9,12 @@ class _PrismaSpy:
     def __init__(self) -> None:
         self.sql = ""
         self.params = ()
+        self.queries: list[str] = []
 
     async def query_raw(self, sql: str, *params):
         self.sql = sql
         self.params = params
+        self.queries.append(sql)
         return []
 
 
@@ -31,3 +33,60 @@ async def test_list_jobs_uses_or_scope_for_api_key_and_team():
     assert "created_by_api_key" in prisma.sql
     assert "created_by_team_id" in prisma.sql
     assert " OR " in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_claim_items_reclaims_expired_in_progress_rows():
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    items = await repository.claim_items(
+        batch_id="batch-1",
+        worker_id="worker-1",
+        limit=10,
+        lease_seconds=120,
+    )
+
+    assert items == []
+    assert "status = 'pending'" in prisma.sql
+    assert "status = 'in_progress'" in prisma.sql
+    assert "lease_expires_at < NOW()" in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_claim_next_job_includes_finalizing_jobs():
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    job = await repository.claim_next_job(worker_id="worker-1", lease_seconds=120)
+
+    assert job is None
+    assert "'finalizing'" in prisma.sql
+    assert "CASE WHEN status = 'finalizing' THEN 1 ELSE 0 END" in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_request_cancel_preserves_finalizing_status():
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    job = await repository.request_cancel("batch-1")
+
+    assert job is None
+    assert "WHEN status = 'finalizing' THEN status" in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_reschedule_finalization_pushes_lease_forward():
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    rescheduled = await repository.reschedule_finalization(
+        batch_id="batch-1",
+        worker_id="worker-1",
+        retry_delay_seconds=60,
+    )
+
+    assert rescheduled is False
+    assert "lease_expires_at = NOW() + ($3 || ' seconds')::interval" in prisma.sql
+    assert "status = 'finalizing'" in prisma.sql

--- a/tests/test_batch_service.py
+++ b/tests/test_batch_service.py
@@ -18,8 +18,13 @@ class _DummyRepo:
 
 
 class _DummyStorage:
+    backend_name = "local"
+
+    def __init__(self) -> None:
+        self.reads: list[str] = []
+
     async def read_bytes(self, storage_key: str) -> bytes:
-        del storage_key
+        self.reads.append(storage_key)
         return b"{}"
 
 
@@ -57,10 +62,13 @@ def _service(
     *,
     callable_target_grant_service: CallableTargetGrantService | None = None,
     callable_target_scope_policy_mode: str = "enforce",
+    storage: _DummyStorage | None = None,
+    storage_registry: dict[str, _DummyStorage] | None = None,
 ) -> BatchService:
     return BatchService(
         repository=_DummyRepo(),
-        storage=_DummyStorage(),
+        storage=storage or _DummyStorage(),
+        storage_registry=storage_registry,
         callable_target_grant_service=callable_target_grant_service,
         callable_target_scope_policy_mode=callable_target_scope_policy_mode,
     )  # type: ignore[arg-type]
@@ -263,6 +271,172 @@ async def test_get_file_content_denies_different_key_without_team_match() -> Non
     with pytest.raises(HTTPException) as exc:
         await service.get_file_content(file_id="f1", auth=UserAPIKeyAuth(api_key="key-b"))
     assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_file_content_uses_file_storage_backend_from_registry() -> None:
+    now = datetime.now(tz=UTC)
+
+    class _Repo:
+        async def get_file(self, file_id: str):
+            del file_id
+            return BatchFileRecord(
+                file_id="f1",
+                purpose="batch",
+                filename="x.jsonl",
+                bytes=1,
+                status="processed",
+                storage_backend="local",
+                storage_key="legacy/local-file",
+                checksum=None,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                expires_at=None,
+            )
+
+    local_storage = _DummyStorage()
+    active_storage = _DummyStorage()
+    active_storage.backend_name = "s3"
+    service = BatchService(
+        repository=_Repo(),  # type: ignore[arg-type]
+        storage=active_storage,  # type: ignore[arg-type]
+        storage_registry={"local": local_storage, "s3": active_storage},  # type: ignore[arg-type]
+    )
+
+    content = await service.get_file_content(file_id="f1", auth=UserAPIKeyAuth(api_key="key-a"))
+
+    assert content == b"{}"
+    assert local_storage.reads == ["legacy/local-file"]
+    assert active_storage.reads == []
+
+
+@pytest.mark.asyncio
+async def test_create_embeddings_batch_reads_input_from_file_storage_backend() -> None:
+    now = datetime.now(tz=UTC)
+
+    class _Repo:
+        async def get_file(self, file_id: str):
+            assert file_id == "f1"
+            return BatchFileRecord(
+                file_id="f1",
+                purpose="batch",
+                filename="x.jsonl",
+                bytes=1,
+                status="processed",
+                storage_backend="local",
+                storage_key="legacy/input-file",
+                checksum=None,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                expires_at=None,
+            )
+
+        async def create_job(self, **kwargs):
+            del kwargs
+            return BatchJobRecord(
+                batch_id="b1",
+                endpoint="/v1/embeddings",
+                status=BatchJobStatus.VALIDATING,
+                execution_mode="managed_internal",
+                input_file_id="f1",
+                output_file_id=None,
+                error_file_id=None,
+                model="m1",
+                metadata={},
+                provider_batch_id=None,
+                provider_status=None,
+                provider_error=None,
+                provider_last_sync_at=None,
+                total_items=0,
+                in_progress_items=0,
+                completed_items=0,
+                failed_items=0,
+                cancelled_items=0,
+                locked_by=None,
+                lease_expires_at=None,
+                cancel_requested_at=None,
+                status_last_updated_at=now,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                started_at=None,
+                completed_at=None,
+                expires_at=None,
+            )
+
+        async def create_items(self, batch_id: str, items):  # noqa: ANN001
+            assert batch_id == "b1"
+            assert len(items) == 1
+            return 1
+
+        async def set_job_queued(self, batch_id: str, total_items: int):
+            assert batch_id == "b1"
+            assert total_items == 1
+            return BatchJobRecord(
+                batch_id="b1",
+                endpoint="/v1/embeddings",
+                status=BatchJobStatus.QUEUED,
+                execution_mode="managed_internal",
+                input_file_id="f1",
+                output_file_id=None,
+                error_file_id=None,
+                model="m1",
+                metadata={},
+                provider_batch_id=None,
+                provider_status=None,
+                provider_error=None,
+                provider_last_sync_at=None,
+                total_items=1,
+                in_progress_items=0,
+                completed_items=0,
+                failed_items=0,
+                cancelled_items=0,
+                locked_by=None,
+                lease_expires_at=None,
+                cancel_requested_at=None,
+                status_last_updated_at=now,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                started_at=None,
+                completed_at=None,
+                expires_at=None,
+            )
+
+    local_storage = _DummyStorage()
+    active_storage = _DummyStorage()
+    active_storage.backend_name = "s3"
+    service = BatchService(
+        repository=_Repo(),  # type: ignore[arg-type]
+        storage=active_storage,  # type: ignore[arg-type]
+        storage_registry={"local": local_storage, "s3": active_storage},  # type: ignore[arg-type]
+    )
+
+    def _fake_parse(payload: bytes, *, endpoint: str, auth):  # noqa: ANN001
+        assert payload == b"{}"
+        assert endpoint == "/v1/embeddings"
+        assert auth.api_key == "key-a"
+        return [type("Item", (), {"line_number": 1, "custom_id": "c1", "request_body": {"model": "m1"}})()], "m1"
+
+    service._parse_input_jsonl = _fake_parse  # type: ignore[method-assign]
+
+    result = await service.create_embeddings_batch(
+        auth=UserAPIKeyAuth(api_key="key-a"),
+        input_file_id="f1",
+        endpoint="/v1/embeddings",
+        metadata=None,
+        completion_window=None,
+    )
+
+    assert result["status"] == "queued"
+    assert local_storage.reads == ["legacy/input-file"]
+    assert active_storage.reads == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_storage.py
+++ b/tests/test_batch_storage.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.batch.storage import LocalBatchArtifactStorage, S3BatchArtifactStorage
+
+
+@pytest.mark.asyncio
+async def test_local_batch_storage_round_trip(tmp_path: Path) -> None:
+    storage = LocalBatchArtifactStorage(str(tmp_path / "batch-artifacts"))
+
+    storage_key, size, checksum = await storage.write_bytes(
+        purpose="batch",
+        filename="input.jsonl",
+        content=b'{"custom_id":"1"}\n',
+    )
+
+    assert size > 0
+    assert checksum
+    assert await storage.read_bytes(storage_key) == b'{"custom_id":"1"}\n'
+
+    await storage.delete(storage_key)
+
+    assert not (tmp_path / "batch-artifacts" / storage_key).exists()
+
+
+class _FakeS3Body:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def read(self) -> bytes:
+        return self.payload
+
+
+class _FakeS3Client:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, Metadata=None) -> None:  # noqa: ANN001
+        del Metadata
+        self.objects[(Bucket, Key)] = Body
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+        return {"Body": _FakeS3Body(self.objects[(Bucket, Key)])}
+
+    def delete_object(self, *, Bucket: str, Key: str) -> None:
+        self.objects.pop((Bucket, Key), None)
+
+
+@pytest.mark.asyncio
+async def test_s3_batch_storage_round_trip() -> None:
+    client = _FakeS3Client()
+    storage = S3BatchArtifactStorage(
+        bucket="batch-bucket",
+        prefix="prefix",
+        client=client,
+    )
+
+    storage_key, size, checksum = await storage.write_bytes(
+        purpose="batch_output",
+        filename="out.jsonl",
+        content=b'{"custom_id":"1","response":{}}\n',
+    )
+
+    assert storage_key.startswith("prefix/batch_output/")
+    assert size > 0
+    assert checksum
+    assert await storage.read_bytes(storage_key) == b'{"custom_id":"1","response":{}}\n'
+
+    await storage.delete(storage_key)
+
+    assert ("batch-bucket", storage_key) not in client.objects

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import asyncio
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -26,10 +27,11 @@ class _FakeRepository:
     def __init__(self) -> None:
         self.completed_calls: list[dict] = []
 
-    async def mark_item_completed(self, **kwargs) -> None:
+    async def mark_item_completed(self, **kwargs) -> bool:
         self.completed_calls.append(kwargs)
+        return True
 
-    async def mark_item_failed(self, **kwargs) -> None:  # pragma: no cover
+    async def mark_item_failed(self, **kwargs) -> bool:  # pragma: no cover
         raise AssertionError(f"unexpected failure path: {kwargs}")
 
     async def get_job(self, batch_id: str):  # for BatchService test
@@ -39,6 +41,10 @@ class _FakeRepository:
 class _FakeStorage:
     async def write_lines(self, **kwargs):  # pragma: no cover
         raise AssertionError(f"unexpected artifact write in this test: {kwargs}")
+
+    async def delete(self, storage_key: str) -> None:  # pragma: no cover
+        del storage_key
+        raise AssertionError("unexpected artifact delete in this test")
 
 
 @pytest.mark.asyncio
@@ -342,7 +348,7 @@ async def test_batch_worker_processes_cancel_requested_job():
             return BatchJobRecord(
                 batch_id="b-cancel",
                 endpoint="/v1/embeddings",
-                status=BatchJobStatus.CANCELLED,
+                status=BatchJobStatus.FINALIZING,
                 execution_mode="managed_internal",
                 input_file_id="f-1",
                 output_file_id=None,
@@ -445,3 +451,618 @@ async def test_batch_status_remains_completed_across_service_instances():
     assert first["status"] == "completed"
     assert second["status"] == "completed"
     assert second["request_counts"] == {"total": 3, "completed": 3, "failed": 0, "cancelled": 0, "in_progress": 0}
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_skips_spend_logging_when_item_completion_loses_ownership(monkeypatch):
+    async def _fake_execute_embedding(request, payload, deployment):
+        del request, payload, deployment
+        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
+
+    class _LeaseLostRepository(_FakeRepository):
+        async def mark_item_completed(self, **kwargs) -> bool:
+            self.completed_calls.append(kwargs)
+            return False
+
+    deployment = SimpleNamespace(
+        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.0,
+        model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
+    )
+
+    class _Router:
+        def resolve_model_group(self, model: str) -> str:
+            return model
+
+        async def select_deployment(self, model_group: str, request_context: dict) -> str:
+            del model_group, request_context
+            return "dep-1"
+
+        def require_deployment(self, model_group: str, deployment: str):
+            del model_group, deployment
+            return deployment_obj
+
+    class _Failover:
+        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+            del model_group, kwargs
+            data = await execute(primary_deployment)
+            if return_deployment:
+                return data, primary_deployment
+            return data
+
+    deployment_obj = deployment
+    repo = _LeaseLostRepository()
+    spend = _SpendRecorder()
+    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    worker = BatchExecutorWorker(
+        app=app,
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    now = datetime.now(tz=UTC)
+    job = BatchJobRecord(
+        batch_id="b1",
+        endpoint="/v1/embeddings",
+        status=BatchJobStatus.IN_PROGRESS,
+        execution_mode="managed_internal",
+        input_file_id="f1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m-1",
+        metadata={},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=1,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="tok-1",
+        created_by_user_id="u1",
+        created_by_team_id="t1",
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+        expires_at=None,
+    )
+    item = BatchItemRecord(
+        item_id="i1",
+        batch_id="b1",
+        line_number=1,
+        custom_id="c1",
+        status="in_progress",
+        request_body={"model": "m-1", "input": "hello"},
+        response_body=None,
+        error_body=None,
+        usage=None,
+        provider_cost=0.0,
+        billed_cost=0.0,
+        attempts=0,
+        last_error=None,
+        locked_by="w1",
+        lease_expires_at=now,
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+    )
+
+    await worker._process_item(job, item)
+
+    assert len(repo.completed_calls) == 1
+    assert spend.events == []
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_retries_finalizing_job_after_storage_failure():
+    now = datetime.now(tz=UTC)
+
+    class _FinalizingRepo:
+        def __init__(self) -> None:
+            self.claim_count = 0
+            self.released = 0
+            self.deleted_files: list[str] = []
+            self.finalized = False
+            self.created_files = 0
+            self.rescheduled: list[int] = []
+            self.job = BatchJobRecord(
+                batch_id="b-finalize",
+                endpoint="/v1/embeddings",
+                status=BatchJobStatus.FINALIZING,
+                execution_mode="managed_internal",
+                input_file_id="f-1",
+                output_file_id=None,
+                error_file_id=None,
+                model="m-1",
+                metadata={},
+                provider_batch_id=None,
+                provider_status=None,
+                provider_error=None,
+                provider_last_sync_at=None,
+                total_items=2,
+                in_progress_items=0,
+                completed_items=1,
+                failed_items=1,
+                cancelled_items=0,
+                locked_by="w1",
+                lease_expires_at=now,
+                cancel_requested_at=None,
+                status_last_updated_at=now,
+                created_by_api_key="tok-1",
+                created_by_user_id="u1",
+                created_by_team_id="t1",
+                created_at=now,
+                started_at=now,
+                completed_at=None,
+                expires_at=None,
+            )
+
+        async def claim_next_job(self, *, worker_id: str, lease_seconds: int = 30):
+            del worker_id, lease_seconds
+            self.claim_count += 1
+            if self.claim_count > 2:
+                return None
+            return self.job
+
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b-finalize"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="completed",
+                    request_body={},
+                    response_body={"ok": True},
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                ),
+                BatchItemRecord(
+                    item_id="i2",
+                    batch_id=batch_id,
+                    line_number=2,
+                    custom_id="req-2",
+                    status="failed",
+                    request_body={},
+                    response_body=None,
+                    error_body={"message": "boom"},
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error="boom",
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                ),
+            ]
+
+        async def create_file(self, **kwargs):
+            self.created_files += 1
+            return SimpleNamespace(file_id=f"file-{self.created_files}", storage_key=kwargs["storage_key"])
+
+        async def reschedule_finalization(self, *, batch_id: str, worker_id: str, retry_delay_seconds: int) -> bool:
+            assert batch_id == "b-finalize"
+            assert worker_id == "w1"
+            self.rescheduled.append(retry_delay_seconds)
+            return True
+
+        async def attach_artifacts_and_finalize(self, **kwargs):
+            self.finalized = True
+            return self.job
+
+        async def release_job_lease(self, *, batch_id: str, worker_id: str) -> None:
+            assert batch_id == "b-finalize"
+            assert worker_id == "w1"
+            self.released += 1
+
+        async def delete_file(self, file_id: str) -> None:
+            self.deleted_files.append(file_id)
+
+    class _FlakyStorage:
+        backend_name = "s3"
+
+        def __init__(self) -> None:
+            self.write_calls = 0
+            self.deleted: list[str] = []
+
+        async def write_lines(self, *, purpose: str, filename: str, lines):  # noqa: ANN001
+            del filename, lines
+            self.write_calls += 1
+            if self.write_calls == 2:
+                raise RuntimeError("storage unavailable")
+            return f"{purpose}/{self.write_calls}.jsonl", 10, "checksum"
+
+        async def delete(self, storage_key: str) -> None:
+            self.deleted.append(storage_key)
+
+    repo = _FinalizingRepo()
+    storage = _FlakyStorage()
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=repo,  # type: ignore[arg-type]
+        storage=storage,  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    did_work = await worker.process_once()
+
+    assert did_work is True
+    assert storage.deleted == ["batch_output/1.jsonl"]
+    assert repo.deleted_files == ["file-1"]
+    assert repo.released == 1
+    assert repo.finalized is False
+    assert repo.rescheduled == [60]
+
+    did_work = await worker.process_once()
+
+    assert did_work is True
+    assert repo.finalized is True
+    assert repo.released == 2
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_renews_job_and_item_leases_during_long_execution(monkeypatch):
+    async def _slow_execute_embedding(request, payload, deployment):
+        del request, payload, deployment
+        await asyncio.sleep(0.05)
+        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _slow_execute_embedding)
+
+    deployment = SimpleNamespace(
+        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.0,
+        model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
+    )
+
+    class _Router:
+        def resolve_model_group(self, model: str) -> str:
+            return model
+
+        async def select_deployment(self, model_group: str, request_context: dict) -> str:
+            del model_group, request_context
+            return "dep-1"
+
+        def require_deployment(self, model_group: str, deployment: str):
+            del model_group, deployment
+            return deployment_obj
+
+    class _Failover:
+        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+            del model_group, kwargs
+            data = await execute(primary_deployment)
+            if return_deployment:
+                return data, primary_deployment
+            return data
+
+    class _LeaseRepo(_FakeRepository):
+        def __init__(self) -> None:
+            super().__init__()
+            self.job_claims = 0
+            self.renew_job_calls = 0
+            self.renew_item_calls = 0
+            self.released = False
+            self.now = datetime.now(tz=UTC)
+
+        async def claim_next_job(self, *, worker_id: str, lease_seconds: int = 30):
+            del worker_id, lease_seconds
+            self.job_claims += 1
+            if self.job_claims > 1:
+                return None
+            return BatchJobRecord(
+                batch_id="b1",
+                endpoint="/v1/embeddings",
+                status=BatchJobStatus.IN_PROGRESS,
+                execution_mode="managed_internal",
+                input_file_id="f1",
+                output_file_id=None,
+                error_file_id=None,
+                model="m-1",
+                metadata={},
+                provider_batch_id=None,
+                provider_status=None,
+                provider_error=None,
+                provider_last_sync_at=None,
+                total_items=1,
+                in_progress_items=1,
+                completed_items=0,
+                failed_items=0,
+                cancelled_items=0,
+                locked_by="w1",
+                lease_expires_at=self.now,
+                cancel_requested_at=None,
+                status_last_updated_at=self.now,
+                created_by_api_key="tok-1",
+                created_by_user_id="u1",
+                created_by_team_id="t1",
+                created_at=self.now,
+                started_at=self.now,
+                completed_at=None,
+                expires_at=None,
+            )
+
+        async def claim_items(self, **kwargs):
+            del kwargs
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id="b1",
+                    line_number=1,
+                    custom_id="c1",
+                    status="in_progress",
+                    request_body={"model": "m-1", "input": "hello"},
+                    response_body=None,
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=0,
+                    last_error=None,
+                    locked_by="w1",
+                    lease_expires_at=self.now,
+                    created_at=self.now,
+                    started_at=self.now,
+                    completed_at=None,
+                )
+            ]
+
+        async def renew_job_lease(self, *, batch_id: str, worker_id: str, lease_seconds: int) -> bool:
+            assert batch_id == "b1"
+            assert worker_id == "w1"
+            assert lease_seconds == 360
+            self.renew_job_calls += 1
+            return True
+
+        async def renew_item_lease(self, *, item_id: str, worker_id: str, lease_seconds: int) -> bool:
+            assert item_id == "i1"
+            assert worker_id == "w1"
+            assert lease_seconds == 360
+            self.renew_item_calls += 1
+            return True
+
+        async def refresh_job_progress(self, batch_id: str):
+            assert batch_id == "b1"
+            return None
+
+        async def release_job_lease(self, *, batch_id: str, worker_id: str) -> None:
+            assert batch_id == "b1"
+            assert worker_id == "w1"
+            self.released = True
+
+    deployment_obj = deployment
+    repo = _LeaseRepo()
+    spend = _SpendRecorder()
+    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    worker = BatchExecutorWorker(
+        app=app,
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1", heartbeat_interval_seconds=0.01, job_lease_seconds=360, item_lease_seconds=360),
+    )
+    worker._running = True
+
+    did_work = await worker.process_once()
+    worker._running = False
+
+    assert did_work is True
+    assert repo.renew_job_calls >= 1
+    assert repo.renew_item_calls >= 1
+    assert repo.released is True
+
+
+@pytest.mark.asyncio
+async def test_second_worker_reclaims_expired_in_progress_item_after_crash(monkeypatch):
+    async def _fake_execute_embedding(request, payload, deployment):
+        del request, payload, deployment
+        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
+
+    deployment = SimpleNamespace(
+        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.0,
+        model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
+    )
+
+    class _Router:
+        def resolve_model_group(self, model: str) -> str:
+            return model
+
+        async def select_deployment(self, model_group: str, request_context: dict) -> str:
+            del model_group, request_context
+            return "dep-1"
+
+        def require_deployment(self, model_group: str, deployment: str):
+            del model_group, deployment
+            return deployment_obj
+
+    class _Failover:
+        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+            del model_group, kwargs
+            data = await execute(primary_deployment)
+            if return_deployment:
+                return data, primary_deployment
+            return data
+
+    class _CrashRecoveryRepo:
+        def __init__(self) -> None:
+            self.now = datetime.now(tz=UTC)
+            self.job_status = BatchJobStatus.IN_PROGRESS
+            self.job_locked_by: str | None = None
+            self.job_lease_expires_at = self.now - timedelta(seconds=1)
+            self.item_status = "pending"
+            self.item_locked_by: str | None = None
+            self.item_lease_expires_at: datetime | None = None
+            self.completed_by: str | None = None
+
+        def advance(self, seconds: int) -> None:
+            self.now += timedelta(seconds=seconds)
+
+        def _job_record(self) -> BatchJobRecord:
+            return BatchJobRecord(
+                batch_id="b1",
+                endpoint="/v1/embeddings",
+                status=self.job_status,
+                execution_mode="managed_internal",
+                input_file_id="f1",
+                output_file_id=None,
+                error_file_id=None,
+                model="m-1",
+                metadata={},
+                provider_batch_id=None,
+                provider_status=None,
+                provider_error=None,
+                provider_last_sync_at=None,
+                total_items=1,
+                in_progress_items=1 if self.item_status == "in_progress" else 0,
+                completed_items=1 if self.item_status == "completed" else 0,
+                failed_items=0,
+                cancelled_items=0,
+                locked_by=self.job_locked_by,
+                lease_expires_at=self.job_lease_expires_at,
+                cancel_requested_at=None,
+                status_last_updated_at=self.now,
+                created_by_api_key="tok-1",
+                created_by_user_id="u1",
+                created_by_team_id="t1",
+                created_at=self.now,
+                started_at=self.now,
+                completed_at=None,
+                expires_at=None,
+            )
+
+        def _item_record(self) -> BatchItemRecord:
+            return BatchItemRecord(
+                item_id="i1",
+                batch_id="b1",
+                line_number=1,
+                custom_id="c1",
+                status=self.item_status,
+                request_body={"model": "m-1", "input": "hello"},
+                response_body=None,
+                error_body=None,
+                usage=None,
+                provider_cost=0.0,
+                billed_cost=0.0,
+                attempts=0,
+                last_error=None,
+                locked_by=self.item_locked_by,
+                lease_expires_at=self.item_lease_expires_at,
+                created_at=self.now,
+                started_at=self.now,
+                completed_at=None,
+            )
+
+        async def claim_next_job(self, *, worker_id: str, lease_seconds: int = 30):
+            if self.job_lease_expires_at is not None and self.job_lease_expires_at >= self.now:
+                return None
+            self.job_locked_by = worker_id
+            self.job_lease_expires_at = self.now + timedelta(seconds=lease_seconds)
+            return self._job_record()
+
+        async def claim_items(self, *, worker_id: str, lease_seconds: int = 60, **kwargs):
+            del kwargs
+            expired_in_progress = self.item_status == "in_progress" and self.item_lease_expires_at is not None and self.item_lease_expires_at < self.now
+            if self.item_status == "pending" or expired_in_progress:
+                self.item_status = "in_progress"
+                self.item_locked_by = worker_id
+                self.item_lease_expires_at = self.now + timedelta(seconds=lease_seconds)
+                return [self._item_record()]
+            return []
+
+        async def mark_item_completed(self, *, item_id: str, worker_id: str | None, **kwargs) -> bool:
+            del kwargs
+            assert item_id == "i1"
+            if worker_id != self.item_locked_by:
+                return False
+            self.item_status = "completed"
+            self.item_locked_by = None
+            self.item_lease_expires_at = None
+            self.completed_by = worker_id
+            return True
+
+        async def mark_item_failed(self, **kwargs) -> bool:  # pragma: no cover
+            raise AssertionError(f"unexpected failure path: {kwargs}")
+
+        async def refresh_job_progress(self, batch_id: str):
+            assert batch_id == "b1"
+            return self._job_record()
+
+        async def release_job_lease(self, *, batch_id: str, worker_id: str) -> None:
+            assert batch_id == "b1"
+            if self.job_locked_by == worker_id:
+                self.job_locked_by = None
+                self.job_lease_expires_at = self.now - timedelta(seconds=1)
+
+        async def renew_job_lease(self, *, batch_id: str, worker_id: str, lease_seconds: int) -> bool:
+            assert batch_id == "b1"
+            if self.job_locked_by != worker_id:
+                return False
+            self.job_lease_expires_at = self.now + timedelta(seconds=lease_seconds)
+            return True
+
+        async def renew_item_lease(self, *, item_id: str, worker_id: str, lease_seconds: int) -> bool:
+            assert item_id == "i1"
+            if self.item_locked_by != worker_id:
+                return False
+            self.item_lease_expires_at = self.now + timedelta(seconds=lease_seconds)
+            return True
+
+    deployment_obj = deployment
+    repo = _CrashRecoveryRepo()
+    spend = _SpendRecorder()
+    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    worker_a = BatchExecutorWorker(
+        app=app,
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1", item_lease_seconds=5),
+    )
+    worker_b = BatchExecutorWorker(
+        app=app,
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w2", item_lease_seconds=5),
+    )
+
+    async def _crash(job, item):  # noqa: ANN001
+        del job, item
+        return None
+
+    worker_a._process_item = _crash  # type: ignore[assignment]
+    await worker_a.process_once()
+
+    assert repo.item_status == "in_progress"
+    assert repo.item_locked_by == "w1"
+
+    repo.advance(10)
+    did_work = await worker_b.process_once()
+
+    assert did_work is True
+    assert repo.item_status == "completed"
+    assert repo.completed_by == "w2"

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -117,6 +117,8 @@ class FakeAuthorizationDB:
             return [row] if row else []
         if "COUNT(*) AS total FROM deltallm_batch_job j" in query:
             return [{"total": 1}]
+        if "COUNT(*) FILTER (WHERE status IN ('in_progress', 'finalizing')) AS in_progress" in query:
+            return [{"total": 1, "queued": 0, "in_progress": 1, "completed": 0, "failed": 0, "cancelled": 0}]
         if "FROM deltallm_batch_job j" in query and "LEFT JOIN deltallm_teamtable t" in query:
             if "WHERE j.batch_id = $1" in query:
                 row = self.batches.get(str(params[0]))
@@ -295,3 +297,26 @@ async def test_list_batches_keeps_developer_read_access_and_hides_cancel(client,
     assert payload["pagination"]["total"] == 1
     assert payload["data"][0]["batch_id"] == "batch-1"
     assert payload["data"][0]["capabilities"] == {"view": True, "cancel": False}
+
+
+@pytest.mark.asyncio
+async def test_batch_summary_counts_finalizing_as_in_progress(client, test_app, monkeypatch):
+    fake_db = FakeAuthorizationDB()
+    fake_db.batches["batch-1"]["status"] = "finalizing"
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.batches.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=False,
+            org_ids=[],
+            team_ids=["team-1"],
+            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ}},
+        ),
+    )
+
+    response = await client.get("/ui/api/batches/summary", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    assert response.json()["in_progress"] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -82,6 +82,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.84"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/89/2d647bd717da55a8cc68602b197f53a5fa36fb95a2f9e76c4aff11a9cfd1/boto3-1.42.84.tar.gz", hash = "sha256:6a84b3293a5d8b3adf827a54588e7dcffcf0a85410d7dadca615544f97d27579", size = 112816, upload-time = "2026-04-06T19:39:07.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/31/cdf4326841613d1d181a77b3038a988800fb3373ca50de1639fba9fa87de/boto3-1.42.84-py3-none-any.whl", hash = "sha256:4d03ad3211832484037337292586f71f48707141288d9ac23049c04204f4ab03", size = 140555, upload-time = "2026-04-06T19:39:06.009Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.84"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/b7/1c03423843fb0d1795b686511c00ee63fed1234c2400f469aeedfd42212f/botocore-1.42.84.tar.gz", hash = "sha256:234064604c80d9272a5e9f6b3566d260bcaa053a5e05246db90d7eca1c2cf44b", size = 15148615, upload-time = "2026-04-06T19:38:56.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl", hash = "sha256:15f3fe07dfa6545e46a60c4b049fe2bdf63803c595ae4a4eec90e8f8172764f3", size = 14827061, upload-time = "2026-04-06T19:38:53.613Z" },
+]
+
+[[package]]
 name = "catalogue"
 version = "2.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -431,6 +459,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+batch-s3 = [
+    { name = "boto3" },
+]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -443,6 +474,7 @@ guardrails-presidio = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "extra == 'batch-s3'", specifier = ">=1.35,<2.0" },
     { name = "fastapi", specifier = ">=0.109,<1.0" },
     { name = "httpx", specifier = ">=0.26,<1.0" },
     { name = "presidio-analyzer", marker = "extra == 'guardrails-presidio'", specifier = ">=2.2,<3.0" },
@@ -460,7 +492,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2,<1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27,<1.0" },
 ]
-provides-extras = ["dev", "guardrails-presidio"]
+provides-extras = ["dev", "batch-s3", "guardrails-presidio"]
 
 [[package]]
 name = "fastapi"
@@ -588,6 +620,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1150,6 +1191,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1405,6 +1458,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1420,6 +1485,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed
- added backend-selectable batch artifact storage with an S3-backed option and explicit bootstrap validation
- made batch reads and cleanup deletes route through the file's stored backend so mixed-backend cutovers remain readable and collectable
- hardened batch job/item lease handling with renewals, expired in-progress reclaim, and owner-guarded terminal writes
- turned `finalizing` into a reclaimable state and delayed finalization retries so a broken batch cannot monopolize the worker queue
- expanded batch reliability coverage for storage selection, mixed-backend routing, cleanup, heartbeat renewal, reclaim-after-crash, and finalization retry fairness

## Why this changed
Embedding batch execution had reliability gaps around worker crashes, final artifact generation, and backend transitions. In-progress items could be stranded, finalization failures could leave batches incomplete or starve the queue, and switching storage backends could make older artifacts unreadable or undeletable.

## User and developer impact
- batch workers can now recover claimed work after lease expiry more safely
- finalization failures back off instead of immediately retrying in a tight loop
- storage backend transitions require keeping the legacy backend configured until old batch files expire, but files remain routable during that period
- the synchronous gateway request path was not changed

## Root cause
The original batch runtime assumed a single active storage backend and a simpler job state model. Once shared storage and resumable finalization were introduced, artifact routing needed to be backend-aware, and finalizing work needed bounded retries so older failing jobs would not starve newer queued work.

## Validation
- `uv run pytest tests/test_batch_storage.py tests/test_batch_cleanup.py tests/test_batch_repository.py tests/test_batch_worker.py tests/test_batch_service.py tests/bootstrap/test_optional_bootstrap.py tests/test_embeddings_batch.py tests/test_ui_authorization.py`
- `uv run ruff check src/batch/service.py src/batch/cleanup.py src/bootstrap/batch.py src/config.py src/batch/storage.py src/batch/repository.py src/batch/repositories/job_repository.py src/batch/worker.py pyproject.toml tests/test_batch_service.py tests/test_batch_cleanup.py tests/test_batch_repository.py tests/test_batch_worker.py tests/bootstrap/test_optional_bootstrap.py`
