### PR TITLE
Add configurable upstream auth headers

### DIFF
--- a/src/api/admin/endpoints/models.py
+++ b/src/api/admin/endpoints/models.py
@@ -5,7 +5,7 @@ import secrets
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
 
 from src.api.admin.endpoints.common import model_entries, to_json_value
 from src.api.audit import emit_control_audit_event
@@ -14,6 +14,11 @@ from src.config import ModelMode
 from src.config_runtime.models import ModelHotReloadManager
 from src.db.named_credentials import NamedCredentialRecord, NamedCredentialRepository
 from src.middleware.admin import require_authenticated, require_master_key
+from src.upstream_auth import (
+    supports_custom_openai_compatible_auth,
+    validate_auth_header_format,
+    validate_auth_header_name,
+)
 from src.providers.healthcheck import probe_provider_health
 from src.providers.model_discovery import discover_provider_models
 from src.providers.resolution import provider_presets, resolve_provider, validate_provider_mode_compatibility
@@ -24,6 +29,7 @@ from src.services.model_deployments import DuplicateModelNameError, ensure_model
 from src.services.named_credentials import (
     canonicalize_named_credential_provider,
     merge_named_credential_params,
+    redact_connection_config,
     resolve_named_credential_record,
 )
 from src.services.organization_callable_target_sync import sync_auto_follow_organization_bindings
@@ -34,7 +40,15 @@ _CREDENTIAL_CONNECTION_FIELDS = {
     "api_key",
     "api_base",
     "api_version",
+    "auth_header_name",
+    "auth_header_format",
     "region",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+}
