### PR TITLE
Cut over public batch create to create sessions

### DIFF
--- a/docs/internal/20260413-batch-create-session-pr4-plan.md
+++ b/docs/internal/20260413-batch-create-session-pr4-plan.md
@@ -57,6 +57,34 @@ Out of scope for PR 4:
 3. Removal of staged repair worker.
 4. UI changes.
 
+## Review Discipline
+
+PR 4 must follow the shared review checklist in:
+
+- [`20260413-batch-create-session-review-checklist.md`](20260413-batch-create-session-review-checklist.md)
+
+PR-specific invariants:
+
+1. Public batch-create success responses remain normal batch objects.
+2. With cutover enabled, new jobs are created directly as `queued`; the public path must not create `preparing` or `validating` jobs.
+3. `Idempotency-Key` resolution must not use a namespace broader than the caller's real access boundary.
+4. Idempotent payload mismatch returns `409` without creating a second session or batch.
+5. New requests rejected for a full pending scope must fail before staged artifact or create-session persistence.
+6. The promoter soft precheck stays advisory; only the promoter's authoritative path may mutate durable promotion state.
+6. The old batch-create path remains available when the create-session service is not bound.
+7. Audit events for `/v1/batches` include whether an idempotency key was present and whether the request used the create-session path.
+
+Failure-mode pass for PR 4:
+
+1. Matching idempotent retry after the original input file is no longer readable.
+2. Same key with mismatched metadata.
+3. Same key with a permanently failed session.
+4. Same organization, different teams, same `Idempotency-Key`.
+5. Early public capacity rejection after cutover.
+6. Promotion-time capacity rejection after cutover.
+5. Storage read failure while validating the uploaded batch input.
+6. Rollback path with create-session cutover disabled.
+
 ## Design Decisions
 
 ### 1. Keep public response contract stable
@@ -74,9 +102,14 @@ Recommended behavior:
 
 Scope key recommendation:
 
-1. organization id if present
-2. else team id
+1. team id if present
+2. else organization id if present
 3. else api key
+
+Pending-cap and scheduling scope recommendation:
+
+1. team id if present
+2. else api key
 
 ### 3. Soft precheck remains advisory
 
@@ -120,15 +153,18 @@ Implementation:
 - `src/models/requests.py` only if request metadata or helper types need small changes
 - `src/batch/service.py`
 - `src/batch/create/service.py`
+- `src/batch/create/__init__.py`
 - `src/batch/create/session_repository.py`
 - `src/batch/create/promoter.py`
-- `src/routers/audit_helpers.py` or related audit helpers if extra metadata is emitted
+- `src/bootstrap/batch.py`
 
 Tests:
 
+- `tests/test_batch_create_service.py`
 - `tests/test_batch_service.py`
 - `tests/test_batch_db_integration.py`
-- request/audit tests if present for public batch endpoints
+- `tests/test_data_plane_audit_extended.py`
+- `tests/bootstrap/test_optional_bootstrap.py`
 
 ## Test Plan
 
@@ -140,6 +176,10 @@ Required:
 4. Payload mismatch under same idempotency key returns `409`.
 5. Promotion failure returns correct client-visible error without creating a partial batch.
 6. Existing old-path behavior still works when the flag is off.
+7. Matching idempotent retry can resolve an existing session before reloading the input file.
+8. Audit coverage records `idempotency_key_present` and the create-path outcome.
+9. Different teams in the same organization do not collide on the same `Idempotency-Key`.
+10. Full pending scope returns `429` before staged artifact or create-session persistence for new requests.
 
 ## Acceptance Criteria
 
@@ -149,6 +189,8 @@ PR 4 is complete when:
 2. New jobs are born `queued`, not `preparing` / `validating`.
 3. Idempotent retry is supported when requested.
 4. Rollback to the old path is still possible by config.
+5. The focused PR4 validation slice passes on unit tests, and DB-backed cutover tests exist for environments with Postgres available.
+6. Cross-team org callers do not share an idempotency namespace.
 
 ## Risks
 
@@ -167,3 +209,27 @@ Mitigation:
 ## Deliverable Summary
 
 PR 4 should turn live create traffic onto the new architecture without yet deleting the fallback.
+
+## Implementation Status
+
+Implemented in this branch:
+
+1. `BatchService` delegates public create requests to `src/batch/create/service.py` when the create-session service is bound.
+2. `/v1/batches` forwards `Idempotency-Key` and emits cutover-aware audit metadata.
+3. Bootstrap wires `BatchCreateSessionService` behind `embeddings_batch_create_sessions_enabled`.
+4. Focused unit and audit tests cover the cutover path.
+5. DB-backed cutover tests cover queued-job creation, idempotent retry reuse, and idempotency mismatch rejection.
+6. Shared batch-scope helpers keep idempotency and pending-cap semantics aligned across the public service, legacy service, and promoter.
+7. The public cutover path restores the cheap pending-cap reject before staged artifact creation.
+
+Validation currently run in this worktree:
+
+1. `tests/test_batch_service.py`
+2. `tests/test_batch_create_service.py`
+3. `tests/test_data_plane_audit_extended.py`
+4. `tests/bootstrap/test_optional_bootstrap.py`
+5. Targeted PR4 DB-backed cutover tests in `tests/test_batch_db_integration.py`
+
+Note:
+
+- the DB-backed PR4 tests are present and collect cleanly, but they skip locally unless `DATABASE_URL` points to a live Postgres instance.

--- a/src/api/v1/endpoints/batches.py
+++ b/src/api/v1/endpoints/batches.py
@@ -27,15 +27,30 @@ async def create_batch(request: Request, payload: dict[str, Any]):
     endpoint = str(payload.get("endpoint") or "").strip()
     completion_window = payload.get("completion_window")
     metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else None
+    idempotency_key = str(request.headers.get("Idempotency-Key") or "").strip() or None
     try:
         service = _batch_service_or_404(request)
-        created = await service.create_embeddings_batch(
-            auth=auth,
-            input_file_id=input_file_id,
-            endpoint=endpoint,
-            metadata=metadata,
-            completion_window=completion_window,
-        )
+        audit_metadata = {"route": request.url.path, "idempotency_key_present": bool(idempotency_key)}
+        if hasattr(service, "create_embeddings_batch_result"):
+            result = await service.create_embeddings_batch_result(
+                auth=auth,
+                input_file_id=input_file_id,
+                endpoint=endpoint,
+                metadata=metadata,
+                completion_window=completion_window,
+                idempotency_key=idempotency_key,
+            )
+            created = result.response
+            audit_metadata.update(result.audit_metadata)
+        else:
+            created = await service.create_embeddings_batch(
+                auth=auth,
+                input_file_id=input_file_id,
+                endpoint=endpoint,
+                metadata=metadata,
+                completion_window=completion_window,
+                idempotency_key=idempotency_key,
+            )
         emit_audit_event(
             request=request,
             request_start=request_start,
@@ -47,9 +62,15 @@ async def create_batch(request: Request, payload: dict[str, Any]):
             api_key=auth.api_key,
             resource_type="batch",
             resource_id=created.get("id") if isinstance(created, dict) else None,
-            request_payload={"input_file_id": input_file_id, "endpoint": endpoint, "completion_window": completion_window, "metadata": metadata},
+            request_payload={
+                "input_file_id": input_file_id,
+                "endpoint": endpoint,
+                "completion_window": completion_window,
+                "metadata": metadata,
+                "idempotency_key_present": bool(idempotency_key),
+            },
             response_payload=created if isinstance(created, dict) else None,
-            metadata={"route": request.url.path},
+            metadata=audit_metadata,
         )
         return created
     except Exception as exc:
@@ -63,9 +84,15 @@ async def create_batch(request: Request, payload: dict[str, Any]):
             organization_id=getattr(auth, "organization_id", None),
             api_key=auth.api_key,
             resource_type="batch",
-            request_payload={"input_file_id": input_file_id, "endpoint": endpoint, "completion_window": completion_window, "metadata": metadata},
+            request_payload={
+                "input_file_id": input_file_id,
+                "endpoint": endpoint,
+                "completion_window": completion_window,
+                "metadata": metadata,
+                "idempotency_key_present": bool(idempotency_key),
+            },
             error=exc,
