### PR TITLE
Issue 75 PR3: add embedding microbatch admin controls

### DIFF
--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -159,6 +159,36 @@ model_list:
       mode: audio_transcription
 ```
 
+## Embedding Batch Worker Micro-batching
+
+`model_info.upstream_max_batch_inputs` only applies to compatible embedding items
+processed by the async batch worker. It does not change synchronous
+`/v1/embeddings` behavior or make realtime embedding requests batch together.
+
+```yaml
+model_list:
+  - model_name: text-embedding-3-large
+    deltallm_params:
+      model: openai/text-embedding-3-large
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      mode: embedding
+      output_vector_size: 3072
+      upstream_max_batch_inputs: 8
+```
+
+Rollout guidance:
+
+- leave the field unset or set it to `1` to disable batch-worker micro-batching
+- start with small values such as `4` or `8`
+- validate provider behavior, error rates, and throughput before increasing further
+
+Operational note:
+
+- when DeltaLLM groups multiple embedding items into one upstream request, the provider usually returns usage at the grouped-call level
+- DeltaLLM allocates per-item usage and cost from that aggregate usage so total usage and total cost stay consistent
+- per-item usage is therefore allocated from aggregate upstream usage, not exact provider-native attribution for each grouped item
+
 ## Add Pricing and Defaults
 
 Pricing metadata powers spend tracking.

--- a/ui/src/components/ModelForm.tsx
+++ b/ui/src/components/ModelForm.tsx
@@ -401,6 +401,15 @@ export default function ModelForm({
       setValidationError('Fill in the required fields highlighted below.');
       return;
     }
+    if (mode === 'embedding' && form.upstream_max_batch_inputs.trim()) {
+      const upstreamMaxBatchInputs = Number(form.upstream_max_batch_inputs);
+      if (!Number.isInteger(upstreamMaxBatchInputs) || upstreamMaxBatchInputs < 1) {
+        setValidationError(
+          'Batch Worker Upstream Max Inputs must be a whole number greater than or equal to 1. Leave it blank to keep batch-worker micro-batching disabled.',
+        );
+        return;
+      }
+    }
     setFieldErrors({});
     if (selectedProviderPreset && !selectedProviderPreset.supported_modes.includes(mode)) {
       const modeLabel = MODE_OPTIONS.find((m) => m.value === mode)?.label || mode;
@@ -751,7 +760,7 @@ export default function ModelForm({
 
       {mode === 'embedding' && (
         <CollapsibleCard title="Embedding Settings">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Context Window</label>
               <input type="number" value={form.max_context_window} onChange={(e) => setForm({ ...form, max_context_window: e.target.value })} placeholder="8192" className={inputClass} />
@@ -759,6 +768,26 @@ export default function ModelForm({
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Output Vector Size</label>
               <input type="number" value={form.output_vector_size} onChange={(e) => setForm({ ...form, output_vector_size: e.target.value })} placeholder="1536" className={inputClass} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Batch Worker Upstream Max Inputs</label>
+              <input
+                type="number"
+                min="1"
+                step="1"
+                value={form.upstream_max_batch_inputs}
+                onChange={(e) => {
+                  setForm({ ...form, upstream_max_batch_inputs: e.target.value });
+                  clearValidation();
+                }}
+                placeholder="Optional, e.g. 8"
+                className={inputClass}
+              />
+              <p className="text-xs text-gray-400 mt-1">
+                Advanced. Only used for compatible async embedding batch jobs, not synchronous /v1/embeddings.
+                Leave blank or use 1 to disable batch-worker micro-batching. Start small and increase only after
+                validating provider behavior and throughput.
+              </p>
             </div>
           </div>
         </CollapsibleCard>

--- a/ui/src/components/modelFormShared.ts
+++ b/ui/src/components/modelFormShared.ts
@@ -76,6 +76,7 @@ export interface ModelFormValues {
   max_input_tokens: string;
   max_output_tokens: string;
   output_vector_size: string;
+  upstream_max_batch_inputs: string;
   input_cost_per_image: string;
   input_cost_per_character: string;
   output_cost_per_character: string;
@@ -128,6 +129,7 @@ export const EMPTY_FORM: ModelFormValues = {
   max_input_tokens: '',
   max_output_tokens: '',
   output_vector_size: '',
+  upstream_max_batch_inputs: '',
   input_cost_per_image: '',
   input_cost_per_character: '',
   output_cost_per_character: '',
@@ -142,6 +144,12 @@ export const EMPTY_FORM: ModelFormValues = {
 
 function numOrUndef(val: string): number | undefined {
   return val ? Number(val) : undefined;
+}
+
+function positiveIntOrUndef(val: string): number | undefined {
+  if (!val) return undefined;
+  const parsed = Number(val);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 export function strOrEmpty(val: unknown): string {
@@ -207,6 +215,7 @@ export function buildModelPayload(
     model_info.input_cost_per_token_cache_hit = numOrUndef(form.input_cost_per_token_cache_hit);
     model_info.output_vector_size = numOrUndef(form.output_vector_size);
     model_info.max_tokens = numOrUndef(form.max_context_window);
+    model_info.upstream_max_batch_inputs = positiveIntOrUndef(form.upstream_max_batch_inputs);
   } else if (form.mode === 'image_generation') {
     model_info.input_cost_per_image = numOrUndef(form.input_cost_per_image);
   } else if (form.mode === 'audio_speech') {
@@ -298,6 +307,7 @@ export function formFromModel(
     max_input_tokens: strOrEmpty(mi.max_input_tokens),
     max_output_tokens: strOrEmpty(mi.max_output_tokens),
     output_vector_size: strOrEmpty(mi.output_vector_size),
+    upstream_max_batch_inputs: strOrEmpty(mi.upstream_max_batch_inputs),
     input_cost_per_image: strOrEmpty(mi.input_cost_per_image),
     input_cost_per_character: strOrEmpty(mi.input_cost_per_character),
     output_cost_per_character: strOrEmpty(mi.output_cost_per_character),

--- a/ui/src/pages/ModelDetail.tsx
+++ b/ui/src/pages/ModelDetail.tsx
@@ -102,6 +102,7 @@ function modeSpecificItems(mode: string, model: any): Array<{ label: string; val
       return [
         { label: 'Context Window', value: formatInteger(mi.max_tokens) },
         { label: 'Vector Size',    value: formatInteger(mi.output_vector_size) },
+        { label: 'Batch Worker Upstream Max Inputs', value: formatInteger(mi.upstream_max_batch_inputs) || '—' },
       ];
     case 'image_generation':
       return [{ label: 'Cost / Image', value: formatCost(mi.input_cost_per_image) }];
@@ -233,7 +234,8 @@ function OverviewTab({ model }: { model: any }) {
 function RuntimeTab({ model }: { model: any }) {
   const lp = model.deltallm_params || {};
   const mi = model.model_info || {};
-  const modeItems = modeSpecificItems(model.mode || mi.mode || 'chat', model)
+  const mode = model.mode || mi.mode || 'chat';
+  const modeItems = modeSpecificItems(mode, model)
     .filter((i) => i.value);
   const defaults = mi.default_params && typeof mi.default_params === 'object'
     ? Object.entries(mi.default_params)
@@ -247,7 +249,14 @@ function RuntimeTab({ model }: { model: any }) {
     <div className="space-y-5">
       {modeItems.length > 0 && (
         <div>
-          <h3 className="mb-3 text-sm font-semibold text-gray-700">Token Limits &amp; Timeouts</h3>
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">Runtime Settings</h3>
+          {mode === 'embedding' && (
+            <p className="mb-3 text-xs text-gray-500">
+              Batch worker settings apply only to compatible async embedding batch jobs. Synchronous{' '}
+              <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-[11px] text-gray-700">/v1/embeddings</code>
+              {' '}requests are unchanged.
+            </p>
+          )}
           <div className="grid grid-cols-2 gap-3">
             {modeItems.map((item) => (
               <Field key={item.label} label={item.label} value={item.value!} />


### PR DESCRIPTION
## What changed

This PR completes the operator-facing portion of issue 75 for upstream embedding micro-batching.

- adds `upstream_max_batch_inputs` to the embedding model form state and payload wiring
- exposes the setting in the embedding settings UI with conservative helper text
- shows the configured value on the model detail runtime view
- documents the setting in the model deployment docs, including rollout guidance and the per-item usage allocation tradeoff
- clarifies in the UI and docs that this setting applies to compatible async embedding batch jobs, not synchronous `/v1/embeddings`

## Why

PR 2 added the backend micro-batching behavior, but operators still could not configure or inspect the setting from the admin surfaces. This PR makes the feature operable and documents the scope so the setting is not misread as a general realtime embedding control.

## Impact

Admins can now:

- set, edit, and clear embedding `upstream_max_batch_inputs`
- see the configured value in the model detail page
- follow public rollout guidance that encourages small initial values and provider validation

## Validation

- `uv run pytest tests/test_batch_worker_microbatch.py -k "groups_eligible_items_into_upstream_microbatch_chunks or keeps_single_prepare_behavior_when_microbatching_is_disabled or fans_out_grouped_embedding_responses_into_single_item_rows"`
- `npm run build` in `ui/`