+_INLINE_SECRET_FIELDS = {
+    "api_key",
     "aws_access_key_id",
     "aws_secret_access_key",
     "aws_session_token",
@@ -48,6 +62,30 @@ class ProviderModelDiscoveryRequest(BaseModel):
     api_key: str | None = None
     api_base: str | None = None
     api_version: str | None = None
+    auth_header_name: str | None = None
+    auth_header_format: str | None = None
+
+    @field_validator("auth_header_name")
+    @classmethod
+    def validate_custom_auth_header_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_auth_header_name(value)
+
+    @field_validator("auth_header_format")
+    @classmethod
+    def validate_custom_auth_header_format(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_auth_header_format(value)
+
+    @model_validator(mode="after")
+    def validate_custom_auth_header_provider(self) -> "ProviderModelDiscoveryRequest":
+        if self.auth_header_name is None and self.auth_header_format is None:
+            return self
+        if not supports_custom_openai_compatible_auth(self.provider):
+            raise ValueError(f"Custom auth headers are not supported for provider '{self.provider}'")
+        return self
 
 
 def _find_runtime_deployment(app: Any, deployment_id: str) -> Any | None:
@@ -176,7 +214,7 @@ def _serialize_model_write_response(
             "credential_source": credential_source,
             "inline_credentials_present": credential_source == "inline" and any(
                 str(deltallm_params.get(field) or "").strip()
-                for field in _CREDENTIAL_CONNECTION_FIELDS
+                for field in _INLINE_SECRET_FIELDS
             ),
             "connection_summary": {
                 "api_base": deltallm_params.get("api_base") or None,
@@ -185,14 +223,7 @@ def _serialize_model_write_response(
             },
             "named_credential_id": named_credential_id,
             "named_credential_name": named_credential_name,
-            "deltallm_params": {
-                **deltallm_params,
-                **{
-                    field: "***REDACTED***"
-                    for field in _CREDENTIAL_CONNECTION_FIELDS
-                    if field in deltallm_params and deltallm_params.get(field) not in (None, "")
-                },
-            },
+            "deltallm_params": redact_connection_config(deltallm_params),
             "model_info": model_info,
         }
     )
@@ -452,6 +483,8 @@ async def discover_models_for_provider(request: Request, payload: ProviderModelD
             "api_key": payload.api_key,
             "api_base": payload.api_base,
             "api_version": payload.api_version,
+            "auth_header_name": payload.auth_header_name,
+            "auth_header_format": payload.auth_header_format,
         },
         named_credential,
     )
@@ -462,6 +495,8 @@ async def discover_models_for_provider(request: Request, payload: ProviderModelD
         api_key=merged_params.get("api_key"),
         api_base=merged_params.get("api_base"),
         api_version=merged_params.get("api_version"),
+        auth_header_name=merged_params.get("auth_header_name"),
+        auth_header_format=merged_params.get("auth_header_format"),
         default_openai_base_url=getattr(request.app.state.settings, "openai_base_url", "https://api.openai.com/v1"),
     )
 

--- a/src/config.py
+++ b/src/config.py
@@ -8,8 +8,14 @@ from typing import Any, Literal
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import yaml
-from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator
+from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from src.upstream_auth import (
+    supports_custom_openai_compatible_auth,
+    validate_auth_header_format,
+    validate_auth_header_name,
+)
 
 
 ModelMode = Literal[
@@ -44,12 +50,42 @@ class DeltaLLMParams(BaseModel):
     api_key: str | None = None
     api_base: str | None = None
     api_version: str | None = None
+    auth_header_name: str | None = None
+    auth_header_format: str | None = None
     timeout: int | None = 300
     rpm: int | None = None
     tpm: int | None = None
     weight: int = 1
     stream_timeout: int | None = None
     max_tokens: int | None = None
+
+    @field_validator("auth_header_name")
+    @classmethod
+    def validate_custom_auth_header_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_auth_header_name(value)
+
+    @field_validator("auth_header_format")
+    @classmethod
+    def validate_custom_auth_header_format(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_auth_header_format(value)
+
+    @model_validator(mode="after")
+    def validate_custom_auth_headers_supported_provider(self) -> "DeltaLLMParams":
+        if self.auth_header_name is None and self.auth_header_format is None:
+            return self
+
+        provider = str(self.provider or "").strip().lower()
+        if not provider:
+            model_value = str(self.model or "").strip()
+            provider = model_value.split("/", 1)[0].strip().lower() if "/" in model_value else ""
+
+        if not supports_custom_openai_compatible_auth(provider):
+            raise ValueError(f"Custom auth headers are not supported for provider '{provider or 'unknown'}'")
+        return self
 
 
 class ModelInfo(BaseModel):

--- a/src/providers/healthcheck.py
+++ b/src/providers/healthcheck.py
@@ -7,6 +7,7 @@ from typing import Any
 import httpx
 
 from src.providers.resolution import is_openai_compatible_provider, resolve_provider
+from src.upstream_auth import build_openai_compatible_auth_headers
 
 
 @dataclass
@@ -123,7 +124,12 @@ async def probe_provider_health(
     try:
         response = await http_client.get(
             f"{api_base}/models",
-            headers={"Authorization": f"Bearer {api_key}"},
+            headers=build_openai_compatible_auth_headers(
+                provider=provider,
+                api_key=api_key,
+                auth_header_name=str(params.get("auth_header_name") or "").strip() or None,
+                auth_header_format=str(params.get("auth_header_format") or "").strip() or None,
+            ),
             timeout=10.0,
         )
         if response.status_code >= 400:

--- a/src/providers/model_discovery.py
+++ b/src/providers/model_discovery.py
@@ -7,6 +7,7 @@ import httpx
 from src.config import ModelMode
 from src.providers.model_catalog import canonical_catalog_provider, catalog_model_metadata, catalog_models_for_provider
 from src.providers.resolution import PROVIDER_PRESETS, is_openai_compatible_provider
+from src.upstream_auth import build_openai_compatible_auth_headers
 
 
 def _normalized_provider(provider: str | None) -> str:
@@ -136,6 +137,8 @@ async def _discover_live_models(
     api_key: str | None,
     api_base: str | None,
     api_version: str | None,
+    auth_header_name: str | None,
+    auth_header_format: str | None,
 ) -> list[dict[str, Any]]:
     if provider == "bedrock":
         raise NotImplementedError("Live discovery is not yet implemented for AWS Bedrock.")
@@ -180,7 +183,12 @@ async def _discover_live_models(
     payload = await _load_json(
         http_client,
         url=f"{str(api_base).rstrip('/')}/models",
-        headers={"Authorization": f"Bearer {api_key}"},
+        headers=build_openai_compatible_auth_headers(
+            provider=provider,
+            api_key=str(api_key),
+            auth_header_name=auth_header_name,
+            auth_header_format=auth_header_format,
+        ),
     )
     return _extract_openai_style_models(payload, provider=response_provider)
 
@@ -246,6 +254,8 @@ async def discover_provider_models(
     api_key: str | None = None,
     api_base: str | None = None,
     api_version: str | None = None,
+    auth_header_name: str | None = None,
+    auth_header_format: str | None = None,
     default_openai_base_url: str,
 ) -> dict[str, Any]:
     normalized_provider = _normalized_provider(provider)
@@ -263,6 +273,8 @@ async def discover_provider_models(
             api_key=str(api_key or "").strip() or None,
             api_base=resolved_api_base,
             api_version=str(api_version or "").strip() or None,
+            auth_header_name=str(auth_header_name or "").strip() or None,
+            auth_header_format=str(auth_header_format or "").strip() or None,
         )
     except NotImplementedError as exc:
         live_options = []

--- a/src/providers/registry.py
+++ b/src/providers/registry.py
@@ -8,6 +8,7 @@ from fastapi import Request
 from src.models.errors import InvalidRequestError
 from src.providers.base import ProviderAdapter
 from src.providers.resolution import is_openai_compatible_provider, resolve_provider, resolve_upstream_model
+from src.upstream_auth import build_openai_compatible_auth_headers
 
 
 @dataclass
@@ -93,6 +94,12 @@ def resolve_chat_upstream(
         adapter=request.app.state.openai_adapter,
         api_base=str(params.get("api_base", request.app.state.settings.openai_base_url)).rstrip("/"),
         endpoint="/chat/completions",
-        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        headers=build_openai_compatible_auth_headers(
+            provider=provider,
+            api_key=str(api_key),
+            auth_header_name=params.get("auth_header_name"),
+            auth_header_format=params.get("auth_header_format"),
+            content_type="application/json",
+        ),
         timeout=timeout,
     )

--- a/src/services/named_credentials.py
+++ b/src/services/named_credentials.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException, status
 
 from src.db.named_credentials import NamedCredentialRecord
+from src.upstream_auth import (
+    supports_custom_openai_compatible_auth,
+    validate_auth_header_format,
+    validate_auth_header_name,
+)
 from src.providers.resolution import PROVIDER_PRESETS, is_openai_compatible_provider, resolve_provider
 
 if TYPE_CHECKING:
@@ -15,6 +20,8 @@ if TYPE_CHECKING:
 _NON_SECRET_CONNECTION_KEYS = {
     "api_base",
     "api_version",
+    "auth_header_format",
+    "auth_header_name",
     "region",
     "provider",
     "endpoint",
@@ -34,6 +41,10 @@ _API_KEY_PROVIDER_FIELDS = {
     "api_base",
     "api_version",
 }
+_CUSTOM_AUTH_PROVIDER_FIELDS = _API_KEY_PROVIDER_FIELDS | {
+    "auth_header_name",
+    "auth_header_format",
+}
 _PROVIDER_LABEL_ALIASES = {
     "azure": "azure_openai",
 }
@@ -41,6 +52,8 @@ INLINE_CONNECTION_FIELDS = (
     "api_key",
     "api_base",
     "api_version",
+    "auth_header_name",
+    "auth_header_format",
     "region",
     "aws_access_key_id",
     "aws_secret_access_key",
@@ -146,6 +159,21 @@ def _validate_connection_config(provider: str, connection_config: dict[str, Any]
                 detail="bedrock aws_session_token requires aws_access_key_id and aws_secret_access_key",
             )
 
+    if supports_custom_openai_compatible_auth(provider):
+        auth_header_name = connection_config.get("auth_header_name")
+        if auth_header_name is not None:
+            try:
+                validate_auth_header_name(str(auth_header_name))
+            except ValueError as exc:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+        auth_header_format = connection_config.get("auth_header_format")
+        if auth_header_format is not None:
+            try:
+                validate_auth_header_format(str(auth_header_format))
+            except ValueError as exc:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
 
 def _allowed_fields_for_provider(provider: str) -> set[str]:
     if provider == "bedrock":
@@ -156,6 +184,8 @@ def _allowed_fields_for_provider(provider: str) -> set[str]:
         return _API_KEY_PROVIDER_FIELDS
     if provider == "gemini":
         return _API_KEY_PROVIDER_FIELDS
+    if supports_custom_openai_compatible_auth(provider):
+        return _CUSTOM_AUTH_PROVIDER_FIELDS
     if is_openai_compatible_provider(provider):
         return _API_KEY_PROVIDER_FIELDS
     return set()

--- a/src/upstream_auth.py
+++ b/src/upstream_auth.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import re
+from string import Formatter
+
+from src.models.errors import InvalidRequestError
+
+DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_NAME = "Authorization"
+DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_FORMAT = "Bearer {api_key}"
+
+CUSTOM_OPENAI_COMPATIBLE_AUTH_PROVIDERS = {
+    "openai",
+    "openrouter",
+    "groq",
+    "together",
+    "fireworks",
+    "deepinfra",
+    "perplexity",
+    "vllm",
+    "lmstudio",
+    "ollama",
+}
+
+_HTTP_HEADER_NAME_PATTERN = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_FORMATTER = Formatter()
+_RESERVED_AUTH_HEADER_NAMES = {
+    "content-type",
+}
+
+
+def supports_custom_openai_compatible_auth(provider: str | None) -> bool:
+    return (provider or "").strip().lower() in CUSTOM_OPENAI_COMPATIBLE_AUTH_PROVIDERS
+
+
+def validate_auth_header_name(value: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError("auth_header_name must not be empty")
+    if not _HTTP_HEADER_NAME_PATTERN.fullmatch(normalized):
+        raise ValueError("auth_header_name must be a valid HTTP header name")
+    if normalized.lower() in _RESERVED_AUTH_HEADER_NAMES:
+        raise ValueError(f"auth_header_name cannot use reserved header name '{normalized}'")
+    return normalized
+
+
+def validate_auth_header_format(value: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError("auth_header_format must not be empty")
+
+    fields: list[str] = []
+    for _, field_name, format_spec, conversion in _FORMATTER.parse(normalized):
+        if field_name is None:
+            continue
+        if not field_name:
+            raise ValueError("auth_header_format must be a valid format string")
+        if field_name != "api_key" or format_spec or conversion is not None:
+            raise ValueError("auth_header_format only supports the {api_key} placeholder without format specifiers or conversions")
+        fields.append(field_name)
+
+    if not fields:
+        raise ValueError("auth_header_format must include the {api_key} placeholder")
+
+    try:
+        normalized.format(api_key="test-key")
+    except (IndexError, KeyError, ValueError) as exc:
+        raise ValueError("auth_header_format must be a valid format string") from exc
+
+    return normalized
+
+
+def build_openai_compatible_auth_headers(
+    *,
+    provider: str | None,
+    api_key: str,
+    auth_header_name: str | None = None,
+    auth_header_format: str | None = None,
+    content_type: str | None = None,
+) -> dict[str, str]:
+    normalized_api_key = str(api_key or "").strip()
+    if not normalized_api_key:
+        raise InvalidRequestError(message="Provider API key is missing for selected model")
+
+    if supports_custom_openai_compatible_auth(provider):
+        header_name = validate_auth_header_name(auth_header_name or DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_NAME)
+        header_format = validate_auth_header_format(auth_header_format or DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_FORMAT)
+    else:
+        header_name = DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_NAME
+        header_format = DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_FORMAT
+
+    headers = {header_name: header_format.format(api_key=normalized_api_key)}
+    if content_type:
+        headers["Content-Type"] = content_type
+    return headers

--- a/tests/services/test_model_deployments.py
+++ b/tests/services/test_model_deployments.py
@@ -231,6 +231,8 @@ async def test_load_model_registry_resolves_named_credential_connection_params()
                 connection_config={
                     "api_key": "named-secret",
                     "api_base": "https://named.example/v1",
+                    "auth_header_name": "X-API-Key",
+                    "auth_header_format": "{api_key}",
                 },
             )
         ]
@@ -249,6 +251,8 @@ async def test_load_model_registry_resolves_named_credential_connection_params()
     assert entry["named_credential_name"] == "OpenAI prod"
     assert entry["deltallm_params"]["api_key"] == "named-secret"
     assert entry["deltallm_params"]["api_base"] == "https://named.example/v1"
+    assert entry["deltallm_params"]["auth_header_name"] == "X-API-Key"
+    assert entry["deltallm_params"]["auth_header_format"] == "{api_key}"
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_named_credentials.py
+++ b/tests/services/test_named_credentials.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
 from src.config_runtime.secrets import SecretResolver
 from src.db.named_credentials import NamedCredentialRecord
 from src.services.named_credentials import resolve_named_credential_connection_config, resolve_named_credential_record
+from src.upstream_auth import validate_auth_header_format, validate_auth_header_name
 
 
 class _FakeAWSSecretsManager:
@@ -43,3 +46,28 @@ def test_resolve_named_credential_record_preserves_metadata_and_resolves_config(
     assert resolved.credential_id == "cred-1"
     assert resolved.metadata == {"env": "prod"}
     assert resolved.connection_config["api_key"] == "aws-secret"
+
+
+def test_validate_auth_header_name_accepts_http_header_tokens() -> None:
+    assert validate_auth_header_name("X-API-Key") == "X-API-Key"
+
+
+def test_validate_auth_header_name_rejects_reserved_header_names() -> None:
+    with pytest.raises(ValueError, match="reserved header name"):
+        validate_auth_header_name("Content-Type")
+
+
+def test_validate_auth_header_format_rejects_non_api_key_placeholders() -> None:
+    with pytest.raises(ValueError, match=r"only supports the \{api_key\} placeholder"):
+        validate_auth_header_format("Bearer {token}")
+
+
+def test_validate_auth_header_format_rejects_escaped_api_key_placeholder() -> None:
+    with pytest.raises(ValueError, match=r"must include the \{api_key\} placeholder"):
+        validate_auth_header_format("Token {{api_key}}")
+
+
+@pytest.mark.parametrize("value", ["Token {api_key!r}", "Token {api_key:>10}"])
+def test_validate_auth_header_format_rejects_format_features(value: str) -> None:
+    with pytest.raises(ValueError, match=r"only supports the \{api_key\} placeholder"):
+        validate_auth_header_format(value)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -797,6 +797,38 @@ async def test_chat_completion_uses_azure_api_key_header_when_provider_is_azure(
 
 
 @pytest.mark.asyncio
+async def test_chat_completion_uses_custom_auth_headers_for_openai_compatible_provider(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = "vllm"
+    deployment.deltallm_params["api_base"] = "https://vllm.example/v1"
+    deployment.deltallm_params["api_key"] = "vllm-provider-key"
+    deployment.deltallm_params["auth_header_name"] = "X-Provider-Auth"
+    deployment.deltallm_params["auth_header_format"] = "Token {api_key}"
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del timeout
+        assert url.endswith("/chat/completions")
+        assert headers.get("X-Provider-Auth") == "Token vllm-provider-key"
+        assert "Authorization" not in headers
+        payload = {
+            "id": "chatcmpl-vllm",
+            "object": "chat.completion",
+            "created": 1700000000,
+            "model": json["model"],
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        return httpx.Response(200, json=payload)
+
+    test_app.state.http_client.post = post
+
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False}
+    response = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_does_not_forward_internal_metadata_upstream(client, test_app):
     async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
         del url, headers, timeout

--- a/tests/test_named_credentials_api.py
+++ b/tests/test_named_credentials_api.py
@@ -194,6 +194,34 @@ async def test_named_credentials_create_and_list_are_redacted(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_named_credentials_create_accepts_custom_auth_header_fields(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    repository = _FakeNamedCredentialRepository()
+    test_app.state.named_credential_repository = repository
+
+    response = await client.post(
+        "/ui/api/named-credentials",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "name": "vLLM Shared",
+            "provider": "vllm",
+            "connection_config": {
+                "api_key": "provider-key",
+                "api_base": "https://vllm.example/v1",
+                "auth_header_name": "X-API-Key",
+                "auth_header_format": "{api_key}",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["connection_config"]["api_key"] == "***REDACTED***"
+    assert payload["connection_config"]["auth_header_name"] == "X-API-Key"
+    assert payload["connection_config"]["auth_header_format"] == "{api_key}"
+
+
+@pytest.mark.asyncio
 async def test_named_credentials_update_reloads_runtime_when_in_use_and_delete_blocks(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
     repository = _FakeNamedCredentialRepository()
@@ -276,6 +304,54 @@ async def test_named_credentials_validate_provider_specific_fields(client, test_
     )
     assert invalid_openai.status_code == 400
     assert "unsupported fields" in invalid_openai.text
+
+    invalid_azure_custom_auth = await client.post(
+        "/ui/api/named-credentials",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "name": "Azure Prod",
+            "provider": "azure_openai",
+            "connection_config": {"api_key": "provider-key", "auth_header_name": "X-API-Key"},
+        },
+    )
+    assert invalid_azure_custom_auth.status_code == 400
+    assert "unsupported fields" in invalid_azure_custom_auth.text
+
+    invalid_auth_format = await client.post(
+        "/ui/api/named-credentials",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "name": "vLLM Prod",
+            "provider": "vllm",
+            "connection_config": {"api_key": "provider-key", "auth_header_format": "Bearer {token}"},
+        },
+    )
+    assert invalid_auth_format.status_code == 400
+    assert "only supports the {api_key} placeholder" in invalid_auth_format.text
+
+    escaped_auth_format = await client.post(
+        "/ui/api/named-credentials",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "name": "vLLM Prod",
+            "provider": "vllm",
+            "connection_config": {"api_key": "provider-key", "auth_header_format": "Token {{api_key}}"},
+        },
+    )
+    assert escaped_auth_format.status_code == 400
+    assert "must include the {api_key} placeholder" in escaped_auth_format.text
+
+    invalid_reserved_header_name = await client.post(
+        "/ui/api/named-credentials",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "name": "vLLM Prod",
+            "provider": "vllm",
+            "connection_config": {"api_key": "provider-key", "auth_header_name": "Content-Type"},
+        },
+    )
+    assert invalid_reserved_header_name.status_code == 400
+    assert "reserved header name" in invalid_reserved_header_name.text
 
     invalid_bedrock = await client.post(
         "/ui/api/named-credentials",

--- a/tests/test_provider_model_discovery.py
+++ b/tests/test_provider_model_discovery.py
@@ -160,6 +160,74 @@ async def test_provider_model_discovery_supports_named_credentials(client, test_
 
 
 @pytest.mark.asyncio
+async def test_provider_model_discovery_supports_named_credentials_with_custom_auth_headers(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.named_credential_repository = _FakeNamedCredentialRepository(
+        [
+            NamedCredentialRecord(
+                credential_id="cred-1",
+                name="vLLM prod",
+                provider="vllm",
+                connection_config={
+                    "api_key": "provider-key",
+                    "api_base": "https://vllm.example/v1",
+                    "auth_header_name": "X-API-Key",
+                    "auth_header_format": "{api_key}",
+                },
+            )
+        ]
+    )
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout: float = 10.0):  # noqa: ANN201
+        assert url == "https://vllm.example/v1/models"
+        assert headers == {"X-API-Key": "provider-key"}
+        del timeout
+        return httpx.Response(200, json={"data": [{"id": "meta-llama/Llama-3.1-8B-Instruct", "name": "Llama"}]})
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "vllm", "mode": "chat", "named_credential_id": "cred-1"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_provider_model_discovery_supports_inline_custom_auth_headers(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout: float = 10.0):  # noqa: ANN201
+        assert url == "https://proxy.example/v1/models"
+        assert headers == {"Authorization": "Token provider-key"}
+        del timeout
+        return httpx.Response(200, json={"data": [{"id": "gpt-4o", "name": "gpt-4o"}]})
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "provider": "openai",
+            "mode": "chat",
+            "api_key": "provider-key",
+            "api_base": "https://proxy.example/v1",
+            "auth_header_name": "Authorization",
+            "auth_header_format": "Token {api_key}",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+
+
+@pytest.mark.asyncio
 async def test_provider_model_discovery_resolves_named_credential_env_refs(
     client,
     test_app,

--- a/tests/test_ui_models.py
+++ b/tests/test_ui_models.py
@@ -276,7 +276,7 @@ async def test_update_model_clears_old_connection_fields_when_provider_changes(c
     assert response.status_code == 200
     payload = response.json()
     assert payload["deltallm_params"]["provider"] == "anthropic"
-    assert payload["deltallm_params"]["api_base"] == "***REDACTED***"
+    assert payload["deltallm_params"]["api_base"] == "https://api.anthropic.com/v1"
     assert "api_key" not in payload["deltallm_params"]
 
 
@@ -343,6 +343,83 @@ async def test_create_model_response_redacts_inline_api_key(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_create_model_accepts_custom_auth_headers_for_openai_compatible_provider(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": "custom-auth-model",
+            "deltallm_params": {
+                "provider": "vllm",
+                "model": "vllm/meta-llama/Llama-3.1-8B-Instruct",
+                "api_base": "https://vllm.example/v1",
+                "api_key": "provider-key",
+                "auth_header_name": "X-API-Key",
+                "auth_header_format": "{api_key}",
+            },
+            "model_info": {"mode": "chat"},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["deltallm_params"]["api_key"] == "***REDACTED***"
+    assert payload["deltallm_params"]["auth_header_name"] == "X-API-Key"
+    assert payload["deltallm_params"]["auth_header_format"] == "{api_key}"
+
+
+@pytest.mark.asyncio
+async def test_create_model_rejects_custom_auth_headers_for_azure_provider(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": "azure-custom-auth-model",
+            "deltallm_params": {
+                "provider": "azure_openai",
+                "model": "azure/gpt-4o-mini",
+                "api_base": "https://example.azure.com/openai/v1",
+                "api_key": "provider-key",
+                "auth_header_name": "X-API-Key",
+            },
+            "model_info": {"mode": "chat"},
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Custom auth headers are not supported" in response.text
+
+
+@pytest.mark.asyncio
+async def test_create_model_rejects_reserved_auth_header_names(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": "reserved-auth-header-model",
+            "deltallm_params": {
+                "provider": "vllm",
+                "model": "vllm/meta-llama/Llama-3.1-8B-Instruct",
+                "api_base": "https://vllm.example/v1",
+                "api_key": "provider-key",
+                "auth_header_name": "Content-Type",
+                "auth_header_format": "Token {api_key}",
+            },
+            "model_info": {"mode": "chat"},
+        },
+    )
+
+    assert response.status_code == 400
+    assert "reserved header name" in response.text
+
+
+@pytest.mark.asyncio
 async def test_update_model_response_redacts_inline_api_key(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
 
@@ -356,6 +433,8 @@ async def test_update_model_response_redacts_inline_api_key(client, test_app):
                 "model": "openai/gpt-4o-mini",
                 "api_base": "https://api.openai.com/v1",
                 "api_key": "provider-key-updated",
+                "auth_header_name": "X-Provider-Auth",
+                "auth_header_format": "Token {api_key}",
             },
             "model_info": {"mode": "chat"},
         },
@@ -365,6 +444,8 @@ async def test_update_model_response_redacts_inline_api_key(client, test_app):
     payload = response.json()
     assert payload["credential_source"] == "inline"
     assert payload["deltallm_params"]["api_key"] == "***REDACTED***"
+    assert payload["deltallm_params"]["auth_header_name"] == "X-Provider-Auth"
+    assert payload["deltallm_params"]["auth_header_format"] == "Token {api_key}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

This PR adds configurable auth-header support for the generic OpenAI-compatible provider paths in the PR1 scope.

Key changes:
- add `auth_header_name` and `auth_header_format` to deployment and discovery validation paths
- add a shared upstream auth helper to build validated auth headers
- wire the helper into chat upstream resolution, provider model discovery, and provider health checks
- keep admin write responses consistent by redacting only true secrets while returning non-secret custom auth fields
- harden validation so only a plain `{api_key}` placeholder is allowed and reserved header names such as `Content-Type` are rejected

## Why it changed

Some OpenAI-compatible upstreams do not use the fixed `Authorization: Bearer <api_key>` convention. The existing implementation assumed Bearer auth in the runtime paths covered by PR1, which prevented operators from using providers that expect different header names or token formats.

## User and developer impact

Operators can now configure custom auth headers for supported OpenAI-compatible providers in the backend contract used by model deployments, named credentials, provider discovery, and health checks.

This keeps the default behavior unchanged when no custom auth settings are supplied:
- default header name remains `Authorization`
- default format remains `Bearer {api_key}`

## Root cause

The affected runtime paths were hardcoded to construct `Authorization: Bearer ...` headers inline instead of using a shared provider-aware auth-header builder with validation.

## Validation

Ran:
- `uv run pytest tests/services/test_named_credentials.py tests/test_named_credentials_api.py tests/test_ui_models.py`
- `uv run pytest tests/test_chat.py tests/test_provider_model_discovery.py`

## Follow-up scope

This PR intentionally does not yet update the remaining non-chat OpenAI-compatible routes that still construct Bearer headers inline, such as embeddings, rerank, images, and audio. Those remain PR2 scope.