### PR TITLE
[batch] Improve embedding batch scalability and streaming

### DIFF
--- a/src/batch/repositories/item_repository.py
+++ b/src/batch/repositories/item_repository.py
@@ -275,3 +275,40 @@ class BatchItemRepository:
             batch_id,
         )
         return [item_from_row(row) for row in rows]
+
+    async def list_items_page(
+        self,
+        *,
+        batch_id: str,
+        limit: int = 500,
+        after_line_number: int | None = None,
+    ) -> list[BatchItemRecord]:
+        if self.prisma is None:
+            return []
+        if after_line_number is None:
+            rows = await self.prisma.query_raw(
+                """
+                SELECT *
+                FROM deltallm_batch_item
+                WHERE batch_id = $1
+                ORDER BY line_number ASC
+                LIMIT $2
+                """,
+                batch_id,
+                max(1, min(limit, 5_000)),
+            )
+        else:
+            rows = await self.prisma.query_raw(
+                """
+                SELECT *
+                FROM deltallm_batch_item
+                WHERE batch_id = $1
+                  AND line_number > $2
+                ORDER BY line_number ASC
+                LIMIT $3
+                """,
+                batch_id,
+                after_line_number,
+                max(1, min(limit, 5_000)),
+            )
+        return [item_from_row(row) for row in rows]

--- a/src/batch/repositories/job_repository.py
+++ b/src/batch/repositories/job_repository.py
@@ -13,6 +13,17 @@ class BatchJobRepository:
     def __init__(self, prisma_client: Any | None = None) -> None:
         self.prisma = prisma_client
 
+    async def acquire_scope_advisory_lock(self, *, scope_type: str, scope_id: str) -> None:
+        if self.prisma is None:
+            return
+        await self.prisma.query_raw(
+            """
+            SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))
+            """,
+            scope_type,
+            scope_id,
+        )
+
     async def create_job(
         self,
         *,
@@ -110,6 +121,39 @@ class BatchJobRepository:
             *params,
         )
         return [job_from_row(row) for row in rows]
+
+    async def count_active_jobs_for_scope(
+        self,
+        *,
+        created_by_api_key: str | None = None,
+        created_by_team_id: str | None = None,
+    ) -> int:
+        if self.prisma is None:
+            return 0
+        terminal = "'completed', 'failed', 'cancelled', 'expired'"
+        if created_by_team_id:
+            rows = await self.prisma.query_raw(
+                f"""
+                SELECT COUNT(*) AS total
+                FROM deltallm_batch_job
+                WHERE created_by_team_id = $1
+                  AND status NOT IN ({terminal})
+                """,
+                created_by_team_id,
+            )
+        elif created_by_api_key:
+            rows = await self.prisma.query_raw(
+                f"""
+                SELECT COUNT(*) AS total
+                FROM deltallm_batch_job
+                WHERE created_by_api_key = $1
+                  AND status NOT IN ({terminal})
+                """,
+                created_by_api_key,
+            )
+        else:
+            return 0
+        return int((rows[0] if rows else {}).get("total") or 0)
 
     async def set_job_queued(self, batch_id: str, total_items: int) -> BatchJobRecord | None:
         if self.prisma is None:

--- a/src/batch/repository.py
+++ b/src/batch/repository.py
@@ -22,6 +22,9 @@ class BatchRepository:
         self.items = BatchItemRepository(prisma_client)
         self.maintenance = BatchMaintenanceRepository(prisma_client)
 
+    def with_prisma(self, prisma_client: Any | None) -> BatchRepository:
+        return BatchRepository(prisma_client)
+
     async def create_file(
         self,
         *,
@@ -80,6 +83,9 @@ class BatchRepository:
     async def get_job(self, batch_id: str) -> BatchJobRecord | None:
         return await self.jobs.get_job(batch_id)
 
+    async def acquire_scope_advisory_lock(self, *, scope_type: str, scope_id: str) -> None:
+        await self.jobs.acquire_scope_advisory_lock(scope_type=scope_type, scope_id=scope_id)
+
     async def list_jobs(
         self,
         *,
@@ -91,6 +97,17 @@ class BatchRepository:
         return await self.jobs.list_jobs(
             limit=limit,
             after=after,
+            created_by_api_key=created_by_api_key,
+            created_by_team_id=created_by_team_id,
+        )
+
+    async def count_active_jobs_for_scope(
+        self,
+        *,
+        created_by_api_key: str | None = None,
+        created_by_team_id: str | None = None,
+    ) -> int:
+        return await self.jobs.count_active_jobs_for_scope(
             created_by_api_key=created_by_api_key,
             created_by_team_id=created_by_team_id,
         )
@@ -190,6 +207,19 @@ class BatchRepository:
 
     async def list_items(self, batch_id: str) -> list[BatchItemRecord]:
         return await self.items.list_items(batch_id)
+
+    async def list_items_page(
+        self,
+        *,
+        batch_id: str,
+        limit: int = 500,
+        after_line_number: int | None = None,
+    ) -> list[BatchItemRecord]:
+        return await self.items.list_items_page(
+            batch_id=batch_id,
+            limit=limit,
+            after_line_number=after_line_number,
+        )
 
     async def attach_artifacts_and_finalize(
         self,

--- a/src/batch/service.py
+++ b/src/batch/service.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import tempfile
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from typing import AsyncIterator
 
 from fastapi import HTTPException, UploadFile, status
 
 from src.batch.access import can_access_owned_resource
-from src.batch.models import BatchItemCreate
+from src.batch.models import BatchItemCreate, BatchJobRecord
 from src.batch.repository import BatchRepository
-from src.batch.storage import BatchArtifactStorage
+from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorage
 from src.models.requests import EmbeddingRequest
 from src.models.responses import UserAPIKeyAuth
 from src.services.model_visibility import CallableTargetPolicyMode, ensure_batch_model_allowed
@@ -24,6 +27,12 @@ class BatchService:
         storage: BatchArtifactStorage,
         storage_registry: dict[str, BatchArtifactStorage] | None = None,
         metadata_retention_days: int = 30,
+        storage_chunk_size: int = 65_536,
+        create_buffer_size: int = 200,
+        max_file_bytes: int = 52_428_800,
+        max_items_per_batch: int = 10_000,
+        max_line_bytes: int = 1_048_576,
+        max_pending_batches_per_scope: int = 20,
         callable_target_grant_service: CallableTargetGrantService | None = None,
         callable_target_scope_policy_mode: CallableTargetPolicyMode | str = "enforce",
     ) -> None:
@@ -36,6 +45,12 @@ class BatchService:
         }
         self.storage_registry.setdefault(active_backend, storage)
         self.metadata_retention_days = metadata_retention_days
+        self.storage_chunk_size = storage_chunk_size
+        self.create_buffer_size = create_buffer_size
+        self.max_file_bytes = max_file_bytes
+        self.max_items_per_batch = max_items_per_batch
+        self.max_line_bytes = max_line_bytes
+        self.max_pending_batches_per_scope = max_pending_batches_per_scope
         self.callable_target_grant_service = callable_target_grant_service
         self.callable_target_scope_policy_mode = callable_target_scope_policy_mode
 
@@ -49,16 +64,266 @@ class BatchService:
             )
         return storage
 
