### PR TITLE
Format large dashboard numbers with K/M/B suffixes

### DIFF
--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,0 +1,28 @@
+/**
+ * Format a number using compact notation (K, M, B) for large values.
+ * Numbers below 1,000 are returned as-is with locale formatting.
+ */
+export function fmtCompact(n: number | null | undefined): string {
+  if (n == null) return '0';
+  const v = Number(n);
+  const tiers: [number, string][] = [
+    [1_000_000_000, 'B'],
+    [1_000_000, 'M'],
+    [1_000, 'K'],
+  ];
+  for (let i = 0; i < tiers.length; i++) {
+    const [threshold, suffix] = tiers[i];
+    if (v >= threshold) {
+      const scaled = v / threshold;
+      const decimals = scaled >= 100 ? 0 : 1;
+      const rounded = Number(scaled.toFixed(decimals));
+      if (rounded >= 1000 && i > 0) {
+        const [upperThreshold, upperSuffix] = tiers[i - 1];
+        const upperScaled = v / upperThreshold;
+        return `${upperScaled.toFixed(1).replace(/\.0$/, '')}${upperSuffix}`;
+      }
+      return `${scaled.toFixed(decimals).replace(/\.0$/, '')}${suffix}`;
+    }
+  }
+  return v.toLocaleString();
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useApi } from '../lib/hooks';
 import { spend, models as modelsApi, keys as keysApi, health, type ProviderHealthStatus } from '../lib/api';
+import { fmtCompact } from '../lib/format';
 import { providerDisplayName } from '../lib/providers';
 import {
   DollarSign,
@@ -38,11 +39,6 @@ function fmtDollar(n: number | null | undefined): string {
 function fmtDollarPrecise(n: number | null | undefined): string {
   if (n == null) return '$0.0000';
   return `$${Number(n).toFixed(4)}`;
-}
-
-function fmtNum(n: number | null | undefined): string {
-  if (n == null) return '0';
-  return Number(n).toLocaleString();
 }
 
 interface ProviderAgg {
@@ -111,7 +107,7 @@ export default function Dashboard() {
             <div>
               <p className="text-sm font-medium text-gray-500">Total Spend</p>
               <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtDollar(summary?.total_spend)}</p>
-              <p className="mt-1 text-xs text-gray-500">{fmtNum(summary?.total_tokens)} tokens used</p>
+              <p className="mt-1 text-xs text-gray-500">{fmtCompact(summary?.total_tokens)} tokens used</p>
             </div>
           </div>
 
@@ -121,8 +117,8 @@ export default function Dashboard() {
             </div>
             <div>
               <p className="text-sm font-medium text-gray-500">Total Requests</p>
-              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(totalRequests)}</p>
-              <p className={`mt-1 text-xs font-medium ${failedRequests > 0 ? 'text-red-500' : 'text-gray-400'}`}>{fmtNum(failedRequests)} failed</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtCompact(totalRequests)}</p>
+              <p className={`mt-1 text-xs font-medium ${failedRequests > 0 ? 'text-red-500' : 'text-gray-400'}`}>{fmtCompact(failedRequests)} failed</p>
             </div>
           </div>
 
@@ -132,7 +128,7 @@ export default function Dashboard() {
             </div>
             <div>
               <p className="text-sm font-medium text-gray-500">Active Keys</p>
-              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(keysResult?.pagination?.total ?? keysResult?.data?.length)}</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtCompact(keysResult?.pagination?.total ?? keysResult?.data?.length)}</p>
             </div>
           </div>
 
@@ -142,7 +138,7 @@ export default function Dashboard() {
             </div>
             <div>
               <p className="text-sm font-medium text-gray-500">Models</p>
-              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtNum(totalModels)}</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtCompact(totalModels)}</p>
             </div>
           </div>
 