-            metadata={"route": request.url.path},
+            metadata={"route": request.url.path, "idempotency_key_present": bool(idempotency_key)},
         )
         raise
 

--- a/src/batch/create/promoter.py
+++ b/src/batch/create/promoter.py
@@ -13,6 +13,7 @@ from src.batch.create.defaults import (
     DEFAULT_CREATE_SESSION_PROMOTION_TX_TIMEOUT_SECONDS,
 )
 from src.batch.create.models import BatchCreateSessionRecord, BatchCreateSessionStatus
+from src.batch.scopes import batch_pending_scope_target_for_session
 from src.batch.create.staging import BatchCreateStagingBackend, staged_artifact_from_session
 from src.batch.models import BatchItemCreate, BatchJobRecord, BatchJobStatus
 from src.batch.storage import BatchArtifactLineTooLongError
@@ -321,11 +322,7 @@ class BatchCreateSessionPromoter:
         self,
         session: BatchCreateSessionRecord,
     ) -> tuple[str, str, str | None, str | None] | None:
-        if session.created_by_team_id:
-            return ("team", session.created_by_team_id, None, session.created_by_team_id)
-        if session.created_by_api_key:
-            return ("api_key", session.created_by_api_key, session.created_by_api_key, None)
-        return None
+        return batch_pending_scope_target_for_session(session)
 
     async def _precheck_pending_capacity(self, session: BatchCreateSessionRecord) -> None:
         if not self.soft_precheck_enabled or self.max_pending_batches_per_scope <= 0:

--- a/src/batch/create/service.py
+++ b/src/batch/create/service.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, AsyncIterator
+from uuid import uuid4
+
+from fastapi import HTTPException, status
+
+from src.batch.access import can_access_owned_resource
+from src.batch.create.models import (
+    BatchCreateSessionCreate,
+    BatchCreateSessionRecord,
+    BatchCreateSessionStatus,
+    BatchCreateStagedRequest,
+)
+from src.batch.create.promoter import BatchCreatePromotionError, BatchCreateSessionPromoter
+from src.batch.create.session_repository import BatchCreateSessionRepository
+from src.batch.create.session_stager import BatchCreateSessionStager
+from src.batch.models import BatchJobRecord
+from src.batch.repository import BatchRepository
+from src.batch.scopes import (
+    batch_idempotency_scope_key,
+    batch_pending_scope_key_for_auth,
+    batch_pending_scope_target_for_auth,
+)
+from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorage
+from src.models.requests import EmbeddingRequest
+from src.models.responses import UserAPIKeyAuth
+from src.services.callable_target_grants import CallableTargetGrantService
+from src.services.model_visibility import CallableTargetPolicyMode, ensure_batch_model_allowed
+from src.metrics import increment_batch_artifact_failure
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BatchCreateSessionServiceResult:
+    job: BatchJobRecord
+    audit_metadata: dict[str, Any]
+
+
+class BatchCreateSessionService:
+    def __init__(
+        self,
+        *,
+        repository: BatchRepository,
+        create_session_repository: BatchCreateSessionRepository,
+        stager: BatchCreateSessionStager,
+        promoter: BatchCreateSessionPromoter,
+        storage_registry: dict[str, BatchArtifactStorage],
+        max_file_bytes: int,
+        max_items_per_batch: int,
+        max_line_bytes: int,
+        storage_chunk_size: int,
+        max_pending_batches_per_scope: int = 20,
+        callable_target_grant_service: CallableTargetGrantService | None = None,
+        callable_target_scope_policy_mode: CallableTargetPolicyMode | str = "enforce",
+        idempotency_enabled: bool = False,
+    ) -> None:
+        self.repository = repository
+        self.create_sessions = create_session_repository
+        self.stager = stager
+        self.promoter = promoter
+        self.storage_registry = {
+            str(key).strip().lower(): value
+            for key, value in (storage_registry or {}).items()
+        }
+        self.max_file_bytes = max(1, int(max_file_bytes))
+        self.max_items_per_batch = max(1, int(max_items_per_batch))
+        self.max_line_bytes = max(1, int(max_line_bytes))
+        self.storage_chunk_size = max(1, int(storage_chunk_size))
+        self.max_pending_batches_per_scope = max(0, int(max_pending_batches_per_scope))
+        self.callable_target_grant_service = callable_target_grant_service
+        self.callable_target_scope_policy_mode = callable_target_scope_policy_mode
+        self.idempotency_enabled = bool(idempotency_enabled)
+
+    async def create_embeddings_batch(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        input_file_id: str,
+        endpoint: str,
+        metadata: dict[str, Any] | None,
+        completion_window: str | None,
+        idempotency_key: str | None = None,
+    ) -> BatchCreateSessionServiceResult:
+        del completion_window
+        if endpoint != "/v1/embeddings":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only /v1/embeddings is supported")
+
+        normalized_metadata = self._normalize_metadata(metadata)
+        idem_scope_key, idem_key = self._idempotency_pair(auth=auth, idempotency_key=idempotency_key)
+
+        if idem_scope_key is not None and idem_key is not None:
+            existing = await self.create_sessions.get_session_by_idempotency_key(
+                idempotency_scope_key=idem_scope_key,
+                idempotency_key=idem_key,
+            )
+            if existing is not None:
+                return await self._resolve_existing_session(
+                    existing,
+                    auth=auth,
+                    input_file_id=input_file_id,
+                    endpoint=endpoint,
+                    metadata=normalized_metadata,
+                    resolution="existing",
+                    idempotency_key_present=True,
+                )
+
+        file_record = await self._load_authorized_input_file(auth=auth, input_file_id=input_file_id)
+        await self._precheck_pending_batch_capacity(auth=auth)
+
+        try:
+            created_session = await self._stage_new_session(
+                auth=auth,
+                file_record=file_record,
+                endpoint=endpoint,
+                metadata=normalized_metadata,
+                idempotency_scope_key=idem_scope_key,
+                idempotency_key=idem_key,
+            )
+        except Exception:
+            if idem_scope_key is not None and idem_key is not None:
+                raced = await self.create_sessions.get_session_by_idempotency_key(
+                    idempotency_scope_key=idem_scope_key,
+                    idempotency_key=idem_key,
+                )
+                if raced is not None:
+                    return await self._resolve_existing_session(
+                        raced,
+                        auth=auth,
+                        input_file_id=input_file_id,
+                        endpoint=endpoint,
+                        metadata=normalized_metadata,
+                        resolution="race_resolved",
+                        idempotency_key_present=True,
+                    )
+            raise
+
+        return await self._promote_session_result(
+            created_session,
+            resolution="created",
+            idempotency_key_present=idem_key is not None,
+        )
+
+    async def _stage_new_session(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        file_record: Any,
+        endpoint: str,
+        metadata: dict[str, Any] | None,
+        idempotency_scope_key: str | None,
+        idempotency_key: str | None,
+    ) -> BatchCreateSessionRecord:
+        storage = self._storage_for_backend(file_record.storage_backend)
+        seen_custom_ids: set[str] = set()
+        inferred_model: str | None = None
+        expected_item_count = 0
+
+        async def _records() -> AsyncIterator[BatchCreateStagedRequest]:
+            nonlocal expected_item_count, inferred_model
+            async for line_number, raw_line in self._iter_storage_lines(storage=storage, storage_key=file_record.storage_key):
+                item, model = self._parse_input_line(
+                    raw_line,
+                    line_number=line_number,
+                    endpoint=endpoint,
+                    auth=auth,
+                    seen_custom_ids=seen_custom_ids,
+                )
+                if item is None:
+                    continue
+                expected_item_count += 1
+                if expected_item_count > self.max_items_per_batch:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Batch exceeds embeddings_batch_max_items_per_batch ({self.max_items_per_batch})",
+                    )
+                inferred_model = inferred_model or model
+                yield BatchCreateStagedRequest(
+                    line_number=item.line_number,
+                    custom_id=item.custom_id,
+                    request_body=item.request_body,
+                )
+
+        def _build_session(artifact) -> BatchCreateSessionCreate:  # noqa: ANN001
+            if expected_item_count <= 0:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid batch items found in file")
+            return BatchCreateSessionCreate(
+                target_batch_id=str(uuid4()),
+                endpoint=endpoint,
+                input_file_id=file_record.file_id,
+                staged_storage_backend=artifact.storage_backend,
+                staged_storage_key=artifact.storage_key,
+                staged_checksum=artifact.checksum,
+                staged_bytes=artifact.bytes_size,
+                expected_item_count=expected_item_count,
+                inferred_model=inferred_model,
+                metadata=metadata,
+                scheduling_scope_key=self._session_scope_key(auth),
+                priority_quota_scope_key=self._session_scope_key(auth),
+                idempotency_scope_key=idempotency_scope_key,
+                idempotency_key=idempotency_key,
+                created_by_api_key=auth.api_key,
+                created_by_user_id=auth.user_id,
+                created_by_team_id=auth.team_id,
+                created_by_organization_id=auth.organization_id,
+            )
+
+        return await self.stager.stage_session(
+            records=_records(),
+            filename=getattr(file_record, "filename", None) or "batch.jsonl",
+            build_session=_build_session,
+        )
+
+    async def _resolve_existing_session(
+        self,
+        session: BatchCreateSessionRecord,
+        *,
+        auth: UserAPIKeyAuth,
+        input_file_id: str,
+        endpoint: str,
+        metadata: dict[str, Any] | None,
+        resolution: str,
+        idempotency_key_present: bool,
+    ) -> BatchCreateSessionServiceResult:
+        if not can_access_owned_resource(
+            owner_api_key=session.created_by_api_key,
+            owner_team_id=session.created_by_team_id,
+            owner_organization_id=session.created_by_organization_id,
+            auth=auth,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Idempotency-Key conflicts with an existing batch create request",
+            )
+        if not self._request_matches_session(
+            session,
+            input_file_id=input_file_id,
+            endpoint=endpoint,
+            metadata=metadata,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Idempotency-Key conflicts with an existing batch create request",
+            )
+
+        if session.status == BatchCreateSessionStatus.FAILED_PERMANENT:
+            raise self._http_exception_for_promotion_error(
+                BatchCreatePromotionError(
+                    session.last_error_message or "Batch create session failed permanently",
+                    code=session.last_error_code or "promotion_failed",
+                    retryable=False,
+                )
+            )
+        if session.status == BatchCreateSessionStatus.EXPIRED:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Idempotency-Key refers to an expired batch create session",
+            )
+        return await self._promote_session_result(
+            session,
+            resolution=resolution,
+            idempotency_key_present=idempotency_key_present,
+        )
+
+    async def _promote_session_result(
+        self,
+        session: BatchCreateSessionRecord,
+        *,
+        resolution: str,
+        idempotency_key_present: bool,
+    ) -> BatchCreateSessionServiceResult:
+        try:
+            promotion = await self.promoter.promote_session(session.session_id)
+        except BatchCreatePromotionError as exc:
+            raise self._http_exception_for_promotion_error(exc) from exc
+
+        job = promotion.job
+        if job is None:
+            job = await self.repository.get_job(promotion.batch_id)
+        if job is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"Batch '{promotion.batch_id}' was not available after promotion",
+            )
+        return BatchCreateSessionServiceResult(
+            job=job,
+            audit_metadata={
+                "create_path": "create_session",
+                "create_session_id": session.session_id,
+                "idempotency_key_present": idempotency_key_present,
+                "idempotency_resolution": resolution if idempotency_key_present else "not_requested",
+                "promotion_result": "promoted" if promotion.promoted else "existing_batch",
+            },
+        )
+
+    async def _load_authorized_input_file(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        input_file_id: str,
+    ) -> Any:
+        file_record = await self.repository.get_file(input_file_id)
+        if file_record is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Input file not found")
+        if not can_access_owned_resource(
+            owner_api_key=file_record.created_by_api_key,
+            owner_team_id=file_record.created_by_team_id,
+            owner_organization_id=file_record.created_by_organization_id,
+            auth=auth,
+        ):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Input file access denied")
+        if file_record.bytes > self.max_file_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail=f"Input file exceeds embeddings_batch_max_file_bytes ({self.max_file_bytes})",
+            )
+        return file_record
+
+    async def _precheck_pending_batch_capacity(self, *, auth: UserAPIKeyAuth) -> None:
+        if self.max_pending_batches_per_scope <= 0:
+            return
+        scope = batch_pending_scope_target_for_auth(auth)
+        if scope is None:
+            return
+        _scope_type, _scope_id, created_by_api_key, created_by_team_id = scope
+        active_batches = await self.repository.count_active_jobs_for_scope(
+            created_by_api_key=created_by_api_key,
+            created_by_team_id=created_by_team_id,
+        )
+        if active_batches >= self.max_pending_batches_per_scope:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=(
+                    "Active batch count exceeds "
+                    f"embeddings_batch_max_pending_batches_per_scope ({self.max_pending_batches_per_scope})"
+                ),
+            )
+
+    def _storage_for_backend(self, backend: str | None) -> BatchArtifactStorage:
+        normalized = str(backend or "local").strip().lower()
+        storage = self.storage_registry.get(normalized)
+        if storage is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"Storage backend '{normalized}' is unavailable; keep create-session artifact storage configured until sessions expire",
+            )
+        return storage
+
+    async def _iter_storage_lines(
+        self,
+        *,
+        storage: BatchArtifactStorage,
+        storage_key: str,
+    ) -> AsyncIterator[tuple[int, str]]:
+        line_number = 0
+        try:
+            async for line in storage.iter_lines(
+                storage_key,
+                chunk_size=self.storage_chunk_size,
+                max_line_bytes=self.max_line_bytes,
+            ):
+                line_number += 1
+                yield line_number, line
+        except BatchArtifactLineTooLongError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Line {exc.line_number} exceeds embeddings_batch_max_line_bytes ({self.max_line_bytes})",
+            ) from exc
+        except Exception as exc:
+            backend = str(getattr(storage, "backend_name", "unknown") or "unknown")
+            increment_batch_artifact_failure(operation="read", backend=backend)
+            logger.warning(
+                "batch create-session input artifact read failed backend=%s storage_key=%s error=%s",
+                backend,
+                storage_key,
+                exc,
+            )
+            raise
+
+    def _parse_input_line(
+        self,
+        raw_line: str,
+        *,
+        line_number: int,
+        endpoint: str,
+        auth: UserAPIKeyAuth,
+        seen_custom_ids: set[str],
+    ):
+        line = raw_line.strip()
+        if not line:
+            return None, None
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid JSONL at line {line_number}: {exc.msg}",
+            ) from exc
+        if not isinstance(obj, dict):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must be an object")
+        custom_id = str(obj.get("custom_id") or "").strip()
+        if not custom_id:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing custom_id")
+        if custom_id in seen_custom_ids:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Duplicate custom_id at line {line_number}")
+        seen_custom_ids.add(custom_id)
+        url = str(obj.get("url") or endpoint)
+        if url != endpoint:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must target {endpoint}")
+        body = obj.get("body")
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing body")
+        validated = EmbeddingRequest.model_validate(body)
+        ensure_batch_model_allowed(
+            auth,
+            validated.model,
+            callable_target_grant_service=self.callable_target_grant_service,
+            policy_mode=self.callable_target_scope_policy_mode,
+        )
+        item = BatchCreateStagedRequest(
+            line_number=line_number,
+            custom_id=custom_id,
+            request_body=validated.model_dump(exclude_none=True),
+        )
+        return item, validated.model
+
+    def _idempotency_pair(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        idempotency_key: str | None,
+    ) -> tuple[str | None, str | None]:
+        if not self.idempotency_enabled:
+            return None, None
+        normalized_key = str(idempotency_key or "").strip() or None
+        if normalized_key is None:
+            return None, None
+        return self._idempotency_scope_key(auth), normalized_key
+
+    def _idempotency_scope_key(self, auth: UserAPIKeyAuth) -> str | None:
+        return batch_idempotency_scope_key(auth)
+
+    def _session_scope_key(self, auth: UserAPIKeyAuth) -> str | None:
+        return batch_pending_scope_key_for_auth(auth)
+
+    def _normalize_metadata(self, metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not isinstance(metadata, dict):
+            return None
+        return dict(metadata) or None
+
+    def _request_matches_session(
+        self,
+        session: BatchCreateSessionRecord,
+        *,
+        input_file_id: str,
+        endpoint: str,
+        metadata: dict[str, Any] | None,
+    ) -> bool:
+        return (
+            session.input_file_id == input_file_id
+            and session.endpoint == endpoint
+            and self._normalize_metadata(session.metadata) == self._normalize_metadata(metadata)
+        )
+
+    def _http_exception_for_promotion_error(self, exc: BatchCreatePromotionError) -> HTTPException:
+        code = str(exc.code or "promotion_failed")
+        if code == "pending_limit_exceeded":
+            return HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc))
+        if code in {"staged_artifact_invalid", "item_count_mismatch"}:
+            return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+        if code == "session_not_promotable":
+            return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+        if code == "session_not_found":
+            return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+        return HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc))