+    def _scope_limit_target(self, auth: UserAPIKeyAuth) -> tuple[str, str, str | None, str | None] | None:
+        if auth.team_id:
+            return ("team", auth.team_id, None, auth.team_id)
+        if auth.api_key:
+            return ("api_key", auth.api_key, auth.api_key, None)
+        return None
+
+    async def _create_job_with_scope_limit(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        endpoint: str,
+        input_file_id: str,
+        inferred_model: str | None,
+        metadata: dict[str, Any] | None,
+    ) -> BatchJobRecord:
+        scope = self._scope_limit_target(auth)
+        db = getattr(self.repository, "prisma", None)
+        if (
+            self.max_pending_batches_per_scope > 0
+            and scope is not None
+            and db is not None
+            and hasattr(db, "tx")
+            and hasattr(self.repository, "with_prisma")
+        ):
+            scope_type, scope_id, created_by_api_key, created_by_team_id = scope
+            async with db.tx() as tx:
+                tx_repository = self.repository.with_prisma(tx)
+                await tx_repository.acquire_scope_advisory_lock(scope_type=scope_type, scope_id=scope_id)
+                active_batches = await tx_repository.count_active_jobs_for_scope(
+                    created_by_api_key=created_by_api_key,
+                    created_by_team_id=created_by_team_id,
+                )
+                if active_batches >= self.max_pending_batches_per_scope:
+                    raise HTTPException(
+                        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                        detail=(
+                            "Active batch count exceeds "
+                            f"embeddings_batch_max_pending_batches_per_scope ({self.max_pending_batches_per_scope})"
+                        ),
+                    )
+                job = await tx_repository.create_job(
+                    endpoint=endpoint,
+                    input_file_id=input_file_id,
+                    model=inferred_model,
+                    metadata=metadata,
+                    created_by_api_key=auth.api_key,
+                    created_by_user_id=auth.user_id,
+                    created_by_team_id=auth.team_id,
+                    expires_at=datetime.now(tz=UTC) + timedelta(days=self.metadata_retention_days),
+                )
+                if job is None:
+                    raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Database unavailable")
+                return job
+
+        if self.max_pending_batches_per_scope > 0 and scope is not None:
+            _scope_type, _scope_id, created_by_api_key, created_by_team_id = scope
+            active_batches = await self.repository.count_active_jobs_for_scope(
+                created_by_api_key=created_by_api_key,
+                created_by_team_id=created_by_team_id,
+            )
+            if active_batches >= self.max_pending_batches_per_scope:
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail=(
+                        "Active batch count exceeds "
+                        f"embeddings_batch_max_pending_batches_per_scope ({self.max_pending_batches_per_scope})"
+                    ),
+                )
+
+        job = await self.repository.create_job(
+            endpoint=endpoint,
+            input_file_id=input_file_id,
+            model=inferred_model,
+            metadata=metadata,
+            created_by_api_key=auth.api_key,
+            created_by_user_id=auth.user_id,
+            created_by_team_id=auth.team_id,
+            expires_at=datetime.now(tz=UTC) + timedelta(days=self.metadata_retention_days),
+        )
+        if job is None:
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Database unavailable")
+        return job
+
+    async def _upload_chunks(self, upload: UploadFile) -> AsyncIterator[bytes]:
+        total_bytes = 0
+        while True:
+            chunk = await upload.read(self.storage_chunk_size)
+            if not chunk:
+                break
+            total_bytes += len(chunk)
+            if total_bytes > self.max_file_bytes:
+                raise HTTPException(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    detail=f"Uploaded file exceeds embeddings_batch_max_file_bytes ({self.max_file_bytes})",
+                )
+            yield chunk
+
+    async def _iter_storage_lines(
+        self,
+        *,
+        storage: BatchArtifactStorage,
+        storage_key: str,
+    ) -> AsyncIterator[tuple[int, str]]:
+        line_number = 0
+        try:
+            async for line in storage.iter_lines(
+                storage_key,
+                chunk_size=self.storage_chunk_size,
+                max_line_bytes=self.max_line_bytes,
+            ):
+                line_number += 1
+                yield line_number, line
+        except BatchArtifactLineTooLongError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Line {exc.line_number} exceeds embeddings_batch_max_line_bytes ({self.max_line_bytes})",
+            ) from exc
+
+    def _parse_input_line(
+        self,
+        raw_line: str,
+        *,
+        line_number: int,
+        endpoint: str,
+        auth: UserAPIKeyAuth,
+        seen_custom_ids: set[str],
+    ) -> tuple[BatchItemCreate | None, str | None]:
+        line = raw_line.strip()
+        if not line:
+            return None, None
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid JSONL at line {line_number}: {exc.msg}",
+            ) from exc
+        if not isinstance(obj, dict):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must be an object")
+        custom_id = str(obj.get("custom_id") or "").strip()
+        if not custom_id:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing custom_id")
+        if custom_id in seen_custom_ids:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Duplicate custom_id at line {line_number}")
+        seen_custom_ids.add(custom_id)
+        url = str(obj.get("url") or endpoint)
+        if url != endpoint:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must target {endpoint}")
+        body = obj.get("body")
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing body")
+        validated = EmbeddingRequest.model_validate(body)
+        ensure_batch_model_allowed(
+            auth,
+            validated.model,
+            callable_target_grant_service=self.callable_target_grant_service,
+            policy_mode=self.callable_target_scope_policy_mode,
+        )
+        return (
+            BatchItemCreate(
+                line_number=line_number,
+                custom_id=custom_id,
+                request_body=validated.model_dump(exclude_none=True),
+            ),
+            validated.model,
+        )
+
+    async def _validate_input_to_spool(
+        self,
+        *,
+        storage: BatchArtifactStorage,
+        storage_key: str,
+        endpoint: str,
+        auth: UserAPIKeyAuth,
+    ) -> tuple[Any, int, str | None]:
+        seen_custom_ids: set[str] = set()
+        inferred_model: str | None = None
+        total_items = 0
+        spool = tempfile.SpooledTemporaryFile(
+            max_size=max(1_048_576, self.storage_chunk_size * 4),
+            mode="w+t",
+            encoding="utf-8",
+            newline="\n",
+        )
+        try:
+            async for line_number, raw_line in self._iter_storage_lines(storage=storage, storage_key=storage_key):
+                item, model = self._parse_input_line(
+                    raw_line,
+                    line_number=line_number,
+                    endpoint=endpoint,
+                    auth=auth,
+                    seen_custom_ids=seen_custom_ids,
+                )
+                if item is None:
+                    continue
+                total_items += 1
+                if total_items > self.max_items_per_batch:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Batch exceeds embeddings_batch_max_items_per_batch ({self.max_items_per_batch})",
+                    )
+                inferred_model = inferred_model or model
+                await asyncio.to_thread(
+                    spool.write,
+                    json.dumps(
+                        {
+                            "line_number": item.line_number,
+                            "custom_id": item.custom_id,
+                            "request_body": item.request_body,
+                        }
+                    )
+                    + "\n",
+                )
+            await asyncio.to_thread(spool.flush)
+            await asyncio.to_thread(spool.seek, 0)
+            return spool, total_items, inferred_model
+        except Exception:
+            await asyncio.to_thread(spool.close)
+            raise
+
+    async def _insert_items_from_spool(
+        self,
+        *,
+        batch_id: str,
+        spool: Any,
+    ) -> int:
+        buffer: list[BatchItemCreate] = []
+        inserted = 0
+        while True:
+            raw_line = await asyncio.to_thread(spool.readline)
+            if not raw_line:
+                break
+            line = raw_line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            buffer.append(
+                BatchItemCreate(
+                    line_number=int(obj["line_number"]),
+                    custom_id=str(obj["custom_id"]),
+                    request_body=dict(obj["request_body"]),
+                )
+            )
+            if len(buffer) >= self.create_buffer_size:
+                inserted += await self.repository.create_items(batch_id, buffer)
+                buffer.clear()
+        if buffer:
+            inserted += await self.repository.create_items(batch_id, buffer)
+        return inserted
+
     async def create_file(self, *, auth: UserAPIKeyAuth, upload: UploadFile, purpose: str) -> dict[str, Any]:
-        body = await upload.read()
-        if not body:
+        storage_key, bytes_size, checksum = await self.storage.write_chunks(
+            purpose=purpose,
+            filename=upload.filename or "batch.jsonl",
+            chunks=self._upload_chunks(upload),
+        )
+        if bytes_size <= 0:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uploaded file is empty")
         filename = upload.filename or "batch.jsonl"
-        storage_key, bytes_size, checksum = await self.storage.write_bytes(
-            purpose=purpose,
-            filename=filename,
-            content=body,
-        )
         record = await self.repository.create_file(
             purpose=purpose,
             filename=filename,
@@ -108,29 +373,40 @@ class BatchService:
             auth=auth,
         ):
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Input file access denied")
+        if file_record.bytes > self.max_file_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail=f"Input file exceeds embeddings_batch_max_file_bytes ({self.max_file_bytes})",
+            )
 
