### PR TITLE
Harden batch release and audit logging

### DIFF
--- a/prisma/migrations/20260301090000_core_schema_baseline/migration.sql
+++ b/prisma/migrations/20260301090000_core_schema_baseline/migration.sql
@@ -1,0 +1,482 @@
+-- Baseline tables that historically existed before the tracked Prisma migration chain.
+-- Keep these definitions compatible with the earliest tracked feature migrations:
+-- later migrations still add service-account ownership to keys, named credentials on
+-- model deployments, and the BatchJob status enum conversion.
+
+CREATE TABLE IF NOT EXISTS "deltallm_organizationtable" (
+  "id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "organization_id" TEXT NOT NULL,
+  "organization_name" TEXT,
+  "max_budget" DOUBLE PRECISION,
+  "soft_budget" DOUBLE PRECISION,
+  "rpm_limit" INTEGER,
+  "tpm_limit" INTEGER,
+  "spend" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "budget_duration" TEXT,
+  "budget_reset_at" TIMESTAMP(3),
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_organizationtable_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_organizationtable_organization_id_key"
+  ON "deltallm_organizationtable" ("organization_id");
+
+CREATE TABLE IF NOT EXISTS "deltallm_teamtable" (
+  "team_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "team_alias" TEXT,
+  "organization_id" TEXT,
+  "max_budget" DOUBLE PRECISION,
+  "soft_budget" DOUBLE PRECISION,
+  "spend" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "budget_duration" TEXT,
+  "budget_reset_at" TIMESTAMP(3),
+  "model_max_budget" JSONB,
+  "tpm_limit" INTEGER,
+  "rpm_limit" INTEGER,
+  "models" TEXT[],
+  "blocked" BOOLEAN NOT NULL DEFAULT false,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_teamtable_pkey" PRIMARY KEY ("team_id")
+);
+
+CREATE INDEX IF NOT EXISTS "deltallm_teamtable_organization_id_idx"
+  ON "deltallm_teamtable" ("organization_id");
+
+CREATE TABLE IF NOT EXISTS "deltallm_usertable" (
+  "user_id" TEXT NOT NULL,
+  "user_email" TEXT,
+  "user_role" TEXT NOT NULL DEFAULT 'internal_user',
+  "max_budget" DOUBLE PRECISION,
+  "soft_budget" DOUBLE PRECISION,
+  "spend" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "budget_duration" TEXT,
+  "budget_reset_at" TIMESTAMP(3),
+  "models" TEXT[],
+  "tpm_limit" INTEGER,
+  "rpm_limit" INTEGER,
+  "team_id" TEXT,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_usertable_pkey" PRIMARY KEY ("user_id"),
+  CONSTRAINT "deltallm_usertable_team_id_fkey"
+    FOREIGN KEY ("team_id") REFERENCES "deltallm_teamtable"("team_id")
+    ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_usertable_user_email_key"
+  ON "deltallm_usertable" ("user_email");
+
+CREATE INDEX IF NOT EXISTS "deltallm_usertable_team_id_idx"
+  ON "deltallm_usertable" ("team_id");
+
+CREATE TABLE IF NOT EXISTS "deltallm_verificationtoken" (
+  "id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "token" TEXT NOT NULL,
+  "key_name" TEXT,
+  "user_id" TEXT,
+  "team_id" TEXT,
+  "models" TEXT[],
+  "max_budget" DOUBLE PRECISION,
+  "soft_budget" DOUBLE PRECISION,
+  "spend" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "budget_duration" TEXT,
+  "budget_reset_at" TIMESTAMP(3),
+  "rpm_limit" INTEGER,
+  "tpm_limit" INTEGER,
+  "max_parallel_requests" INTEGER,
+  "expires" TIMESTAMP(3),
+  "permissions" JSONB,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_verificationtoken_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "deltallm_verificationtoken_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "deltallm_usertable"("user_id")
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT "deltallm_verificationtoken_team_id_fkey"
+    FOREIGN KEY ("team_id") REFERENCES "deltallm_teamtable"("team_id")
+    ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_verificationtoken_token_key"
+  ON "deltallm_verificationtoken" ("token");
+
+CREATE INDEX IF NOT EXISTS "deltallm_verificationtoken_user_id_idx"
+  ON "deltallm_verificationtoken" ("user_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_verificationtoken_team_id_idx"
+  ON "deltallm_verificationtoken" ("team_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_verificationtoken_expires_idx"
+  ON "deltallm_verificationtoken" ("expires");
+
+CREATE TABLE IF NOT EXISTS "deltallm_platformaccount" (
+  "account_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "email" TEXT NOT NULL,
+  "password_hash" TEXT,
+  "role" TEXT NOT NULL DEFAULT 'org_user',
+  "is_active" BOOLEAN NOT NULL DEFAULT true,
+  "force_password_change" BOOLEAN NOT NULL DEFAULT false,
+  "mfa_enabled" BOOLEAN NOT NULL DEFAULT false,
+  "mfa_secret" TEXT,
+  "mfa_pending_secret" TEXT,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "last_login_at" TIMESTAMP(3),
+  CONSTRAINT "deltallm_platformaccount_pkey" PRIMARY KEY ("account_id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_platformaccount_email_key"
+  ON "deltallm_platformaccount" ("email");
+
+CREATE TABLE IF NOT EXISTS "deltallm_platformsession" (
+  "session_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "account_id" TEXT NOT NULL,
+  "session_token_hash" TEXT NOT NULL,
+  "mfa_verified" BOOLEAN NOT NULL DEFAULT false,
+  "expires_at" TIMESTAMP(3) NOT NULL,
+  "revoked_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "last_seen_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_platformsession_pkey" PRIMARY KEY ("session_id"),
+  CONSTRAINT "deltallm_platformsession_account_id_fkey"
+    FOREIGN KEY ("account_id") REFERENCES "deltallm_platformaccount"("account_id")
+    ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_platformsession_session_token_hash_key"
+  ON "deltallm_platformsession" ("session_token_hash");
+
+CREATE INDEX IF NOT EXISTS "deltallm_platformsession_account_id_idx"
+  ON "deltallm_platformsession" ("account_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_platformsession_expires_at_idx"
+  ON "deltallm_platformsession" ("expires_at");
+
+CREATE TABLE IF NOT EXISTS "deltallm_platformidentity" (
+  "identity_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "account_id" TEXT NOT NULL,
+  "provider" TEXT NOT NULL,
+  "subject" TEXT NOT NULL,
+  "email" TEXT,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_platformidentity_pkey" PRIMARY KEY ("identity_id"),
+  CONSTRAINT "deltallm_platformidentity_account_id_fkey"
+    FOREIGN KEY ("account_id") REFERENCES "deltallm_platformaccount"("account_id")
+    ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_platformidentity_provider_subject_key"
+  ON "deltallm_platformidentity" ("provider", "subject");
+
+CREATE INDEX IF NOT EXISTS "deltallm_platformidentity_account_id_idx"
+  ON "deltallm_platformidentity" ("account_id");
+
+CREATE TABLE IF NOT EXISTS "deltallm_organizationmembership" (
+  "membership_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "account_id" TEXT NOT NULL,
+  "organization_id" TEXT NOT NULL,
+  "role" TEXT NOT NULL DEFAULT 'org_member',
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_organizationmembership_pkey" PRIMARY KEY ("membership_id"),
+  CONSTRAINT "deltallm_organizationmembership_account_id_fkey"
+    FOREIGN KEY ("account_id") REFERENCES "deltallm_platformaccount"("account_id")
+    ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_organizationmembership_account_id_organization_id_key"
+  ON "deltallm_organizationmembership" ("account_id", "organization_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_organizationmembership_organization_id_idx"
+  ON "deltallm_organizationmembership" ("organization_id");
+
+CREATE TABLE IF NOT EXISTS "deltallm_teammembership" (
+  "membership_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "account_id" TEXT NOT NULL,
+  "team_id" TEXT NOT NULL,
+  "role" TEXT NOT NULL DEFAULT 'team_viewer',
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_teammembership_pkey" PRIMARY KEY ("membership_id"),
+  CONSTRAINT "deltallm_teammembership_account_id_fkey"
+    FOREIGN KEY ("account_id") REFERENCES "deltallm_platformaccount"("account_id")
+    ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_teammembership_account_id_team_id_key"
+  ON "deltallm_teammembership" ("account_id", "team_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_teammembership_team_id_idx"
+  ON "deltallm_teammembership" ("team_id");
+
+CREATE TABLE IF NOT EXISTS "deltallm_config" (
+  "config_name" TEXT NOT NULL,
+  "config_value" TEXT NOT NULL,
+  "updated_by" TEXT,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_config_pkey" PRIMARY KEY ("config_name")
+);
+
+CREATE TABLE IF NOT EXISTS "deltallm_spendlogs" (
+  "id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "request_id" TEXT,
+  "call_type" TEXT,
+  "api_key" TEXT,
+  "user" TEXT,
+  "team_id" TEXT,
+  "end_user" TEXT,
+  "model" TEXT,
+  "start_time" TIMESTAMP(3),
+  "end_time" TIMESTAMP(3),
+  "spend" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "total_tokens" INTEGER NOT NULL DEFAULT 0,
+  "prompt_tokens" INTEGER NOT NULL DEFAULT 0,
+  "completion_tokens" INTEGER NOT NULL DEFAULT 0,
+  "request_tags" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  CONSTRAINT "deltallm_spendlogs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "deltallm_modeldeployment" (
+  "deployment_id" TEXT NOT NULL,
+  "model_name" TEXT NOT NULL,
+  "deltallm_params" JSONB NOT NULL,
+  "model_info" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_modeldeployment_pkey" PRIMARY KEY ("deployment_id")
+);
+
+CREATE INDEX IF NOT EXISTS "deltallm_modeldeployment_model_name_idx"
+  ON "deltallm_modeldeployment" ("model_name");
+
+CREATE TABLE IF NOT EXISTS "deltallm_routegroup" (
+  "route_group_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "group_key" TEXT NOT NULL,
+  "name" TEXT,
+  "mode" TEXT NOT NULL DEFAULT 'chat',
+  "routing_strategy" TEXT,
+  "enabled" BOOLEAN NOT NULL DEFAULT true,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_routegroup_pkey" PRIMARY KEY ("route_group_id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_routegroup_group_key_key"
+  ON "deltallm_routegroup" ("group_key");
+
+CREATE INDEX IF NOT EXISTS "deltallm_routegroup_enabled_idx"
+  ON "deltallm_routegroup" ("enabled");
+
+CREATE TABLE IF NOT EXISTS "deltallm_routegroupbinding" (
+  "route_group_binding_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "route_group_id" TEXT NOT NULL,
+  "scope_type" TEXT NOT NULL,
+  "scope_id" TEXT NOT NULL,
+  "enabled" BOOLEAN NOT NULL DEFAULT true,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_routegroupbinding_pkey" PRIMARY KEY ("route_group_binding_id"),
+  CONSTRAINT "deltallm_routegroupbinding_route_group_id_fkey"
+    FOREIGN KEY ("route_group_id") REFERENCES "deltallm_routegroup"("route_group_id")
+    ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_routegroupbinding_scope_target_key"
+  ON "deltallm_routegroupbinding" ("route_group_id", "scope_type", "scope_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_routegroupbinding_scope_idx"
+  ON "deltallm_routegroupbinding" ("scope_type", "scope_id", "enabled");
+
+CREATE INDEX IF NOT EXISTS "deltallm_routegroupbinding_group_idx"
+  ON "deltallm_routegroupbinding" ("route_group_id");
+
+CREATE TABLE IF NOT EXISTS "deltallm_callabletargetbinding" (
+  "callable_target_binding_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "callable_key" TEXT NOT NULL,
+  "scope_type" TEXT NOT NULL,
+  "scope_id" TEXT NOT NULL,
+  "enabled" BOOLEAN NOT NULL DEFAULT true,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_callabletargetbinding_pkey" PRIMARY KEY ("callable_target_binding_id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_callabletargetbinding_scope_target_key"
+  ON "deltallm_callabletargetbinding" ("callable_key", "scope_type", "scope_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_callabletargetbinding_scope_idx"
+  ON "deltallm_callabletargetbinding" ("scope_type", "scope_id", "enabled");
+
+CREATE INDEX IF NOT EXISTS "deltallm_callabletargetbinding_target_idx"
+  ON "deltallm_callabletargetbinding" ("callable_key");
+
+CREATE TABLE IF NOT EXISTS "deltallm_callabletargetscopepolicy" (
+  "callable_target_scope_policy_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "scope_type" TEXT NOT NULL,
+  "scope_id" TEXT NOT NULL,
+  "mode" TEXT NOT NULL DEFAULT 'inherit',
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_callabletargetscopepolicy_pkey" PRIMARY KEY ("callable_target_scope_policy_id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_callabletargetscopepolicy_scope_key"
+  ON "deltallm_callabletargetscopepolicy" ("scope_type", "scope_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_callabletargetscopepolicy_scope_idx"
+  ON "deltallm_callabletargetscopepolicy" ("scope_type", "scope_id");
+
+CREATE TABLE IF NOT EXISTS "deltallm_mcpscopepolicy" (
+  "mcp_scope_policy_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "scope_type" TEXT NOT NULL,
+  "scope_id" TEXT NOT NULL,
+  "mode" TEXT NOT NULL DEFAULT 'inherit',
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "deltallm_mcpscopepolicy_pkey" PRIMARY KEY ("mcp_scope_policy_id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_mcpscopepolicy_scope_key"
+  ON "deltallm_mcpscopepolicy" ("scope_type", "scope_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_mcpscopepolicy_scope_idx"
+  ON "deltallm_mcpscopepolicy" ("scope_type", "scope_id");
+
+CREATE TABLE IF NOT EXISTS "deltallm_batch_file" (
+  "file_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "purpose" TEXT NOT NULL,
+  "filename" TEXT NOT NULL,
+  "bytes" INTEGER NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'processed',
+  "storage_backend" TEXT NOT NULL DEFAULT 'local',
+  "storage_key" TEXT NOT NULL,
+  "checksum" TEXT,
+  "created_by_api_key" TEXT,
+  "created_by_user_id" TEXT,
+  "created_by_team_id" TEXT,
+  "created_by_organization_id" TEXT,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expires_at" TIMESTAMP(3),
+  CONSTRAINT "deltallm_batch_file_pkey" PRIMARY KEY ("file_id")
+);
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_file_purpose_idx"
+  ON "deltallm_batch_file" ("purpose");
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_file_created_at_idx"
+  ON "deltallm_batch_file" ("created_at");
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_file_expires_at_idx"
+  ON "deltallm_batch_file" ("expires_at");
+
+CREATE TABLE IF NOT EXISTS "deltallm_batch_job" (
+  "batch_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "endpoint" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'validating',
+  "execution_mode" TEXT NOT NULL DEFAULT 'managed_internal',
+  "input_file_id" TEXT NOT NULL,
+  "output_file_id" TEXT,
+  "error_file_id" TEXT,
+  "model" TEXT,
+  "metadata" JSONB,
+  "provider_batch_id" TEXT,
+  "provider_status" TEXT,
+  "provider_error" TEXT,
+  "provider_last_sync_at" TIMESTAMP(3),
+  "total_items" INTEGER NOT NULL DEFAULT 0,
+  "in_progress_items" INTEGER NOT NULL DEFAULT 0,
+  "completed_items" INTEGER NOT NULL DEFAULT 0,
+  "failed_items" INTEGER NOT NULL DEFAULT 0,
+  "cancelled_items" INTEGER NOT NULL DEFAULT 0,
+  "locked_by" TEXT,
+  "lease_expires_at" TIMESTAMP(3),
+  "cancel_requested_at" TIMESTAMP(3),
+  "status_last_updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "created_by_api_key" TEXT,
+  "created_by_user_id" TEXT,
+  "created_by_team_id" TEXT,
+  "created_by_organization_id" TEXT,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "started_at" TIMESTAMP(3),
+  "completed_at" TIMESTAMP(3),
+  "expires_at" TIMESTAMP(3),
+  CONSTRAINT "deltallm_batch_job_pkey" PRIMARY KEY ("batch_id"),
+  CONSTRAINT "deltallm_batch_job_input_file_id_fkey"
+    FOREIGN KEY ("input_file_id") REFERENCES "deltallm_batch_file"("file_id")
+    ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "deltallm_batch_job_output_file_id_fkey"
+    FOREIGN KEY ("output_file_id") REFERENCES "deltallm_batch_file"("file_id")
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT "deltallm_batch_job_error_file_id_fkey"
+    FOREIGN KEY ("error_file_id") REFERENCES "deltallm_batch_file"("file_id")
+    ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_job_status_created_at_idx"
+  ON "deltallm_batch_job" ("status", "created_at");
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_job_lease_expires_at_idx"
+  ON "deltallm_batch_job" ("lease_expires_at");
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_job_created_by_api_key_created_at_idx"
+  ON "deltallm_batch_job" ("created_by_api_key", "created_at");
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_job_created_by_team_id_created_at_idx"
+  ON "deltallm_batch_job" ("created_by_team_id", "created_at");
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_job_created_by_organization_id_created_at_idx"
+  ON "deltallm_batch_job" ("created_by_organization_id", "created_at");
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_job_expires_at_idx"
+  ON "deltallm_batch_job" ("expires_at");
+
+CREATE TABLE IF NOT EXISTS "deltallm_batch_item" (
+  "item_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "batch_id" TEXT NOT NULL,
+  "line_number" INTEGER NOT NULL,
+  "custom_id" TEXT NOT NULL,
+  "status" TEXT NOT NULL,
+  "request_body" JSONB NOT NULL,
+  "response_body" JSONB,
+  "error_body" JSONB,
+  "usage" JSONB,
+  "provider_cost" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "billed_cost" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "attempts" INTEGER NOT NULL DEFAULT 0,
+  "last_error" TEXT,
+  "locked_by" TEXT,
+  "lease_expires_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "started_at" TIMESTAMP(3),
+  "completed_at" TIMESTAMP(3),
+  CONSTRAINT "deltallm_batch_item_pkey" PRIMARY KEY ("item_id"),
+  CONSTRAINT "deltallm_batch_item_batch_id_fkey"
+    FOREIGN KEY ("batch_id") REFERENCES "deltallm_batch_job"("batch_id")
+    ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_batch_item_batch_id_line_number_key"
+  ON "deltallm_batch_item" ("batch_id", "line_number");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_batch_item_batch_id_custom_id_key"
+  ON "deltallm_batch_item" ("batch_id", "custom_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_item_batch_id_status_idx"
+  ON "deltallm_batch_item" ("batch_id", "status");
+
+CREATE INDEX IF NOT EXISTS "deltallm_batch_item_lease_expires_at_idx"
+  ON "deltallm_batch_item" ("lease_expires_at");

--- a/prisma/migrations/20260413190000_batch_job_status_constraint/migration.sql
+++ b/prisma/migrations/20260413190000_batch_job_status_constraint/migration.sql
@@ -83,6 +83,10 @@ BEGIN
     ) THEN
         EXECUTE '
             ALTER TABLE "deltallm_batch_job"
+            ALTER COLUMN "status" DROP DEFAULT
+        ';
+        EXECUTE '
+            ALTER TABLE "deltallm_batch_job"
             ALTER COLUMN "status" TYPE "DeltaLLM_BatchJobStatus"
             USING ("status"::"DeltaLLM_BatchJobStatus")
         ';

--- a/prisma/migrations/20260414103000_batch_job_remove_validating_status/migration.sql
+++ b/prisma/migrations/20260414103000_batch_job_remove_validating_status/migration.sql
@@ -67,6 +67,11 @@ BEGIN
 
     EXECUTE '
         ALTER TABLE "deltallm_batch_job"
+        ALTER COLUMN "status" DROP DEFAULT
+    ';
+
+    EXECUTE '
+        ALTER TABLE "deltallm_batch_job"
         ALTER COLUMN "status" TYPE "DeltaLLM_BatchJobStatus_next"
         USING ("status"::text::"DeltaLLM_BatchJobStatus_next")
     ';

--- a/src/api/admin/endpoints/audit.py
+++ b/src/api/admin/endpoints/audit.py
@@ -165,7 +165,7 @@ async def get_audit_event(
         scope=scope,
     )
     params.append(event_id)
-    event_clause = f"event_id = ${len(params)}"
+    event_clause = f"event_id = ${len(params)}::uuid"
     if where_sql:
         where_sql = f"{where_sql} AND {event_clause}"
     else:
@@ -190,7 +190,7 @@ async def get_audit_event(
         """
         SELECT payload_id, event_id, kind, storage_mode, content_json, storage_uri, content_sha256, size_bytes, redacted, created_at
         FROM deltallm_auditpayload
-        WHERE event_id = $1
+        WHERE event_id = $1::uuid
         ORDER BY created_at ASC
         """,
         event_id,

--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -151,7 +151,7 @@ async def list_batches(
     valid_statuses = {"queued", "in_progress", "finalizing", "completed", "failed", "cancelled", "expired"}
     if status_filter and status_filter in valid_statuses:
         params.append(status_filter)
-        clauses.append(f"j.status = ${len(params)}")
+        clauses.append(f'j.status = ${len(params)}::"DeltaLLM_BatchJobStatus"')
 
     where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
 

--- a/src/api/audit.py
+++ b/src/api/audit.py
@@ -6,6 +6,7 @@ from typing import Any
 from fastapi import Request
 
 from src.audit.actions import AuditAction, normalize_audit_action
+from src.audit.errors import derive_audit_error_code
 from src.auth.roles import Permission, has_platform_permission
 from src.middleware.platform_auth import get_platform_auth_context
 from src.services.audit_service import AuditEventInput, AuditPayloadInput, AuditService
@@ -140,7 +141,7 @@ async def emit_control_audit_event(
         status=status,
         latency_ms=int((perf_counter() - request_start) * 1000),
         error_type=error.__class__.__name__ if error is not None else None,
-        error_code=getattr(getattr(error, "response", None), "status_code", None) if error is not None else None,
+        error_code=derive_audit_error_code(error),
         metadata=event_metadata,
     )
     if _should_sync_control_audit(request, action, critical=critical):

--- a/src/audit/errors.py
+++ b/src/audit/errors.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import re
+
+
+_CAMEL_TO_SNAKE_FIRST = re.compile("(.)([A-Z][a-z]+)")
+_CAMEL_TO_SNAKE_SECOND = re.compile("([a-z0-9])([A-Z])")
+
+
+def _camel_to_snake(value: str) -> str:
+    first = _CAMEL_TO_SNAKE_FIRST.sub(r"\1_\2", value)
+    return _CAMEL_TO_SNAKE_SECOND.sub(r"\1_\2", first).lower()
+
+
+def derive_audit_error_code(error: Exception | None) -> str | None:
+    if error is None:
+        return None
+
+    for attr_name in ("code", "error_code", "status_code"):
+        value = getattr(error, attr_name, None)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+
+    response = getattr(error, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if status_code is not None:
+        text = str(status_code).strip()
+        if text:
+            return text
+
+    error_type = getattr(error, "error_type", None)
+    if error_type is not None:
+        text = str(error_type).strip()
+        if text:
+            return text
+
+    return _camel_to_snake(error.__class__.__name__) or None

--- a/src/batch/repositories/job_repository.py
+++ b/src/batch/repositories/job_repository.py
@@ -238,7 +238,7 @@ class BatchJobRepository:
         rows = await self.prisma.query_raw(
             """
             UPDATE deltallm_batch_job
-            SET status = $2,
+            SET status = $2::"DeltaLLM_BatchJobStatus",
                 total_items = $3,
                 status_last_updated_at = NOW()
             WHERE batch_id = $1
@@ -259,11 +259,13 @@ class BatchJobRepository:
             """
             UPDATE deltallm_batch_job
             SET cancel_requested_at = NOW(),
-                status = CASE
+                status = (
+                    CASE
                     WHEN status IN ('completed', 'failed', 'cancelled', 'expired') THEN status
                     WHEN status = 'finalizing' THEN status
                     ELSE 'in_progress'
-                END,
+                    END
+                )::"DeltaLLM_BatchJobStatus",
                 status_last_updated_at = NOW()
             WHERE batch_id = $1
             RETURNING *
@@ -291,10 +293,12 @@ class BatchJobRepository:
             UPDATE deltallm_batch_job j
             SET locked_by = $1,
                 lease_expires_at = NOW() + ($2 || ' seconds')::interval,
-                status = CASE
+                status = (
+                    CASE
                     WHEN j.status = 'queued' THEN 'in_progress'
                     ELSE j.status
-                END,
+                    END
+                )::"DeltaLLM_BatchJobStatus",
                 started_at = COALESCE(j.started_at, NOW()),
                 status_last_updated_at = NOW()
             FROM candidate
@@ -374,12 +378,14 @@ class BatchJobRepository:
                 completed_items = s.completed_items,
                 failed_items = s.failed_items,
                 cancelled_items = s.cancelled_items,
-                status = CASE
+                status = (
+                    CASE
                     WHEN j.status IN ('completed', 'failed', 'cancelled', 'expired') THEN j.status
                     WHEN s.pending_items = 0 AND s.in_progress_items = 0 THEN 'finalizing'
                     WHEN s.in_progress_items > 0 OR s.completed_items > 0 OR s.failed_items > 0 OR s.cancelled_items > 0 THEN 'in_progress'
                     ELSE j.status
-                END,
+                    END
+                )::"DeltaLLM_BatchJobStatus",
                 completed_at = CASE WHEN j.status IN ('completed', 'failed', 'cancelled', 'expired') THEN COALESCE(j.completed_at, NOW()) ELSE NULL END,
                 status_last_updated_at = NOW()
             FROM stats s
@@ -418,13 +424,14 @@ class BatchJobRepository:
     ) -> BatchJobRecord | None:
         if self.prisma is None:
             return None
+        normalized_final_status = normalize_batch_job_status(final_status)
         if worker_id is None:
             rows = await self.prisma.query_raw(
                 """
                 UPDATE deltallm_batch_job
                 SET output_file_id = $2,
                     error_file_id = $3,
-                    status = $4,
+                    status = $4::"DeltaLLM_BatchJobStatus",
                     completed_at = COALESCE(completed_at, NOW()),
                     lease_expires_at = NULL,
                     locked_by = NULL,
@@ -435,7 +442,7 @@ class BatchJobRepository:
                 batch_id,
                 output_file_id,
                 error_file_id,
-                final_status,
+                normalized_final_status,
             )
         else:
             rows = await self.prisma.query_raw(
@@ -443,7 +450,7 @@ class BatchJobRepository:
                 UPDATE deltallm_batch_job
                 SET output_file_id = $3,
                     error_file_id = $4,
-                    status = $5,
+                    status = $5::"DeltaLLM_BatchJobStatus",
                     completed_at = COALESCE(completed_at, NOW()),
                     lease_expires_at = NULL,
                     locked_by = NULL,
@@ -457,7 +464,7 @@ class BatchJobRepository:
                 worker_id,
                 output_file_id,
                 error_file_id,
-                final_status,
+                normalized_final_status,
             )
         if not rows:
             return None

--- a/src/chat/audit.py
+++ b/src/chat/audit.py
@@ -6,6 +6,7 @@ from typing import Any
 from fastapi import Request
 
 from src.audit.actions import AuditAction
+from src.audit.errors import derive_audit_error_code
 from src.services.audit_service import AuditEventInput, AuditPayloadInput, AuditService
 
 
@@ -74,7 +75,7 @@ def emit_text_audit_event(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             error_type=error.__class__.__name__ if error is not None else None,
-            error_code=getattr(getattr(error, "response", None), "status_code", None) if error is not None else None,
+            error_code=derive_audit_error_code(error),
             metadata=metadata or {},
         ),
         payloads=payloads,
@@ -113,7 +114,7 @@ def emit_prompt_resolution_audit_event(
             status=status,
             latency_ms=int((perf_counter() - request_start) * 1000),
             error_type=error.__class__.__name__ if error is not None else None,
-            error_code=getattr(getattr(error, "response", None), "status_code", None) if error is not None else None,
+            error_code=derive_audit_error_code(error),
             metadata=metadata or {},
         ),
         critical=False,

--- a/src/db/repositories.py
+++ b/src/db/repositories.py
@@ -454,7 +454,7 @@ class AuditRepository:
                 error_type, error_code, metadata, content_stored, prev_hash, event_hash
             )
             VALUES (
-                $1, $2, $3, $4, $5, $6,
+                $1::uuid, $2, $3, $4, $5, $6,
                 $7, $8, $9, $10,
                 $11, $12, $13, $14, $15, $16,
                 $17, $18, $19::jsonb, $20, $21, $22
@@ -506,7 +506,7 @@ class AuditRepository:
                 payload_id, event_id, kind, storage_mode, content_json, storage_uri,
                 content_sha256, size_bytes, redacted
             )
-            VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9)
+            VALUES ($1::uuid, $2::uuid, $3, $4, $5::jsonb, $6, $7, $8, $9)
             RETURNING payload_id, event_id, kind, storage_mode, content_json, storage_uri,
                       content_sha256, size_bytes, redacted, created_at
             """,

--- a/src/routers/audit_helpers.py
+++ b/src/routers/audit_helpers.py
@@ -6,6 +6,7 @@ from typing import Any
 from fastapi import Request
 
 from src.audit.actions import AuditAction, normalize_audit_action
+from src.audit.errors import derive_audit_error_code
 from src.services.audit_service import AuditEventInput, AuditPayloadInput, AuditService
 
 
@@ -69,7 +70,7 @@ def emit_audit_event(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             error_type=error.__class__.__name__ if error is not None else None,
-            error_code=getattr(getattr(error, "response", None), "status_code", None) if error is not None else None,
+            error_code=derive_audit_error_code(error),
             metadata=metadata or {},
         ),
         payloads=payloads,

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -41,6 +41,7 @@ from src.routers.utils import enforce_budget_if_configured, fire_and_forget
 from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
 from src.services.audit_service import AuditEventInput, AuditPayloadInput, AuditService
 from src.audit.actions import AuditAction
+from src.audit.errors import derive_audit_error_code
 
 router = APIRouter(prefix="/v1", tags=["embeddings"])
 
@@ -100,7 +101,7 @@ def _emit_embedding_audit_event(
             input_tokens=prompt_tokens,
             output_tokens=completion_tokens,
             error_type=error.__class__.__name__ if error is not None else None,
-            error_code=getattr(getattr(error, "response", None), "status_code", None) if error is not None else None,
+            error_code=derive_audit_error_code(error),
             metadata=metadata or {},
         ),
         payloads=payloads,

--- a/tests/db/test_audit_repository.py
+++ b/tests/db/test_audit_repository.py
@@ -102,6 +102,8 @@ async def test_audit_repository_creates_event_and_payload():
     assert event.organization_id == "org-1"
     assert event.metadata == {"model": "openai/gpt-4o-mini"}
     assert event.content_stored is False
+    assert prisma.last_query is not None
+    assert "$1::uuid" in prisma.last_query
 
     payload = await repo.create_payload(
         AuditPayloadRecord(
@@ -117,6 +119,9 @@ async def test_audit_repository_creates_event_and_payload():
     assert payload.event_id == event.event_id
     assert payload.kind == "prompt"
     assert payload.content_json == {"messages": [{"role": "user", "content": "hello"}]}
+    assert prisma.last_query is not None
+    assert "$1::uuid" in prisma.last_query
+    assert "$2::uuid" in prisma.last_query
 
 
 @pytest.mark.asyncio

--- a/tests/test_audit_api.py
+++ b/tests/test_audit_api.py
@@ -66,6 +66,12 @@ async def test_audit_event_detail_includes_payloads(client, test_app):
     payload = response.json()
     assert payload["event_id"] == "evt-1"
     assert payload["payloads"][0]["payload_id"] == "pl-1"
+    event_query, event_params = fake_db.calls[0]
+    assert "event_id = $1::uuid" in event_query or "event_id = $2::uuid" in event_query
+    assert event_params[-1] == "evt-1"
+    payload_query, payload_params = fake_db.calls[1]
+    assert "where event_id = $1::uuid" in " ".join(payload_query.lower().split())
+    assert payload_params == ("evt-1",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_audit_error_code.py
+++ b/tests/test_audit_error_code.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from src.audit.errors import derive_audit_error_code
+from src.email.models import EmailConfigurationError
+from src.models.errors import ModelNotFoundError
+
+
+def test_derive_audit_error_code_prefers_explicit_code() -> None:
+    error = ModelNotFoundError(code="model_not_found")
+    assert derive_audit_error_code(error) == "model_not_found"
+
+
+def test_derive_audit_error_code_falls_back_to_class_name() -> None:
+    error = EmailConfigurationError("email is disabled")
+    assert derive_audit_error_code(error) == "email_configuration_error"
+

--- a/tests/test_batch_repository.py
+++ b/tests/test_batch_repository.py
@@ -126,6 +126,7 @@ async def test_claim_next_job_includes_finalizing_jobs():
     assert job is None
     assert "'finalizing'" in prisma.sql
     assert "CASE WHEN status = 'finalizing' THEN 1 ELSE 0 END" in prisma.sql
+    assert '::"DeltaLLM_BatchJobStatus"' in prisma.sql
 
 
 @pytest.mark.asyncio
@@ -137,6 +138,7 @@ async def test_request_cancel_preserves_finalizing_status():
 
     assert job is None
     assert "WHEN status = 'finalizing' THEN status" in prisma.sql
+    assert '::"DeltaLLM_BatchJobStatus"' in prisma.sql
 
 
 @pytest.mark.asyncio
@@ -267,3 +269,59 @@ async def test_create_job_defaults_to_queued_status() -> None:
 
     assert '::"DeltaLLM_BatchJobStatus"' in prisma.sql
     assert prisma.params[2] == "queued"
+
+
+@pytest.mark.asyncio
+async def test_set_job_queued_casts_status_parameter_to_enum() -> None:
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    queued = await repository.set_job_queued("batch-1", 2)
+
+    assert queued is None
+    assert 'status = $2::"DeltaLLM_BatchJobStatus"' in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_refresh_job_progress_casts_status_case_to_enum() -> None:
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    refreshed = await repository.refresh_job_progress("batch-1")
+
+    assert refreshed is None
+    assert "WHEN s.pending_items = 0 AND s.in_progress_items = 0 THEN 'finalizing'" in prisma.sql
+    assert '::"DeltaLLM_BatchJobStatus"' in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_attach_artifacts_and_finalize_casts_status_parameter_to_enum() -> None:
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id="batch-1",
+        output_file_id="out-1",
+        error_file_id="err-1",
+        final_status="completed",
+    )
+
+    assert finalized is None
+    assert 'status = $4::"DeltaLLM_BatchJobStatus"' in prisma.sql
+    assert prisma.params[3] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_attach_artifacts_and_finalize_rejects_invalid_status_before_sql() -> None:
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    with pytest.raises(ValueError, match="batch job status"):
+        await repository.attach_artifacts_and_finalize(
+            batch_id="batch-1",
+            output_file_id=None,
+            error_file_id=None,
+            final_status="broken",
+        )
+
+    assert prisma.queries == []

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -413,6 +413,54 @@ async def test_list_batches_exposes_repair_capabilities_for_updating_scope(clien
 
 
 @pytest.mark.asyncio
+async def test_list_batches_status_filter_uses_enum_safe_query(client, test_app, monkeypatch):
+    class FilteredBatchDB(FakeAuthorizationDB):
+        async def query_raw(self, query: str, *params):
+            if 'COUNT(*) AS total FROM deltallm_batch_job j' in query:
+                if 'j.status =' in query:
+                    assert '::"DeltaLLM_BatchJobStatus"' in query
+                    return [{"total": 1 if "queued" in params else 0}]
+                return [{"total": len(self.batches)}]
+            if "FROM deltallm_batch_job j" in query and "LEFT JOIN deltallm_teamtable t" in query:
+                if "WHERE j.batch_id = $1" in query:
+                    row = self.batches.get(str(params[0]))
+                    return [row] if row else []
+                if 'j.status =' in query:
+                    assert '::"DeltaLLM_BatchJobStatus"' in query
+                    return [{
+                        **self.batches["batch-1"],
+                        "batch_id": "batch-queued",
+                        "status": "queued",
+                        "in_progress_items": 0,
+                        "completed_items": 0,
+                    }] if "queued" in params else []
+                return [self.batches["batch-1"]]
+            return await super().query_raw(query, *params)
+
+    fake_db = FilteredBatchDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.batches.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=False,
+            org_ids=[],
+            team_ids=["team-1"],
+            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ}},
+        ),
+    )
+
+    response = await client.get("/ui/api/batches?status=queued", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["pagination"]["total"] == 1
+    assert payload["data"][0]["batch_id"] == "batch-queued"
+    assert payload["data"][0]["status"] == "queued"
+
+
+@pytest.mark.asyncio
 async def test_list_batches_includes_org_owned_batches_when_scope_has_team_and_org_memberships(client, test_app, monkeypatch):
     class MixedScopeBatchDB(FakeAuthorizationDB):
         def __init__(self) -> None:

--- a/ui/src/pages/AuditLogs.tsx
+++ b/ui/src/pages/AuditLogs.tsx
@@ -38,6 +38,12 @@ function formatActionLabel(action: string): string {
     .join(' ');
 }
 
+function formatErrorSummary(event: Pick<AuditEvent, 'error_type' | 'error_code'>): string | null {
+  if (!event.error_type && !event.error_code) return null;
+  if (event.error_type && event.error_code) return `${event.error_type} (${event.error_code})`;
+  return event.error_type || event.error_code || null;
+}
+
 function timeAgo(dateStr: string): string {
   const now = Date.now();
   const then = new Date(dateStr).getTime();
@@ -84,6 +90,7 @@ function DetailField({ label, value, mono = false }: { label: string; value: Rea
 
 function EventDetailPanel({ eventId, onClose, onViewTimeline }: { eventId: string; onClose: () => void; onViewTimeline: (requestId: string) => void }) {
   const { data: event, loading, error } = useApi(() => audit.get(eventId), [eventId]);
+  const errorSummary = event ? formatErrorSummary(event) : null;
   if (loading) {
     return (
       <div className="fixed inset-y-0 right-0 w-full max-w-lg bg-white shadow-xl z-50 flex items-center justify-center">
@@ -125,6 +132,19 @@ function EventDetailPanel({ eventId, onClose, onViewTimeline }: { eventId: strin
             <DetailField label="Action" value={event.action} mono />
             <DetailField label="Status" value={event.status || 'unknown'} />
           </div>
+
+          {errorSummary ? (
+            <CollapsibleSection title="Error" defaultOpen>
+              <div className="grid grid-cols-2 gap-x-4">
+                <DetailField label="Error Type" value={event.error_type} mono />
+                <DetailField label="Error Code" value={event.error_code} mono />
+              </div>
+              <div className="mt-3 rounded-lg border border-red-100 bg-red-50 px-3 py-2">
+                <p className="text-xs font-medium uppercase tracking-wider text-red-700">Summary</p>
+                <p className="mt-1 text-sm text-red-900">{errorSummary}</p>
+              </div>
+            </CollapsibleSection>
+          ) : null}
 
           <CollapsibleSection title="Actor Information" defaultOpen>
             <div className="grid grid-cols-2 gap-x-4">


### PR DESCRIPTION
## Summary
- add release-hardening fixes for fresh database bootstrap and batch job status writes
- fix audit event persistence and UUID-safe audit lookups
- surface audit error details in the event detail view without cluttering the table view

## Why
Final compose, smoke, and stress validation uncovered a few release blockers on top of the merged batch-create stack:
- fresh installs could fail during the migration chain
- some raw batch job status writes were not enum-safe after the status enum migration
- audit events could fail to persist because UUID fields were written as plain text
- audit error details were available in the backend but not visible in the audit UI detail view

## Validation
- `python -m pytest tests/test_batch_repository.py`
- `python -m pytest tests/db/test_audit_repository.py tests/test_audit_api.py tests/services/test_audit_service.py tests/test_audit_error_code.py`
- `python -m ruff check src/batch/repositories/job_repository.py src/db/repositories.py src/api/admin/endpoints/audit.py src/api/audit.py src/audit/errors.py src/routers/audit_helpers.py src/routers/embeddings.py src/chat/audit.py tests/test_batch_repository.py tests/db/test_audit_repository.py tests/test_audit_api.py tests/test_audit_error_code.py`
- `npm run build` in `ui/`
- `prisma validate --schema=./prisma/schema.prisma`
- `docker compose --profile single up -d --build`
- local batch release smoke completed successfully
- local stress runs completed successfully, including 40 batches / 10,000 requests across two scoped keys

## Notes
- local-only stress artifacts and helper scripts were intentionally left out of this PR
- the branch also includes the admin batch status filter fix and the audit UUID write fix used during release validation