@@ -277,14 +273,14 @@ export default function Dashboard() {
 
           <div className="flex items-center gap-1.5 text-gray-600">
             <Database className="h-4 w-4 text-gray-400" />
-            <span>{fmtNum(totalModels)} Model{totalModels !== 1 ? 's' : ''} Deployed</span>
+            <span>{fmtCompact(totalModels)} Model{totalModels !== 1 ? 's' : ''} Deployed</span>
           </div>
 
           <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
 
           <div className="flex items-center gap-1.5 text-gray-600">
             <TrendingUp className="h-4 w-4 text-gray-400" />
-            <span>{fmtNum(totalRequests)} Total Requests</span>
+            <span>{fmtCompact(totalRequests)} Total Requests</span>
           </div>
         </div>
 

--- a/ui/src/pages/Usage.tsx
+++ b/ui/src/pages/Usage.tsx
@@ -14,6 +14,7 @@ import { useApi } from '../lib/hooks';
 import Card from '../components/Card';
 import DataTable from '../components/DataTable';
 import StatCard from '../components/StatCard';
+import { fmtCompact } from '../lib/format';
 import Modal from '../components/Modal';
 import { DollarSign, LoaderCircle, Zap, Hash, Calendar, Info } from 'lucide-react';
 import { XAxis, YAxis, Tooltip, ResponsiveContainer, AreaChart, Area } from 'recharts';
@@ -376,8 +377,8 @@ export default function Usage() {
       render: (row: SpendGroupRow) => renderSpendGroupValue(spendBy, row),
     },
     { key: 'total_spend', header: 'Spend', render: (r: any) => fmt(r.total_spend) },
-    { key: 'total_tokens', header: 'Tokens', render: (r: any) => fmtNum(r.total_tokens) },
-    { key: 'request_count', header: 'Requests', render: (r: any) => fmtNum(r.request_count) },
+    { key: 'total_tokens', header: 'Tokens', render: (r: any) => fmtCompact(r.total_tokens) },
+    { key: 'request_count', header: 'Requests', render: (r: any) => fmtCompact(r.request_count) },
   ];
 
   const logColumns = [
@@ -386,9 +387,9 @@ export default function Usage() {
     { key: 'call_type', header: 'Type', render: (r: SpendLog) => <span className="text-xs capitalize">{r.call_type}</span> },
     { key: 'status', header: 'Status', render: (r: SpendLog) => <StatusBadge status={logStatus(r)} /> },
     { key: 'spend', header: 'Cost', render: (r: SpendLog) => fmt(r.spend) },
-    { key: 'prompt_tokens', header: 'Prompt', render: (r: SpendLog) => fmtNum(r.prompt_tokens) },
-    { key: 'completion_tokens', header: 'Completion', render: (r: SpendLog) => fmtNum(r.completion_tokens) },
-    { key: 'prompt_tokens_cached', header: 'Cached Prompt', render: (r: SpendLog) => fmtNum(r.prompt_tokens_cached) },
+    { key: 'prompt_tokens', header: 'Prompt', render: (r: SpendLog) => fmtCompact(r.prompt_tokens) },
+    { key: 'completion_tokens', header: 'Completion', render: (r: SpendLog) => fmtCompact(r.completion_tokens) },
+    { key: 'prompt_tokens_cached', header: 'Cached Prompt', render: (r: SpendLog) => fmtCompact(r.prompt_tokens_cached) },
     { key: 'team_id', header: 'Team', render: (r: SpendLog) => <span className="text-xs">{r.team_id || '—'}</span> },
     { key: 'cache_hit', header: 'Cache', render: (r: SpendLog) => r.cache_hit ? <span className="text-green-600 text-xs">Hit</span> : <span className="text-gray-400 text-xs">Miss</span> },
   ];
@@ -402,9 +403,9 @@ export default function Usage() {
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <StatCard title="Total Spend" value={fmt(summary?.total_spend)} icon={<DollarSign className="w-5 h-5" />} />
-        <StatCard title="Total Tokens" value={fmtNum(summary?.total_tokens)} icon={<Hash className="w-5 h-5" />} />
-        <StatCard title="Total Requests" value={fmtNum(summary?.total_requests)} icon={<Zap className="w-5 h-5" />} />
-        <StatCard title="Unique Models" value={fmtNum(summary?.unique_models)} icon={<Calendar className="w-5 h-5" />} />
+        <StatCard title="Total Tokens" value={fmtCompact(summary?.total_tokens)} icon={<Hash className="w-5 h-5" />} />
+        <StatCard title="Total Requests" value={fmtCompact(summary?.total_requests)} icon={<Zap className="w-5 h-5" />} />
+        <StatCard title="Unique Models" value={fmtCompact(summary?.unique_models)} icon={<Calendar className="w-5 h-5" />} />
       </div>
 
       <div className="mb-6 flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">


### PR DESCRIPTION
## Summary
- Adds a shared `fmtCompact` utility (`ui/src/lib/format.ts`) that formats numbers ≥ 1K with compact suffixes (e.g. `1,234,567` → `1.2M`)
- Applies compact formatting to token counts, request counts, and similar metrics in both the Dashboard and Usage pages
- Replaces the previous `toLocaleString()` formatting which displayed raw numbers

## Test plan
- [ ] Verify Dashboard stat cards show K/M/B suffixes for large token and request counts
- [ ] Verify Usage page stat cards (Total Tokens, Total Requests, Unique Models) use compact format
- [ ] Verify Usage table columns (Tokens, Requests, Prompt, Completion, Cached) use compact format
- [ ] Verify small numbers (< 1,000) still display normally
- [ ] Verify the request log detail modal shows compact token counts

Closes #83