### PR TITLE
Complete custom upstream auth header runtime and UI coverage

### DIFF
--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -10,6 +10,7 @@ from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 from src.providers.base import ProviderAdapter
 from src.providers.resolution import normalize_openai_chat_payload, resolve_provider, resolve_upstream_model
+from src.upstream_auth import build_openai_compatible_auth_headers
 
 
 class OpenAIAdapter(ProviderAdapter):
@@ -89,7 +90,12 @@ class OpenAIAdapter(ProviderAdapter):
         try:
             response = await self.http_client.get(
                 f"{api_base}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
+                headers=build_openai_compatible_auth_headers(
+                    provider=resolve_provider(provider_config),
+                    api_key=str(api_key),
+                    auth_header_name=provider_config.get("auth_header_name"),
+                    auth_header_format=provider_config.get("auth_header_format"),
+                ),
                 timeout=10.0,
             )
             return response.status_code < 500

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -27,6 +27,7 @@ from src.metrics import (
 from src.models.errors import InvalidRequestError
 from src.models.requests import AudioSpeechRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
+from src.upstream_auth import build_openai_compatible_auth_headers
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
@@ -81,7 +82,13 @@ async def _execute_tts(
             api_key=str(api_key),
         )
 
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    headers = build_openai_compatible_auth_headers(
+        provider=provider,
+        api_key=str(api_key),
+        auth_header_name=params.get("auth_header_name"),
+        auth_header_format=params.get("auth_header_format"),
+        content_type="application/json",
+    )
 
     upstream_payload = payload.model_dump(exclude_unset=True)
     upstream_model = resolve_upstream_model(params)

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -26,6 +26,7 @@ from src.providers.resolution import (
     resolve_provider,
     resolve_upstream_model,
 )
+from src.upstream_auth import build_openai_compatible_auth_headers
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
@@ -64,8 +65,13 @@ async def _execute_stt(
         raise InvalidRequestError(message="Provider API key is missing for selected model")
 
     api_base = params.get("api_base", request.app.state.settings.openai_base_url).rstrip("/")
-    headers = {"Authorization": f"Bearer {api_key}"}
     api_provider = resolve_provider(params)
+    headers = build_openai_compatible_auth_headers(
+        provider=api_provider,
+        api_key=str(api_key),
+        auth_header_name=params.get("auth_header_name"),
+        auth_header_format=params.get("auth_header_format"),
+    )
     upstream_response_format = _resolve_upstream_response_format(
         requested_response_format=response_format,
         model_info=deployment.model_info,

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -24,6 +24,7 @@ from src.metrics import (
 from src.models.errors import InvalidRequestError
 from src.models.requests import EmbeddingRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
+from src.upstream_auth import build_openai_compatible_auth_headers
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.telemetry.request_failures import enqueue_request_log_write, seed_request_failure_context
@@ -118,7 +119,13 @@ async def _execute_embedding(
         raise InvalidRequestError(message="Provider API key is missing for selected model")
 
     api_base = params.get("api_base", request.app.state.settings.openai_base_url).rstrip("/")
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    headers = build_openai_compatible_auth_headers(
+        provider=resolve_provider(params),
+        api_key=str(api_key),
+        auth_header_name=params.get("auth_header_name"),
+        auth_header_format=params.get("auth_header_format"),
+        content_type="application/json",
+    )
 
     upstream_payload = payload.model_dump(exclude_none=True)
     upstream_model = resolve_upstream_model(params)

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -26,6 +26,7 @@ from src.providers.resolution import (
     resolve_provider,
     resolve_upstream_model,
 )
+from src.upstream_auth import build_openai_compatible_auth_headers
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.telemetry.request_failures import enqueue_request_log_write, seed_request_failure_context
@@ -57,10 +58,15 @@ async def _execute_image_generation(
         raise InvalidRequestError(message="Provider API key is missing for selected model")
 
     api_base = params.get("api_base", request.app.state.settings.openai_base_url).rstrip("/")
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
-
     upstream_payload = payload.model_dump(exclude_none=True)
     provider = resolve_provider(params)
+    headers = build_openai_compatible_auth_headers(
+        provider=provider,
+        api_key=str(api_key),
+        auth_header_name=params.get("auth_header_name"),
+        auth_header_format=params.get("auth_header_format"),
+        content_type="application/json",
+    )
     upstream_model = resolve_upstream_model(params)
     if upstream_model:
         upstream_payload["model"] = upstream_model

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -22,6 +22,7 @@ from src.metrics import (
 from src.models.errors import InvalidRequestError
 from src.models.requests import RerankRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
+from src.upstream_auth import build_openai_compatible_auth_headers
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
@@ -53,7 +54,13 @@ async def _execute_rerank(
         raise InvalidRequestError(message="Provider API key is missing for selected model")
 
     api_base = params.get("api_base", request.app.state.settings.openai_base_url).rstrip("/")
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    headers = build_openai_compatible_auth_headers(
+        provider=resolve_provider(params),
+        api_key=str(api_key),
+        auth_header_name=params.get("auth_header_name"),
+        auth_header_format=params.get("auth_header_format"),
+        content_type="application/json",
+    )
 
     upstream_payload = payload.model_dump(exclude_none=True)
     upstream_model = resolve_upstream_model(params)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -65,3 +65,46 @@ async def test_embeddings_runs_failure_callback(client, test_app):
     assert response.status_code == 503
     await asyncio.sleep(0.05)
     assert recorder.failure == 1
+
+
+@pytest.mark.asyncio
+async def test_embeddings_use_custom_auth_headers_for_openai_compatible_provider(client, test_app):
+    deployment = test_app.state.router.deployment_registry["text-embedding-3-small"][0]
+    deployment.deltallm_params["provider"] = "vllm"
+    deployment.deltallm_params["api_base"] = "https://vllm.example/v1"
+    deployment.deltallm_params["api_key"] = "provider-key"
+    deployment.deltallm_params["auth_header_name"] = "X-Provider-Auth"
+    deployment.deltallm_params["auth_header_format"] = "Token {api_key}"
+
+    captured: dict[str, object] = {}
+
+    async def fake_post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        captured["url"] = url
+        captured["headers"] = dict(headers)
+        captured["json"] = dict(json)
+        del timeout
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                "model": json["model"],
+                "usage": {"prompt_tokens": 2, "total_tokens": 2},
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = fake_post
+
+    response = await client.post(
+        "/v1/embeddings",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "text-embedding-3-small", "input": "hello"},
+    )
+
+    assert response.status_code == 200
+    assert captured["url"] == "https://vllm.example/v1/embeddings"
+    assert captured["headers"] == {
+        "X-Provider-Auth": "Token provider-key",
+        "Content-Type": "application/json",
+    }

--- a/tests/test_provider_compat.py
+++ b/tests/test_provider_compat.py
@@ -159,6 +159,38 @@ async def test_openai_adapter_surfaces_provider_error_message() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openai_adapter_health_check_uses_custom_auth_headers() -> None:
+    adapter = OpenAIAdapter(httpx.AsyncClient())
+    try:
+        captured: dict[str, object] = {}
+
+        async def fake_get(url, headers, timeout):  # noqa: ANN001, ANN201
+            captured["url"] = url
+            captured["headers"] = dict(headers)
+            captured["timeout"] = timeout
+            return httpx.Response(200, json={"data": []}, request=httpx.Request("GET", url))
+
+        adapter.http_client.get = fake_get  # type: ignore[method-assign]
+
+        healthy = await adapter.health_check(
+            {
+                "provider": "vllm",
+                "api_base": "https://vllm.example/v1",
+                "api_key": "provider-key",
+                "auth_header_name": "X-API-Key",
+                "auth_header_format": "{api_key}",
+            }
+        )
+
+        assert healthy is True
+        assert captured["url"] == "https://vllm.example/v1/models"
+        assert captured["headers"] == {"X-API-Key": "provider-key"}
+        assert captured["timeout"] == 10.0
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_azure_openai_adapter_maps_max_tokens_to_max_completion_tokens_for_gpt5() -> None:
     adapter = AzureOpenAIAdapter(httpx.AsyncClient())
     try:

--- a/tests/test_route_decision_multimodal.py
+++ b/tests/test_route_decision_multimodal.py
@@ -91,3 +91,88 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
     assert rerank_response.headers.get("x-deltallm-route-fallback-used") == "false"
     rerank_usage = await test_app.state.router_state_backend.get_usage(rerank_response.headers["x-deltallm-route-deployment"])
     assert rerank_usage == {"rpm": 1, "tpm": 0, "rerank_units_pm": 2}
+
+
+@pytest.mark.asyncio
+async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatible_providers(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = "openrouter"
+    deployment.deltallm_params["api_base"] = "https://openrouter.example/api/v1"
+    deployment.deltallm_params["api_key"] = "provider-key"
+    deployment.deltallm_params["auth_header_name"] = "X-Provider-Auth"
+    deployment.deltallm_params["auth_header_format"] = "Token {api_key}"
+
+    captured: dict[str, dict[str, str]] = {}
+
+    async def post(url, headers=None, json=None, timeout=None, files=None, data=None):  # noqa: ANN001, ANN201
+        captured[url] = dict(headers or {})
+        del timeout, files, data
+        request = httpx.Request("POST", url)
+        if url.endswith("/images/generations"):
+            return httpx.Response(
+                200,
+                json={"created": 1700000000, "data": [{"url": "https://example.com/image.png"}], "model": json["model"]},
+                request=request,
+            )
+        if url.endswith("/audio/speech"):
+            return httpx.Response(200, content=b"audio-bytes", request=request)
+        if url.endswith("/audio/transcriptions"):
+            return httpx.Response(200, json={"text": "hello", "duration": 1.0}, request=request)
+        if url.endswith("/rerank"):
+            return httpx.Response(
+                200,
+                json={"results": [{"index": 0, "relevance_score": 0.91}], "model": json["model"]},
+                request=request,
+            )
+        return httpx.Response(404, json={"error": "not found"}, request=request)
+
+    test_app.state.http_client.post = post
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+
+    image_response = await client.post(
+        "/v1/images/generations",
+        headers=headers,
+        json={"model": "gpt-4o-mini", "prompt": "sunset"},
+    )
+    assert image_response.status_code == 200
+    test_app.state.redis.store.clear()
+
+    speech_response = await client.post(
+        "/v1/audio/speech",
+        headers=headers,
+        json={"model": "gpt-4o-mini", "input": "hello world", "voice": "alloy"},
+    )
+    assert speech_response.status_code == 200
+    test_app.state.redis.store.clear()
+
+    transcription_response = await client.post(
+        "/v1/audio/transcriptions",
+        headers=headers,
+        data={"model": "gpt-4o-mini", "response_format": "json"},
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+    assert transcription_response.status_code == 200
+    test_app.state.redis.store.clear()
+
+    rerank_response = await client.post(
+        "/v1/rerank",
+        headers=headers,
+        json={"model": "gpt-4o-mini", "query": "hello", "documents": ["hello world", "bye world"]},
+    )
+    assert rerank_response.status_code == 200
+
+    assert captured["https://openrouter.example/api/v1/images/generations"] == {
+        "X-Provider-Auth": "Token provider-key",
+        "Content-Type": "application/json",
+    }
+    assert captured["https://openrouter.example/api/v1/audio/speech"] == {
+        "X-Provider-Auth": "Token provider-key",
+        "Content-Type": "application/json",
+    }
+    assert captured["https://openrouter.example/api/v1/audio/transcriptions"] == {
+        "X-Provider-Auth": "Token provider-key",
+    }
+    assert captured["https://openrouter.example/api/v1/rerank"] == {
+        "X-Provider-Auth": "Token provider-key",
+        "Content-Type": "application/json",
+    }

--- a/ui/src/components/ModelForm.tsx
+++ b/ui/src/components/ModelForm.tsx
@@ -4,7 +4,13 @@ import { ChevronDown, Plus, X } from 'lucide-react';
 import ProviderBadge from './ProviderBadge';
 import { useApi } from '../lib/hooks';
 import { models, namedCredentials, type NamedCredential, type ProviderModelDiscoveryPayload, type ProviderModelOption } from '../lib/api';
-import { canonicalNamedCredentialProvider, providerDisplayName } from '../lib/providers';
+import {
+  canonicalNamedCredentialProvider,
+  DEFAULT_CUSTOM_AUTH_HEADER_FORMAT,
+  DEFAULT_CUSTOM_AUTH_HEADER_NAME,
+  providerDisplayName,
+  supportsCustomUpstreamAuthProvider,
+} from '../lib/providers';
 import {
   EMPTY_FORM,
   MODE_OPTIONS,
@@ -123,6 +129,8 @@ function buildLiveDiscoveryRequestKey(payload: ProviderModelDiscoveryPayload): s
     payload.api_key || '',
     payload.api_base || '',
     payload.api_version || '',
+    payload.auth_header_name || '',
+    payload.auth_header_format || '',
   ].join('::');
 }
 
@@ -204,6 +212,7 @@ export default function ModelForm({
 
   const providerPresets = providerPresetResponse?.data || [];
   const availableNamedCredentials = namedCredentialResponse?.data || [];
+  const supportsCustomAuth = supportsCustomUpstreamAuthProvider(form.provider, form.model);
   const liveDiscoveryPayload: ProviderModelDiscoveryPayload = {
     provider: form.provider,
     mode,
@@ -211,6 +220,8 @@ export default function ModelForm({
     api_key: form.credential_source === 'inline' ? form.api_key.trim() || null : null,
     api_base: form.credential_source === 'inline' ? form.api_base.trim() || null : null,
     api_version: form.credential_source === 'inline' ? form.api_version.trim() || null : null,
+    auth_header_name: form.credential_source === 'inline' && supportsCustomAuth ? form.auth_header_name.trim() || null : null,
+    auth_header_format: form.credential_source === 'inline' && supportsCustomAuth ? form.auth_header_format.trim() || null : null,
   };
   const liveDiscoveryRequestKey = buildLiveDiscoveryRequestKey(liveDiscoveryPayload);
   const hasActiveLiveDiscovery = liveDiscoveryState.requestKey === liveDiscoveryRequestKey;
@@ -639,6 +650,31 @@ export default function ModelForm({
                     <input type="number" value={form.timeout} onChange={(e) => setForm({ ...form, timeout: e.target.value })} placeholder="300" className={inputClass} />
                   </div>
                 </div>
+                {supportsCustomAuth ? (
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <div>
+                      <FieldLabel label="Auth Header Name" />
+                      <input
+                        value={form.auth_header_name}
+                        onChange={(e) => setForm({ ...form, auth_header_name: e.target.value })}
+                        placeholder={DEFAULT_CUSTOM_AUTH_HEADER_NAME}
+                        className={inputClass}
+                      />
+                    </div>
+                    <div>
+                      <FieldLabel label="Auth Header Format" />
+                      <input
+                        value={form.auth_header_format}
+                        onChange={(e) => setForm({ ...form, auth_header_format: e.target.value })}
+                        placeholder={DEFAULT_CUSTOM_AUTH_HEADER_FORMAT}
+                        className={inputClass}
+                      />
+                    </div>
+                    <p className="sm:col-span-2 text-xs text-gray-400">
+                      Optional override for OpenAI-compatible providers. Only the <code>{'{api_key}'}</code> placeholder is supported.
+                    </p>
+                  </div>
+                ) : null}
               </>
             )}
           </div>

--- a/ui/src/components/NamedCredentialForm.tsx
+++ b/ui/src/components/NamedCredentialForm.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import { type NamedCredential, type ProviderPreset } from '../lib/api';
-import { providerDisplayName } from '../lib/providers';
+import {
+  DEFAULT_CUSTOM_AUTH_HEADER_FORMAT,
+  DEFAULT_CUSTOM_AUTH_HEADER_NAME,
+  providerDisplayName,
+  supportsCustomUpstreamAuthProvider,
+} from '../lib/providers';
 
 type SecretField = 'api_key' | 'aws_access_key_id' | 'aws_secret_access_key' | 'aws_session_token';
 
@@ -10,6 +15,8 @@ type NamedCredentialFormValues = {
   api_key: string;
   api_base: string;
   api_version: string;
+  auth_header_name: string;
+  auth_header_format: string;
   region: string;
   aws_access_key_id: string;
   aws_secret_access_key: string;
@@ -43,6 +50,8 @@ function emptyForm(): NamedCredentialFormValues {
     api_key: '',
     api_base: '',
     api_version: '',
+    auth_header_name: '',
+    auth_header_format: '',
     region: '',
     aws_access_key_id: '',
     aws_secret_access_key: '',
@@ -75,6 +84,8 @@ function formFromCredential(credential: NamedCredential | null | undefined): Nam
     api_key: '',
     api_base: typeof config.api_base === 'string' ? config.api_base : '',
     api_version: typeof config.api_version === 'string' ? config.api_version : '',
+    auth_header_name: typeof config.auth_header_name === 'string' ? config.auth_header_name : '',
+    auth_header_format: typeof config.auth_header_format === 'string' ? config.auth_header_format : '',
     region: typeof config.region === 'string' ? config.region : '',
     aws_access_key_id: '',
     aws_secret_access_key: '',
@@ -93,7 +104,7 @@ function buildPayload(values: NamedCredentialFormValues, initialCredential?: Nam
   const trim = (value: string) => value.trim();
   const initialConfig = initialCredential?.connection_config || {};
 
-  const assignOptionalText = (field: 'api_base' | 'api_version' | 'region') => {
+  const assignOptionalText = (field: 'api_base' | 'api_version' | 'auth_header_name' | 'auth_header_format' | 'region') => {
     const nextValue = trim(values[field]);
     const hadInitial = typeof initialConfig[field] === 'string' && String(initialConfig[field]).trim() !== '';
     if (nextValue) {
@@ -124,6 +135,10 @@ function buildPayload(values: NamedCredentialFormValues, initialCredential?: Nam
     assignOptionalText('api_base');
     assignOptionalText('api_version');
     assignSecretField('api_key');
+    if (supportsCustomUpstreamAuthProvider(values.provider)) {
+      assignOptionalText('auth_header_name');
+      assignOptionalText('auth_header_format');
+    }
   }
 
   return {
@@ -144,6 +159,7 @@ export default function NamedCredentialForm({
   const [form, setForm] = useState<NamedCredentialFormValues>(() => formFromCredential(initialCredential));
   const [validationError, setValidationError] = useState<string | null>(null);
   const editing = Boolean(initialCredential);
+  const supportsCustomAuth = supportsCustomUpstreamAuthProvider(form.provider);
 
   useEffect(() => {
     setForm(formFromCredential(initialCredential));
@@ -281,6 +297,31 @@ export default function NamedCredentialForm({
               />
             </div>
           </div>
+          {supportsCustomAuth ? (
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">Auth Header Name</label>
+                <input
+                  value={form.auth_header_name}
+                  onChange={(e) => setForm((current) => ({ ...current, auth_header_name: e.target.value }))}
+                  placeholder={DEFAULT_CUSTOM_AUTH_HEADER_NAME}
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">Auth Header Format</label>
+                <input
+                  value={form.auth_header_format}
+                  onChange={(e) => setForm((current) => ({ ...current, auth_header_format: e.target.value }))}
+                  placeholder={DEFAULT_CUSTOM_AUTH_HEADER_FORMAT}
+                  className={inputClass}
+                />
+              </div>
+              <p className="sm:col-span-2 text-xs text-gray-400">
+                Optional override for OpenAI-compatible providers. Only the <code>{'{api_key}'}</code> placeholder is supported.
+              </p>
+            </div>
+          ) : null}
         </>
       )}
 

--- a/ui/src/components/modelFormShared.ts
+++ b/ui/src/components/modelFormShared.ts
@@ -8,7 +8,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import type { ModelDeploymentDetail } from '../lib/api';
-import { normalizeProvider } from '../lib/providers';
+import { normalizeProvider, supportsCustomUpstreamAuthProvider } from '../lib/providers';
 
 export type ModelMode =
   | 'chat'
@@ -56,6 +56,10 @@ export interface ModelFormValues {
   api_key: string;
   api_base: string;
   api_version: string;
+  auth_header_name: string;
+  auth_header_format: string;
+  existing_auth_header_name: boolean;
+  existing_auth_header_format: boolean;
   rpm: string;
   tpm: string;
   timeout: string;
@@ -104,6 +108,10 @@ export const EMPTY_FORM: ModelFormValues = {
   api_key: '',
   api_base: '',
   api_version: '',
+  auth_header_name: '',
+  auth_header_format: '',
+  existing_auth_header_name: false,
+  existing_auth_header_format: false,
   rpm: '',
   tpm: '',
   timeout: '',
@@ -151,6 +159,7 @@ export function buildModelPayload(
   defaultParams: { key: string; value: string }[],
 ): ModelPayload {
   const useNamedCredential = form.credential_source === 'named';
+  const supportsCustomAuth = supportsCustomUpstreamAuthProvider(form.provider, form.model);
   const deltallm_params: Record<string, unknown> = {
     provider: form.provider.trim() || undefined,
     model: form.model.trim(),
@@ -161,6 +170,12 @@ export function buildModelPayload(
         : form.api_key || undefined,
     api_base: useNamedCredential ? undefined : form.api_base.trim() || undefined,
     api_version: useNamedCredential ? undefined : form.api_version.trim() || undefined,
+    auth_header_name: useNamedCredential || !supportsCustomAuth
+      ? undefined
+      : form.auth_header_name.trim() || (form.existing_auth_header_name ? null : undefined),
+    auth_header_format: useNamedCredential || !supportsCustomAuth
+      ? undefined
+      : form.auth_header_format.trim() || (form.existing_auth_header_format ? null : undefined),
     rpm: numOrUndef(form.rpm),
     tpm: numOrUndef(form.tpm),
     timeout: numOrUndef(form.timeout),
@@ -263,6 +278,10 @@ export function formFromModel(
     api_key: '',
     api_base: strOrEmpty(lp.api_base),
     api_version: strOrEmpty(lp.api_version),
+    auth_header_name: strOrEmpty(lp.auth_header_name),
+    auth_header_format: strOrEmpty(lp.auth_header_format),
+    existing_auth_header_name: Boolean(strOrEmpty(lp.auth_header_name).trim()),
+    existing_auth_header_format: Boolean(strOrEmpty(lp.auth_header_format).trim()),
     rpm: strOrEmpty(lp.rpm),
     tpm: strOrEmpty(lp.tpm),
     timeout: strOrEmpty(lp.timeout),

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -527,6 +527,8 @@ export interface ProviderModelDiscoveryPayload {
   api_key?: string | null;
   api_base?: string | null;
   api_version?: string | null;
+  auth_header_name?: string | null;
+  auth_header_format?: string | null;
 }
 
 export interface ProviderModelDiscoveryResponse {

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -17,6 +17,22 @@ const PROVIDER_LABELS: Record<string, string> = {
   unknown: 'Unknown',
 };
 
+const CUSTOM_UPSTREAM_AUTH_PROVIDERS = new Set([
+  'openai',
+  'openrouter',
+  'groq',
+  'together',
+  'fireworks',
+  'deepinfra',
+  'perplexity',
+  'vllm',
+  'lmstudio',
+  'ollama',
+]);
+
+export const DEFAULT_CUSTOM_AUTH_HEADER_NAME = 'Authorization';
+export const DEFAULT_CUSTOM_AUTH_HEADER_FORMAT = 'Bearer {api_key}';
+
 export function providerFromModelString(model: string | null | undefined): string {
   const value = (model || '').trim();
   if (!value) return 'unknown';
@@ -38,4 +54,30 @@ export function canonicalNamedCredentialProvider(provider: string | null | undef
 export function providerDisplayName(provider: string | null | undefined): string {
   const key = (provider || '').trim().toLowerCase() || 'unknown';
   return PROVIDER_LABELS[key] || key;
+}
+
+export function supportsCustomUpstreamAuthProvider(
+  provider: string | null | undefined,
+  model?: string | null | undefined,
+): boolean {
+  return CUSTOM_UPSTREAM_AUTH_PROVIDERS.has(normalizeProvider(provider, model));
+}
+
+export function customUpstreamAuthHeaderLabel(
+  connectionConfig: Record<string, unknown> | null | undefined,
+): string | null {
+  const authHeaderName = typeof connectionConfig?.auth_header_name === 'string'
+    ? connectionConfig.auth_header_name.trim()
+    : '';
+  const authHeaderFormat = typeof connectionConfig?.auth_header_format === 'string'
+    ? connectionConfig.auth_header_format.trim()
+    : '';
+  const normalizedHeaderName = authHeaderName || DEFAULT_CUSTOM_AUTH_HEADER_NAME;
+  const normalizedHeaderFormat = authHeaderFormat || DEFAULT_CUSTOM_AUTH_HEADER_FORMAT;
+  const usesCustomAuth = Boolean(authHeaderName || authHeaderFormat)
+    && (
+      normalizedHeaderName !== DEFAULT_CUSTOM_AUTH_HEADER_NAME
+      || normalizedHeaderFormat !== DEFAULT_CUSTOM_AUTH_HEADER_FORMAT
+    );
+  return usesCustomAuth ? normalizedHeaderName : null;
 }

--- a/ui/src/pages/NamedCredentials.tsx
+++ b/ui/src/pages/NamedCredentials.tsx
@@ -6,7 +6,7 @@ import NamedCredentialForm from '../components/NamedCredentialForm';
 import { ContentCard, IndexShell } from '../components/admin/shells';
 import DataTable from '../components/DataTable';
 import { models, namedCredentials, type InlineCredentialGroup, type NamedCredential } from '../lib/api';
-import { providerDisplayName } from '../lib/providers';
+import { customUpstreamAuthHeaderLabel, providerDisplayName, supportsCustomUpstreamAuthProvider } from '../lib/providers';
 import { useApi } from '../lib/hooks';
 import { useToast } from '../components/ToastProvider';
 
@@ -14,6 +14,12 @@ function connectionSummary(credential: NamedCredential): string {
   const config = credential.connection_config || {};
   if (typeof config.api_base === 'string' && config.api_base.trim()) {
     return config.api_base;
+  }
+  const customAuthHeader = supportsCustomUpstreamAuthProvider(credential.provider)
+    ? customUpstreamAuthHeaderLabel(config)
+    : null;
+  if (customAuthHeader) {
+    return `Custom auth header: ${customAuthHeader}`;
   }
   if (typeof config.region === 'string' && config.region.trim()) {
     return `Region ${config.region}`;


### PR DESCRIPTION
## Summary

This PR completes phase 2 of the custom upstream auth header work.

It finishes the remaining OpenAI-compatible runtime paths and exposes the new auth header settings in the admin UI for both named credentials and inline deployments.

## What Changed

- moved the remaining OpenAI-compatible runtime routes onto the shared auth header helper
- aligned the OpenAI adapter health check with the same helper
- added admin UI support for `auth_header_name` and `auth_header_format` in:
  - named credential create/edit
  - inline model deployment configuration
  - provider model discovery request payloads
- added provider-aware UI visibility helpers so unsupported providers do not show the new controls
- improved named credential list summaries to surface custom auth header usage when relevant
- extended regression coverage for embeddings, multimodal routes, and adapter health checks

## Why

PR1 added the backend contract, validation, and core helper, but product behavior was still incomplete because several non-chat OpenAI-compatible routes still hardcoded `Authorization: Bearer ...`, and the admin UI did not expose the new fields.

This PR finishes the runtime and operator-facing parts of the feature.

## Validation

- `npm run build` in `ui`
- `uv run pytest tests/test_embeddings.py tests/test_route_decision_multimodal.py tests/test_provider_compat.py`
- `uv run pytest tests/test_ui_models.py tests/test_provider_model_discovery.py tests/test_chat.py tests/test_named_credentials_api.py`

## Follow-up

Docs and any remaining polish stay in the phase 3 slice.