### PR TITLE
Add disabled-state warnings for batches and cache

### DIFF
--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -256,6 +256,19 @@ async def batch_summary(
     }
 
 
+@router.get("/ui/api/batches/feature-status")
+async def batch_feature_status(
+    request: Request,
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
+) -> dict[str, bool]:
+    get_auth_scope(request, authorization, x_master_key, required_permission=Permission.KEY_READ)
+    general_settings = getattr(getattr(request.app.state, "app_config", None), "general_settings", None)
+    return {
+        "embeddings_batch_enabled": bool(getattr(general_settings, "embeddings_batch_enabled", False)),
+    }
+
+
 @router.get("/ui/api/batches/{batch_id}")
 async def get_batch(
     request: Request,

--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Iterator
 from time import perf_counter
 
-from fastapi import APIRouter, Header, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from pydantic import BaseModel
 
 from src.auth.roles import Permission
@@ -18,6 +18,7 @@ from src.metrics import (
     increment_batch_repair_action,
     publish_batch_runtime_summary,
 )
+from src.middleware.admin import require_admin_permission
 from src.services.ui_authorization import build_batch_capabilities
 
 router = APIRouter(tags=["Admin Batches"])
@@ -256,13 +257,10 @@ async def batch_summary(
     }
 
 
-@router.get("/ui/api/batches/feature-status")
+@router.get("/ui/api/batches/feature-status", dependencies=[Depends(require_admin_permission(Permission.KEY_READ))])
 async def batch_feature_status(
     request: Request,
-    authorization: str | None = Header(default=None, alias="Authorization"),
-    x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, bool]:
-    get_auth_scope(request, authorization, x_master_key, required_permission=Permission.KEY_READ)
     general_settings = getattr(getattr(request.app.state, "app_config", None), "general_settings", None)
     return {
         "embeddings_batch_enabled": bool(getattr(general_settings, "embeddings_batch_enabled", False)),

--- a/src/api/admin/endpoints/spend.py
+++ b/src/api/admin/endpoints/spend.py
@@ -423,6 +423,19 @@ async def spend_report(
     }
 
 
+@router.get("/ui/api/spend/feature-status", dependencies=[Depends(require_admin_permission(Permission.SPEND_READ))])
+async def spend_feature_status(
+    request: Request,
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
+) -> dict[str, bool]:
+    get_auth_scope(request, authorization, x_master_key, required_permission=Permission.SPEND_READ)
+    general_settings = getattr(getattr(request.app.state, "app_config", None), "general_settings", None)
+    return {
+        "cache_enabled": bool(getattr(general_settings, "cache_enabled", False)),
+    }
+
+
 @router.get("/ui/api/logs", dependencies=[Depends(require_admin_permission(Permission.SPEND_READ))])
 async def request_logs(
     request: Request,

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -213,6 +213,18 @@ async def test_auth_me_hides_team_create_for_team_scoped_admin_only(client, test
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("enabled", [False, True])
+async def test_batch_feature_status_returns_embeddings_batch_flag(client, test_app, enabled):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    setattr(test_app.state.app_config.general_settings, "embeddings_batch_enabled", enabled)
+
+    response = await client.get("/ui/api/batches/feature-status", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    assert response.json() == {"embeddings_batch_enabled": enabled}
+
+
+@pytest.mark.asyncio
 async def test_list_teams_uses_team_scope_and_returns_capabilities(client, test_app, monkeypatch):
     fake_db = FakeAuthorizationDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -225,6 +225,32 @@ async def test_batch_feature_status_returns_embeddings_batch_flag(client, test_a
 
 
 @pytest.mark.asyncio
+async def test_batch_feature_status_requires_batch_page_permission(client, test_app):
+    class StubIdentityService:
+        async def get_context_for_session(self, token: str):
+            if token != "session-token":
+                return None
+            return PlatformAuthContext(
+                account_id="acct-3",
+                email="viewer@example.com",
+                role="org_user",
+                permissions=[],
+                organization_memberships=[],
+                team_memberships=[{"team_id": "team-1", "role": "team_viewer"}],
+                mfa_enabled=False,
+                mfa_verified=False,
+                force_password_change=False,
+            )
+
+    test_app.state.platform_identity_service = StubIdentityService()
+
+    response = await client.get("/ui/api/batches/feature-status", cookies={"deltallm_session": "session-token"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Insufficient permissions"
+
+
+@pytest.mark.asyncio
 async def test_list_teams_uses_team_scope_and_returns_capabilities(client, test_app, monkeypatch):
     fake_db = FakeAuthorizationDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()

--- a/tests/test_ui_rbac_scoping.py
+++ b/tests/test_ui_rbac_scoping.py
@@ -24,6 +24,18 @@ class FakeSpendDB:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("enabled", [False, True])
+async def test_spend_feature_status_returns_cache_flag(client, test_app, enabled):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    setattr(test_app.state.app_config.general_settings, "cache_enabled", enabled)
+
+    response = await client.get("/ui/api/spend/feature-status", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    assert response.json() == {"cache_enabled": enabled}
+
+
+@pytest.mark.asyncio
 async def test_spend_summary_applies_org_scope_for_non_platform(client, test_app, monkeypatch):
     fake_db = FakeSpendDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -147,6 +147,10 @@ export interface SpendGroupReport {
   pagination: Pagination;
 }
 
+export interface SpendFeatureStatus {
+  cache_enabled: boolean;
+}
+
 export type ProviderHealthStatus = 'healthy' | 'degraded' | 'down';
 
 export interface ProviderHealthSummaryRow {
@@ -348,6 +352,10 @@ export interface ApiKey {
 export interface BatchCapabilities {
   view: boolean;
   cancel: boolean;
+}
+
+export interface BatchFeatureStatus {
+  embeddings_batch_enabled: boolean;
 }
 
 export interface BatchJobListItem {
@@ -651,6 +659,7 @@ export const health = {
 };
 
 export const spend = {
+  featureStatus: (opts?: RequestInit) => apiFetch<SpendFeatureStatus>('/ui/api/spend/feature-status', opts),
   summary: (start_date?: string, end_date?: string, opts?: RequestInit) => {
     const qs = new URLSearchParams();
     if (start_date) qs.set('start_date', start_date);
@@ -1072,6 +1081,7 @@ export const users = {
 };
 
 export const batches = {
+  featureStatus: () => apiFetch<BatchFeatureStatus>('/ui/api/batches/feature-status'),
   list: (params?: { search?: string; status?: string; limit?: number; offset?: number }) =>
     apiFetch<Paginated<BatchJobListItem>>(withQuery('/ui/api/batches', params as any)),
   summary: () => apiFetch<BatchJobSummary>('/ui/api/batches/summary'),

--- a/ui/src/pages/BatchJobs.tsx
+++ b/ui/src/pages/BatchJobs.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useApi } from '../lib/hooks';
-import { batches, type BatchJobListItem, type BatchJobSummary } from '../lib/api';
+import { batches, type BatchFeatureStatus, type BatchJobListItem, type BatchJobSummary } from '../lib/api';
 import DataTable from '../components/DataTable';
-import { Layers, Search, Clock, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
+import { Layers, Search, Clock, CheckCircle2, XCircle, Loader2, Info } from 'lucide-react';
 import clsx from 'clsx';
 import { ContentCard, IndexShell } from '../components/admin/shells';
 
@@ -97,6 +97,7 @@ export default function BatchJobs() {
     return () => clearTimeout(t);
   }, [searchInput]);
 
+  const { data: featureStatus } = useApi<BatchFeatureStatus | null>(() => batches.featureStatus(), []);
   const { data: summary } = useApi<BatchJobSummary | null>(() => batches.summary(), []);
   const { data: result, loading } = useApi(
     () => batches.list({ search, status: statusFilter || undefined, limit: pageSize, offset: pageOffset }),
@@ -227,17 +228,34 @@ export default function BatchJobs() {
         </div>
       )}
     >
-      <ContentCard>
-        <DataTable
-          columns={columns}
-          data={items}
-          loading={loading}
-          emptyMessage="No batch jobs found"
-          onRowClick={(row) => navigate(`/batches/${row.batch_id}`)}
-          pagination={pagination}
-          onPageChange={setPageOffset}
-        />
-      </ContentCard>
+      <div className="space-y-4">
+        {featureStatus?.embeddings_batch_enabled === false && (
+          <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+            <div className="flex items-start gap-3">
+              <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+              <div>
+                <p className="font-medium">Embeddings batch API is disabled.</p>
+                <p className="mt-1 text-amber-800">
+                  Enable <code className="rounded bg-amber-100 px-1 py-0.5 text-xs">general_settings.embeddings_batch_enabled: true</code>{' '}
+                  to allow <code className="rounded bg-amber-100 px-1 py-0.5 text-xs">/v1/files</code> and{' '}
+                  <code className="rounded bg-amber-100 px-1 py-0.5 text-xs">/v1/batches</code>. Existing batch records remain visible here.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+        <ContentCard>
+          <DataTable
+            columns={columns}
+            data={items}
+            loading={loading}
+            emptyMessage="No batch jobs found"
+            onRowClick={(row) => navigate(`/batches/${row.batch_id}`)}
+            pagination={pagination}
+            onPageChange={setPageOffset}
+          />
+        </ContentCard>
+      </div>
     </IndexShell>
   );
 }

--- a/ui/src/pages/Usage.tsx
+++ b/ui/src/pages/Usage.tsx
@@ -3,17 +3,19 @@ import type { ReactNode } from 'react';
 import {
   spend,
   type Pagination,
+  type SpendFeatureStatus,
   type SpendGroupBy,
   type SpendGroupReport,
   type SpendGroupRow,
   type SpendLog,
   type SpendSummary,
 } from '../lib/api';
+import { useApi } from '../lib/hooks';
 import Card from '../components/Card';
 import DataTable from '../components/DataTable';
 import StatCard from '../components/StatCard';
 import Modal from '../components/Modal';
-import { DollarSign, LoaderCircle, Zap, Hash, Calendar } from 'lucide-react';
+import { DollarSign, LoaderCircle, Zap, Hash, Calendar, Info } from 'lucide-react';
 import { XAxis, YAxis, Tooltip, ResponsiveContainer, AreaChart, Area } from 'recharts';
 
 const SPEND_GROUP_OPTIONS: Array<{ value: SpendGroupBy; label: string }> = [
@@ -167,6 +169,10 @@ export default function Usage() {
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [autoRefreshMs, setAutoRefreshMs] = useState<AutoRefreshMs>(0);
   const [pageVisible, setPageVisible] = useState(() => (typeof document === 'undefined' ? true : document.visibilityState === 'visible'));
+  const { data: spendFeatureStatus } = useApi<SpendFeatureStatus | null>(
+    () => (tab === 'logs' ? spend.featureStatus() : Promise.resolve(null)),
+    [tab],
+  );
   const spendPageSize = 5;
   const logsPageSize = 25;
   const activeControllerRef = useRef<AbortController | null>(null);
@@ -515,6 +521,20 @@ export default function Usage() {
           title="Request Logs"
           action={<span className="text-xs text-gray-500">Click a row for details</span>}
         >
+          {spendFeatureStatus?.cache_enabled === false && (
+            <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+              <div className="flex items-start gap-3">
+                <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+                <div>
+                  <p className="font-medium">Cache is disabled.</p>
+                  <p className="mt-1 text-amber-800">
+                    New requests are expected to appear as <code className="rounded bg-amber-100 px-1 py-0.5 text-xs">Miss</code> in the{' '}
+                    <code className="rounded bg-amber-100 px-1 py-0.5 text-xs">Cache</code> column while caching is off.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
           <DataTable
             columns={logColumns}
             data={logs || []}


### PR DESCRIPTION
## Summary

This PR adds explicit UI warnings when feature-dependent views are available but the underlying feature is disabled.

- adds a Batch Jobs warning when `general_settings.embeddings_batch_enabled` is `false`
- adds a Request Logs warning when `general_settings.cache_enabled` is `false`
- adds small feature-status endpoints so the UI can read those flags with the same permission model as each page
- adds backend tests covering both new status endpoints

## Why

Two UX issues were confusing in the admin UI:

- the Batch Jobs page could be visible even when embeddings batch APIs were disabled
- the Usage page showed the `Cache` column without telling users that caching was disabled, so `Miss` values could be misread as a malfunction rather than expected behavior

Per the latest clarification on `#54`, this keeps caching disabled by default and adds the warning in Usage instead of enabling caching by default.

## Validation

- `uv run pytest tests/test_ui_authorization.py tests/test_embeddings_batch.py`
- `uv run pytest tests/test_ui_rbac_scoping.py`
- `npm run build` in `ui/`

Closes #79
Closes #54