### PR TITLE
polish custom upstream auth summaries and docs

### DIFF
--- a/docs/admin-ui/models.md
+++ b/docs/admin-ui/models.md
@@ -59,6 +59,49 @@ Create a route group when:
 - you want controlled failover behavior
 - you want to bind prompt behavior at the route-group level
 
+## Custom Upstream Auth Headers
+
+For these OpenAI-compatible providers, the model form supports inline upstream auth-header overrides:
+
+- `openai`
+- `openrouter`
+- `groq`
+- `together`
+- `fireworks`
+- `deepinfra`
+- `perplexity`
+- `vllm`
+- `lmstudio`
+- `ollama`
+
+In the model form:
+
+1. Choose **Inline credentials**
+2. Enter `api_key` and any `api_base`
+3. Expand the provider connection fields
+4. Fill `Auth Header Name` and `Auth Header Format` if the upstream does not accept `Authorization: Bearer ...`
+
+Example inline deployment payload:
+
+```json
+{
+  "model_name": "support-vllm",
+  "deltallm_params": {
+    "provider": "vllm",
+    "model": "vllm/meta-llama/Llama-3.1-8B-Instruct",
+    "api_key": "gateway-key",
+    "api_base": "https://vllm.example/v1",
+    "auth_header_name": "X-API-Key",
+    "auth_header_format": "{api_key}"
+  },
+  "model_info": {
+    "mode": "chat"
+  }
+}
+```
+
+For shared gateway credentials, [Named Credentials](named-credentials.md) remain the recommended workflow. If a deployment references a named credential and also carries overlapping connection fields locally, the named credential values win.
+
 ## Operational Notes
 
 - DeltaLLM validates provider and mode compatibility when you create or update a deployment

--- a/docs/admin-ui/named-credentials.md
+++ b/docs/admin-ui/named-credentials.md
@@ -26,12 +26,43 @@ Typical connection fields include:
 - `api_key`
 - `api_base`
 - `api_version`
+- `auth_header_name`
+- `auth_header_format`
 - `region`
 - `aws_access_key_id`
 - `aws_secret_access_key`
 - `aws_session_token`
 
-Responses always redact secret-bearing values. You can read metadata and connection summaries, but not the raw stored secret back out of the API.
+Responses always redact secret-bearing values. You can read metadata and connection summaries, but not the raw stored secret back out of the API. For custom upstream auth, compact summaries may show labels such as `X-API-Key` or `Authorization (Token)`.
+
+## Custom Upstream Auth Headers
+
+For these OpenAI-compatible providers, named credentials can override the default `Authorization: Bearer ...` upstream auth behavior:
+
+- `openai`
+- `openrouter`
+- `groq`
+- `together`
+- `fireworks`
+- `deepinfra`
+- `perplexity`
+- `vllm`
+- `lmstudio`
+- `ollama`
+
+Use:
+
+- `auth_header_name` to choose the header key, such as `X-API-Key`
+- `auth_header_format` to choose the header value template, such as `Token {api_key}`
+
+Validation rules:
+
+- `auth_header_format` must contain the exact `{api_key}` placeholder
+- format specifiers or conversions such as `{api_key!r}` or `{api_key:>10}` are rejected
+- escaped placeholders such as `{{api_key}}` are rejected
+- reserved header names such as `Content-Type` are rejected
+
+If you leave both fields unset, DeltaLLM keeps the default upstream behavior: `Authorization: Bearer {api_key}`.
 
 ## UI Workflow
 
@@ -59,6 +90,7 @@ The page shows whether credentials are present and how many deployments currentl
 6. Save the deployment
 
 The deployment keeps its own runtime identity, but shared provider connection settings come from the named credential.
+If both the named credential and the deployment define overlapping connection fields, the named credential wins.
 
 ### Rotate a credential
 
@@ -89,18 +121,20 @@ Admin endpoints accept either:
 
 ### 1. Create the named credential
 
-Example with Groq:
+Example with a shared vLLM gateway that expects `X-API-Key`:
 
 ```bash
 curl http://localhost:4002/ui/api/named-credentials \
   -H "Authorization: Bearer $DELTALLM_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "Groq Shared Prod",
-    "provider": "groq",
+    "name": "vLLM Shared Gateway",
+    "provider": "vllm",
     "connection_config": {
-      "api_key": "gsk_...",
-      "api_base": "https://api.groq.com/openai/v1"
+      "api_key": "gateway-key",
+      "api_base": "https://vllm.example/v1",
+      "auth_header_name": "X-API-Key",
+      "auth_header_format": "{api_key}"
     }
   }'
 ```