-        raw = await self._storage_for_backend(file_record.storage_backend).read_bytes(file_record.storage_key)
-        items, inferred_model = self._parse_input_jsonl(raw, endpoint=endpoint, auth=auth)
-        if not items:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid batch items found in file")
-
-        job = await self.repository.create_job(
+        file_storage = self._storage_for_backend(file_record.storage_backend)
+        spool, item_count, inferred_model = await self._validate_input_to_spool(
+            storage=file_storage,
+            storage_key=file_record.storage_key,
             endpoint=endpoint,
-            input_file_id=input_file_id,
-            model=inferred_model,
-            metadata=metadata,
-            created_by_api_key=auth.api_key,
-            created_by_user_id=auth.user_id,
-            created_by_team_id=auth.team_id,
-            expires_at=datetime.now(tz=UTC) + timedelta(days=self.metadata_retention_days),
+            auth=auth,
         )
-        if job is None:
-            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Database unavailable")
-        inserted = await self.repository.create_items(job.batch_id, items)
-        job = await self.repository.set_job_queued(job.batch_id, inserted)
-        if job is None:
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to queue batch")
-        return self.job_to_response(job)
+        try:
+            if item_count <= 0:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid batch items found in file")
+
+            job = await self._create_job_with_scope_limit(
+                auth=auth,
+                endpoint=endpoint,
+                input_file_id=input_file_id,
+                metadata=metadata,
+                inferred_model=inferred_model,
+            )
+            inserted = await self._insert_items_from_spool(
+                batch_id=job.batch_id,
+                spool=spool,
+            )
+            job = await self.repository.set_job_queued(job.batch_id, inserted)
+            if job is None:
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to queue batch")
+            return self.job_to_response(job)
+        finally:
+            await asyncio.to_thread(spool.close)
 
     async def get_batch(self, *, batch_id: str, auth: UserAPIKeyAuth) -> dict[str, Any]:
         job = await self.repository.get_job(batch_id)
@@ -212,43 +488,15 @@ class BatchService:
         seen_custom_ids: set[str] = set()
         inferred_model: str | None = None
         for line_number, raw_line in enumerate(text.splitlines(), start=1):
-            line = raw_line.strip()
-            if not line:
+            item, model = self._parse_input_line(
+                raw_line,
+                line_number=line_number,
+                endpoint=endpoint,
+                auth=auth,
+                seen_custom_ids=seen_custom_ids,
+            )
+            if item is None:
                 continue
-            try:
-                obj = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Invalid JSONL at line {line_number}: {exc.msg}",
-                ) from exc
-            if not isinstance(obj, dict):
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must be an object")
-            custom_id = str(obj.get("custom_id") or "").strip()
-            if not custom_id:
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing custom_id")
-            if custom_id in seen_custom_ids:
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Duplicate custom_id at line {line_number}")
-            seen_custom_ids.add(custom_id)
-            url = str(obj.get("url") or endpoint)
-            if url != endpoint:
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must target {endpoint}")
-            body = obj.get("body")
-            if not isinstance(body, dict):
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing body")
-            validated = EmbeddingRequest.model_validate(body)
-            ensure_batch_model_allowed(
-                auth,
-                validated.model,
-                callable_target_grant_service=self.callable_target_grant_service,
-                policy_mode=self.callable_target_scope_policy_mode,
-            )
-            inferred_model = inferred_model or validated.model
-            items.append(
-                BatchItemCreate(
-                    line_number=line_number,
-                    custom_id=custom_id,
-                    request_body=validated.model_dump(exclude_none=True),
-                )
-            )
+            items.append(item)
+            inferred_model = inferred_model or model
         return items, inferred_model

--- a/src/batch/storage.py
+++ b/src/batch/storage.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
+import tempfile
 from pathlib import Path
-from typing import Iterable
+from typing import AsyncIterable, AsyncIterator, Iterable
 from uuid import uuid4
 
 try:
@@ -15,21 +17,88 @@ except ImportError:
     boto3 = None  # type: ignore[assignment]
 
 
+class BatchArtifactLineTooLongError(ValueError):
+    def __init__(self, *, line_number: int, max_line_bytes: int) -> None:
+        super().__init__(f"Line {line_number} exceeds max_line_bytes={max_line_bytes}")
+        self.line_number = line_number
+        self.max_line_bytes = max_line_bytes
+
+
 class BatchArtifactStorage:
     backend_name = "unknown"
 
-    async def write_bytes(self, *, purpose: str, filename: str, content: bytes) -> tuple[str, int, str]:
+    async def write_chunks(
+        self,
+        *,
+        purpose: str,
+        filename: str,
+        chunks: AsyncIterable[bytes],
+    ) -> tuple[str, int, str]:
         raise NotImplementedError
 
-    async def read_bytes(self, storage_key: str) -> bytes:
+    async def iter_bytes(self, storage_key: str, chunk_size: int = 65_536) -> AsyncIterator[bytes]:
         raise NotImplementedError
 
     async def delete(self, storage_key: str) -> None:
         raise NotImplementedError
 
+    async def write_bytes(self, *, purpose: str, filename: str, content: bytes) -> tuple[str, int, str]:
+        async def _chunks() -> AsyncIterator[bytes]:
+            if content:
+                yield content
+
+        return await self.write_chunks(purpose=purpose, filename=filename, chunks=_chunks())
+
+    async def read_bytes(self, storage_key: str) -> bytes:
+        parts: list[bytes] = []
+        async for chunk in self.iter_bytes(storage_key):
+            parts.append(chunk)
+        return b"".join(parts)
+
+    async def iter_lines(
+        self,
+        storage_key: str,
+        chunk_size: int = 65_536,
+        max_line_bytes: int | None = None,
+    ) -> AsyncIterator[str]:
+        buffer = b""
+        line_number = 1
+        async for chunk in self.iter_bytes(storage_key, chunk_size=chunk_size):
+            buffer += chunk
+            while True:
+                newline = buffer.find(b"\n")
+                if newline == -1:
+                    break
+                raw_line = buffer[:newline]
+                if max_line_bytes is not None and len(raw_line) > max_line_bytes:
+                    raise BatchArtifactLineTooLongError(line_number=line_number, max_line_bytes=max_line_bytes)
+                buffer = buffer[newline + 1 :]
+                yield raw_line.decode("utf-8")
+                line_number += 1
+            if max_line_bytes is not None and len(buffer) > max_line_bytes:
+                raise BatchArtifactLineTooLongError(line_number=line_number, max_line_bytes=max_line_bytes)
+        if buffer:
+            yield buffer.decode("utf-8")
+
     async def write_lines(self, *, purpose: str, filename: str, lines: Iterable[str]) -> tuple[str, int, str]:
-        payload = ("\n".join(lines) + "\n").encode("utf-8")
-        return await self.write_bytes(purpose=purpose, filename=filename, content=payload)
+        async def _chunks() -> AsyncIterator[bytes]:
+            for line in lines:
+                yield (line + "\n").encode("utf-8")
+
+        return await self.write_chunks(purpose=purpose, filename=filename, chunks=_chunks())
+
+    async def write_lines_stream(
+        self,
+        *,
+        purpose: str,
+        filename: str,
+        lines: AsyncIterable[str],
+    ) -> tuple[str, int, str]:
+        async def _chunks() -> AsyncIterator[bytes]:
+            async for line in lines:
+                yield (line + "\n").encode("utf-8")
+
+        return await self.write_chunks(purpose=purpose, filename=filename, chunks=_chunks())
 
 
 class LocalBatchArtifactStorage(BatchArtifactStorage):
@@ -39,23 +108,66 @@ class LocalBatchArtifactStorage(BatchArtifactStorage):
         self.base_dir = Path(base_dir).resolve()
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
-    async def write_bytes(self, *, purpose: str, filename: str, content: bytes) -> tuple[str, int, str]:
+    def _build_target(self, *, purpose: str, filename: str) -> tuple[str, Path]:
         safe_name = filename.replace("/", "_")
         storage_key = f"{purpose}/{uuid4().hex}-{safe_name}"
-        target = self.base_dir / storage_key
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(content)
-        checksum = hashlib.sha256(content).hexdigest()
-        return storage_key, len(content), checksum
+        return storage_key, self.base_dir / storage_key
 
-    async def read_bytes(self, storage_key: str) -> bytes:
+    async def write_chunks(
+        self,
+        *,
+        purpose: str,
+        filename: str,
+        chunks: AsyncIterable[bytes],
+    ) -> tuple[str, int, str]:
+        storage_key, target = self._build_target(purpose=purpose, filename=filename)
+        checksum = hashlib.sha256()
+        total_bytes = 0
+        temp_target: Path | None = None
+        handle = None
+        try:
+            async for chunk in chunks:
+                if not chunk:
+                    continue
+                if handle is None:
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    temp_target = target.parent / f".tmp-{uuid4().hex}-{target.name}"
+                    handle = temp_target.open("wb")
+                total_bytes += len(chunk)
+                checksum.update(chunk)
+                await asyncio.to_thread(handle.write, chunk)
+            if handle is None:
+                return "", 0, checksum.hexdigest()
+            await asyncio.to_thread(handle.flush)
+            await asyncio.to_thread(handle.close)
+            await asyncio.to_thread(temp_target.replace, target)
+        except Exception:
+            with contextlib.suppress(Exception):
+                if handle is not None:
+                    await asyncio.to_thread(handle.close)
+            if temp_target is not None:
+                with contextlib.suppress(FileNotFoundError):
+                    await asyncio.to_thread(temp_target.unlink)
+            raise
+        return storage_key, total_bytes, checksum.hexdigest()
+
+    async def iter_bytes(self, storage_key: str, chunk_size: int = 65_536) -> AsyncIterator[bytes]:
         target = self.base_dir / storage_key
-        return target.read_bytes()
+        handle = target.open("rb")
+        try:
+            while True:
+                chunk = await asyncio.to_thread(handle.read, chunk_size)
+                if not chunk:
+                    break
+                yield chunk
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(handle.close)
 
     async def delete(self, storage_key: str) -> None:
         target = self.base_dir / storage_key
         if target.exists():
-            target.unlink()
+            await asyncio.to_thread(target.unlink)
 
 
 class S3BatchArtifactStorage(BatchArtifactStorage):
@@ -70,6 +182,7 @@ class S3BatchArtifactStorage(BatchArtifactStorage):
         endpoint_url: str | None = None,
         access_key_id: str | None = None,
         secret_access_key: str | None = None,
+        spool_max_bytes: int = 8_388_608,
         client: object | None = None,
     ) -> None:
         if not bucket:
@@ -82,6 +195,7 @@ class S3BatchArtifactStorage(BatchArtifactStorage):
         self.endpoint_url = endpoint_url
         self.access_key_id = access_key_id
         self.secret_access_key = secret_access_key
+        self.spool_max_bytes = spool_max_bytes
         self._client = client
 
     @property
@@ -102,24 +216,52 @@ class S3BatchArtifactStorage(BatchArtifactStorage):
         relative = f"{purpose}/{uuid4().hex}-{safe_name}"
         return f"{self.prefix}/{relative}" if self.prefix else relative
 
-    async def write_bytes(self, *, purpose: str, filename: str, content: bytes) -> tuple[str, int, str]:
+    async def write_chunks(
+        self,
+        *,
+        purpose: str,
+        filename: str,
+        chunks: AsyncIterable[bytes],
+    ) -> tuple[str, int, str]:
         storage_key = self._storage_key(purpose=purpose, filename=filename)
-        checksum = hashlib.sha256(content).hexdigest()
-        await asyncio.to_thread(
-            self.s3.put_object,
-            Bucket=self.bucket,
-            Key=storage_key,
-            Body=content,
-            Metadata={"sha256": checksum, "purpose": purpose, "filename": filename},
-        )
-        return storage_key, len(content), checksum
+        checksum = hashlib.sha256()
+        total_bytes = 0
+        spool = tempfile.SpooledTemporaryFile(max_size=self.spool_max_bytes)
+        try:
+            async for chunk in chunks:
+                if not chunk:
+                    continue
+                total_bytes += len(chunk)
+                checksum.update(chunk)
+                await asyncio.to_thread(spool.write, chunk)
+            if total_bytes == 0:
+                return "", 0, checksum.hexdigest()
+            await asyncio.to_thread(spool.seek, 0)
+            await asyncio.to_thread(
+                self.s3.upload_fileobj,
+                spool,
+                self.bucket,
+                storage_key,
+                ExtraArgs={"Metadata": {"sha256": checksum.hexdigest(), "purpose": purpose, "filename": filename}},
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(spool.close)
+        return storage_key, total_bytes, checksum.hexdigest()
 
-    async def read_bytes(self, storage_key: str) -> bytes:
-        def _read() -> bytes:
-            response = self.s3.get_object(Bucket=self.bucket, Key=storage_key)
-            return response["Body"].read()
-
-        return await asyncio.to_thread(_read)
+    async def iter_bytes(self, storage_key: str, chunk_size: int = 65_536) -> AsyncIterator[bytes]:
+        spool = tempfile.SpooledTemporaryFile(max_size=self.spool_max_bytes)
+        try:
+            await asyncio.to_thread(self.s3.download_fileobj, self.bucket, storage_key, spool)
+            await asyncio.to_thread(spool.seek, 0)
+            while True:
+                chunk = await asyncio.to_thread(spool.read, chunk_size)
+                if not chunk:
+                    break
+                yield chunk
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(spool.close)
 
     async def delete(self, storage_key: str) -> None:
         await asyncio.to_thread(self.s3.delete_object, Bucket=self.bucket, Key=storage_key)

--- a/src/batch/worker.py
+++ b/src/batch/worker.py
@@ -6,7 +6,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, AsyncIterator
 
 import httpx
 
@@ -31,6 +31,9 @@ class BatchWorkerConfig:
     job_lease_seconds: int = 120
     item_lease_seconds: int = 360
     finalization_retry_delay_seconds: int = 60
+    worker_concurrency: int = 4
+    item_buffer_multiplier: int = 2
+    finalization_page_size: int = 500
     item_claim_limit: int = 20
     max_attempts: int = 3
     completed_artifact_retention_days: int = 7
@@ -72,6 +75,12 @@ class BatchExecutorWorker:
     def stop(self) -> None:
         self._running = False
 
+    def _claim_limit(self) -> int:
+        return max(
+            self.config.item_claim_limit,
+            self.config.worker_concurrency * self.config.item_buffer_multiplier,
+        )
+
     async def process_once(self) -> bool:
         job = await self.repository.claim_next_job(
             worker_id=self.config.worker_id,
@@ -98,11 +107,10 @@ class BatchExecutorWorker:
             items = await self.repository.claim_items(
                 batch_id=job.batch_id,
                 worker_id=self.config.worker_id,
-                limit=self.config.item_claim_limit,
+                limit=self._claim_limit(),
                 lease_seconds=self.config.item_lease_seconds,
             )
-            for item in items:
-                await self._process_item(job, item)
+            await self._process_items(job, items)
 
             refreshed = await self.repository.refresh_job_progress(job.batch_id)
             if refreshed and refreshed.status == BatchJobStatus.FINALIZING:
@@ -211,6 +219,19 @@ class BatchExecutorWorker:
             await self.repository.refresh_job_progress(batch_id)
         finally:
             await self._stop_heartbeat(item_heartbeat)
+
+    async def _process_items(self, job, items) -> None:
+        if not items:
+            return
+        semaphore = asyncio.Semaphore(self.config.worker_concurrency)
+
+        async def _runner(item) -> None:  # noqa: ANN001
+            async with semaphore:
+                await self._process_item(job, item)
+
+        async with asyncio.TaskGroup() as task_group:
+            for item in items:
+                task_group.create_task(_runner(item))
 
     async def _record_success_side_effects(
         self,
@@ -345,27 +366,47 @@ class BatchExecutorWorker:
             with contextlib.suppress(Exception):
                 await self.repository.delete_file(file_id)
 
-    async def _finalize_artifacts(self, job) -> None:
-        items = await self.repository.list_items(job.batch_id)
-        output_lines: list[str] = []
-        error_lines: list[str] = []
-        for item in items:
-            if item.status == "completed":
-                output_lines.append(json.dumps({"custom_id": item.custom_id, "response": item.response_body or {}}))
-            elif item.status in {"failed", "cancelled"}:
-                error_lines.append(json.dumps({"custom_id": item.custom_id, "error": item.error_body or {}}))
+    async def _iter_batch_items(self, batch_id: str) -> AsyncIterator[Any]:
+        if hasattr(self.repository, "list_items_page"):
+            after_line_number: int | None = None
+            while True:
+                page = await self.repository.list_items_page(
+                    batch_id=batch_id,
+                    limit=self.config.finalization_page_size,
+                    after_line_number=after_line_number,
+                )
+                if not page:
+                    break
+                for item in page:
+                    yield item
+                after_line_number = page[-1].line_number
+            return
 
+        for item in await self.repository.list_items(batch_id):
+            yield item
+
+    async def _iter_output_lines(self, batch_id: str) -> AsyncIterator[str]:
+        async for item in self._iter_batch_items(batch_id):
+            if item.status == "completed":
+                yield json.dumps({"custom_id": item.custom_id, "response": item.response_body or {}})
+
+    async def _iter_error_lines(self, batch_id: str) -> AsyncIterator[str]:
+        async for item in self._iter_batch_items(batch_id):
+            if item.status in {"failed", "cancelled"}:
+                yield json.dumps({"custom_id": item.custom_id, "error": item.error_body or {}})
+
+    async def _finalize_artifacts(self, job) -> None:
         storage_backend = getattr(self.storage, "backend_name", "local")
         created_artifacts: list[tuple[str, str]] = []
         output_file_id: str | None = None
         error_file_id: str | None = None
         final_status = self._resolve_final_status(job)
         try:
-            if output_lines:
-                key, size, checksum = await self.storage.write_lines(
+            if job.completed_items > 0:
+                key, size, checksum = await self.storage.write_lines_stream(
                     purpose="batch_output",
                     filename=f"{job.batch_id}-output.jsonl",
-                    lines=output_lines,
+                    lines=self._iter_output_lines(job.batch_id),
                 )
                 file_record = await self.repository.create_file(
                     purpose="batch_output",
@@ -384,11 +425,11 @@ class BatchExecutorWorker:
                 created_artifacts.append((file_record.file_id, key))
                 output_file_id = file_record.file_id
 
-            if error_lines:
-                key, size, checksum = await self.storage.write_lines(
+            if job.failed_items > 0 or job.cancelled_items > 0:
+                key, size, checksum = await self.storage.write_lines_stream(
                     purpose="batch_error",
                     filename=f"{job.batch_id}-error.jsonl",
-                    lines=error_lines,
+                    lines=self._iter_error_lines(job.batch_id),
                 )
                 retention_days = (
                     self.config.failed_artifact_retention_days

--- a/src/bootstrap/batch.py
+++ b/src/bootstrap/batch.py
@@ -36,6 +36,7 @@ def _build_s3_batch_storage(cfg: Any) -> S3BatchArtifactStorage:
             endpoint_url=getattr(general, "embeddings_batch_s3_endpoint_url", None),
             access_key_id=getattr(general, "embeddings_batch_s3_access_key_id", None),
             secret_access_key=getattr(general, "embeddings_batch_s3_secret_access_key", None),
+            spool_max_bytes=int(getattr(general, "embeddings_batch_s3_spool_max_bytes", 8_388_608) or 8_388_608),
         )
     except ImportError as exc:
         raise RuntimeError(
@@ -89,6 +90,12 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
         storage=batch_storage,
         storage_registry=batch_storage_registry,
         metadata_retention_days=cfg.general_settings.batch_metadata_retention_days,
+        storage_chunk_size=cfg.general_settings.embeddings_batch_storage_chunk_size,
+        create_buffer_size=cfg.general_settings.embeddings_batch_create_buffer_size,
+        max_file_bytes=cfg.general_settings.embeddings_batch_max_file_bytes,
+        max_items_per_batch=cfg.general_settings.embeddings_batch_max_items_per_batch,
+        max_line_bytes=cfg.general_settings.embeddings_batch_max_line_bytes,
+        max_pending_batches_per_scope=cfg.general_settings.embeddings_batch_max_pending_batches_per_scope,
         callable_target_grant_service=getattr(app.state, "callable_target_grant_service", None),
         callable_target_scope_policy_mode=normalize_callable_target_policy_mode(
             getattr(cfg.general_settings, "callable_target_scope_policy_mode", "enforce")
@@ -107,6 +114,9 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
                 job_lease_seconds=cfg.general_settings.embeddings_batch_job_lease_seconds,
                 item_lease_seconds=cfg.general_settings.embeddings_batch_item_lease_seconds,
                 finalization_retry_delay_seconds=cfg.general_settings.embeddings_batch_finalization_retry_delay_seconds,
+                worker_concurrency=cfg.general_settings.embeddings_batch_worker_concurrency,
+                item_buffer_multiplier=cfg.general_settings.embeddings_batch_item_buffer_multiplier,
+                finalization_page_size=cfg.general_settings.embeddings_batch_finalization_page_size,
                 item_claim_limit=cfg.general_settings.embeddings_batch_item_claim_limit,
                 max_attempts=cfg.general_settings.embeddings_batch_max_attempts,
                 completed_artifact_retention_days=cfg.general_settings.batch_completed_artifact_retention_days,

--- a/src/config.py
+++ b/src/config.py
@@ -256,11 +256,21 @@ class GeneralSettings(BaseModel):
     embeddings_batch_s3_endpoint_url: str | None = None
     embeddings_batch_s3_access_key_id: str | None = None
     embeddings_batch_s3_secret_access_key: str | None = None
+    embeddings_batch_s3_spool_max_bytes: int = Field(default=8_388_608, gt=0)
     embeddings_batch_poll_interval_seconds: float = 1.0
     embeddings_batch_heartbeat_interval_seconds: float = Field(default=15.0, gt=0)
     embeddings_batch_job_lease_seconds: int = Field(default=120, ge=5)
     embeddings_batch_item_lease_seconds: int = Field(default=360, ge=30)
     embeddings_batch_finalization_retry_delay_seconds: int = Field(default=60, ge=1)
+    embeddings_batch_worker_concurrency: int = Field(default=4, ge=1, le=100)
+    embeddings_batch_item_buffer_multiplier: int = Field(default=2, ge=1, le=10)
+    embeddings_batch_storage_chunk_size: int = Field(default=65_536, ge=1_024)
+    embeddings_batch_finalization_page_size: int = Field(default=500, ge=10, le=10_000)
+    embeddings_batch_create_buffer_size: int = Field(default=200, ge=1, le=10_000)
+    embeddings_batch_max_file_bytes: int = Field(default=52_428_800, ge=1_024)
+    embeddings_batch_max_items_per_batch: int = Field(default=10_000, ge=1)
+    embeddings_batch_max_line_bytes: int = Field(default=1_048_576, ge=1_024)
+    embeddings_batch_max_pending_batches_per_scope: int = Field(default=20, ge=0)
     embeddings_batch_item_claim_limit: int = 20
     embeddings_batch_max_attempts: int = 3
     batch_completed_artifact_retention_days: int = 7

--- a/tests/bootstrap/test_optional_bootstrap.py
+++ b/tests/bootstrap/test_optional_bootstrap.py
@@ -44,12 +44,22 @@ def _batch_config(
             embeddings_batch_s3_endpoint_url=None,
             embeddings_batch_s3_access_key_id=None,
             embeddings_batch_s3_secret_access_key=None,
+            embeddings_batch_s3_spool_max_bytes=8_388_608,
             batch_metadata_retention_days=14,
             embeddings_batch_poll_interval_seconds=5,
             embeddings_batch_heartbeat_interval_seconds=15,
             embeddings_batch_job_lease_seconds=120,
             embeddings_batch_item_lease_seconds=360,
             embeddings_batch_finalization_retry_delay_seconds=60,
+            embeddings_batch_worker_concurrency=4,
+            embeddings_batch_item_buffer_multiplier=2,
+            embeddings_batch_storage_chunk_size=65_536,
+            embeddings_batch_finalization_page_size=500,
+            embeddings_batch_create_buffer_size=200,
+            embeddings_batch_max_file_bytes=52_428_800,
+            embeddings_batch_max_items_per_batch=10_000,
+            embeddings_batch_max_line_bytes=1_048_576,
+            embeddings_batch_max_pending_batches_per_scope=20,
             embeddings_batch_item_claim_limit=10,
             embeddings_batch_max_attempts=3,
             batch_completed_artifact_retention_days=7,
@@ -152,6 +162,12 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
             storage,  # noqa: ANN001
             metadata_retention_days,  # noqa: ANN001
             storage_registry=None,  # noqa: ANN001
+            storage_chunk_size=65_536,  # noqa: ANN001
+            create_buffer_size=200,  # noqa: ANN001
+            max_file_bytes=52_428_800,  # noqa: ANN001
+            max_items_per_batch=10_000,  # noqa: ANN001
+            max_line_bytes=1_048_576,  # noqa: ANN001
+            max_pending_batches_per_scope=20,  # noqa: ANN001
             callable_target_grant_service=None,  # noqa: ANN001
             callable_target_scope_policy_mode="enforce",  # noqa: ANN001
         ) -> None:
@@ -159,6 +175,12 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
             self.storage = storage
             self.storage_registry = storage_registry
             self.metadata_retention_days = metadata_retention_days
+            self.storage_chunk_size = storage_chunk_size
+            self.create_buffer_size = create_buffer_size
+            self.max_file_bytes = max_file_bytes
+            self.max_items_per_batch = max_items_per_batch
+            self.max_line_bytes = max_line_bytes
+            self.max_pending_batches_per_scope = max_pending_batches_per_scope
             self.callable_target_grant_service = callable_target_grant_service
             self.callable_target_scope_policy_mode = callable_target_scope_policy_mode
             created["service"] = self
@@ -212,11 +234,16 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
     assert isinstance(app.state.batch_service, FakeBatchService)
     assert created["service"].repository is repository
     assert created["service"].storage_registry == {"local": {"path": "/tmp/batch-artifacts"}}
+    assert created["service"].storage_chunk_size == 65_536
+    assert created["service"].create_buffer_size == 200
     assert runtime.worker is created["worker"]
     assert runtime.worker_task is not None
     assert runtime.gc_worker is created["gc_worker"]
     assert runtime.gc_task is not None
     assert created["gc_worker"].storage_registry == {"local": {"path": "/tmp/batch-artifacts"}}
+    assert created["worker"].config.worker_concurrency == 4
+    assert created["worker"].config.item_buffer_multiplier == 2
+    assert created["worker"].config.finalization_page_size == 500
     assert runtime.statuses == (
         BootstrapStatus("embeddings_batch", "ready"),
         BootstrapStatus("embeddings_batch_worker", "ready"),
@@ -234,8 +261,24 @@ async def test_init_batch_runtime_selects_s3_storage(monkeypatch: pytest.MonkeyP
     created: dict[str, object] = {}
 
     class FakeBatchService:
-        def __init__(self, repository, storage, storage_registry=None, metadata_retention_days=30, callable_target_grant_service=None, callable_target_scope_policy_mode="enforce") -> None:  # noqa: ANN001
-            del metadata_retention_days, callable_target_grant_service, callable_target_scope_policy_mode
+        def __init__(
+            self,
+            repository,
+            storage,
+            metadata_retention_days=30,
+            storage_registry=None,
+            storage_chunk_size=65_536,
+            create_buffer_size=200,
+            max_file_bytes=52_428_800,
+            max_items_per_batch=10_000,
+            max_line_bytes=1_048_576,
+            max_pending_batches_per_scope=20,
+            callable_target_grant_service=None,
+            callable_target_scope_policy_mode="enforce",
+        ) -> None:  # noqa: ANN001
+            del metadata_retention_days, storage_chunk_size, create_buffer_size, max_file_bytes
+            del max_items_per_batch, max_line_bytes, max_pending_batches_per_scope
+            del callable_target_grant_service, callable_target_scope_policy_mode
             self.repository = repository
             self.storage = storage
             self.storage_registry = storage_registry

--- a/tests/test_batch_repository.py
+++ b/tests/test_batch_repository.py
@@ -90,3 +90,46 @@ async def test_reschedule_finalization_pushes_lease_forward():
     assert rescheduled is False
     assert "lease_expires_at = NOW() + ($3 || ' seconds')::interval" in prisma.sql
     assert "status = 'finalizing'" in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_count_active_jobs_for_scope_prefers_team_scope():
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    count = await repository.count_active_jobs_for_scope(
+        created_by_api_key="key-1",
+        created_by_team_id="team-1",
+    )
+
+    assert count == 0
+    assert "created_by_team_id = $1" in prisma.sql
+    assert "status NOT IN ('completed', 'failed', 'cancelled', 'expired')" in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_list_items_page_uses_line_number_cursor():
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    items = await repository.list_items_page(
+        batch_id="batch-1",
+        limit=200,
+        after_line_number=10,
+    )
+
+    assert items == []
+    assert "line_number > $2" in prisma.sql
+    assert "ORDER BY line_number ASC" in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_acquire_scope_advisory_lock_uses_postgres_advisory_lock():
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    await repository.acquire_scope_advisory_lock(scope_type="team", scope_id="team-1")
+
+    assert "pg_advisory_xact_lock" in prisma.sql
+    assert "hashtext($1)" in prisma.sql
+    assert "hashtext($2)" in prisma.sql

--- a/tests/test_batch_service.py
+++ b/tests/test_batch_service.py
@@ -22,10 +22,26 @@ class _DummyStorage:
 
     def __init__(self) -> None:
         self.reads: list[str] = []
+        self.lines_by_key: dict[str, list[str]] = {}
+        self.writes: list[bytes] = []
 
     async def read_bytes(self, storage_key: str) -> bytes:
         self.reads.append(storage_key)
         return b"{}"
+
+    async def iter_lines(self, storage_key: str, chunk_size: int = 65_536, max_line_bytes: int | None = None):  # noqa: ARG002
+        del max_line_bytes
+        self.reads.append(storage_key)
+        for line in self.lines_by_key.get(storage_key, []):
+            yield line
+
+    async def write_chunks(self, *, purpose: str, filename: str, chunks):  # noqa: ANN001
+        del purpose, filename
+        payload = bytearray()
+        async for chunk in chunks:
+            payload.extend(chunk)
+        self.writes.append(bytes(payload))
+        return "batch/file.jsonl", len(payload), "checksum"
 
 
 class _FakeCallableTargetBindingRepository:
@@ -313,17 +329,21 @@ async def test_get_file_content_uses_file_storage_backend_from_registry() -> Non
 
 
 @pytest.mark.asyncio
-async def test_create_embeddings_batch_reads_input_from_file_storage_backend() -> None:
+async def test_create_embeddings_batch_reads_input_from_file_storage_backend(monkeypatch: pytest.MonkeyPatch) -> None:
     now = datetime.now(tz=UTC)
+    monkeypatch.setattr("src.batch.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
 
     class _Repo:
+        def __init__(self) -> None:
+            self.active_scope_kwargs: dict[str, str | None] | None = None
+
         async def get_file(self, file_id: str):
             assert file_id == "f1"
             return BatchFileRecord(
                 file_id="f1",
                 purpose="batch",
                 filename="x.jsonl",
-                bytes=1,
+                bytes=100,
                 status="processed",
                 storage_backend="local",
                 storage_key="legacy/input-file",
@@ -334,6 +354,10 @@ async def test_create_embeddings_batch_reads_input_from_file_storage_backend() -
                 created_at=now,
                 expires_at=None,
             )
+
+        async def count_active_jobs_for_scope(self, **kwargs):
+            self.active_scope_kwargs = kwargs
+            return 0
 
         async def create_job(self, **kwargs):
             del kwargs
@@ -410,21 +434,248 @@ async def test_create_embeddings_batch_reads_input_from_file_storage_backend() -
             )
 
     local_storage = _DummyStorage()
+    local_storage.lines_by_key["legacy/input-file"] = [
+        '{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}'
+    ]
     active_storage = _DummyStorage()
     active_storage.backend_name = "s3"
+    repo = _Repo()
     service = BatchService(
-        repository=_Repo(),  # type: ignore[arg-type]
+        repository=repo,  # type: ignore[arg-type]
         storage=active_storage,  # type: ignore[arg-type]
         storage_registry={"local": local_storage, "s3": active_storage},  # type: ignore[arg-type]
     )
 
-    def _fake_parse(payload: bytes, *, endpoint: str, auth):  # noqa: ANN001
-        assert payload == b"{}"
-        assert endpoint == "/v1/embeddings"
-        assert auth.api_key == "key-a"
-        return [type("Item", (), {"line_number": 1, "custom_id": "c1", "request_body": {"model": "m1"}})()], "m1"
+    result = await service.create_embeddings_batch(
+        auth=UserAPIKeyAuth(api_key="key-a", models=["m1"]),
+        input_file_id="f1",
+        endpoint="/v1/embeddings",
+        metadata=None,
+        completion_window=None,
+    )
 
-    service._parse_input_jsonl = _fake_parse  # type: ignore[method-assign]
+    assert result["status"] == "queued"
+    assert local_storage.reads == ["legacy/input-file"]
+    assert active_storage.reads == []
+    assert repo.active_scope_kwargs == {"created_by_api_key": "key-a", "created_by_team_id": None}
+
+
+@pytest.mark.asyncio
+async def test_create_file_enforces_max_file_bytes() -> None:
+    class _Upload:
+        def __init__(self) -> None:
+            self.filename = "batch.jsonl"
+            self._chunks = [b"a" * 10, b"b" * 10, b""]
+
+        async def read(self, size: int = -1):  # noqa: ARG002
+            return self._chunks.pop(0)
+
+    service = BatchService(
+        repository=_DummyRepo(),  # type: ignore[arg-type]
+        storage=_DummyStorage(),  # type: ignore[arg-type]
+        max_file_bytes=15,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_file(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            upload=_Upload(),  # type: ignore[arg-type]
+            purpose="batch",
+        )
+
+    assert exc.value.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_create_embeddings_batch_enforces_pending_batch_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.now(tz=UTC)
+    monkeypatch.setattr("src.batch.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+
+    class _Repo:
+        async def get_file(self, file_id: str):
+            del file_id
+            return BatchFileRecord(
+                file_id="f1",
+                purpose="batch",
+                filename="x.jsonl",
+                bytes=100,
+                status="processed",
+                storage_backend="local",
+                storage_key="legacy/input-file",
+                checksum=None,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                expires_at=None,
+            )
+
+        async def count_active_jobs_for_scope(self, **kwargs):
+            del kwargs
+            return 2
+
+    local_storage = _DummyStorage()
+    local_storage.lines_by_key["legacy/input-file"] = [
+        '{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}'
+    ]
+    service = BatchService(
+        repository=_Repo(),  # type: ignore[arg-type]
+        storage=local_storage,  # type: ignore[arg-type]
+        max_pending_batches_per_scope=2,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_embeddings_batch(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            input_file_id="f1",
+            endpoint="/v1/embeddings",
+            metadata=None,
+            completion_window=None,
+        )
+
+    assert exc.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_create_embeddings_batch_uses_transactional_scope_lock_for_pending_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.now(tz=UTC)
+    monkeypatch.setattr("src.batch.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+
+    class _TxDB:
+        def __init__(self) -> None:
+            self.entries = 0
+
+        def tx(self):  # noqa: ANN201
+            return self
+
+        async def __aenter__(self):  # noqa: ANN202
+            self.entries += 1
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: ANN202
+            del exc_type, exc, tb
+            return False
+
+    class _Repo:
+        def __init__(self, prisma, state):  # noqa: ANN001
+            self.prisma = prisma
+            self.state = state
+
+        def with_prisma(self, prisma_client):  # noqa: ANN201
+            return _Repo(prisma_client, self.state)
+
+        async def get_file(self, file_id: str):
+            del file_id
+            return BatchFileRecord(
+                file_id="f1",
+                purpose="batch",
+                filename="x.jsonl",
+                bytes=100,
+                status="processed",
+                storage_backend="local",
+                storage_key="legacy/input-file",
+                checksum=None,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                expires_at=None,
+            )
+
+        async def acquire_scope_advisory_lock(self, *, scope_type: str, scope_id: str) -> None:
+            self.state["locks"].append((scope_type, scope_id, self.prisma))
+
+        async def count_active_jobs_for_scope(self, **kwargs):
+            self.state["counts"].append((kwargs, self.prisma))
+            return 0
+
+        async def create_job(self, **kwargs):
+            self.state["create_job_prismas"].append(self.prisma)
+            del kwargs
+            return BatchJobRecord(
+                batch_id="b1",
+                endpoint="/v1/embeddings",
+                status=BatchJobStatus.VALIDATING,
+                execution_mode="managed_internal",
+                input_file_id="f1",
+                output_file_id=None,
+                error_file_id=None,
+                model="m1",
+                metadata={},
+                provider_batch_id=None,
+                provider_status=None,
+                provider_error=None,
+                provider_last_sync_at=None,
+                total_items=0,
+                in_progress_items=0,
+                completed_items=0,
+                failed_items=0,
+                cancelled_items=0,
+                locked_by=None,
+                lease_expires_at=None,
+                cancel_requested_at=None,
+                status_last_updated_at=now,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                started_at=None,
+                completed_at=None,
+                expires_at=None,
+            )
+
+        async def create_items(self, batch_id: str, items):  # noqa: ANN001
+            assert batch_id == "b1"
+            self.state["create_items_calls"] += 1
+            return len(items)
+
+        async def set_job_queued(self, batch_id: str, total_items: int):
+            assert batch_id == "b1"
+            assert total_items == 1
+            return BatchJobRecord(
+                batch_id="b1",
+                endpoint="/v1/embeddings",
+                status=BatchJobStatus.QUEUED,
+                execution_mode="managed_internal",
+                input_file_id="f1",
+                output_file_id=None,
+                error_file_id=None,
+                model="m1",
+                metadata={},
+                provider_batch_id=None,
+                provider_status=None,
+                provider_error=None,
+                provider_last_sync_at=None,
+                total_items=1,
+                in_progress_items=0,
+                completed_items=0,
+                failed_items=0,
+                cancelled_items=0,
+                locked_by=None,
+                lease_expires_at=None,
+                cancel_requested_at=None,
+                status_last_updated_at=now,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                started_at=None,
+                completed_at=None,
+                expires_at=None,
+            )
+
+    state = {"locks": [], "counts": [], "create_job_prismas": [], "create_items_calls": 0}
+    tx_db = _TxDB()
+    local_storage = _DummyStorage()
+    local_storage.lines_by_key["legacy/input-file"] = [
+        '{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}'
+    ]
+    repo = _Repo(tx_db, state)
+    service = BatchService(
+        repository=repo,  # type: ignore[arg-type]
+        storage=local_storage,  # type: ignore[arg-type]
+        max_pending_batches_per_scope=2,
+    )
 
     result = await service.create_embeddings_batch(
         auth=UserAPIKeyAuth(api_key="key-a"),
@@ -435,8 +686,151 @@ async def test_create_embeddings_batch_reads_input_from_file_storage_backend() -
     )
 
     assert result["status"] == "queued"
-    assert local_storage.reads == ["legacy/input-file"]
-    assert active_storage.reads == []
+    assert tx_db.entries == 1
+    assert state["locks"] == [("api_key", "key-a", tx_db)]
+    assert state["counts"] == [({"created_by_api_key": "key-a", "created_by_team_id": None}, tx_db)]
+    assert state["create_job_prismas"] == [tx_db]
+    assert state["create_items_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_embeddings_batch_blocks_in_transaction_before_create_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.now(tz=UTC)
+    monkeypatch.setattr("src.batch.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+
+    class _TxDB:
+        def tx(self):  # noqa: ANN201
+            return self
+
+        async def __aenter__(self):  # noqa: ANN202
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: ANN202
+            del exc_type, exc, tb
+            return False
+
+    class _Repo:
+        def __init__(self, prisma, state):  # noqa: ANN001
+            self.prisma = prisma
+            self.state = state
+
+        def with_prisma(self, prisma_client):  # noqa: ANN201
+            return _Repo(prisma_client, self.state)
+
+        async def get_file(self, file_id: str):
+            del file_id
+            return BatchFileRecord(
+                file_id="f1",
+                purpose="batch",
+                filename="x.jsonl",
+                bytes=100,
+                status="processed",
+                storage_backend="local",
+                storage_key="legacy/input-file",
+                checksum=None,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                expires_at=None,
+            )
+
+        async def acquire_scope_advisory_lock(self, *, scope_type: str, scope_id: str) -> None:
+            self.state["locks"].append((scope_type, scope_id))
+
+        async def count_active_jobs_for_scope(self, **kwargs):
+            del kwargs
+            return 2
+
+        async def create_job(self, **kwargs):
+            del kwargs
+            self.state["create_job_called"] = True
+            raise AssertionError("create_job should not be called when limit is reached")
+
+    state = {"locks": [], "create_job_called": False}
+    tx_db = _TxDB()
+    local_storage = _DummyStorage()
+    local_storage.lines_by_key["legacy/input-file"] = [
+        '{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}'
+    ]
+    service = BatchService(
+        repository=_Repo(tx_db, state),  # type: ignore[arg-type]
+        storage=local_storage,  # type: ignore[arg-type]
+        max_pending_batches_per_scope=2,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_embeddings_batch(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            input_file_id="f1",
+            endpoint="/v1/embeddings",
+            metadata=None,
+            completion_window=None,
+        )
+
+    assert exc.value.status_code == 429
+    assert state["locks"] == [("api_key", "key-a")]
+    assert state["create_job_called"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_embeddings_batch_rejects_invalid_later_line_before_creating_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.now(tz=UTC)
+    monkeypatch.setattr("src.batch.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+
+    class _Repo:
+        def __init__(self) -> None:
+            self.create_job_called = False
+
+        async def get_file(self, file_id: str):
+            del file_id
+            return BatchFileRecord(
+                file_id="f1",
+                purpose="batch",
+                filename="x.jsonl",
+                bytes=100,
+                status="processed",
+                storage_backend="local",
+                storage_key="legacy/input-file",
+                checksum=None,
+                created_by_api_key="key-a",
+                created_by_user_id=None,
+                created_by_team_id=None,
+                created_at=now,
+                expires_at=None,
+            )
+
+        async def count_active_jobs_for_scope(self, **kwargs):
+            del kwargs
+            return 0
+
+        async def create_job(self, **kwargs):
+            del kwargs
+            self.create_job_called = True
+            raise AssertionError("create_job should not be called for invalid input")
+
+    local_storage = _DummyStorage()
+    local_storage.lines_by_key["legacy/input-file"] = [
+        '{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}',
+        '{"custom_id":"c2","url":"/v1/embeddings","body":',
+    ]
+    repo = _Repo()
+    service = BatchService(
+        repository=repo,  # type: ignore[arg-type]
+        storage=local_storage,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_embeddings_batch(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            input_file_id="f1",
+            endpoint="/v1/embeddings",
+            metadata=None,
+            completion_window=None,
+        )
+
+    assert exc.value.status_code == 400
+    assert repo.create_job_called is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_storage.py
+++ b/tests/test_batch_storage.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from src.batch.storage import LocalBatchArtifactStorage, S3BatchArtifactStorage
+from src.batch.storage import BatchArtifactLineTooLongError, LocalBatchArtifactStorage, S3BatchArtifactStorage
 
 
 @pytest.mark.asyncio
@@ -26,6 +26,23 @@ async def test_local_batch_storage_round_trip(tmp_path: Path) -> None:
     assert not (tmp_path / "batch-artifacts" / storage_key).exists()
 
 
+@pytest.mark.asyncio
+async def test_local_batch_storage_skips_persisting_empty_write(tmp_path: Path) -> None:
+    base_dir = tmp_path / "batch-artifacts"
+    storage = LocalBatchArtifactStorage(str(base_dir))
+
+    storage_key, size, checksum = await storage.write_bytes(
+        purpose="batch",
+        filename="empty.jsonl",
+        content=b"",
+    )
+
+    assert storage_key == ""
+    assert size == 0
+    assert checksum
+    assert list(base_dir.rglob("*")) == []
+
+
 class _FakeS3Body:
     def __init__(self, payload: bytes) -> None:
         self.payload = payload
@@ -38,12 +55,13 @@ class _FakeS3Client:
     def __init__(self) -> None:
         self.objects: dict[tuple[str, str], bytes] = {}
 
-    def put_object(self, *, Bucket: str, Key: str, Body: bytes, Metadata=None) -> None:  # noqa: ANN001
-        del Metadata
-        self.objects[(Bucket, Key)] = Body
+    def upload_fileobj(self, fileobj, bucket: str, key: str, ExtraArgs=None) -> None:  # noqa: ANN001, N803
+        del ExtraArgs
+        self.objects[(bucket, key)] = fileobj.read()
 
-    def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
-        return {"Body": _FakeS3Body(self.objects[(Bucket, Key)])}
+    def download_fileobj(self, bucket: str, key: str, fileobj) -> None:  # noqa: ANN001
+        fileobj.write(self.objects[(bucket, key)])
+        fileobj.seek(0)
 
     def delete_object(self, *, Bucket: str, Key: str) -> None:
         self.objects.pop((Bucket, Key), None)
@@ -72,3 +90,62 @@ async def test_s3_batch_storage_round_trip() -> None:
     await storage.delete(storage_key)
 
     assert ("batch-bucket", storage_key) not in client.objects
+
+
+@pytest.mark.asyncio
+async def test_s3_batch_storage_skips_uploading_empty_write() -> None:
+    client = _FakeS3Client()
+    storage = S3BatchArtifactStorage(
+        bucket="batch-bucket",
+        prefix="prefix",
+        client=client,
+    )
+
+    storage_key, size, checksum = await storage.write_bytes(
+        purpose="batch_output",
+        filename="empty.jsonl",
+        content=b"",
+    )
+
+    assert storage_key == ""
+    assert size == 0
+    assert checksum
+    assert client.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_storage_write_lines_stream_and_iter_lines_round_trip(tmp_path: Path) -> None:
+    storage = LocalBatchArtifactStorage(str(tmp_path / "batch-artifacts"))
+
+    async def _lines():
+        yield '{"custom_id":"1"}'
+        yield '{"custom_id":"2"}'
+
+    storage_key, size, checksum = await storage.write_lines_stream(
+        purpose="batch_output",
+        filename="out.jsonl",
+        lines=_lines(),
+    )
+
+    assert size > 0
+    assert checksum
+
+    lines = [line async for line in storage.iter_lines(storage_key)]
+
+    assert lines == ['{"custom_id":"1"}', '{"custom_id":"2"}']
+
+
+@pytest.mark.asyncio
+async def test_iter_lines_raises_before_unbounded_oversized_line_buffer(tmp_path: Path) -> None:
+    storage = LocalBatchArtifactStorage(str(tmp_path / "batch-artifacts"))
+    storage_key, _, _ = await storage.write_bytes(
+        purpose="batch",
+        filename="input.jsonl",
+        content=b"a" * 32,
+    )
+
+    with pytest.raises(BatchArtifactLineTooLongError) as exc:
+        async for _line in storage.iter_lines(storage_key, chunk_size=8, max_line_bytes=16):
+            pass
+
+    assert exc.value.line_number == 1

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -42,6 +42,9 @@ class _FakeStorage:
     async def write_lines(self, **kwargs):  # pragma: no cover
         raise AssertionError(f"unexpected artifact write in this test: {kwargs}")
 
+    async def write_lines_stream(self, **kwargs):  # pragma: no cover
+        raise AssertionError(f"unexpected streaming artifact write in this test: {kwargs}")
+
     async def delete(self, storage_key: str) -> None:  # pragma: no cover
         del storage_key
         raise AssertionError("unexpected artifact delete in this test")
@@ -284,6 +287,151 @@ async def test_batch_worker_keeps_completed_state_when_side_effects_fail(monkeyp
 
     await worker._process_item(job, item)
     assert len(repo.completed_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_processes_items_with_bounded_concurrency(monkeypatch):
+    active_calls = 0
+    max_active_calls = 0
+
+    async def _slow_execute_embedding(request, payload, deployment):
+        nonlocal active_calls, max_active_calls
+        del request, payload, deployment
+        active_calls += 1
+        max_active_calls = max(max_active_calls, active_calls)
+        try:
+            await asyncio.sleep(0.05)
+            return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+        finally:
+            active_calls -= 1
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _slow_execute_embedding)
+
+    deployment = SimpleNamespace(
+        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.0,
+        model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
+    )
+
+    class _Router:
+        def resolve_model_group(self, model: str) -> str:
+            return model
+
+        async def select_deployment(self, model_group: str, request_context: dict) -> str:
+            del model_group, request_context
+            return "dep-1"
+
+        def require_deployment(self, model_group: str, deployment: str):
+            del model_group, deployment
+            return deployment_obj
+
+    class _Failover:
+        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+            del model_group, kwargs
+            data = await execute(primary_deployment)
+            if return_deployment:
+                return data, primary_deployment
+            return data
+
+    class _ConcurrencyRepo(_FakeRepository):
+        def __init__(self) -> None:
+            super().__init__()
+            self.claim_count = 0
+            self.released = False
+            self.now = datetime.now(tz=UTC)
+
+        async def claim_next_job(self, *, worker_id: str, lease_seconds: int = 30):
+            del worker_id, lease_seconds
+            self.claim_count += 1
+            if self.claim_count > 1:
+                return None
+            return BatchJobRecord(
+                batch_id="b1",
+                endpoint="/v1/embeddings",
+                status=BatchJobStatus.IN_PROGRESS,
+                execution_mode="managed_internal",
+                input_file_id="f1",
+                output_file_id=None,
+                error_file_id=None,
+                model="m-1",
+                metadata={},
+                provider_batch_id=None,
+                provider_status=None,
+                provider_error=None,
+                provider_last_sync_at=None,
+                total_items=4,
+                in_progress_items=4,
+                completed_items=0,
+                failed_items=0,
+                cancelled_items=0,
+                locked_by="w1",
+                lease_expires_at=self.now,
+                cancel_requested_at=None,
+                status_last_updated_at=self.now,
+                created_by_api_key="tok-1",
+                created_by_user_id="u1",
+                created_by_team_id="t1",
+                created_at=self.now,
+                started_at=self.now,
+                completed_at=None,
+                expires_at=None,
+            )
+
+        async def claim_items(self, **kwargs):
+            del kwargs
+            return [
+                BatchItemRecord(
+                    item_id=f"i{index}",
+                    batch_id="b1",
+                    line_number=index,
+                    custom_id=f"c{index}",
+                    status="in_progress",
+                    request_body={"model": "m-1", "input": f"hello-{index}"},
+                    response_body=None,
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=0,
+                    last_error=None,
+                    locked_by="w1",
+                    lease_expires_at=self.now,
+                    created_at=self.now,
+                    started_at=self.now,
+                    completed_at=None,
+                )
+                for index in range(1, 5)
+            ]
+
+        async def refresh_job_progress(self, batch_id: str):
+            assert batch_id == "b1"
+            return None
+
+        async def release_job_lease(self, *, batch_id: str, worker_id: str) -> None:
+            assert batch_id == "b1"
+            assert worker_id == "w1"
+            self.released = True
+
+    deployment_obj = deployment
+    repo = _ConcurrencyRepo()
+    spend = _SpendRecorder()
+    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    worker = BatchExecutorWorker(
+        app=app,
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1", worker_concurrency=2, item_buffer_multiplier=2),
+    )
+    worker._running = True
+
+    did_work = await worker.process_once()
+    worker._running = False
+
+    assert did_work is True
+    assert len(repo.completed_calls) == 4
+    assert max_active_calls == 2
+    assert repo.released is True
 
 
 @pytest.mark.asyncio
@@ -688,7 +836,7 @@ async def test_batch_worker_retries_finalizing_job_after_storage_failure():
             self.write_calls = 0
             self.deleted: list[str] = []
 
-        async def write_lines(self, *, purpose: str, filename: str, lines):  # noqa: ANN001
+        async def write_lines_stream(self, *, purpose: str, filename: str, lines):  # noqa: ANN001
             del filename, lines
             self.write_calls += 1
             if self.write_calls == 2:


### PR DESCRIPTION
## What changed
- added bounded worker concurrency for embedding batch item execution
- added streaming storage primitives for chunked writes, chunk iteration, and streamed line writing
- refactored batch file upload and batch creation to avoid full-buffer reads and to parse JSONL line-by-line
- changed batch creation to validate once from source storage and replay validated items from a local spool instead of rereading the source backend
- added paged item reads and streamed output/error artifact generation for finalization
- added explicit limits for file size, line size, item count, pending active batches, and related buffering/concurrency knobs
- enforced the pending-batch scope cap transactionally with a scope advisory lock when `db.tx()` is available

## Why this changed
Phase 2 of the embedding batching hardening work is focused on throughput and memory behavior. The previous implementation still processed items serially, loaded large inputs into memory, concatenated artifact output into whole buffers, and reread source storage multiple times during batch creation. Those patterns limited throughput and made memory usage scale poorly with batch size.

## User and developer impact
- batch workers can process multiple items concurrently within a claimed batch while preserving Phase 1 lease and ownership protections
- large uploads and large batch files are handled through streamed/chunked paths instead of whole-buffer operations
- batch creation now applies stricter file, line, and pending-batch controls with clearer failure behavior
- finalization now pages item reads and streams output/error artifacts
- the synchronous gateway request path was not changed

## Validation
- `uv run pytest tests/test_batch_storage.py tests/test_batch_repository.py tests/test_batch_service.py tests/test_batch_worker.py tests/bootstrap/test_optional_bootstrap.py tests/test_batch_cleanup.py tests/test_embeddings_batch.py tests/test_ui_authorization.py`
- `uv run ruff check src/batch/storage.py src/batch/service.py src/batch/repository.py src/batch/repositories/item_repository.py src/batch/repositories/job_repository.py src/batch/worker.py src/bootstrap/batch.py src/config.py tests/test_batch_storage.py tests/test_batch_service.py tests/test_batch_repository.py tests/test_batch_worker.py tests/bootstrap/test_optional_bootstrap.py`