--- a/src/batch/repository.py
+++ b/src/batch/repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from src.batch.create import BatchCreateSessionRepository
+from src.batch.create.session_repository import BatchCreateSessionRepository
 from src.batch.models import (
     BatchCompletionOutboxCreate,
     BatchCompletionOutboxRecord,

--- a/src/batch/scopes.py
+++ b/src/batch/scopes.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.models.responses import UserAPIKeyAuth
+
+if TYPE_CHECKING:
+    from src.batch.create.models import BatchCreateSessionRecord
+
+
+def batch_pending_scope_target_for_auth(
+    auth: UserAPIKeyAuth,
+) -> tuple[str, str, str | None, str | None] | None:
+    if auth.team_id:
+        return ("team", auth.team_id, None, auth.team_id)
+    if auth.api_key:
+        return ("api_key", auth.api_key, auth.api_key, None)
+    return None
+
+
+def batch_pending_scope_target_for_session(
+    session: "BatchCreateSessionRecord",
+) -> tuple[str, str, str | None, str | None] | None:
+    if session.created_by_team_id:
+        return ("team", session.created_by_team_id, None, session.created_by_team_id)
+    if session.created_by_api_key:
+        return ("api_key", session.created_by_api_key, session.created_by_api_key, None)
+    return None
+
+
+def batch_pending_scope_key_for_auth(auth: UserAPIKeyAuth) -> str | None:
+    if auth.team_id:
+        return f"team:{auth.team_id}"
+    if auth.api_key:
+        return f"api_key:{auth.api_key}"
+    return None
+
+
+def batch_idempotency_scope_key(auth: UserAPIKeyAuth) -> str | None:
+    if auth.team_id:
+        return f"team:{auth.team_id}"
+    if auth.organization_id:
+        return f"organization:{auth.organization_id}"
+    if auth.api_key:
+        return f"api_key:{auth.api_key}"
+    return None

--- a/src/batch/service.py
+++ b/src/batch/service.py
@@ -4,16 +4,17 @@ import asyncio
 import json
 import logging
 import tempfile
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from time import perf_counter
-from typing import Any
-from typing import AsyncIterator
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from fastapi import HTTPException, UploadFile, status
 
 from src.batch.access import can_access_owned_resource
 from src.batch.models import BatchItemCreate, BatchJobRecord
 from src.batch.repository import BatchRepository
+from src.batch.scopes import batch_pending_scope_target_for_auth
 from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorage
 from src.metrics import (
     increment_batch_artifact_failure,
@@ -25,7 +26,16 @@ from src.models.responses import UserAPIKeyAuth
 from src.services.model_visibility import CallableTargetPolicyMode, ensure_batch_model_allowed
 from src.services.callable_target_grants import CallableTargetGrantService
 
+if TYPE_CHECKING:
+    from src.batch.create import BatchCreateSessionService
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BatchCreateResponseResult:
+    response: dict[str, Any]
+    audit_metadata: dict[str, Any]
 
 
 class BatchService:
@@ -44,6 +54,7 @@ class BatchService:
         max_pending_batches_per_scope: int = 20,
         callable_target_grant_service: CallableTargetGrantService | None = None,
         callable_target_scope_policy_mode: CallableTargetPolicyMode | str = "enforce",
+        create_session_service: "BatchCreateSessionService" | None = None,
     ) -> None:
         self.repository = repository
         self.storage = storage
@@ -62,6 +73,10 @@ class BatchService:
         self.max_pending_batches_per_scope = max_pending_batches_per_scope
         self.callable_target_grant_service = callable_target_grant_service
         self.callable_target_scope_policy_mode = callable_target_scope_policy_mode
+        self.create_session_service = create_session_service
+
+    def bind_create_session_service(self, create_session_service: "BatchCreateSessionService" | None) -> None:
+        self.create_session_service = create_session_service
 
     async def _refresh_batch_runtime_metrics(self) -> None:
         try:
@@ -82,11 +97,7 @@ class BatchService:
         return storage
 
     def _scope_limit_target(self, auth: UserAPIKeyAuth) -> tuple[str, str, str | None, str | None] | None:
-        if auth.team_id:
-            return ("team", auth.team_id, None, auth.team_id)
-        if auth.api_key:
-            return ("api_key", auth.api_key, auth.api_key, None)
-        return None
+        return batch_pending_scope_target_for_auth(auth)
 
     async def _precheck_pending_batch_capacity(self, *, auth: UserAPIKeyAuth) -> None:
         if self.max_pending_batches_per_scope <= 0:
@@ -390,6 +401,65 @@ class BatchService:
             raise
 
     async def create_embeddings_batch(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        input_file_id: str,
+        endpoint: str,
+        metadata: dict[str, Any] | None,
+        completion_window: str | None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        result = await self.create_embeddings_batch_result(
+            auth=auth,
+            input_file_id=input_file_id,
+            endpoint=endpoint,
+            metadata=metadata,
+            completion_window=completion_window,
+            idempotency_key=idempotency_key,
+        )
+        return result.response
+
+    async def create_embeddings_batch_result(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        input_file_id: str,
+        endpoint: str,
+        metadata: dict[str, Any] | None,
+        completion_window: str | None,
+        idempotency_key: str | None = None,
+    ) -> BatchCreateResponseResult:
+        if self.create_session_service is not None:
+            result = await self.create_session_service.create_embeddings_batch(
+                auth=auth,
+                input_file_id=input_file_id,
+                endpoint=endpoint,
+                metadata=metadata,
+                completion_window=completion_window,
+                idempotency_key=idempotency_key,
+            )
+            return BatchCreateResponseResult(
+                response=self.job_to_response(result.job),
+                audit_metadata=result.audit_metadata,
+            )
+        response = await self._create_embeddings_batch_legacy(
+            auth=auth,
+            input_file_id=input_file_id,
+            endpoint=endpoint,
+            metadata=metadata,
+            completion_window=completion_window,
+        )
+        return BatchCreateResponseResult(
+            response=response,
+            audit_metadata={
+                "create_path": "legacy",
+                "idempotency_key_present": bool(str(idempotency_key or "").strip()),
+                "idempotency_resolution": "disabled",
+            },
+        )
+
+    async def _create_embeddings_batch_legacy(
         self,
         *,
         auth: UserAPIKeyAuth,

--- a/src/bootstrap/batch.py
+++ b/src/bootstrap/batch.py
@@ -10,7 +10,9 @@ from typing import Any
 from src.batch import BatchCleanupConfig, BatchRetentionCleanupWorker, BatchRepository
 from src.batch.create.cleanup import BatchCreateSessionCleanupConfig, BatchCreateSessionCleanupWorker
 from src.batch.create.promoter import BatchCreateSessionPromoter
+from src.batch.create.service import BatchCreateSessionService
 from src.batch.create.session_repository import BatchCreateSessionRepository
+from src.batch.create.session_stager import BatchCreateSessionStager
 from src.batch.create.staging import BatchCreateArtifactStorageBackend
 from src.batch.completion_outbox import BatchCompletionOutboxWorker, BatchCompletionOutboxWorkerConfig
 from src.batch.service import BatchService
@@ -164,6 +166,7 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
         app.state.batch_create_session_repository = None
         app.state.batch_create_staging_backend = None
         app.state.batch_create_promoter = None
+        app.state.batch_create_session_service = None
         app.state.batch_create_session_cleanup_worker = None
         runtime.statuses = (BootstrapStatus("embeddings_batch", "disabled"),)
         return runtime
@@ -175,6 +178,7 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
     app.state.batch_create_session_repository = getattr(repository, "create_sessions", None)
     app.state.batch_create_staging_backend = None
     app.state.batch_create_promoter = None
+    app.state.batch_create_session_service = None
     app.state.batch_create_session_cleanup_worker = None
     app.state.batch_service = BatchService(
         repository=repository,
@@ -261,6 +265,27 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
             staging_backend=runtime.create_session_staging_backend,
         )
         app.state.batch_create_promoter = runtime.create_session_promoter
+        app.state.batch_create_session_service = BatchCreateSessionService(
+            repository=repository,
+            create_session_repository=session_repository,
+            stager=BatchCreateSessionStager(
+                repository=session_repository,
+                staging=runtime.create_session_staging_backend,
+            ),
+            promoter=runtime.create_session_promoter,
+            storage_registry=batch_storage_registry,
+            max_file_bytes=cfg.general_settings.embeddings_batch_max_file_bytes,
+            max_items_per_batch=cfg.general_settings.embeddings_batch_max_items_per_batch,
+            max_line_bytes=cfg.general_settings.embeddings_batch_max_line_bytes,
+            storage_chunk_size=cfg.general_settings.embeddings_batch_storage_chunk_size,
+            max_pending_batches_per_scope=cfg.general_settings.embeddings_batch_max_pending_batches_per_scope,
+            callable_target_grant_service=getattr(app.state, "callable_target_grant_service", None),
+            callable_target_scope_policy_mode=normalize_callable_target_policy_mode(
+                getattr(cfg.general_settings, "callable_target_scope_policy_mode", "enforce")
+            ),
+            idempotency_enabled=cfg.general_settings.embeddings_batch_create_idempotency_enabled,
+        )
+        app.state.batch_service.bind_create_session_service(app.state.batch_create_session_service)
 
     if (
         cfg.general_settings.embeddings_batch_create_sessions_enabled

--- a/tests/bootstrap/test_optional_bootstrap.py
+++ b/tests/bootstrap/test_optional_bootstrap.py
@@ -164,6 +164,7 @@ async def test_init_batch_runtime_disabled_sets_batch_state_to_none() -> None:
     assert app.state.batch_create_session_repository is None
     assert app.state.batch_create_staging_backend is None
     assert app.state.batch_create_promoter is None
+    assert app.state.batch_create_session_service is None
     assert app.state.batch_create_session_cleanup_worker is None
     assert runtime.worker is None
     assert runtime.gc_worker is None
@@ -202,7 +203,11 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
             self.max_pending_batches_per_scope = max_pending_batches_per_scope
             self.callable_target_grant_service = callable_target_grant_service
             self.callable_target_scope_policy_mode = callable_target_scope_policy_mode
+            self.create_session_service = None
             created["service"] = self
+
+        def bind_create_session_service(self, create_session_service) -> None:  # noqa: ANN001
+            self.create_session_service = create_session_service
 
     class FakeBatchWorker:
         def __init__(self, app, repository, storage, config) -> None:  # noqa: ANN001
@@ -270,6 +275,7 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
     assert app.state.batch_storage_registry == {"local": {"path": "/tmp/batch-artifacts"}}
     assert app.state.batch_create_session_repository == "create-session-repo"
     assert app.state.batch_create_staging_backend is None
+    assert app.state.batch_create_session_service is None
     assert app.state.batch_create_session_cleanup_worker is None
     assert isinstance(app.state.batch_service, FakeBatchService)
     assert created["service"].repository is repository
@@ -313,6 +319,10 @@ async def test_init_and_shutdown_batch_runtime_with_create_session_cleanup_worke
     class FakeBatchService:
         def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
             del args, kwargs
+            self.create_session_service = None
+
+        def bind_create_session_service(self, create_session_service) -> None:  # noqa: ANN001
+            self.create_session_service = create_session_service
 
     class FakeCompletionOutboxWorker:
         def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
@@ -386,6 +396,7 @@ async def test_init_and_shutdown_batch_runtime_with_create_session_cleanup_worke
     assert app.state.batch_create_session_repository == "create-session-repo"
     assert app.state.batch_create_staging_backend is created["staging_backend"]
     assert app.state.batch_create_promoter is created["promoter"]
+    assert app.state.batch_create_session_service is not None
     assert app.state.batch_create_session_cleanup_worker is created["cleanup_worker"]
     assert runtime.create_session_staging_backend is created["staging_backend"]
     assert runtime.create_session_promoter is created["promoter"]
@@ -430,6 +441,10 @@ async def test_init_batch_runtime_with_create_sessions_enabled_builds_staging_ba
     class FakeBatchService:
         def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
             del args, kwargs
+            self.create_session_service = None
+
+        def bind_create_session_service(self, create_session_service) -> None:  # noqa: ANN001
+            self.create_session_service = create_session_service
 
     class FakeCompletionOutboxWorker:
         def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
@@ -487,6 +502,7 @@ async def test_init_batch_runtime_with_create_sessions_enabled_builds_staging_ba
     assert app.state.batch_create_session_repository == "create-session-repo"
     assert app.state.batch_create_staging_backend is created["staging_backend"]
     assert app.state.batch_create_promoter is created["promoter"]
+    assert app.state.batch_create_session_service is not None
     assert app.state.batch_create_session_cleanup_worker is None
     assert runtime.create_session_staging_backend is created["staging_backend"]
     assert runtime.create_session_promoter is created["promoter"]

--- a/tests/test_batch_create_service.py
+++ b/tests/test_batch_create_service.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from src.batch.create import (
+    BatchCreatePromotionResult,
+    BatchCreateSessionRecord,
+    BatchCreateSessionStatus,
+)
+from src.batch.create.service import BatchCreateSessionService, BatchCreateSessionServiceResult
+from src.batch.models import BatchJobRecord, BatchJobStatus
+from src.batch.service import BatchService
+from src.models.responses import UserAPIKeyAuth
+
+
+def _job(*, batch_id: str = "batch-1") -> BatchJobRecord:
+    now = datetime.now(tz=UTC)
+    return BatchJobRecord(
+        batch_id=batch_id,
+        endpoint="/v1/embeddings",
+        status=BatchJobStatus.QUEUED,
+        execution_mode="managed_internal",
+        input_file_id="file-1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m1",
+        metadata=None,
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=0,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="key-a",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_at=now,
+        started_at=None,
+        completed_at=None,
+        expires_at=None,
+        created_by_organization_id=None,
+    )
+
+
+def _session(
+    *,
+    status: str = BatchCreateSessionStatus.COMPLETED,
+    input_file_id: str = "file-1",
+    metadata: dict | None = None,
+) -> BatchCreateSessionRecord:
+    now = datetime.now(tz=UTC)
+    return BatchCreateSessionRecord(
+        session_id="session-1",
+        target_batch_id="batch-1",
+        status=status,
+        endpoint="/v1/embeddings",
+        input_file_id=input_file_id,
+        staged_storage_backend="local",
+        staged_storage_key="batch-create-stage/session-1.jsonl",
+        staged_checksum="abc",
+        staged_bytes=12,
+        expected_item_count=1,
+        inferred_model="m1",
+        metadata=metadata,
+        requested_service_tier=None,
+        effective_service_tier=None,
+        service_tier_source=None,
+        scheduling_scope_key="api_key:key-a",
+        priority_quota_scope_key="api_key:key-a",
+        idempotency_scope_key="api_key:key-a",
+        idempotency_key="idem-1",
+        last_error_code=None,
+        last_error_message=None,
+        promotion_attempt_count=0,
+        created_by_api_key="key-a",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_by_organization_id=None,
+        created_at=now,
+        completed_at=now if status == BatchCreateSessionStatus.COMPLETED else None,
+        last_attempt_at=now,
+        expires_at=None,
+    )
+
+
+class _FailIfLoadedRepo:
+    def __init__(self, *, job: BatchJobRecord) -> None:
+        self._job = job
+
+    async def get_file(self, file_id: str):  # noqa: ANN201
+        raise AssertionError(f"get_file should not be called for matching idempotent retry: {file_id}")
+
+    async def get_job(self, batch_id: str):  # noqa: ANN201
+        assert batch_id == self._job.batch_id
+        return self._job
+
+
+class _PromoterStub:
+    def __init__(self, *, result: BatchCreatePromotionResult) -> None:
+        self.result = result
+        self.calls: list[str] = []
+
+    async def promote_session(self, session_id: str) -> BatchCreatePromotionResult:
+        self.calls.append(session_id)
+        return self.result
+
+
+class _NeverCalledStager:
+    async def stage_session(self, **kwargs):  # noqa: ANN003, ANN201
+        raise AssertionError("stage_session should not be called")
+
+
+@pytest.mark.asyncio
+async def test_create_session_service_resolves_matching_existing_session_before_loading_input_file() -> None:
+    existing_session = _session(status=BatchCreateSessionStatus.COMPLETED)
+    job = _job(batch_id=existing_session.target_batch_id)
+
+    async def _get_session_by_idempotency_key(**kwargs):  # noqa: ANN003, ANN201
+        del kwargs
+        return existing_session
+
+    promoter = _PromoterStub(
+        result=BatchCreatePromotionResult(
+            session_id=existing_session.session_id,
+            batch_id=job.batch_id,
+            promoted=False,
+            job=job,
+        )
+    )
+    service = BatchCreateSessionService(
+        repository=_FailIfLoadedRepo(job=job),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(
+            get_session_by_idempotency_key=_get_session_by_idempotency_key
+        ),  # type: ignore[arg-type]
+        stager=SimpleNamespace(),  # type: ignore[arg-type]
+        promoter=promoter,  # type: ignore[arg-type]
+        storage_registry={},
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+        idempotency_enabled=True,
+    )
+
+    result = await service.create_embeddings_batch(
+        auth=UserAPIKeyAuth(api_key="key-a"),
+        input_file_id="file-1",
+        endpoint="/v1/embeddings",
+        metadata=None,
+        completion_window=None,
+        idempotency_key="idem-1",
+    )
+
+    assert result.job.batch_id == "batch-1"
+    assert result.audit_metadata["idempotency_resolution"] == "existing"
+    assert promoter.calls == ["session-1"]
+
+
+@pytest.mark.asyncio
+async def test_create_session_service_rejects_mismatched_existing_idempotent_request() -> None:
+    existing_session = _session(metadata={"region": "eu"})
+
+    async def _get_session_by_idempotency_key(**kwargs):  # noqa: ANN003, ANN201
+        del kwargs
+        return existing_session
+
+    service = BatchCreateSessionService(
+        repository=SimpleNamespace(),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(
+            get_session_by_idempotency_key=_get_session_by_idempotency_key
+        ),  # type: ignore[arg-type]
+        stager=SimpleNamespace(),  # type: ignore[arg-type]
+        promoter=SimpleNamespace(),  # type: ignore[arg-type]
+        storage_registry={},
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+        idempotency_enabled=True,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_embeddings_batch(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            input_file_id="file-1",
+            endpoint="/v1/embeddings",
+            metadata={"region": "us"},
+            completion_window=None,
+            idempotency_key="idem-1",
+        )
+
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_batch_service_create_result_delegates_to_bound_create_session_service() -> None:
+    class _CreateSessionServiceStub:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        async def create_embeddings_batch(self, **kwargs):  # noqa: ANN003, ANN201
+            self.calls.append(kwargs)
+            return BatchCreateSessionServiceResult(
+                job=_job(batch_id="batch-delegated"),
+                audit_metadata={"create_path": "create_session", "idempotency_resolution": "created"},
+            )
+
+    create_session_service = _CreateSessionServiceStub()
+    batch_service = BatchService(
+        repository=SimpleNamespace(),  # type: ignore[arg-type]
+        storage=SimpleNamespace(backend_name="local"),  # type: ignore[arg-type]
+        create_session_service=create_session_service,  # type: ignore[arg-type]
+    )
+
+    result = await batch_service.create_embeddings_batch_result(
+        auth=UserAPIKeyAuth(api_key="key-a"),
+        input_file_id="file-1",
+        endpoint="/v1/embeddings",
+        metadata=None,
+        completion_window=None,
+        idempotency_key="idem-1",
+    )
+
+    assert result.response["id"] == "batch-delegated"
+    assert result.response["status"] == "queued"
+    assert result.audit_metadata["create_path"] == "create_session"
+    assert create_session_service.calls[0]["idempotency_key"] == "idem-1"
+
+
+@pytest.mark.asyncio
+async def test_create_session_service_retries_existing_permanent_failure_as_client_error() -> None:
+    existing_session = _session(status=BatchCreateSessionStatus.FAILED_PERMANENT)
+    existing_session.last_error_code = "item_count_mismatch"
+    existing_session.last_error_message = "stored mismatch"
+
+    async def _get_session_by_idempotency_key(**kwargs):  # noqa: ANN003, ANN201
+        del kwargs
+        return existing_session
+
+    service = BatchCreateSessionService(
+        repository=SimpleNamespace(),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(
+            get_session_by_idempotency_key=_get_session_by_idempotency_key
+        ),  # type: ignore[arg-type]
+        stager=SimpleNamespace(),  # type: ignore[arg-type]
+        promoter=SimpleNamespace(),  # type: ignore[arg-type]
+        storage_registry={},
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+        idempotency_enabled=True,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_embeddings_batch(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            input_file_id="file-1",
+            endpoint="/v1/embeddings",
+            metadata=None,
+            completion_window=None,
+            idempotency_key="idem-1",
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "stored mismatch"
+
+
+def test_create_session_service_uses_team_scope_for_idempotency_and_api_key_scope_for_org_only_pending_limit() -> None:
+    service = BatchCreateSessionService(
+        repository=SimpleNamespace(),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(),  # type: ignore[arg-type]
+        stager=SimpleNamespace(),  # type: ignore[arg-type]
+        promoter=SimpleNamespace(),  # type: ignore[arg-type]
+        storage_registry={},
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+        idempotency_enabled=True,
+    )
+
+    assert service._idempotency_scope_key(  # noqa: SLF001
+        UserAPIKeyAuth(api_key="key-a", team_id="team-1", organization_id="org-1")
+    ) == "team:team-1"
+    assert service._session_scope_key(  # noqa: SLF001
+        UserAPIKeyAuth(api_key="key-a", team_id="team-1", organization_id="org-1")
+    ) == "team:team-1"
+    assert service._idempotency_scope_key(  # noqa: SLF001
+        UserAPIKeyAuth(api_key="key-a", organization_id="org-1")
+    ) == "organization:org-1"
+    assert service._session_scope_key(  # noqa: SLF001
+        UserAPIKeyAuth(api_key="key-a", organization_id="org-1")
+    ) == "api_key:key-a"
+
+
+@pytest.mark.asyncio
+async def test_create_session_service_precheck_rejects_before_staging_new_request() -> None:
+    file_record = SimpleNamespace(
+        file_id="file-1",
+        created_by_api_key="key-a",
+        created_by_team_id=None,
+        created_by_organization_id=None,
+        bytes=32,
+        storage_backend="local",
+        storage_key="input/file-1.jsonl",
+    )
+
+    async def _get_session_by_idempotency_key(**kwargs):  # noqa: ANN003, ANN201
+        del kwargs
+        return None
+
+    async def _get_file(file_id: str):  # noqa: ANN201
+        assert file_id == "file-1"
+        return file_record
+
+    async def _count_active_jobs_for_scope(**kwargs):  # noqa: ANN003, ANN201
+        del kwargs
+        return 1
+
+    service = BatchCreateSessionService(
+        repository=SimpleNamespace(
+            get_file=_get_file,
+            count_active_jobs_for_scope=_count_active_jobs_for_scope,
+        ),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(
+            get_session_by_idempotency_key=_get_session_by_idempotency_key
+        ),  # type: ignore[arg-type]
+        stager=_NeverCalledStager(),  # type: ignore[arg-type]
+        promoter=SimpleNamespace(),  # type: ignore[arg-type]
+        storage_registry={"local": SimpleNamespace()},
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+        max_pending_batches_per_scope=1,
+        idempotency_enabled=True,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_embeddings_batch(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            input_file_id="file-1",
+            endpoint="/v1/embeddings",
+            metadata=None,
+            completion_window=None,
+            idempotency_key="idem-1",
+        )
+
+    assert exc.value.status_code == 429

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -18,9 +18,11 @@ from src.batch.create import (
     BatchCreateSessionCleanupWorker,
     BatchCreateSessionCreate,
     BatchCreateSessionPromoter,
+    BatchCreateSessionStatus,
     BatchCreateSessionStager,
     BatchCreateStagedRequest,
 )
+from src.batch.create.service import BatchCreateSessionService
 from src.batch.cleanup import BatchCleanupConfig, BatchRetentionCleanupWorker
 from src.batch.models import BatchCompletionOutboxCreate, BatchItemCreate
 from src.batch.models import encode_operator_failed_reason
@@ -228,6 +230,46 @@ async def _seed_staged_create_session(
     return session
 
 
+def _build_cutover_batch_service(
+    *,
+    repository: BatchRepository,
+    storage: LocalBatchArtifactStorage,
+    idempotency_enabled: bool = False,
+    max_pending_batches_per_scope: int = 20,
+) -> BatchService:
+    storage_registry = {"local": storage}
+    staging_backend = BatchCreateArtifactStorageBackend(
+        storage=storage,
+        storage_registry=storage_registry,
+    )
+    create_session_service = BatchCreateSessionService(
+        repository=repository,
+        create_session_repository=repository.create_sessions,
+        stager=BatchCreateSessionStager(
+            repository=repository.create_sessions,
+            staging=staging_backend,
+        ),
+        promoter=BatchCreateSessionPromoter(
+            repository=repository,
+            staging=staging_backend,
+            max_pending_batches_per_scope=max_pending_batches_per_scope,
+        ),
+        storage_registry=storage_registry,
+        max_file_bytes=52_428_800,
+        max_items_per_batch=10_000,
+        max_line_bytes=1_048_576,
+        storage_chunk_size=65_536,
+        idempotency_enabled=idempotency_enabled,
+    )
+    return BatchService(
+        repository=repository,
+        storage=storage,
+        storage_registry=storage_registry,
+        max_pending_batches_per_scope=max_pending_batches_per_scope,
+        create_session_service=create_session_service,
+    )
+
+
 @pytest.mark.asyncio
 async def test_db_backed_concurrent_batch_create_enforces_pending_cap(
     batch_db,
@@ -379,6 +421,285 @@ async def test_db_backed_batch_create_persists_organization_ownership(
         "created_by_team_id": None,
         "created_by_organization_id": "org-1",
     }
+
+
+@pytest.mark.asyncio
+async def test_db_backed_batch_create_cutover_returns_normal_batch_object_and_queued_job(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("src.batch.create.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+
+    repository = BatchRepository(batch_db)
+    storage = LocalBatchArtifactStorage(str(tmp_path / "cutover-artifacts"))
+    service = _build_cutover_batch_service(repository=repository, storage=storage)
+    auth = UserAPIKeyAuth(api_key="key-a")
+    input_file_id = await _create_input_file(
+        service,
+        auth=auth,
+        payload=b'{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}\n',
+    )
+
+    result = await service.create_embeddings_batch_result(
+        auth=auth,
+        input_file_id=input_file_id,
+        endpoint="/v1/embeddings",
+        metadata={"region": "eu"},
+        completion_window=None,
+    )
+
+    assert result.response["id"]
+    assert result.response["status"] == "queued"
+    assert result.audit_metadata["create_path"] == "create_session"
+    assert result.audit_metadata["idempotency_resolution"] == "not_requested"
+
+    session = await repository.create_sessions.get_session_by_target_batch_id(str(result.response["id"]))
+    assert session is not None
+    assert session.status == BatchCreateSessionStatus.COMPLETED
+
+    job_rows = await batch_db.query_raw(
+        """
+        SELECT batch_id, status, total_items
+        FROM deltallm_batch_job
+        WHERE batch_id = $1
+        """,
+        str(result.response["id"]),
+    )
+    assert len(job_rows) == 1
+    assert dict(job_rows[0])["status"] == "queued"
+    assert int(dict(job_rows[0])["total_items"]) == 1
+
+    all_job_rows = await batch_db.query_raw("SELECT status FROM deltallm_batch_job")
+    assert {str(dict(row)["status"]) for row in all_job_rows} == {"queued"}
+
+
+@pytest.mark.asyncio
+async def test_db_backed_batch_create_cutover_reuses_same_batch_for_same_idempotency_key(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("src.batch.create.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+
+    repository = BatchRepository(batch_db)
+    storage = LocalBatchArtifactStorage(str(tmp_path / "cutover-idempotent-artifacts"))
+    service = _build_cutover_batch_service(
+        repository=repository,
+        storage=storage,
+        idempotency_enabled=True,
+    )
+    auth = UserAPIKeyAuth(api_key="key-a")
+    input_file_id = await _create_input_file(
+        service,
+        auth=auth,
+        payload=b'{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}\n',
+    )
+
+    first = await service.create_embeddings_batch_result(
+        auth=auth,
+        input_file_id=input_file_id,
+        endpoint="/v1/embeddings",
+        metadata={"region": "eu"},
+        completion_window=None,
+        idempotency_key="idem-1",
+    )
+    second = await service.create_embeddings_batch_result(
+        auth=auth,
+        input_file_id=input_file_id,
+        endpoint="/v1/embeddings",
+        metadata={"region": "eu"},
+        completion_window=None,
+        idempotency_key="idem-1",
+    )
+
+    assert first.response["id"] == second.response["id"]
+    assert second.audit_metadata["idempotency_resolution"] == "existing"
+
+    session = await repository.create_sessions.get_session_by_idempotency_key(
+        idempotency_scope_key="api_key:key-a",
+        idempotency_key="idem-1",
+    )
+    assert session is not None
+    assert session.status == BatchCreateSessionStatus.COMPLETED
+    assert session.promotion_attempt_count == 1
+
+    session_rows = await batch_db.query_raw("SELECT session_id FROM deltallm_batch_create_session")
+    job_rows = await batch_db.query_raw("SELECT batch_id FROM deltallm_batch_job")
+    assert len(session_rows) == 1
+    assert len(job_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_db_backed_batch_create_cutover_rejects_idempotency_payload_mismatch(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("src.batch.create.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+
+    repository = BatchRepository(batch_db)
+    storage = LocalBatchArtifactStorage(str(tmp_path / "cutover-idempotent-mismatch-artifacts"))
+    service = _build_cutover_batch_service(
+        repository=repository,
+        storage=storage,
+        idempotency_enabled=True,
+    )
+    auth = UserAPIKeyAuth(api_key="key-a")
+    input_file_id = await _create_input_file(
+        service,
+        auth=auth,
+        payload=b'{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}\n',
+    )
+
+    first = await service.create_embeddings_batch_result(
+        auth=auth,
+        input_file_id=input_file_id,
+        endpoint="/v1/embeddings",
+        metadata={"region": "eu"},
+        completion_window=None,
+        idempotency_key="idem-1",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_embeddings_batch_result(
+            auth=auth,
+            input_file_id=input_file_id,
+            endpoint="/v1/embeddings",
+            metadata={"region": "us"},
+            completion_window=None,
+            idempotency_key="idem-1",
+        )
+
+    assert exc.value.status_code == 409
+    assert first.response["id"]
+
+    session_rows = await batch_db.query_raw("SELECT session_id FROM deltallm_batch_create_session")
+    job_rows = await batch_db.query_raw("SELECT batch_id FROM deltallm_batch_job")
+    assert len(session_rows) == 1
+    assert len(job_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_db_backed_batch_create_cutover_isolates_idempotency_by_team_within_same_org(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("src.batch.create.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+
+    repository = BatchRepository(batch_db)
+    storage = LocalBatchArtifactStorage(str(tmp_path / "cutover-team-idempotency-artifacts"))
+    service = _build_cutover_batch_service(
+        repository=repository,
+        storage=storage,
+        idempotency_enabled=True,
+    )
+    team_a_auth = UserAPIKeyAuth(api_key="key-a", team_id="team-a", organization_id="org-1")
+    team_b_auth = UserAPIKeyAuth(api_key="key-b", team_id="team-b", organization_id="org-1")
+
+    input_file_id_a = await _create_input_file(
+        service,
+        auth=team_a_auth,
+        payload=b'{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}\n',
+    )
+    input_file_id_b = await _create_input_file(
+        service,
+        auth=team_b_auth,
+        payload=b'{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}\n',
+    )
+
+    first = await service.create_embeddings_batch_result(
+        auth=team_a_auth,
+        input_file_id=input_file_id_a,
+        endpoint="/v1/embeddings",
+        metadata={"region": "eu"},
+        completion_window=None,
+        idempotency_key="shared-key",
+    )
+    second = await service.create_embeddings_batch_result(
+        auth=team_b_auth,
+        input_file_id=input_file_id_b,
+        endpoint="/v1/embeddings",
+        metadata={"region": "eu"},
+        completion_window=None,
+        idempotency_key="shared-key",
+    )
+
+    assert first.response["id"] != second.response["id"]
+
+    session_rows = await batch_db.query_raw(
+        """
+        SELECT idempotency_scope_key, target_batch_id
+        FROM deltallm_batch_create_session
+        ORDER BY idempotency_scope_key ASC
+        """
+    )
+    assert [dict(row) for row in session_rows] == [
+        {"idempotency_scope_key": "team:team-a", "target_batch_id": str(first.response["id"])},
+        {"idempotency_scope_key": "team:team-b", "target_batch_id": str(second.response["id"])},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_db_backed_batch_create_cutover_precheck_rejects_before_session_staging(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("src.batch.create.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+
+    repository = BatchRepository(batch_db)
+    storage_root = tmp_path / "cutover-precheck-artifacts"
+    storage = LocalBatchArtifactStorage(str(storage_root))
+    service = _build_cutover_batch_service(
+        repository=repository,
+        storage=storage,
+        max_pending_batches_per_scope=1,
+    )
+    auth = UserAPIKeyAuth(api_key="key-a")
+
+    existing_input_file_id = await _seed_batch_file(repository)
+    existing_job = await repository.create_job(
+        batch_id="existing-batch",
+        endpoint="/v1/embeddings",
+        input_file_id=existing_input_file_id,
+        model="m1",
+        metadata=None,
+        created_by_api_key="key-a",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_by_organization_id=None,
+        execution_mode="managed_internal",
+        status="queued",
+        total_items=1,
+    )
+    assert existing_job is not None
+
+    input_file_id = await _create_input_file(
+        service,
+        auth=auth,
+        payload=b'{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}\n',
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_embeddings_batch_result(
+            auth=auth,
+            input_file_id=input_file_id,
+            endpoint="/v1/embeddings",
+            metadata=None,
+            completion_window=None,
+        )
+
+    assert exc.value.status_code == 429
+
+    session_rows = await batch_db.query_raw("SELECT session_id FROM deltallm_batch_create_session")
+    job_rows = await batch_db.query_raw("SELECT batch_id FROM deltallm_batch_job ORDER BY batch_id ASC")
+    assert session_rows == []
+    assert [dict(row) for row in job_rows] == [{"batch_id": "existing-batch"}]
+
+    staged_paths = [path for path in storage_root.rglob("*") if "batch-create-stage" in path.parts]
+    assert staged_paths == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_data_plane_audit_extended.py
+++ b/tests/test_data_plane_audit_extended.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from types import SimpleNamespace
+from dataclasses import dataclass
 
 import httpx
 import pytest
@@ -41,6 +42,11 @@ class _FakeBatchRepository:
 
 
 class _FakeBatchService:
+    @dataclass
+    class _CreateResult:
+        response: dict
+        audit_metadata: dict
+
     async def create_file(self, auth, upload, purpose):  # noqa: ANN001, ANN201
         del auth, upload, purpose
         return {"id": "file-1", "object": "file", "status": "processed"}
@@ -55,6 +61,17 @@ class _FakeBatchService:
     async def create_embeddings_batch(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
         return {"id": "batch-1", "status": "validating"}
+
+    async def create_embeddings_batch_result(self, **kwargs):  # noqa: ANN003, ANN201
+        idempotency_key = kwargs.get("idempotency_key")
+        return self._CreateResult(
+            response={"id": "batch-1", "status": "queued"},
+            audit_metadata={
+                "create_path": "create_session",
+                "idempotency_key_present": bool(idempotency_key),
+                "idempotency_resolution": "created" if idempotency_key else "not_requested",
+            },
+        )
 
     async def get_batch(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
@@ -250,6 +267,39 @@ async def test_files_and_batches_emit_audit_success(client, test_app):
     assert "BATCH_READ_REQUEST" in actions
     assert "BATCH_LIST_REQUEST" in actions
     assert "BATCH_CANCEL_REQUEST" in actions
+    batch_create_records = [record[0] for record in audit.records if record[0].action == "BATCH_CREATE_REQUEST"]
+    assert batch_create_records
+    assert batch_create_records[-1].metadata["create_path"] == "create_session"
+    assert batch_create_records[-1].metadata["idempotency_key_present"] is False
+
+
+@pytest.mark.asyncio
+async def test_batch_create_audit_marks_idempotency_key_presence(client, test_app):
+    audit = _RecordingAuditService()
+    test_app.state.audit_service = audit
+    test_app.state.batch_service = _FakeBatchService()
+    test_app.state.batch_repository = _FakeBatchRepository()
+
+    headers = {
+        "Authorization": f"Bearer {test_app.state._test_key}",
+        "x-request-id": "req-batch-idempotency",
+        "Idempotency-Key": "idem-1",
+    }
+
+    response = await client.post(
+        "/v1/batches",
+        headers=headers,
+        json={"input_file_id": "file-1", "endpoint": "/v1/embeddings", "completion_window": "24h"},
+    )
+    assert response.status_code == 200
+
+    batch_create_records = [record[0] for record in audit.records if record[0].action == "BATCH_CREATE_REQUEST"]
+    assert batch_create_records
+    assert batch_create_records[-1].metadata["idempotency_key_present"] is True
+    assert batch_create_records[-1].metadata["idempotency_resolution"] == "created"
+    batch_create_payloads = [record[1] for record in audit.records if record[0].action == "BATCH_CREATE_REQUEST"]
+    assert batch_create_payloads
+    assert batch_create_payloads[-1][0].content_json["idempotency_key_present"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- cut over `POST /v1/batches` to the create-session path behind the existing feature flag while keeping the legacy fallback intact
- add `Idempotency-Key` handling, cutover-aware audit metadata, and shared batch scope helpers so idempotency and pending-cap semantics stay aligned
- add focused unit, audit, bootstrap, and DB-backed cutover tests for queued-job creation, idempotent reuse, mismatch rejection, team-scoped idempotency, and early precheck rejection

## Validation
- `/Users/mehditantaoui/Documents/Challenges/deltallm/.venv/bin/ruff check src/batch/scopes.py src/batch/create/service.py src/batch/create/promoter.py src/batch/service.py src/bootstrap/batch.py tests/test_batch_create_service.py tests/test_batch_db_integration.py`
- `/Users/mehditantaoui/Documents/Challenges/deltallm/.venv/bin/pytest tests/test_batch_service.py tests/test_batch_create_service.py tests/test_data_plane_audit_extended.py tests/bootstrap/test_optional_bootstrap.py`
- `/Users/mehditantaoui/Documents/Challenges/deltallm/.venv/bin/pytest tests/test_batch_create_service.py tests/test_batch_db_integration.py -k "precheck or idempotency or team or create_session_service or cutover"`

## Notes
- DB-backed PR4 tests are present and collect cleanly, but they skip locally unless `DATABASE_URL` points to a live Postgres instance.
- The PR4 plan doc under `docs/internal/` is force-added because that directory is git-ignored in this repo.