@@ -110,11 +144,13 @@ Example response shape:
 ```json
 {
   "credential_id": "cred-123",
-  "name": "Groq Shared Prod",
-  "provider": "groq",
+  "name": "vLLM Shared Gateway",
+  "provider": "vllm",
   "connection_config": {
     "api_key": "***REDACTED***",
-    "api_base": "https://api.groq.com/openai/v1"
+    "api_base": "https://vllm.example/v1",
+    "auth_header_name": "X-API-Key",
+    "auth_header_format": "{api_key}"
   },
   "credentials_present": true,
   "usage_count": 0
@@ -123,18 +159,18 @@ Example response shape:
 
 ### 2. Create deployments that reference it
 
-When a deployment uses a named credential, keep provider-specific connection fields out of the deployment payload unless you intentionally want deployment-local overrides.
+When a deployment uses a named credential, keep provider-specific connection fields out of the deployment payload. If both are present, the named credential connection config wins over deployment-local connection fields.
 
 ```bash
 curl http://localhost:4002/ui/api/models \
   -H "Authorization: Bearer $DELTALLM_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model_name": "groq-support",
+    "model_name": "support-vllm",
     "named_credential_id": "cred-123",
     "deltallm_params": {
-      "provider": "groq",
-      "model": "llama-3.1-8b-instant"
+      "provider": "vllm",
+      "model": "vllm/meta-llama/Llama-3.1-8B-Instruct"
     },
     "model_info": {
       "mode": "chat"
@@ -152,13 +188,16 @@ curl http://localhost:4002/ui/api/named-credentials/cred-123 \
   -H "Authorization: Bearer $DELTALLM_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "Groq Shared Prod",
-    "provider": "groq",
+    "name": "vLLM Shared Gateway",
+    "provider": "vllm",
     "connection_config": {
-      "api_key": "gsk_rotated_..."
+      "auth_header_name": "Authorization",
+      "auth_header_format": "Token {api_key}"
     }
   }'
 ```
+
+That example switches the upstream request format from `X-API-Key: <api_key>` to `Authorization: Token <api_key>` without changing linked deployments.
 
 Update semantics:
 

--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -68,6 +68,49 @@ These endpoints back browser login, invitation acceptance, password recovery, MF
 | `GET` | `/ui/api/provider-presets` | List provider presets for the UI |
 | `POST` | `/ui/api/provider-models/discover` | Discover provider model suggestions for the UI |
 
+Model create and update payloads accept custom upstream auth-header overrides inside `deltallm_params` for these OpenAI-compatible providers:
+
+- `openai`
+- `openrouter`
+- `groq`
+- `together`
+- `fireworks`
+- `deepinfra`
+- `perplexity`
+- `vllm`
+- `lmstudio`
+- `ollama`
+
+Relevant fields:
+
+- `deltallm_params.auth_header_name`
+- `deltallm_params.auth_header_format`
+
+`auth_header_format` must contain the exact `{api_key}` placeholder, and reserved header names such as `Content-Type` are rejected. If a deployment uses `named_credential_id` and also carries overlapping local connection fields, the named credential values win.
+
+List, detail, create, and update responses continue to redact secrets such as `api_key`. When custom upstream auth is configured, `connection_summary` may include the effective `auth_header_name` plus a compact `custom_auth_label` such as `X-API-Key` or `Authorization (Token)`, but not the rendered header value.
+
+Example inline model create payload:
+
+```json
+{
+  "model_name": "support-vllm",
+  "deltallm_params": {
+    "provider": "vllm",
+    "model": "vllm/meta-llama/Llama-3.1-8B-Instruct",
+    "api_key": "gateway-key",
+    "api_base": "https://vllm.example/v1",
+    "auth_header_name": "X-API-Key",
+    "auth_header_format": "{api_key}"
+  },
+  "model_info": {
+    "mode": "chat"
+  }
+}
+```
+
+`POST /ui/api/provider-models/discover` accepts the same connection fields, including `auth_header_name` and `auth_header_format`, so the UI can probe OpenAI-compatible gateways before saving a deployment.
+
 ### Named Credentials
 
 | Method | Endpoint | Purpose |
@@ -88,7 +131,12 @@ Use them when you want to:
 - reduce duplicated inline secrets in model payloads
 - centralize shared connection settings such as `api_key`, `api_base`, `api_version`, or Bedrock fields
 
-Read responses always redact secret-bearing fields. Updating an in-use named credential triggers a runtime reload so linked deployments pick up the new connection settings.
+For the same OpenAI-compatible providers listed above, named-credential `connection_config` also supports:
+
+- `auth_header_name`
+- `auth_header_format`
+
+Read responses always redact secret-bearing fields. Updating an in-use named credential triggers a runtime reload so linked deployments pick up the new connection settings. The raw secret value is never readable back out of the admin API.
 
 For full UI and `curl` examples, see [Admin UI: Named Credentials](../admin-ui/named-credentials.md).
 

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -66,8 +66,53 @@ After the initial seed, set `model_deployment_bootstrap_from_config` back to `fa
 | `deltallm_params.model` | Yes | Provider-prefixed upstream model ID, such as `openai/gpt-4o-mini` |
 | `deltallm_params.api_key` | Yes | Provider API key |
 | `deltallm_params.api_base` | No | Custom provider base URL |
+| `deltallm_params.auth_header_name` | No | Custom upstream auth header key for supported OpenAI-compatible providers |
+| `deltallm_params.auth_header_format` | No | Custom upstream auth header value template, must include `{api_key}` |
 | `deltallm_params.timeout` | No | Upstream timeout in seconds |
 | `deltallm_params.weight` | No | Relative weight when multiple deployments share one public model |
+
+## Custom Upstream Auth Headers
+
+These `deltallm_params` fields are available for the OpenAI-compatible providers that support custom upstream auth headers:
+
+- `openai`
+- `openrouter`
+- `groq`
+- `together`
+- `fireworks`
+- `deepinfra`
+- `perplexity`
+- `vllm`
+- `lmstudio`
+- `ollama`
+
+Use:
+
+- `auth_header_name` for the header key, such as `X-API-Key`
+- `auth_header_format` for the value template, such as `Token {api_key}`
+
+If you omit both fields, DeltaLLM uses the default `Authorization: Bearer {api_key}` upstream auth pattern.
+
+Example config-file deployment for a vLLM gateway that expects `X-API-Key`:
+
+```yaml
+model_list:
+  - model_name: support-vllm
+    deltallm_params:
+      model: vllm/meta-llama/Llama-3.1-8B-Instruct
+      api_key: os.environ/VLLM_GATEWAY_KEY
+      api_base: https://vllm.example/v1
+      auth_header_name: X-API-Key
+      auth_header_format: "{api_key}"
+    model_info:
+      mode: chat
+```
+
+Validation rules:
+
+- `auth_header_format` must contain the exact `{api_key}` placeholder
+- extra placeholders, format specifiers, and conversions are rejected
+- reserved header names such as `Content-Type` are rejected
 
 ## Multiple Deployments Behind One Public Model
 

--- a/src/api/admin/endpoints/common.py
+++ b/src/api/admin/endpoints/common.py
@@ -19,6 +19,11 @@ from src.guardrails.catalog import (
 )
 from src.providers.resolution import resolve_provider
 from src.services.named_credentials import redact_connection_config
+from src.upstream_auth import (
+    DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_FORMAT,
+    DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_NAME,
+    supports_custom_openai_compatible_auth,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -357,16 +362,17 @@ def model_entries(app: Any) -> list[dict[str, Any]]:
                 if deployment.get("named_credential_id") is not None
                 else None
             )
+            provider = resolve_provider(params)
             credential_source = "named" if named_credential_id else "inline"
             entries.append(
                 {
                     "deployment_id": deployment_id,
                     "model_name": model_name,
-                    "provider": resolve_provider(params),
+                    "provider": provider,
                     "mode": model_info.get("mode", "chat"),
                     "credential_source": credential_source,
                     "inline_credentials_present": _inline_credentials_present(params) if credential_source == "inline" else False,
-                    "connection_summary": _connection_summary(params),
+                    "connection_summary": build_connection_summary(params, provider=provider),
                     "named_credential_id": named_credential_id or None,
                     "named_credential_name": (
                         str(deployment.get("named_credential_name")).strip()
@@ -384,11 +390,60 @@ def _inline_credentials_present(params: dict[str, Any]) -> bool:
     return any(str(params.get(field) or "").strip() for field in _INLINE_SECRET_FIELDS)
 
 
-def _connection_summary(params: dict[str, Any]) -> dict[str, Any]:
-    return {
+def build_connection_summary(params: dict[str, Any], *, provider: str | None = None) -> dict[str, Any]:
+    summary = {
         field: params.get(field) or None
         for field in _CONNECTION_SUMMARY_FIELDS
     }
+    summary_auth_header_name, custom_auth_label = _custom_auth_summary(params, provider=provider)
+    if summary_auth_header_name:
+        summary["auth_header_name"] = summary_auth_header_name
+    if custom_auth_label:
+        summary["custom_auth_label"] = custom_auth_label
+    return summary
+
+
+def _custom_auth_summary(params: dict[str, Any], *, provider: str | None = None) -> tuple[str | None, str | None]:
+    resolved_provider = provider or resolve_provider(params)
+    if not supports_custom_openai_compatible_auth(resolved_provider):
+        return None, None
+
+    raw_header_name = str(params.get("auth_header_name") or "").strip()
+    raw_header_format = str(params.get("auth_header_format") or "").strip()
+    if not raw_header_name and not raw_header_format:
+        return None, None
+
+    effective_header_name = raw_header_name or DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_NAME
+    effective_header_format = raw_header_format or DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_FORMAT
+    uses_custom_auth = (
+        effective_header_name != DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_NAME
+        or effective_header_format != DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_FORMAT
+    )
+    if not uses_custom_auth:
+        return None, None
+
+    return effective_header_name, _custom_auth_label(effective_header_name, effective_header_format)
+
+
+def _custom_auth_label(header_name: str, header_format: str) -> str:
+    if header_name != DEFAULT_OPENAI_COMPATIBLE_AUTH_HEADER_NAME:
+        return header_name
+
+    auth_scheme = _extract_auth_scheme(header_format)
+    if auth_scheme and auth_scheme != "Bearer":
+        return f"{header_name} ({auth_scheme})"
+    return f"{header_name} (custom)"
+
+
+def _extract_auth_scheme(header_format: str) -> str | None:
+    if header_format.count("{api_key}") != 1:
+        return None
+    prefix, suffix = header_format.split("{api_key}", 1)
+    if suffix.strip():
+        return None
+    scheme = prefix.strip()
+    return scheme or None
+
 
 def serialize_guardrail(raw: Any) -> dict[str, Any]:
     item = raw.model_dump(mode="python") if hasattr(raw, "model_dump") else dict(raw)

--- a/src/api/admin/endpoints/models.py
+++ b/src/api/admin/endpoints/models.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, field_validator, model_validator
 
-from src.api.admin.endpoints.common import model_entries, to_json_value
+from src.api.admin.endpoints.common import build_connection_summary, model_entries, to_json_value
 from src.api.audit import emit_control_audit_event
 from src.audit.actions import AuditAction
 from src.config import ModelMode
@@ -202,9 +202,11 @@ def _serialize_model_write_response(
     named_credential_id: str | None,
     named_credential_name: str | None,
     deltallm_params: dict[str, Any],
+    summary_params: dict[str, Any] | None,
     model_info: dict[str, Any],
 ) -> dict[str, Any]:
     credential_source = "named" if named_credential_id else "inline"
+    effective_summary_params = summary_params or deltallm_params
     return to_json_value(
         {
             "deployment_id": deployment_id,
@@ -216,11 +218,10 @@ def _serialize_model_write_response(
                 str(deltallm_params.get(field) or "").strip()
                 for field in _INLINE_SECRET_FIELDS
             ),
-            "connection_summary": {
-                "api_base": deltallm_params.get("api_base") or None,
-                "api_version": deltallm_params.get("api_version") or None,
-                "region": deltallm_params.get("region") or None,
-            },
+            "connection_summary": build_connection_summary(
+                effective_summary_params,
+                provider=provider or resolve_provider(effective_summary_params),
+            ),
             "named_credential_id": named_credential_id,
             "named_credential_name": named_credential_name,
             "deltallm_params": redact_connection_config(deltallm_params),
@@ -594,6 +595,7 @@ async def create_model(request: Request, payload: dict[str, Any]) -> dict[str, A
         named_credential_id=named_credential_id,
         named_credential_name=named_credential.name if named_credential is not None else None,
         deltallm_params=deltallm_params,
+        summary_params=effective_params,
         model_info=model_info,
     )
     await emit_control_audit_event(
@@ -720,6 +722,7 @@ async def update_model(request: Request, deployment_id: str, payload: dict[str, 
         named_credential_id=named_credential_id,
         named_credential_name=named_credential.name if named_credential is not None else None,
         deltallm_params=deltallm_params,
+        summary_params=effective_params,
         model_info=model_info,
     )
     await emit_control_audit_event(

--- a/tests/test_ui_models.py
+++ b/tests/test_ui_models.py
@@ -192,6 +192,8 @@ async def test_get_model_returns_health_block(client, test_app):
     assert payload["credential_source"] == "inline"
     assert payload["inline_credentials_present"] is True
     assert payload["connection_summary"]["api_base"] is None
+    assert "auth_header_name" not in payload["connection_summary"]
+    assert "custom_auth_label" not in payload["connection_summary"]
     assert payload["deltallm_params"]["api_key"] == "***REDACTED***"
 
 
@@ -209,6 +211,7 @@ async def test_get_model_redacts_named_credential_backed_params(client, test_app
                     "model": "openai/gpt-4o-mini",
                     "api_base": "https://api.openai.com/v1",
                     "api_key": "provider-key",
+                    "auth_header_format": "Token {api_key}",
                 },
                 "model_info": {"mode": "chat"},
             }
@@ -228,7 +231,10 @@ async def test_get_model_redacts_named_credential_backed_params(client, test_app
     assert payload["named_credential_name"] == "OpenAI prod"
     assert payload["deltallm_params"]["api_key"] == "***REDACTED***"
     assert payload["deltallm_params"]["api_base"] == "https://api.openai.com/v1"
+    assert payload["deltallm_params"]["auth_header_format"] == "Token {api_key}"
     assert payload["connection_summary"]["api_base"] == "https://api.openai.com/v1"
+    assert payload["connection_summary"]["auth_header_name"] == "Authorization"
+    assert payload["connection_summary"]["custom_auth_label"] == "Authorization (Token)"
 
 
 @pytest.mark.asyncio
@@ -343,6 +349,48 @@ async def test_create_model_response_redacts_inline_api_key(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_create_model_response_uses_effective_named_credential_custom_auth_summary(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.named_credential_repository = _FakeNamedCredentialRepository(
+        [
+            NamedCredentialRecord(
+                credential_id="cred-vllm",
+                name="vLLM Shared Gateway",
+                provider="vllm",
+                connection_config={
+                    "api_key": "provider-key",
+                    "api_base": "https://vllm.example/v1",
+                    "auth_header_format": "Token {api_key}",
+                },
+            )
+        ]
+    )
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": "named-custom-auth-model",
+            "named_credential_id": "cred-vllm",
+            "deltallm_params": {
+                "provider": "vllm",
+                "model": "vllm/meta-llama/Llama-3.1-8B-Instruct",
+            },
+            "model_info": {"mode": "chat"},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["credential_source"] == "named"
+    assert payload["named_credential_id"] == "cred-vllm"
+    assert payload["connection_summary"]["api_base"] == "https://vllm.example/v1"
+    assert payload["connection_summary"]["auth_header_name"] == "Authorization"
+    assert payload["connection_summary"]["custom_auth_label"] == "Authorization (Token)"
+    assert "auth_header_format" not in payload["deltallm_params"]
+
+
+@pytest.mark.asyncio
 async def test_create_model_accepts_custom_auth_headers_for_openai_compatible_provider(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
 
@@ -368,6 +416,8 @@ async def test_create_model_accepts_custom_auth_headers_for_openai_compatible_pr
     assert payload["deltallm_params"]["api_key"] == "***REDACTED***"
     assert payload["deltallm_params"]["auth_header_name"] == "X-API-Key"
     assert payload["deltallm_params"]["auth_header_format"] == "{api_key}"
+    assert payload["connection_summary"]["auth_header_name"] == "X-API-Key"
+    assert payload["connection_summary"]["custom_auth_label"] == "X-API-Key"
 
 
 @pytest.mark.asyncio
@@ -446,6 +496,50 @@ async def test_update_model_response_redacts_inline_api_key(client, test_app):
     assert payload["deltallm_params"]["api_key"] == "***REDACTED***"
     assert payload["deltallm_params"]["auth_header_name"] == "X-Provider-Auth"
     assert payload["deltallm_params"]["auth_header_format"] == "Token {api_key}"
+    assert payload["connection_summary"]["auth_header_name"] == "X-Provider-Auth"
+    assert payload["connection_summary"]["custom_auth_label"] == "X-Provider-Auth"
+
+
+@pytest.mark.asyncio
+async def test_update_model_response_uses_effective_named_credential_custom_auth_summary(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.named_credential_repository = _FakeNamedCredentialRepository(
+        [
+            NamedCredentialRecord(
+                credential_id="cred-vllm",
+                name="vLLM Shared Gateway",
+                provider="vllm",
+                connection_config={
+                    "api_key": "provider-key",
+                    "api_base": "https://vllm.example/v1",
+                    "auth_header_format": "Token {api_key}",
+                },
+            )
+        ]
+    )
+
+    response = await client.put(
+        "/ui/api/models/gpt-4o-mini-0",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": "named-custom-auth-model",
+            "named_credential_id": "cred-vllm",
+            "deltallm_params": {
+                "provider": "vllm",
+                "model": "vllm/meta-llama/Llama-3.1-8B-Instruct",
+            },
+            "model_info": {"mode": "chat"},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["credential_source"] == "named"
+    assert payload["named_credential_id"] == "cred-vllm"
+    assert payload["connection_summary"]["api_base"] == "https://vllm.example/v1"
+    assert payload["connection_summary"]["auth_header_name"] == "Authorization"
+    assert payload["connection_summary"]["custom_auth_label"] == "Authorization (Token)"
+    assert "auth_header_format" not in payload["deltallm_params"]
 
 
 @pytest.mark.asyncio

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -558,6 +558,8 @@ export interface ModelDeploymentDetail {
     api_base?: string | null;
     api_version?: string | null;
     region?: string | null;
+    auth_header_name?: string | null;
+    custom_auth_label?: string | null;
   };
   healthy?: boolean;
   health?: DeploymentHealth;

--- a/ui/src/pages/ModelDetail.tsx
+++ b/ui/src/pages/ModelDetail.tsx
@@ -195,6 +195,7 @@ function OverviewTab({ model }: { model: any }) {
   const lp = model.deltallm_params || {};
   const connectionSummary = model.connection_summary || {};
   const health: DeploymentHealth = model.health || EMPTY_DEPLOYMENT_HEALTH;
+  const customAuthSummary = connectionSummary.custom_auth_label || connectionSummary.auth_header_name || null;
   const credentialSource = model.credential_source === 'named' ? 'Named credential' : 'Inline credentials';
   const credentialDetail = model.credential_source === 'named'
     ? (model.named_credential_name || 'Managed by named credential')
@@ -211,6 +212,7 @@ function OverviewTab({ model }: { model: any }) {
       <Field label="API Base"             value={connectionSummary.api_base || lp.api_base || '—'} mono full />
       {connectionSummary.api_version && <Field label="API Version" value={connectionSummary.api_version} mono />}
       {connectionSummary.region && <Field label="Region" value={connectionSummary.region} mono />}
+      {customAuthSummary && <Field label="Custom Auth" value={customAuthSummary} mono />}
       <Field label="Timeout"              value={formatDurationSeconds(lp.timeout) || '—'} />
       <Field label="Consecutive Failures" value={String(health.consecutive_failures ?? 0)} />
       <Field label="Last Success"         value={timeSince(health.last_success_at) || '—'} />


### PR DESCRIPTION
## What changed

This PR completes the phase 3 follow-up for configurable upstream auth headers.

- exposes compact custom-auth summary details in model responses
- makes create/update model responses use the effective merged connection config for `connection_summary`
- surfaces the custom auth summary in the model detail UI
- documents supported providers, validation rules, precedence, and example payloads for admin UI, config, and API usage
- adds regression coverage for named-credential-backed and inline custom auth response shapes

## Why

PR1 and PR2 added configurable upstream auth headers, but the admin surface still had gaps:

- create/update responses were summarizing raw deployment-local params instead of the effective merged runtime config
- the model detail page could not distinguish default Bearer auth from custom `Authorization: Token ...` style auth
- the docs did not yet fully describe the shipped behavior and precedence rules

## Impact

Operators can now immediately see the effective custom auth setup after create/update calls and in the model detail view without exposing rendered secret values.

Named-credential-backed deployments now report the same effective summary in write responses as they do in list/detail reads.

## Validation

- `uv run pytest tests/test_ui_models.py tests/services/test_model_deployments.py tests/test_named_credentials_api.py`
- `npm run build`

## Notes

This PR is documentation and admin-surface polish on top of the already landed runtime support for custom upstream auth headers.