### PR TITLE
Fix batch embedding output compatibility and refactor worker internals

### DIFF
--- a/docs/internal/20260416-issue95-openai-batch-output-compat-plan.md
+++ b/docs/internal/20260416-issue95-openai-batch-output-compat-plan.md
@@ -1,0 +1,311 @@
+# Issue 95 Plan: OpenAI-Compatible Batch Output For Embeddings
+
+## Objective
+
+Make `/v1/embeddings` batch output artifacts OpenAI Batch-compatible without changing the existing batch lifecycle, file download route, or unrelated provider behavior.
+
+Target outcome:
+
+- success rows in output artifacts use the OpenAI Batch envelope
+- the embedding payload is nested under `response.body`
+- top-level `id`, `custom_id`, `response`, and `error` are present on every row
+- provider-specific `_provider` metadata does not leak into the public compatibility artifact
+- single-item and microbatched executions serialize to the same public shape
+
+Related issue:
+
+- [#95](https://github.com/deltawi/deltallm/issues/95)
+
+Recommended branch:
+
+- `fix/95-openai-batch-output-compat`
+
+## Problem Statement
+
+Current finalized output rows are emitted directly from the batch worker as:
+
+```json
+{"custom_id":"...","response":{...}}
+```
+
+Current finalized error rows are emitted as:
+
+```json
+{"custom_id":"...","error":{...}}
+```
+
+That is not OpenAI Batch-compatible because the outer row is missing:
+
+- `id`
+- `error` on success rows
+- `response.status_code`
+- `response.request_id`
+- `response.body`
+
+It also exposes `_provider` inside the embedding payload even though that is internal/provider-specific metadata rather than part of the OpenAI-compatible artifact contract.
+
+## Scope
+
+In scope:
+
+1. Fix only the public artifact row shape for `/v1/embeddings` batch output/error JSONL files.
+2. Introduce one serializer/builder for public batch artifact rows.
+3. Remove `_provider` from public embedding artifact payloads.
+4. Add targeted regression tests for single-item, microbatch, failure, and cancellation rows.
+
+Out of scope:
+
+1. Broad batch API redesign.
+2. New batch endpoint support beyond `/v1/embeddings`.
+3. Unrelated provider uniformity cleanup.
+4. UI changes.
+
+## Design Decisions
+
+### 1. Keep the fix artifact-focused
+
+This issue is about compatibility of the downloaded JSONL artifacts, not the batch job state machine.
+
+Do not change:
+
+- batch status transitions
+- retention behavior
+- file download route or MIME type
+- request authorization or ownership behavior
+
+### 2. Use a dedicated artifact-row serializer
+
+Do not keep composing public rows inline in `_iter_output_lines()` and `_iter_error_lines()`.
+
+Add one serializer helper that receives a `BatchItemRecord` and emits the public row shape. This is the lowest-risk way to prevent future schema drift.
+
+Recommended location:
+
+- `src/batch/worker.py` first, if we want the smallest patch
+- or a dedicated helper module if the logic grows beyond a few small functions
+
+### 3. Generate deterministic synthetic IDs for managed internal batches
+
+Managed internal execution does not currently have upstream OpenAI Batch request ids, so the public artifact needs deterministic synthetic values.
+
+Recommended rule:
+
+- row `id`: `batch_req_{item_id}`
+- success `response.request_id`: `req_batch_{item_id}`
+- success `response.status_code`: `200`
+
+These values should be documented as synthetic compatibility fields for internally managed execution.
+
+### 4. Preserve the endpoint payload under `response.body`
+
+Existing completed items already persist the embedding endpoint payload in `response_body`.
+
+Use that value as:
+
+- `response.body` for successful rows
+
+Do not wrap or mutate the payload beyond removing internal-only fields that are not part of the public compatibility contract.
+
+### 5. Strip internal-only provider metadata from public artifacts
+
+`_provider` is useful for internal accounting/debugging, but it should not be present in the downloaded public artifact that claims OpenAI compatibility.
+
+Keep `_provider` available for internal hooks/persistence if needed, but remove it from the serialized JSONL row body returned to users.
+
+### 6. Use a consistent row envelope for failed and cancelled items
+
+Every emitted row should contain:
+
+- `id`
+- `custom_id`
+- `response`
+- `error`
+
+Recommended failure/cancellation shape for this fix:
+
+- `response: null`
+- `error`: existing normalized error payload plus any available code/type/message fields
+
+This avoids blocking the compatibility fix on a larger migration to persist upstream HTTP failure bodies.
+
+If later we want richer failure envelopes with HTTP status/body details, that can be a follow-up without changing the success-path contract again.
+
+## Concrete Implementation Plan
+
+### Phase 1: Lock the target row contract
+
+Define one explicit public row contract for artifacts produced by `/v1/embeddings` batches.
+
+Success row:
+
+```json
+{
+  "id": "batch_req_<item_id>",
+  "custom_id": "<custom_id>",
+  "response": {
+    "status_code": 200,
+    "request_id": "req_batch_<item_id>",
+    "body": {
+      "object": "list",
+      "data": [
+        {
+          "object": "embedding",
+          "index": 0,
+          "embedding": [0.1, 0.2]
+        }
+      ],
+      "model": "text-embedding-3-small",
+      "usage": {
+        "prompt_tokens": 10,
+        "total_tokens": 10
+      }
+    }
+  },
+  "error": null
+}
+```
+
+Failure/cancel row:
+
+```json
+{
+  "id": "batch_req_<item_id>",
+  "custom_id": "<custom_id>",
+  "response": null,
+  "error": {
+    "message": "...",
+    "type": "..."
+  }
+}
+```
+
+### Phase 2: Build serializer helpers
+
+Add small helpers for:
+
+1. building the synthetic public row id
+2. building the synthetic public request id
+3. sanitizing the stored embedding payload for public artifact use
+4. serializing a completed item into a public success row
+5. serializing a failed/cancelled item into a public error row
+
+Recommended names:
+
+- `_public_batch_row_id(item)`
+- `_public_batch_request_id(item)`
+- `_sanitize_public_embedding_body(response_body)`
+- `_serialize_completed_artifact_row(item)`
+- `_serialize_failed_artifact_row(item)`
+
+### Phase 3: Remove inline row construction from finalization
+
+Replace the current direct `json.dumps(...)` calls in:
+
+- `src/batch/worker.py`
+
+Current paths to update:
+
+- `_iter_output_lines()`
+- `_iter_error_lines()`
+
+Both should delegate to the serializer helpers so the emitted JSONL lines share one source of truth.
+
+### Phase 4: Sanitize public success payloads
+
+Update public success serialization so it:
+
+1. uses existing `item.response_body` as `response.body`
+2. removes `_provider`
+3. preserves:
+   - `object`
+   - `data`
+   - `model`
+   - `usage`
+4. preserves `data[0].object == "embedding"` and `data[0].index == 0`
+
+This phase should not change internal completion accounting, pricing, or outbox payloads.
+
+### Phase 5: Normalize error/cancel rows
+
+Update public error serialization so:
+
+1. the top-level row always includes `id`, `custom_id`, `response`, and `error`
+2. `response` is `null` for current failed/cancelled items
+3. `error` uses the stored `item.error_body` when present
+4. a fallback normalized error object is emitted if `item.error_body` is absent
+
+Do not block this phase on persisting upstream HTTP failure response bodies.
+
+### Phase 6: Add focused regression tests
+
+Add tests that assert exact artifact-row shape, not just partial fields.
+
+Required coverage:
+
+1. single-item success row is wrapped in the OpenAI Batch envelope
+2. microbatched success row is wrapped in the same envelope for each item
+3. success row contains `response.body` and not raw payload directly under `response`
+4. success row contains `error: null`
+5. success row does not contain `_provider` in the public artifact body
+6. failed row contains `response: null` and top-level `error`
+7. cancelled row uses the same envelope
+
+Recommended test touchpoints:
+
+- `tests/test_batch_worker.py`
+- any artifact finalization tests already covering `write_lines_stream`
+
+### Phase 7: Verify file-serving compatibility
+
+Run a focused regression pass to confirm:
+
+1. output artifacts still download through `GET /v1/files/{file_id}/content`
+2. content type remains `application/jsonl`
+3. only the row schema changed
+
+## File-Level Change Set
+
+Expected files to touch:
+
+- `src/batch/worker.py`
+- `tests/test_batch_worker.py`
+
+Possible additional files if helper extraction is cleaner:
+
+- `src/batch/models.py`
+- `src/batch/repositories/mappers.py`
+- `tests/test_batch_repository.py`
+
+Files that should probably not change for this fix:
+
+- `src/api/v1/endpoints/files.py`
+- `src/batch/repository.py`
+- DB migration files
+
+## Acceptance Criteria
+
+The fix is complete when all of the following are true:
+
+1. Completed `/v1/embeddings` batch artifact rows are OpenAI Batch-compatible.
+2. The embedding payload is nested under `response.body`.
+3. Each emitted row has top-level `id`, `custom_id`, `response`, and `error`.
+4. Successful rows set `error` to `null`.
+5. Failed/cancelled rows set `response` to `null` and populate `error`.
+6. Public artifact payloads do not expose `_provider`.
+7. Focused tests lock the contract for both single-item and microbatched execution.
+
+## Validation Checklist
+
+- [ ] Serializer helpers added and used by finalization.
+- [ ] Success rows emit `response.status_code = 200`.
+- [ ] Success rows emit synthetic `response.request_id`.
+- [ ] Success rows place the embedding payload under `response.body`.
+- [ ] Error rows emit top-level `error`.
+- [ ] `_provider` removed from public artifact output.
+- [ ] Focused worker/finalization tests pass.
+
+## Notes
+
+- Keep the patch surgical. This issue does not justify a repository-wide batch refactor.
+- Prefer compatibility at the artifact boundary over introducing new persistence fields unless tests prove they are necessary.
+- If richer HTTP failure envelopes are desired later, capture that as a follow-up issue after the success-path compatibility contract is shipped.

--- a/src/batch/worker.py
+++ b/src/batch/worker.py
@@ -246,24 +246,48 @@ class BatchExecutorWorker:
 
     def _sanitize_public_embedding_body(self, response_body: dict[str, Any] | None) -> dict[str, Any]:
         if not isinstance(response_body, dict):
-            return {}
+            raise ValueError("completed batch item is missing an embedding response body")
 
         sanitized = dict(response_body)
         sanitized.pop("_provider", None)
-        sanitized["object"] = str(sanitized.get("object") or "list")
+        object_type = sanitized.get("object")
+        if object_type is None:
+            sanitized["object"] = "list"
+        elif object_type != "list":
+            raise ValueError(f"completed batch item has invalid embedding response object={object_type!r}")
+
+        data_rows = sanitized.get("data")
+        if not isinstance(data_rows, list):
+            raise ValueError("completed batch item embedding response data is not a list")
+        if not data_rows:
+            raise ValueError("completed batch item embedding response data is empty")
 
         normalized_rows: list[Any] = []
-        for row_number, row in enumerate(sanitized.get("data") or []):
+        for row_number, row in enumerate(data_rows):
             if not isinstance(row, dict):
-                normalized_rows.append(row)
-                continue
+                raise ValueError(f"completed batch item embedding response row {row_number} is not an object")
             normalized_row = dict(row)
-            normalized_row["object"] = str(normalized_row.get("object") or "embedding")
-            if type(normalized_row.get("index")) is not int:
+            if "embedding" not in normalized_row:
+                raise ValueError(f"completed batch item embedding response row {row_number} is missing embedding")
+
+            row_object = normalized_row.get("object")
+            if row_object is None:
+                normalized_row["object"] = "embedding"
+            elif row_object != "embedding":
+                raise ValueError(
+                    f"completed batch item embedding response row {row_number} has invalid object={row_object!r}"
+                )
+
+            response_index = normalized_row.get("index")
+            if response_index is None:
                 normalized_row["index"] = row_number
+            elif type(response_index) is not int:
+                raise ValueError(
+                    f"completed batch item embedding response row {row_number} has invalid index={response_index!r}"
+                )
             normalized_rows.append(normalized_row)
-        if isinstance(sanitized.get("data"), list):
-            sanitized["data"] = normalized_rows
+
+        sanitized["data"] = normalized_rows
 
         return sanitized
 

--- a/src/batch/worker.py
+++ b/src/batch/worker.py
@@ -1,91 +1,39 @@
 from __future__ import annotations
 
 import asyncio
-from collections import deque
 import contextlib
-import json
 import logging
-from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
-from time import perf_counter
-from typing import Any, AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
 
-import httpx
-
-from src.batch.embedding_microbatch import (
-    _ExecutionSignature,
-    allocate_embedding_usage,
-    build_embedding_execution_signature,
-    classify_embedding_microbatch_request,
-    estimate_embedding_microbatch_weight,
-    resolve_effective_upstream_max_batch_inputs,
-)
 from src.batch.models import BatchJobStatus
-from src.batch.models import is_operator_failed_reason
 from src.batch.repository import BatchRepository
 from src.batch.storage import BatchArtifactStorage
-from src.billing.cost import ModelPricing, completion_cost
+from src.batch.worker_artifacts import BatchArtifactFinalizer
+from src.batch.worker_execution import BatchExecutionEngine
+from src.batch.worker_types import (
+    BatchArtifactValidationError,
+    BatchWorkerConfig,
+    _PreparedEmbeddingItem,
+    _RequestShim,
+)
 from src.metrics import (
-    increment_batch_artifact_failure,
-    increment_batch_finalization_retry,
-    increment_batch_microbatch_inputs,
-    increment_batch_microbatch_ineligible_item,
-    increment_batch_microbatch_isolation_fallback,
-    increment_batch_microbatch_requests,
-    observe_batch_finalize_latency,
     observe_batch_item_execution_latency,
-    observe_batch_microbatch_size,
     publish_batch_runtime_summary,
     set_batch_worker_saturation,
 )
-from src.models.requests import EmbeddingRequest
-from src.providers.resolution import resolve_provider
 from src.router.usage import record_router_usage
-from src.routers.routing_decision import route_failover_kwargs
 from src.routers.embeddings import _execute_embedding
 
 logger = logging.getLogger(__name__)
-_COMPLETION_OUTBOX_MAX_ATTEMPTS = 5
 
-
-@dataclass
-class BatchWorkerConfig:
-    worker_id: str
-    poll_interval_seconds: float = 1.0
-    heartbeat_interval_seconds: float = 15.0
-    job_lease_seconds: int = 120
-    item_lease_seconds: int = 360
-    finalization_retry_delay_seconds: int = 60
-    worker_concurrency: int = 4
-    item_buffer_multiplier: int = 2
-    finalization_page_size: int = 500
-    item_claim_limit: int = 20
-    max_attempts: int = 3
-    completed_artifact_retention_days: int = 7
-    failed_artifact_retention_days: int = 14
-
-
-@dataclass
-class _RequestShim:
-    app: Any
-
-
-@dataclass(slots=True)
-class _PreparedEmbeddingItem:
-    item: Any
-    started_at_monotonic: float
-    payload: EmbeddingRequest
-    model_name: str
-    model_group: str
-    primary_deployment: Any
-    request_context: dict[str, Any]
-    failover_kwargs: dict[str, Any]
-    request_shim: _RequestShim
-    effective_upstream_max_batch_inputs: int
-    microbatch_eligible: bool
-    microbatch_ineligible_reason: str | None
-    microbatch_weight: int | None
-    execution_signature: _ExecutionSignature
+__all__ = [
+    "BatchArtifactValidationError",
+    "BatchExecutorWorker",
+    "BatchWorkerConfig",
+    "_PreparedEmbeddingItem",
+    "_RequestShim",
+]
 
 
 class BatchExecutorWorker:
@@ -102,7 +50,50 @@ class BatchExecutorWorker:
         self.storage = storage
         self.config = config
         self._running = False
-        self._prepared_item_overrides: dict[str, _PreparedEmbeddingItem] = {}
+        self._artifact_finalizer = BatchArtifactFinalizer(
+            repository=repository,
+            storage=storage,
+            config=config,
+        )
+        self._execution_engine = BatchExecutionEngine(
+            app=app,
+            repository=repository,
+            config=config,
+            normalize_persisted_embedding_response_body=self._artifact_finalizer.normalize_persisted_embedding_response_body,
+            execute_embedding=self._call_execute_embedding,
+            record_router_usage=self._call_record_router_usage,
+            observe_item_execution_latency=self._call_observe_item_execution_latency,
+            start_heartbeat=self._call_start_heartbeat,
+            stop_heartbeat=self._call_stop_heartbeat,
+        )
+
+    def _sync_dependencies(self) -> None:
+        self._artifact_finalizer.repository = self.repository
+        self._artifact_finalizer.storage = self.storage
+        self._artifact_finalizer.config = self.config
+        self._execution_engine.app = self.app
+        self._execution_engine.repository = self.repository
+        self._execution_engine.config = self.config
+
+    async def _call_execute_embedding(self, request, payload, deployment):  # noqa: ANN001, ANN201
+        return await _execute_embedding(request, payload, deployment)
+
+    async def _call_record_router_usage(self, router_state_backend, deployment_id: str, *, mode: str, usage: dict) -> None:
+        await record_router_usage(
+            router_state_backend,
+            deployment_id,
+            mode=mode,
+            usage=usage,
+        )
+
+    def _call_observe_item_execution_latency(self, *, status: str, latency_seconds: float) -> None:
+        observe_batch_item_execution_latency(status=status, latency_seconds=latency_seconds)
+
+    def _call_start_heartbeat(self, *, renew, label: str) -> asyncio.Task[None]:  # noqa: ANN001
+        return self._start_heartbeat(renew=renew, label=label)
+
+    async def _call_stop_heartbeat(self, task: asyncio.Task[None]) -> None:
+        await self._stop_heartbeat(task)
 
     async def run(self) -> None:
         self._running = True
@@ -139,7 +130,11 @@ class BatchExecutorWorker:
             lease_seconds=self.config.job_lease_seconds,
         )
         if job is None:
-            set_batch_worker_saturation(worker_id=self.config.worker_id, active=0, capacity=self.config.worker_concurrency)
+            set_batch_worker_saturation(
+                worker_id=self.config.worker_id,
+                active=0,
+                capacity=self.config.worker_concurrency,
+            )
             return False
         logger.info("batch claimed id=%s status=%s", job.batch_id, job.status)
         job_heartbeat = self._start_heartbeat(
@@ -173,1010 +168,52 @@ class BatchExecutorWorker:
             await self._refresh_batch_runtime_metrics()
             return True
         finally:
-            set_batch_worker_saturation(worker_id=self.config.worker_id, active=0, capacity=self.config.worker_concurrency)
+            set_batch_worker_saturation(
+                worker_id=self.config.worker_id,
+                active=0,
+                capacity=self.config.worker_concurrency,
+            )
             await self._stop_heartbeat(job_heartbeat)
             await self.repository.release_job_lease(batch_id=job.batch_id, worker_id=self.config.worker_id)
 
-    async def _prepare_item_for_execution(self, job, item) -> _PreparedEmbeddingItem:
-        started_at_monotonic = perf_counter()
-        payload = EmbeddingRequest.model_validate(item.request_body)
-        budget_service = getattr(self.app.state, "budget_service", None)
-        if budget_service is not None:
-            await budget_service.check_budgets(
-                api_key=job.created_by_api_key,
-                user_id=job.created_by_user_id,
-                team_id=job.created_by_team_id,
-                organization_id=job.created_by_organization_id,
-                model=payload.model,
-            )
+    async def _prepare_item_for_execution(self, job, item) -> _PreparedEmbeddingItem:  # noqa: ANN001
+        self._sync_dependencies()
+        return await self._execution_engine.prepare_item_for_execution(job, item)
 
-        request_context: dict[str, Any] = {"metadata": {}, "user_id": "batch-worker"}
-        app_router = self.app.state.router
-        model_group = app_router.resolve_model_group(payload.model)
-        primary_deployment = app_router.require_deployment(
-            model_group=model_group,
-            deployment=await app_router.select_deployment(model_group, request_context),
-        )
-        input_kind, microbatch_eligible, microbatch_ineligible_reason = classify_embedding_microbatch_request(payload)
-        primary_deployment_id = str(getattr(primary_deployment, "deployment_id", None) or "")
-        return _PreparedEmbeddingItem(
-            item=item,
-            started_at_monotonic=started_at_monotonic,
-            payload=payload,
-            model_name=payload.model,
-            model_group=model_group,
-            primary_deployment=primary_deployment,
-            request_context=request_context,
-            failover_kwargs=route_failover_kwargs(request_context),
-            request_shim=_RequestShim(app=self.app),
-            effective_upstream_max_batch_inputs=resolve_effective_upstream_max_batch_inputs(
-                getattr(primary_deployment, "model_info", None)
-            ),
-            microbatch_eligible=microbatch_eligible,
-            microbatch_ineligible_reason=microbatch_ineligible_reason,
-            microbatch_weight=estimate_embedding_microbatch_weight(payload) if microbatch_eligible else None,
-            execution_signature=build_embedding_execution_signature(
-                payload=payload,
-                model_group=model_group,
-                primary_deployment_id=primary_deployment_id,
-                input_kind=input_kind,
-            ),
+    async def _process_item(self, job, item) -> None:  # noqa: ANN001
+        self._sync_dependencies()
+        await self._execution_engine.process_item(job, item, prepare_item=self._prepare_item_for_execution)
+
+    async def _process_items(self, job, items) -> None:  # noqa: ANN001
+        self._sync_dependencies()
+        await self._execution_engine.process_items(
+            job,
+            items,
+            prepare_item=self._prepare_item_for_execution,
+            process_item=self._process_item,
         )
 
-    def _deployment_pricing(self, deployment) -> ModelPricing | None:  # noqa: ANN001
-        if deployment.input_cost_per_token or deployment.output_cost_per_token:
-            return ModelPricing(
-                input_cost_per_token=deployment.input_cost_per_token,
-                output_cost_per_token=deployment.output_cost_per_token,
-            )
-        return None
-
-    def _sanitize_embedding_response(self, data: dict[str, Any]) -> tuple[dict[str, Any], str | None, str | None]:
-        response_body = dict(data)
-        response_body.pop("_api_latency_ms", None)
-        api_base = response_body.pop("_api_base", None)
-        deployment_model = response_body.pop("_deployment_model", None)
-        return response_body, api_base, deployment_model
-
-    def _public_batch_row_id(self, item) -> str:  # noqa: ANN001
-        return f"batch_req_{item.item_id}"
-
-    def _public_batch_request_id(self, item) -> str:  # noqa: ANN001
-        return f"req_batch_{item.item_id}"
-
-    def _sanitize_public_embedding_body(self, response_body: dict[str, Any] | None) -> dict[str, Any]:
-        if not isinstance(response_body, dict):
-            raise ValueError("completed batch item is missing an embedding response body")
-
-        sanitized = dict(response_body)
-        sanitized.pop("_provider", None)
-        object_type = sanitized.get("object")
-        if object_type is None:
-            sanitized["object"] = "list"
-        elif object_type != "list":
-            raise ValueError(f"completed batch item has invalid embedding response object={object_type!r}")
-
-        data_rows = sanitized.get("data")
-        if not isinstance(data_rows, list):
-            raise ValueError("completed batch item embedding response data is not a list")
-        if not data_rows:
-            raise ValueError("completed batch item embedding response data is empty")
-
-        normalized_rows: list[Any] = []
-        for row_number, row in enumerate(data_rows):
-            if not isinstance(row, dict):
-                raise ValueError(f"completed batch item embedding response row {row_number} is not an object")
-            normalized_row = dict(row)
-            if "embedding" not in normalized_row:
-                raise ValueError(f"completed batch item embedding response row {row_number} is missing embedding")
-
-            row_object = normalized_row.get("object")
-            if row_object is None:
-                normalized_row["object"] = "embedding"
-            elif row_object != "embedding":
-                raise ValueError(
-                    f"completed batch item embedding response row {row_number} has invalid object={row_object!r}"
-                )
-
-            response_index = normalized_row.get("index")
-            if response_index is None:
-                normalized_row["index"] = row_number
-            elif type(response_index) is not int:
-                raise ValueError(
-                    f"completed batch item embedding response row {row_number} has invalid index={response_index!r}"
-                )
-            normalized_rows.append(normalized_row)
-
-        sanitized["data"] = normalized_rows
-
-        return sanitized
-
-    def _serialize_completed_artifact_row(self, item) -> dict[str, Any]:  # noqa: ANN001
-        return {
-            "id": self._public_batch_row_id(item),
-            "custom_id": item.custom_id,
-            "response": {
-                "status_code": 200,
-                "request_id": self._public_batch_request_id(item),
-                "body": self._sanitize_public_embedding_body(item.response_body),
-            },
-            "error": None,
-        }
-
-    def _serialize_failed_artifact_row(self, item) -> dict[str, Any]:  # noqa: ANN001
-        error_body = dict(item.error_body) if isinstance(item.error_body, dict) else {}
-        if not error_body.get("message"):
-            error_body["message"] = item.last_error or (
-                "Batch request cancelled" if item.status == "cancelled" else "Batch request failed"
-            )
-        if not error_body.get("type"):
-            error_body["type"] = "BatchItemCancelled" if item.status == "cancelled" else "BatchItemError"
-
-        return {
-            "id": self._public_batch_row_id(item),
-            "custom_id": item.custom_id,
-            "response": None,
-            "error": error_body,
-        }
-
-    def _build_single_item_embedding_response_body(
-        self,
-        *,
-        chunk_response: dict[str, Any],
-        item_response: dict[str, Any],
-        usage: dict[str, Any],
-        api_provider: str,
-    ) -> dict[str, Any]:
-        response_body: dict[str, Any] = {
-            "object": chunk_response.get("object") or "list",
-            "data": [{**item_response, "index": 0}],
-            "usage": dict(usage),
-            "_provider": api_provider,
-        }
-        if chunk_response.get("model") is not None:
-            response_body["model"] = chunk_response.get("model")
-        return response_body
-
-    def _validate_embedding_microbatch_response(
-        self,
-        *,
-        response_body: dict[str, Any],
-        expected_count: int,
-    ) -> list[dict[str, Any]]:
-        data_rows = response_body.get("data")
-        if not isinstance(data_rows, list):
-            raise ValueError("microbatch response data is not a list")
-        if len(data_rows) != expected_count:
-            raise ValueError(
-                f"microbatch response length mismatch expected={expected_count} actual={len(data_rows)}"
-            )
-
-        normalized_rows: list[dict[str, Any] | None] = [None] * expected_count
-        for row_number, row in enumerate(data_rows):
-            if not isinstance(row, dict):
-                raise ValueError(f"microbatch response item {row_number} is not an object")
-            if "embedding" not in row:
-                raise ValueError(f"microbatch response item {row_number} is missing embedding")
-
-            response_index = row.get("index")
-            if type(response_index) is not int:
-                raise ValueError(f"microbatch response item {row_number} has invalid index")
-            if response_index < 0 or response_index >= expected_count:
-                raise ValueError(
-                    f"microbatch response item {row_number} index out of range index={response_index}"
-                )
-            if normalized_rows[response_index] is not None:
-                raise ValueError(f"microbatch response contains duplicate index={response_index}")
-            normalized_rows[response_index] = dict(row)
-
-        if any(row is None for row in normalized_rows):
-            raise ValueError("microbatch response is missing one or more expected indexes")
-
-        return [row for row in normalized_rows if row is not None]
-
-    def _build_microbatch_request(self, prepared_items: list[_PreparedEmbeddingItem]) -> EmbeddingRequest:
-        if not prepared_items:
-            raise ValueError("cannot build microbatch request without items")
-        request_data = prepared_items[0].payload.model_dump(exclude_none=True)
-        request_data["input"] = [prepared.payload.input for prepared in prepared_items]
-        return EmbeddingRequest.model_validate(request_data)
-
-    def _microbatch_group_key(self, prepared: _PreparedEmbeddingItem) -> tuple[_ExecutionSignature, str]:
-        return (
-            prepared.execution_signature,
-            json.dumps(prepared.failover_kwargs, sort_keys=True, default=str),
-        )
-
-    async def _mark_item_failed(
-        self,
-        *,
-        job,
-        item,
-        model_name: str,
-        exc: Exception,
-        deployment_id: str | None,
-        started_at_monotonic: float,
-    ) -> None:
-        batch_id = job.batch_id
-        retryable = self._is_retryable(exc) and item.attempts < self.config.max_attempts
-        error_payload = {"message": str(exc), "type": exc.__class__.__name__}
-        retry_delay = min(30, max(1, item.attempts * 2))
-        updated = await self.repository.mark_item_failed(
-            item_id=item.item_id,
-            worker_id=self.config.worker_id,
-            error_body=error_payload,
-            last_error=str(exc),
-            retryable=retryable,
-            retry_delay_seconds=retry_delay,
-        )
-        if not updated:
-            logger.warning("batch item failure update skipped after lease loss batch_id=%s item_id=%s", batch_id, item.item_id)
-            return
-        await self.repository.refresh_job_progress(batch_id)
-        await self._record_failure_runtime_hooks(
-            job=job,
-            item=item,
-            batch_id=batch_id,
-            model_name=model_name,
-            exc=exc,
-            deployment_id=deployment_id,
-        )
-        self._observe_item_execution_latency(
-            status="error",
-            latency_seconds=perf_counter() - started_at_monotonic,
-            reference=item.item_id,
-        )
-
-    def _observe_item_execution_latency(self, *, status: str, latency_seconds: float, reference: str) -> None:
-        try:
-            observe_batch_item_execution_latency(status=status, latency_seconds=latency_seconds)
-        except Exception as exc:
-            logger.warning(
-                "batch item latency metric publish failed reference=%s status=%s error=%s",
-                reference,
-                status,
-                exc,
-            )
-
-    async def _renew_item_lease_once(self, item_id: str) -> bool:
-        try:
-            return await self.repository.renew_item_lease(
-                item_id=item_id,
-                worker_id=self.config.worker_id,
-                lease_seconds=self.config.item_lease_seconds,
-            )
-        except Exception as exc:
-            logger.warning(
-                "batch item lease renewal before persistence failed item_id=%s error=%s",
-                item_id,
-                exc,
-                exc_info=True,
-            )
-            return False
-
-    def _build_completion_outbox_payload(
-        self,
-        *,
-        job,
-        prepared: _PreparedEmbeddingItem,
-        usage: dict[str, Any],
-        api_provider: str,
-        billed_cost: float,
-        provider_cost: float,
-        api_base: str | None,
-        deployment_model: str | None,
-    ) -> dict[str, Any]:
-        return {
-            "request_id": f"batch:{job.batch_id}:{prepared.item.item_id}",
-            "batch_id": job.batch_id,
-            "item_id": prepared.item.item_id,
-            "api_key": job.created_by_api_key,
-            "user_id": job.created_by_user_id,
-            "team_id": job.created_by_team_id,
-            "organization_id": job.created_by_organization_id,
-            "model": prepared.payload.model,
-            "call_type": "embedding_batch",
-            "usage": dict(usage),
-            "billed_cost": billed_cost,
-            "provider_cost": provider_cost,
-            "api_provider": api_provider,
-            "api_base": api_base,
-            "deployment_model": deployment_model,
-            "execution_mode": job.execution_mode,
-            "completed_at": datetime.now(tz=UTC).isoformat(),
-        }
-
-    async def _persist_completion_rows_with_outbox(
-        self,
-        *,
-        items: list[dict[str, Any]],
-        item_ids: list[str],
-        context_label: str,
-    ) -> bool:
-        for attempt in range(2):
-            try:
-                result = await self.repository.complete_items_with_outbox_bulk(
-                    items=items,
-                    worker_id=self.config.worker_id,
-                )
-            except Exception as exc:
-                logger.warning(
-                    "batch completion persistence attempt failed context=%s item_ids=%s attempt=%s error=%s",
-                    context_label,
-                    item_ids,
-                    attempt + 1,
-                    exc,
-                    exc_info=True,
-                )
-                continue
-
-            if result in {"completed", "already_completed"}:
-                return True
-            if result == "not_owned":
-                logger.warning(
-                    "batch completion persistence lost ownership context=%s item_ids=%s",
-                    context_label,
-                    item_ids,
-                )
-                return False
-
-        try:
-            requeued_item_ids = await self.repository.release_items_for_retry(
-                item_ids=item_ids,
-                worker_id=self.config.worker_id,
-            )
-        except Exception as exc:
-            logger.warning(
-                "batch completion persistence requeue failed context=%s item_ids=%s error=%s",
-                context_label,
-                item_ids,
-                exc,
-                exc_info=True,
-            )
-            return False
-
-        expected_ids = set(item_ids)
-        if set(requeued_item_ids) != expected_ids:
-            logger.warning(
-                "batch completion persistence requeue incomplete context=%s item_ids=%s requeued_item_ids=%s",
-                context_label,
-                item_ids,
-                requeued_item_ids,
-            )
-            return False
-        logger.warning(
-            "batch completion persistence requeued context=%s item_ids=%s",
-            context_label,
-            item_ids,
-        )
-        return False
-
-    async def _execute_prepared_item(self, job, prepared: _PreparedEmbeddingItem) -> None:
-        item_heartbeat: asyncio.Task[None] | None = None
-        try:
-            item_heartbeat = self._start_heartbeat(
-                renew=lambda: self.repository.renew_item_lease(
-                    item_id=prepared.item.item_id,
-                    worker_id=self.config.worker_id,
-                    lease_seconds=self.config.item_lease_seconds,
-                ),
-                label=f"item:{prepared.item.item_id}",
-            )
-            data, served_deployment = await self.app.state.failover_manager.execute_with_failover(
-                primary_deployment=prepared.primary_deployment,
-                model_group=prepared.model_group,
-                execute=lambda dep: _execute_embedding(prepared.request_shim, prepared.payload, dep),
-                return_deployment=True,
-                **prepared.failover_kwargs,
-            )
-            response_body, api_base, deployment_model = self._sanitize_embedding_response(data)
-            usage_allocations = allocate_embedding_usage(response_body.get("usage"), item_weights=[1])
-            usage = dict(usage_allocations[0] if usage_allocations else {})
-            api_provider = resolve_provider(served_deployment.deltallm_params)
-            response_body["_provider"] = api_provider
-            api_base = api_base or served_deployment.deltallm_params.get("api_base")
-            deployment_model = deployment_model or (str(served_deployment.deltallm_params.get("model") or "") or None)
-            deployment_pricing = self._deployment_pricing(served_deployment)
-            model_info = served_deployment.model_info or {}
-            billed_cost = completion_cost(
-                model=prepared.payload.model,
-                usage=usage,
-                cache_hit=False,
-                custom_pricing=deployment_pricing,
-                pricing_tier="batch",
-                model_info=model_info,
-            )
-            provider_cost = completion_cost(
-                model=prepared.payload.model,
-                usage=usage,
-                cache_hit=False,
-                custom_pricing=deployment_pricing,
-                pricing_tier="sync",
-                model_info=model_info,
-            )
-            served_deployment_id = str(
-                getattr(served_deployment, "deployment_id", None)
-                or getattr(prepared.primary_deployment, "deployment_id", None)
-                or ""
-            )
-            await self._record_upstream_success_runtime_hooks(
-                batch_id=job.batch_id,
-                deployment_id=served_deployment_id,
-                usage=usage,
-                    reference=prepared.item.item_id,
-                )
-            await self._renew_item_lease_once(prepared.item.item_id)
-            if item_heartbeat is not None:
-                await self._stop_heartbeat(item_heartbeat)
-                item_heartbeat = None
-            persisted = await self._persist_completion_rows_with_outbox(
-                items=[
-                    {
-                        "item_id": prepared.item.item_id,
-                        "response_body": response_body,
-                        "usage": usage,
-                        "provider_cost": provider_cost,
-                        "billed_cost": billed_cost,
-                        "outbox_payload": self._build_completion_outbox_payload(
-                            job=job,
-                            prepared=prepared,
-                            usage=usage,
-                            api_provider=api_provider,
-                            billed_cost=billed_cost,
-                            provider_cost=provider_cost,
-                            api_base=api_base,
-                            deployment_model=deployment_model,
-                        ),
-                        "outbox_max_attempts": _COMPLETION_OUTBOX_MAX_ATTEMPTS,
-                    }
-                ],
-                item_ids=[prepared.item.item_id],
-                context_label="single",
-            )
-            if persisted:
-                self._observe_item_execution_latency(
-                    status="success",
-                    latency_seconds=perf_counter() - prepared.started_at_monotonic,
-                    reference=prepared.item.item_id,
-                )
-        except Exception as exc:
-            await self._mark_item_failed(
-                job=job,
-                item=prepared.item,
-                model_name=prepared.model_name,
-                exc=exc,
-                deployment_id=str(getattr(prepared.primary_deployment, "deployment_id", None) or "") or None,
-                started_at_monotonic=prepared.started_at_monotonic,
-            )
-            return
-        finally:
-            if item_heartbeat is not None:
-                await self._stop_heartbeat(item_heartbeat)
-
-    async def _process_item_with_prepared_override(self, job, prepared: _PreparedEmbeddingItem) -> None:
-        self._prepared_item_overrides[prepared.item.item_id] = prepared
-        try:
-            await self._process_item(job, prepared.item)
-        finally:
-            self._prepared_item_overrides.pop(prepared.item.item_id, None)
-
-    async def _execute_prepared_microbatch_chunk(
-        self,
-        job,
-        prepared_items: list[_PreparedEmbeddingItem],
-    ) -> None:
-        if len(prepared_items) <= 1:
-            await self._execute_prepared_item(job, prepared_items[0])
-            return
-
-        batch_id = job.batch_id
-        chunk_size = len(prepared_items)
-        first_item = prepared_items[0]
-        item_ids = [prepared.item.item_id for prepared in prepared_items]
-        item_heartbeats: dict[str, asyncio.Task[None]] = {}
-        served_deployment = None
-
-        try:
-            for prepared in prepared_items:
-                item_heartbeats[prepared.item.item_id] = self._start_heartbeat(
-                    renew=lambda item_id=prepared.item.item_id: self.repository.renew_item_lease(
-                        item_id=item_id,
-                        worker_id=self.config.worker_id,
-                        lease_seconds=self.config.item_lease_seconds,
-                    ),
-                    label=f"item:{prepared.item.item_id}",
-                )
-            chunk_payload = self._build_microbatch_request(prepared_items)
-            logger.info(
-                "batch embedding microbatch started batch_id=%s deployment_id=%s size=%s item_ids=%s",
-                batch_id,
-                getattr(first_item.primary_deployment, "deployment_id", None),
-                chunk_size,
-                item_ids,
-            )
-            increment_batch_microbatch_requests()
-            increment_batch_microbatch_inputs(count=chunk_size)
-            observe_batch_microbatch_size(batch_size=chunk_size)
-            data, served_deployment = await self.app.state.failover_manager.execute_with_failover(
-                primary_deployment=first_item.primary_deployment,
-                model_group=first_item.model_group,
-                execute=lambda dep: _execute_embedding(first_item.request_shim, chunk_payload, dep),
-                return_deployment=True,
-                **first_item.failover_kwargs,
-            )
-            response_body, api_base, deployment_model = self._sanitize_embedding_response(data)
-            item_responses = self._validate_embedding_microbatch_response(
-                response_body=response_body,
-                expected_count=chunk_size,
-            )
-            usage_allocations = allocate_embedding_usage(
-                response_body.get("usage"),
-                item_weights=[prepared.microbatch_weight or 1 for prepared in prepared_items],
-            )
-        except Exception as exc:
-            await self._record_upstream_failure_runtime_hook(
-                batch_id=batch_id,
-                deployment_id=str(
-                    getattr(served_deployment, "deployment_id", None)
-                    or getattr(first_item.primary_deployment, "deployment_id", None)
-                    or ""
-                )
-                or None,
-                exc=exc,
-                reference=",".join(item_ids),
-            )
-            if isinstance(exc, ValueError):
-                logger.warning(
-                    "batch embedding microbatch response mismatch batch_id=%s deployment_id=%s size=%s error=%s",
-                    batch_id,
-                    getattr(served_deployment or first_item.primary_deployment, "deployment_id", None),
-                    chunk_size,
-                    exc,
-                )
-            increment_batch_microbatch_isolation_fallback()
-            logger.warning(
-                "batch embedding microbatch isolated batch_id=%s deployment_id=%s size=%s item_ids=%s error=%s",
-                batch_id,
-                getattr(served_deployment or first_item.primary_deployment, "deployment_id", None),
-                chunk_size,
-                item_ids,
-                exc,
-            )
-            for prepared in prepared_items:
-                item_heartbeat = item_heartbeats.pop(prepared.item.item_id, None)
-                if item_heartbeat is not None:
-                    await self._stop_heartbeat(item_heartbeat)
-                await self._process_item(job, prepared.item)
-            return
-
-        try:
-            api_provider = resolve_provider(served_deployment.deltallm_params)
-            api_base = api_base or served_deployment.deltallm_params.get("api_base")
-            deployment_model = deployment_model or (str(served_deployment.deltallm_params.get("model") or "") or None)
-            deployment_pricing = self._deployment_pricing(served_deployment)
-            model_info = served_deployment.model_info or {}
-            served_deployment_id = str(
-                getattr(served_deployment, "deployment_id", None)
-                or getattr(first_item.primary_deployment, "deployment_id", None)
-                or ""
-            )
-            await self._record_upstream_success_runtime_hooks(
-                batch_id=batch_id,
-                deployment_id=served_deployment_id,
-                usage=dict(response_body.get("usage") or {}),
-                reference=",".join(item_ids),
-            )
-            completion_rows: list[dict[str, Any]] = []
-            for prepared, item_response, usage in zip(prepared_items, item_responses, usage_allocations, strict=False):
-                normalized_response_body = self._build_single_item_embedding_response_body(
-                    chunk_response=response_body,
-                    item_response=item_response,
-                    usage=usage,
-                    api_provider=api_provider,
-                )
-                billed_cost = completion_cost(
-                    model=prepared.payload.model,
-                    usage=usage,
-                    cache_hit=False,
-                    custom_pricing=deployment_pricing,
-                    pricing_tier="batch",
-                    model_info=model_info,
-                )
-                provider_cost = completion_cost(
-                    model=prepared.payload.model,
-                    usage=usage,
-                    cache_hit=False,
-                    custom_pricing=deployment_pricing,
-                    pricing_tier="sync",
-                    model_info=model_info,
-                )
-                completion_rows.append(
-                    {
-                        "prepared": prepared,
-                        "response_body": normalized_response_body,
-                        "usage": usage,
-                        "provider_cost": provider_cost,
-                        "billed_cost": billed_cost,
-                    }
-                )
-
-            for item_id in item_ids:
-                await self._renew_item_lease_once(item_id)
-            await self._stop_heartbeat_tasks(item_heartbeats.values())
-            item_heartbeats.clear()
-
-            persisted = await self._persist_completion_rows_with_outbox(
-                items=[
-                    {
-                        "item_id": row["prepared"].item.item_id,
-                        "response_body": row["response_body"],
-                        "usage": row["usage"],
-                        "provider_cost": row["provider_cost"],
-                        "billed_cost": row["billed_cost"],
-                        "outbox_payload": self._build_completion_outbox_payload(
-                            job=job,
-                            prepared=row["prepared"],
-                            usage=row["usage"],
-                            api_provider=api_provider,
-                            billed_cost=row["billed_cost"],
-                            provider_cost=row["provider_cost"],
-                            api_base=api_base,
-                            deployment_model=deployment_model,
-                        ),
-                        "outbox_max_attempts": _COMPLETION_OUTBOX_MAX_ATTEMPTS,
-                    }
-                    for row in completion_rows
-                ],
-                item_ids=item_ids,
-                context_label=f"microbatch:{served_deployment_id or getattr(first_item.primary_deployment, 'deployment_id', None) or 'unknown'}",
-            )
-            if not persisted:
-                return
-
-            for row in completion_rows:
-                self._observe_item_execution_latency(
-                    status="success",
-                    latency_seconds=perf_counter() - row["prepared"].started_at_monotonic,
-                    reference=row["prepared"].item.item_id,
-                )
-            logger.info(
-                "batch embedding microbatch succeeded batch_id=%s primary_deployment_id=%s served_deployment_id=%s size=%s item_ids=%s",
-                batch_id,
-                getattr(first_item.primary_deployment, "deployment_id", None),
-                served_deployment_id,
-                chunk_size,
-                item_ids,
-            )
-        finally:
-            await self._stop_heartbeat_tasks(item_heartbeats.values())
-
-    async def _process_item(self, job, item) -> None:
-        request_body = item.request_body if isinstance(item.request_body, dict) else {}
-        model_name = str(request_body.get("model") or job.model or "")
-        started_at_monotonic = perf_counter()
-        prepared = self._prepared_item_overrides.get(item.item_id)
-        try:
-            if prepared is None:
-                prepared = await self._prepare_item_for_execution(job, item)
-        except Exception as exc:
-            await self._mark_item_failed(
-                job=job,
-                item=item,
-                model_name=model_name,
-                exc=exc,
-                deployment_id=None,
-                started_at_monotonic=started_at_monotonic,
-            )
-            return
-        await self._execute_prepared_item(job, prepared)
-
-    async def _stop_heartbeat_tasks(self, tasks) -> None:  # noqa: ANN001
-        for task in tasks:
-            await self._stop_heartbeat(task)
-
-    async def _process_items(self, job, items) -> None:
-        if not items:
-            set_batch_worker_saturation(worker_id=self.config.worker_id, active=0, capacity=self.config.worker_concurrency)
-            return
-
-        raw_items: deque[Any] = deque(items)
-        deferred_grouped_raw_items: deque[Any] = deque()
-        prepared_backlog: deque[_PreparedEmbeddingItem] = deque()
-        planned_work_units: deque[Any] = deque()
-        planning_lock = asyncio.Lock()
-        grouped_chunk_available = asyncio.Event()
-        grouped_chunk_available.set()
-        grouped_chunk_in_flight = False
-        grouped_chunk_blocked = object()
-        active = 0
-
-        logger.info(
-            "batch embedding microbatch planner started batch_id=%s claimed_items=%s",
-            job.batch_id,
-            len(items),
-        )
-
-        def _requeue_prepared_candidates(candidates: list[_PreparedEmbeddingItem]) -> None:
-            for candidate in reversed(candidates):
-                prepared_backlog.appendleft(candidate)
-
-        def _requeue_grouped_raw_items(candidates: list[Any]) -> None:  # noqa: ANN401
-            for candidate in reversed(candidates):
-                deferred_grouped_raw_items.appendleft(candidate)
-
-        def _requeue_deferred_candidates(candidates: list[_PreparedEmbeddingItem]) -> None:
-            prepared_candidates: list[_PreparedEmbeddingItem] = []
-            grouped_candidates: list[Any] = []
-            for candidate in candidates:
-                if candidate.microbatch_eligible and candidate.effective_upstream_max_batch_inputs > 1:
-                    grouped_candidates.append(candidate.item)
-                else:
-                    prepared_candidates.append(candidate)
-            _requeue_prepared_candidates(prepared_candidates)
-            _requeue_grouped_raw_items(grouped_candidates)
-
-        def _queue_preparation_failure(item, model_name: str, exc: Exception, started_at_monotonic: float) -> None:  # noqa: ANN001
-            planned_work_units.append(
-                lambda item=item, model_name=model_name, exc=exc, started_at_monotonic=started_at_monotonic: self._mark_item_failed(
-                    job=job,
-                    item=item,
-                    model_name=model_name,
-                    exc=exc,
-                    deployment_id=None,
-                    started_at_monotonic=started_at_monotonic,
-                )
-            )
-
-        async def _prepare_candidate_item(item) -> _PreparedEmbeddingItem | None:  # noqa: ANN001
-            started_at_monotonic = perf_counter()
-            request_body = item.request_body if isinstance(item.request_body, dict) else {}
-            model_name = str(request_body.get("model") or job.model or "")
-            try:
-                prepared = await self._prepare_item_for_execution(job, item)
-            except Exception as exc:
-                _queue_preparation_failure(item, model_name, exc, started_at_monotonic)
-                return None
-            if not prepared.microbatch_eligible:
-                increment_batch_microbatch_ineligible_item(
-                    reason=prepared.microbatch_ineligible_reason or "unknown",
-                )
-            return prepared
-
-        def _raw_item_looks_groupable(item) -> bool:  # noqa: ANN001
-            payload = EmbeddingRequest.model_validate(item.request_body)
-            _, microbatch_eligible, _ = classify_embedding_microbatch_request(payload)
-            return microbatch_eligible
-
-        async def _pop_next_candidate(*, allow_grouped_chunks: bool) -> _PreparedEmbeddingItem | object | None:
-            while True:
-                if allow_grouped_chunks and deferred_grouped_raw_items:
-                    prepared = await _prepare_candidate_item(deferred_grouped_raw_items.popleft())
-                    if prepared is None:
-                        continue
-                    return prepared
-
-                if prepared_backlog:
-                    return prepared_backlog.popleft()
-
-                if not raw_items:
-                    if deferred_grouped_raw_items and not allow_grouped_chunks:
-                        return grouped_chunk_blocked
-                    return None
-
-                item = raw_items.popleft()
-                if not allow_grouped_chunks:
-                    started_at_monotonic = perf_counter()
-                    request_body = item.request_body if isinstance(item.request_body, dict) else {}
-                    model_name = str(request_body.get("model") or job.model or "")
-                    try:
-                        if _raw_item_looks_groupable(item):
-                            deferred_grouped_raw_items.append(item)
-                            continue
-                    except Exception as exc:
-                        _queue_preparation_failure(item, model_name, exc, started_at_monotonic)
-                        continue
-                prepared = await _prepare_candidate_item(item)
-                if prepared is None:
-                    continue
-                grouped_chunk_candidate = (
-                    prepared.microbatch_eligible and prepared.effective_upstream_max_batch_inputs > 1
-                )
-                if grouped_chunk_candidate and not allow_grouped_chunks:
-                    deferred_grouped_raw_items.append(prepared.item)
-                    continue
-                return prepared
-
-        async def _run_grouped_chunk(chunk: list[_PreparedEmbeddingItem]) -> None:
-            nonlocal grouped_chunk_in_flight
-            try:
-                await self._execute_prepared_microbatch_chunk(job, chunk)
-            finally:
-                async with planning_lock:
-                    grouped_chunk_in_flight = False
-                    grouped_chunk_available.set()
-
-        async def _wait_for_grouped_chunk_slot() -> None:
-            await grouped_chunk_available.wait()
-
-        async def _plan_next_work_unit():
-            nonlocal grouped_chunk_in_flight
-            async with planning_lock:
-                if planned_work_units:
-                    return planned_work_units.popleft()
-
-                seed = await _pop_next_candidate(allow_grouped_chunks=not grouped_chunk_in_flight)
-                while seed is None:
-                    if planned_work_units:
-                        return planned_work_units.popleft()
-                    return None
-                if seed is grouped_chunk_blocked:
-                    return _wait_for_grouped_chunk_slot
-
-                if not seed.microbatch_eligible or seed.effective_upstream_max_batch_inputs <= 1:
-                    return lambda seed=seed: self._process_item_with_prepared_override(job, seed)
-
-                chunk = [seed]
-                chunk_key = self._microbatch_group_key(seed)
-                deferred_candidates: list[_PreparedEmbeddingItem] = []
-
-                while len(chunk) < seed.effective_upstream_max_batch_inputs:
-                    candidate = await _pop_next_candidate(allow_grouped_chunks=True)
-                    if candidate is None:
-                        break
-                    if candidate is grouped_chunk_blocked:
-                        break
-
-                    candidate_matches_chunk = (
-                        candidate.microbatch_eligible
-                        and candidate.effective_upstream_max_batch_inputs > 1
-                        and candidate.effective_upstream_max_batch_inputs == seed.effective_upstream_max_batch_inputs
-                        and self._microbatch_group_key(candidate) == chunk_key
-                    )
-                    if candidate_matches_chunk:
-                        chunk.append(candidate)
-                    else:
-                        deferred_candidates.append(candidate)
-
-                _requeue_deferred_candidates(deferred_candidates)
-                grouped_chunk_in_flight = True
-                grouped_chunk_available.clear()
-                return lambda chunk=list(chunk): _run_grouped_chunk(chunk)
-
-        async def _runner() -> None:
-            nonlocal active
-            while True:
-                work_unit = await _plan_next_work_unit()
-                if work_unit is None:
-                    return
-
-                active += 1
-                set_batch_worker_saturation(worker_id=self.config.worker_id, active=active, capacity=self.config.worker_concurrency)
-                try:
-                    await work_unit()
-                finally:
-                    active -= 1
-                    set_batch_worker_saturation(worker_id=self.config.worker_id, active=active, capacity=self.config.worker_concurrency)
-
-        runner_count = min(max(1, self.config.worker_concurrency), len(items))
-        async with asyncio.TaskGroup() as task_group:
-            for _ in range(runner_count):
-                task_group.create_task(_runner())
-
-    async def _record_upstream_success_runtime_hooks(
-        self,
-        *,
-        batch_id: str,
-        deployment_id: str,
-        usage: dict[str, Any],
-        reference: str,
-    ) -> None:
-        passive_health_tracker = getattr(self.app.state, "passive_health_tracker", None)
-        if passive_health_tracker is not None and deployment_id:
-            try:
-                await passive_health_tracker.record_request_outcome(deployment_id, success=True)
-            except Exception as exc:
-                logger.warning(
-                    "batch passive health success hook failed batch_id=%s reference=%s deployment_id=%s error=%s",
-                    batch_id,
-                    reference,
-                    deployment_id,
-                    exc,
-                )
-        router_state_backend = getattr(self.app.state, "router_state_backend", None)
-        if router_state_backend is not None and deployment_id:
-            try:
-                await record_router_usage(
-                    router_state_backend,
-                    deployment_id,
-                    mode="embedding",
-                    usage=usage,
-                )
-            except Exception as exc:
-                logger.warning(
-                    "batch router usage hook failed batch_id=%s reference=%s deployment_id=%s error=%s",
-                    batch_id,
-                    reference,
-                    deployment_id,
-                    exc,
-                )
-
-    async def _record_upstream_failure_runtime_hook(
-        self,
-        *,
-        batch_id: str,
-        deployment_id: str | None,
-        exc: Exception,
-        reference: str,
-    ) -> None:
-        passive_health_tracker = getattr(self.app.state, "passive_health_tracker", None)
-        if passive_health_tracker is None or deployment_id is None:
-            return
-        try:
-            await passive_health_tracker.record_request_outcome(deployment_id, success=False, error=str(exc))
-        except Exception as hook_exc:
-            logger.warning(
-                "batch passive health upstream failure hook failed batch_id=%s reference=%s deployment_id=%s error=%s",
-                batch_id,
-                reference,
-                deployment_id,
-                hook_exc,
-            )
-
-    async def _record_failure_runtime_hooks(
-        self,
-        *,
-        job,
-        item,
-        batch_id: str,
-        model_name: str,
-        exc: Exception,
-        deployment_id: str | None,
-    ) -> None:
-        passive_health_tracker = getattr(self.app.state, "passive_health_tracker", None)
-        if passive_health_tracker is not None and deployment_id is not None:
-            try:
-                await passive_health_tracker.record_request_outcome(deployment_id, success=False, error=str(exc))
-            except Exception as hook_exc:
-                logger.warning(
-                    "batch passive health failure hook failed batch_id=%s item_id=%s deployment_id=%s error=%s",
-                    batch_id,
-                    item.item_id,
-                    deployment_id,
-                    hook_exc,
-                )
-        spend_tracking_service = getattr(self.app.state, "spend_tracking_service", None)
-        if job.created_by_api_key and spend_tracking_service is not None:
-            try:
-                await spend_tracking_service.log_request_failure(
-                    request_id=f"batch:{batch_id}:{item.item_id}",
-                    api_key=job.created_by_api_key,
-                    user_id=job.created_by_user_id,
-                    team_id=job.created_by_team_id,
-                    organization_id=job.created_by_organization_id,
-                    end_user_id=None,
-                    model=model_name,
-                    call_type="embedding_batch",
-                    metadata={"batch_id": batch_id, "batch_item_id": item.item_id},
-                    cache_hit=False,
-                    start_time=None,
-                    end_time=datetime.now(tz=UTC),
-                    exc=exc,
-                )
-            except Exception as hook_exc:
-                logger.warning(
-                    "batch failure logging hook failed batch_id=%s item_id=%s error=%s",
-                    batch_id,
-                    item.item_id,
-                    hook_exc,
-                )
-
-    def _is_retryable(self, exc: Exception) -> bool:
-        if isinstance(exc, httpx.TimeoutException):
-            return True
-        if isinstance(exc, httpx.HTTPStatusError):
-            status_code = exc.response.status_code
-            return status_code == 429 or status_code >= 500
-        return False
+    def _resolve_final_status(self, job) -> str:  # noqa: ANN001
+        self._sync_dependencies()
+        return self._artifact_finalizer.resolve_final_status(job)
+
+    async def _finalize_with_retry(self, job) -> None:  # noqa: ANN001
+        self._sync_dependencies()
+        await self._artifact_finalizer.finalize_with_retry(job, finalize_artifacts=self._finalize_artifacts)
+
+    async def _iter_output_lines(self, batch_id: str):  # noqa: ANN201
+        self._sync_dependencies()
+        async for line in self._artifact_finalizer.iter_output_lines(batch_id):
+            yield line
+
+    async def _iter_error_lines(self, batch_id: str):  # noqa: ANN201
+        self._sync_dependencies()
+        async for line in self._artifact_finalizer.iter_error_lines(batch_id):
+            yield line
+
+    async def _finalize_artifacts(self, job) -> None:  # noqa: ANN001
+        self._sync_dependencies()
+        await self._artifact_finalizer.finalize_artifacts(job)
 
     def _start_heartbeat(self, *, renew, label: str) -> asyncio.Task[None]:
         return asyncio.create_task(self._run_heartbeat(renew=renew, label=label))
@@ -1202,156 +239,3 @@ class BatchExecutorWorker:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
-
-    def _resolve_final_status(self, job) -> str:
-        if job.cancel_requested_at is not None:
-            return BatchJobStatus.CANCELLED
-        if is_operator_failed_reason(job.provider_error):
-            return BatchJobStatus.FAILED
-        if job.completed_items == 0 and job.failed_items > 0:
-            return BatchJobStatus.FAILED
-        return BatchJobStatus.COMPLETED
-
-    async def _finalize_with_retry(self, job) -> None:
-        started = perf_counter()
-        try:
-            await self._finalize_artifacts(job)
-            observe_batch_finalize_latency(status="success", latency_seconds=perf_counter() - started)
-        except Exception as exc:
-            logger.warning("batch finalization failed batch_id=%s error=%s", job.batch_id, exc, exc_info=True)
-            rescheduled = await self.repository.reschedule_finalization(
-                batch_id=job.batch_id,
-                worker_id=self.config.worker_id,
-                retry_delay_seconds=self.config.finalization_retry_delay_seconds,
-            )
-            if not rescheduled:
-                logger.warning("batch finalization retry skipped after lease loss batch_id=%s", job.batch_id)
-                increment_batch_finalization_retry(result="lease_lost")
-            else:
-                logger.info(
-                    "batch finalization retry scheduled batch_id=%s worker_id=%s delay_seconds=%s",
-                    job.batch_id,
-                    self.config.worker_id,
-                    self.config.finalization_retry_delay_seconds,
-                )
-                increment_batch_finalization_retry(result="scheduled")
-            observe_batch_finalize_latency(status="error", latency_seconds=perf_counter() - started)
-
-    async def _cleanup_unattached_artifacts(self, artifacts: list[tuple[str, str]]) -> None:
-        for file_id, storage_key in artifacts:
-            with contextlib.suppress(Exception):
-                await self.storage.delete(storage_key)
-            with contextlib.suppress(Exception):
-                await self.repository.delete_file(file_id)
-
-    async def _iter_batch_items(self, batch_id: str) -> AsyncIterator[Any]:
-        if hasattr(self.repository, "list_items_page"):
-            after_line_number: int | None = None
-            while True:
-                page = await self.repository.list_items_page(
-                    batch_id=batch_id,
-                    limit=self.config.finalization_page_size,
-                    after_line_number=after_line_number,
-                )
-                if not page:
-                    break
-                for item in page:
-                    yield item
-                after_line_number = page[-1].line_number
-            return
-
-        for item in await self.repository.list_items(batch_id):
-            yield item
-
-    async def _iter_output_lines(self, batch_id: str) -> AsyncIterator[str]:
-        async for item in self._iter_batch_items(batch_id):
-            if item.status == "completed":
-                yield json.dumps(self._serialize_completed_artifact_row(item))
-
-    async def _iter_error_lines(self, batch_id: str) -> AsyncIterator[str]:
-        async for item in self._iter_batch_items(batch_id):
-            if item.status in {"failed", "cancelled"}:
-                yield json.dumps(self._serialize_failed_artifact_row(item))
-
-    async def _finalize_artifacts(self, job) -> None:
-        storage_backend = getattr(self.storage, "backend_name", "local")
-        created_artifacts: list[tuple[str, str]] = []
-        output_file_id: str | None = None
-        error_file_id: str | None = None
-        final_status = self._resolve_final_status(job)
-        try:
-            if job.completed_items > 0:
-                key, size, checksum = await self.storage.write_lines_stream(
-                    purpose="batch_output",
-                    filename=f"{job.batch_id}-output.jsonl",
-                    lines=self._iter_output_lines(job.batch_id),
-                )
-                file_record = await self.repository.create_file(
-                    purpose="batch_output",
-                    filename=f"{job.batch_id}-output.jsonl",
-                    bytes_size=size,
-                    storage_backend=storage_backend,
-                    storage_key=key,
-                    checksum=checksum,
-                    created_by_api_key=job.created_by_api_key,
-                    created_by_user_id=job.created_by_user_id,
-                    created_by_team_id=job.created_by_team_id,
-                    created_by_organization_id=job.created_by_organization_id,
-                    expires_at=datetime.now(tz=UTC) + timedelta(days=self.config.completed_artifact_retention_days),
-                )
-                if file_record is None:
-                    increment_batch_artifact_failure(operation="create_record", backend=storage_backend)
-                    raise RuntimeError(f"Failed to create output artifact record for batch {job.batch_id}")
-                created_artifacts.append((file_record.file_id, key))
-                output_file_id = file_record.file_id
-
-            if job.failed_items > 0 or job.cancelled_items > 0:
-                key, size, checksum = await self.storage.write_lines_stream(
-                    purpose="batch_error",
-                    filename=f"{job.batch_id}-error.jsonl",
-                    lines=self._iter_error_lines(job.batch_id),
-                )
-                retention_days = (
-                    self.config.failed_artifact_retention_days
-                    if final_status in {BatchJobStatus.FAILED, BatchJobStatus.CANCELLED}
-                    else self.config.completed_artifact_retention_days
-                )
-                file_record = await self.repository.create_file(
-                    purpose="batch_error",
-                    filename=f"{job.batch_id}-error.jsonl",
-                    bytes_size=size,
-                    storage_backend=storage_backend,
-                    storage_key=key,
-                    checksum=checksum,
-                    created_by_api_key=job.created_by_api_key,
-                    created_by_user_id=job.created_by_user_id,
-                    created_by_team_id=job.created_by_team_id,
-                    created_by_organization_id=job.created_by_organization_id,
-                    expires_at=datetime.now(tz=UTC) + timedelta(days=retention_days),
-                )
-                if file_record is None:
-                    increment_batch_artifact_failure(operation="create_record", backend=storage_backend)
-                    raise RuntimeError(f"Failed to create error artifact record for batch {job.batch_id}")
-                created_artifacts.append((file_record.file_id, key))
-                error_file_id = file_record.file_id
-
-            finalized = await self.repository.attach_artifacts_and_finalize(
-                batch_id=job.batch_id,
-                output_file_id=output_file_id,
-                error_file_id=error_file_id,
-                final_status=final_status,
-                worker_id=self.config.worker_id,
-            )
-            if finalized is None:
-                raise RuntimeError(f"Failed to finalize batch {job.batch_id}")
-        except Exception:
-            increment_batch_artifact_failure(operation="write_or_finalize", backend=storage_backend)
-            await self._cleanup_unattached_artifacts(created_artifacts)
-            raise
-        logger.info(
-            "batch finalized id=%s status=%s completed=%s failed=%s",
-            job.batch_id,
-            final_status,
-            job.completed_items,
-            job.failed_items,
-        )

--- a/src/batch/worker.py
+++ b/src/batch/worker.py
@@ -238,6 +238,63 @@ class BatchExecutorWorker:
         deployment_model = response_body.pop("_deployment_model", None)
         return response_body, api_base, deployment_model
 
+    def _public_batch_row_id(self, item) -> str:  # noqa: ANN001
+        return f"batch_req_{item.item_id}"
+
+    def _public_batch_request_id(self, item) -> str:  # noqa: ANN001
+        return f"req_batch_{item.item_id}"
+
+    def _sanitize_public_embedding_body(self, response_body: dict[str, Any] | None) -> dict[str, Any]:
+        if not isinstance(response_body, dict):
+            return {}
+
+        sanitized = dict(response_body)
+        sanitized.pop("_provider", None)
+        sanitized["object"] = str(sanitized.get("object") or "list")
+
+        normalized_rows: list[Any] = []
+        for row_number, row in enumerate(sanitized.get("data") or []):
+            if not isinstance(row, dict):
+                normalized_rows.append(row)
+                continue
+            normalized_row = dict(row)
+            normalized_row["object"] = str(normalized_row.get("object") or "embedding")
+            if type(normalized_row.get("index")) is not int:
+                normalized_row["index"] = row_number
+            normalized_rows.append(normalized_row)
+        if isinstance(sanitized.get("data"), list):
+            sanitized["data"] = normalized_rows
+
+        return sanitized
+
+    def _serialize_completed_artifact_row(self, item) -> dict[str, Any]:  # noqa: ANN001
+        return {
+            "id": self._public_batch_row_id(item),
+            "custom_id": item.custom_id,
+            "response": {
+                "status_code": 200,
+                "request_id": self._public_batch_request_id(item),
+                "body": self._sanitize_public_embedding_body(item.response_body),
+            },
+            "error": None,
+        }
+
+    def _serialize_failed_artifact_row(self, item) -> dict[str, Any]:  # noqa: ANN001
+        error_body = dict(item.error_body) if isinstance(item.error_body, dict) else {}
+        if not error_body.get("message"):
+            error_body["message"] = item.last_error or (
+                "Batch request cancelled" if item.status == "cancelled" else "Batch request failed"
+            )
+        if not error_body.get("type"):
+            error_body["type"] = "BatchItemCancelled" if item.status == "cancelled" else "BatchItemError"
+
+        return {
+            "id": self._public_batch_row_id(item),
+            "custom_id": item.custom_id,
+            "response": None,
+            "error": error_body,
+        }
+
     def _build_single_item_embedding_response_body(
         self,
         *,
@@ -1185,12 +1242,12 @@ class BatchExecutorWorker:
     async def _iter_output_lines(self, batch_id: str) -> AsyncIterator[str]:
         async for item in self._iter_batch_items(batch_id):
             if item.status == "completed":
-                yield json.dumps({"custom_id": item.custom_id, "response": item.response_body or {}})
+                yield json.dumps(self._serialize_completed_artifact_row(item))
 
     async def _iter_error_lines(self, batch_id: str) -> AsyncIterator[str]:
         async for item in self._iter_batch_items(batch_id):
             if item.status in {"failed", "cancelled"}:
-                yield json.dumps({"custom_id": item.custom_id, "error": item.error_body or {}})
+                yield json.dumps(self._serialize_failed_artifact_row(item))
 
     async def _finalize_artifacts(self, job) -> None:
         storage_backend = getattr(self.storage, "backend_name", "local")

--- a/src/batch/worker_artifacts.py
+++ b/src/batch/worker_artifacts.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime, timedelta
+import json
+import logging
+from time import perf_counter
+from typing import Any, AsyncIterator, Awaitable, Callable
+
+from src.batch.models import BatchJobStatus, is_operator_failed_reason
+from src.batch.repository import BatchRepository
+from src.batch.storage import BatchArtifactStorage
+from src.metrics import (
+    increment_batch_artifact_failure,
+    increment_batch_finalization_retry,
+    observe_batch_finalize_latency,
+)
+
+from src.batch.worker_types import BatchArtifactValidationError, BatchWorkerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class BatchArtifactFinalizer:
+    def __init__(
+        self,
+        *,
+        repository: BatchRepository,
+        storage: BatchArtifactStorage,
+        config: BatchWorkerConfig,
+    ) -> None:
+        self.repository = repository
+        self.storage = storage
+        self.config = config
+
+    def _public_batch_row_id(self, item) -> str:  # noqa: ANN001
+        return f"batch_req_{item.item_id}"
+
+    def _public_batch_request_id(self, item) -> str:  # noqa: ANN001
+        return f"req_batch_{item.item_id}"
+
+    def normalize_persisted_embedding_response_body(
+        self,
+        *,
+        response_body: dict[str, Any],
+        usage: dict[str, Any],
+        api_provider: str,
+        model_fallback: str | None,
+    ) -> dict[str, Any]:
+        normalized = dict(response_body)
+        if normalized.get("object") is None:
+            normalized["object"] = "list"
+
+        data_rows = normalized.get("data")
+        if isinstance(data_rows, list):
+            normalized_rows: list[Any] = []
+            for row_number, row in enumerate(data_rows):
+                if not isinstance(row, dict):
+                    normalized_rows.append(row)
+                    continue
+                normalized_row = dict(row)
+                normalized_row.setdefault("object", "embedding")
+                normalized_row["index"] = row_number
+                normalized_rows.append(normalized_row)
+            normalized["data"] = normalized_rows
+
+        normalized["usage"] = dict(usage)
+        normalized["_provider"] = api_provider
+
+        model_name = normalized.get("model")
+        if not isinstance(model_name, str) or not model_name.strip():
+            fallback_model = str(model_fallback or "").strip()
+            if fallback_model:
+                normalized["model"] = fallback_model
+
+        return normalized
+
+    def _normalized_embedding_usage_or_none(self, value: Any) -> dict[str, int] | None:
+        if not isinstance(value, dict):
+            return None
+
+        normalized_usage = dict(value)
+        for token_field in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            token_value = normalized_usage.get(token_field)
+            if type(token_value) is not int or token_value < 0:
+                return None
+
+        return normalized_usage
+
+    def _validate_public_embedding_usage(self, value: Any) -> dict[str, int]:
+        if not isinstance(value, dict):
+            raise BatchArtifactValidationError("completed batch item embedding response usage is not an object")
+
+        normalized_usage = dict(value)
+        for token_field in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            token_value = normalized_usage.get(token_field)
+            if type(token_value) is not int:
+                raise BatchArtifactValidationError(
+                    f"completed batch item embedding response usage has invalid {token_field}={token_value!r}"
+                )
+            if token_value < 0:
+                raise BatchArtifactValidationError(
+                    f"completed batch item embedding response usage has negative {token_field}={token_value!r}"
+                )
+
+        return normalized_usage
+
+    def _public_embedding_model_fallback(self, item) -> str | None:  # noqa: ANN001
+        request_body = item.request_body if isinstance(item.request_body, dict) else {}
+        request_model = request_body.get("model")
+        if not isinstance(request_model, str):
+            return None
+        normalized_model = request_model.strip()
+        return normalized_model or None
+
+    def _sanitize_public_embedding_body(self, item) -> dict[str, Any]:  # noqa: ANN001
+        response_body = item.response_body
+        if not isinstance(response_body, dict):
+            raise BatchArtifactValidationError("completed batch item is missing an embedding response body")
+
+        sanitized = dict(response_body)
+        sanitized.pop("_provider", None)
+        object_type = sanitized.get("object")
+        if object_type is None:
+            sanitized["object"] = "list"
+        elif object_type != "list":
+            raise BatchArtifactValidationError(
+                f"completed batch item has invalid embedding response object={object_type!r}"
+            )
+
+        data_rows = sanitized.get("data")
+        if not isinstance(data_rows, list):
+            raise BatchArtifactValidationError("completed batch item embedding response data is not a list")
+        if not data_rows:
+            raise BatchArtifactValidationError("completed batch item embedding response data is empty")
+
+        normalized_rows: list[Any] = []
+        for row_number, row in enumerate(data_rows):
+            if not isinstance(row, dict):
+                raise BatchArtifactValidationError(
+                    f"completed batch item embedding response row {row_number} is not an object"
+                )
+            normalized_row = dict(row)
+            if "embedding" not in normalized_row:
+                raise BatchArtifactValidationError(
+                    f"completed batch item embedding response row {row_number} is missing embedding"
+                )
+
+            row_object = normalized_row.get("object")
+            if row_object is None:
+                normalized_row["object"] = "embedding"
+            elif row_object != "embedding":
+                raise BatchArtifactValidationError(
+                    f"completed batch item embedding response row {row_number} has invalid object={row_object!r}"
+                )
+
+            response_index = normalized_row.get("index")
+            if response_index is None:
+                normalized_row["index"] = row_number
+            elif type(response_index) is not int:
+                raise BatchArtifactValidationError(
+                    f"completed batch item embedding response row {row_number} has invalid index={response_index!r}"
+                )
+            normalized_rows.append(normalized_row)
+
+        sanitized["data"] = normalized_rows
+
+        model_name = sanitized.get("model")
+        if not isinstance(model_name, str) or not model_name.strip():
+            fallback_model = self._public_embedding_model_fallback(item)
+            if fallback_model is not None:
+                sanitized["model"] = fallback_model
+        model_name = sanitized.get("model")
+        if not isinstance(model_name, str) or not model_name.strip():
+            raise BatchArtifactValidationError("completed batch item embedding response is missing a valid model")
+
+        try:
+            normalized_usage = self._validate_public_embedding_usage(sanitized.get("usage"))
+        except BatchArtifactValidationError:
+            normalized_usage = self._normalized_embedding_usage_or_none(item.usage)
+            if normalized_usage is None:
+                raise
+        sanitized["usage"] = normalized_usage
+
+        return sanitized
+
+    def _serialize_completed_artifact_row(self, item) -> dict[str, Any]:  # noqa: ANN001
+        return {
+            "id": self._public_batch_row_id(item),
+            "custom_id": item.custom_id,
+            "response": {
+                "status_code": 200,
+                "request_id": self._public_batch_request_id(item),
+                "body": self._sanitize_public_embedding_body(item),
+            },
+            "error": None,
+        }
+
+    def _serialize_failed_artifact_row(self, item) -> dict[str, Any]:  # noqa: ANN001
+        error_body = dict(item.error_body) if isinstance(item.error_body, dict) else {}
+        if not error_body.get("message"):
+            error_body["message"] = item.last_error or (
+                "Batch request cancelled" if item.status == "cancelled" else "Batch request failed"
+            )
+        if not error_body.get("type"):
+            error_body["type"] = "BatchItemCancelled" if item.status == "cancelled" else "BatchItemError"
+
+        return {
+            "id": self._public_batch_row_id(item),
+            "custom_id": item.custom_id,
+            "response": None,
+            "error": error_body,
+        }
+
+    def resolve_final_status(self, job) -> str:  # noqa: ANN001
+        if job.cancel_requested_at is not None:
+            return BatchJobStatus.CANCELLED
+        if is_operator_failed_reason(job.provider_error):
+            return BatchJobStatus.FAILED
+        if job.completed_items == 0 and job.failed_items > 0:
+            return BatchJobStatus.FAILED
+        return BatchJobStatus.COMPLETED
+
+    async def _persist_permanent_finalization_failure(self, job, *, reason: str) -> bool:
+        finalized = await self.repository.attach_artifacts_and_finalize(
+            batch_id=job.batch_id,
+            output_file_id=None,
+            error_file_id=None,
+            final_status=BatchJobStatus.FAILED,
+            worker_id=self.config.worker_id,
+        )
+        if finalized is None:
+            return False
+        try:
+            await self.repository.set_provider_error(
+                batch_id=job.batch_id,
+                provider_error=f"artifact_validation_failed: {reason}",
+            )
+        except Exception:
+            logger.warning(
+                "batch finalization failed to persist permanent failure reason batch_id=%s",
+                job.batch_id,
+                exc_info=True,
+            )
+        return True
+
+    async def _schedule_finalization_retry(self, job) -> None:
+        rescheduled = await self.repository.reschedule_finalization(
+            batch_id=job.batch_id,
+            worker_id=self.config.worker_id,
+            retry_delay_seconds=self.config.finalization_retry_delay_seconds,
+        )
+        if not rescheduled:
+            logger.warning("batch finalization retry skipped after lease loss batch_id=%s", job.batch_id)
+            increment_batch_finalization_retry(result="lease_lost")
+            return
+        logger.info(
+            "batch finalization retry scheduled batch_id=%s worker_id=%s delay_seconds=%s",
+            job.batch_id,
+            self.config.worker_id,
+            self.config.finalization_retry_delay_seconds,
+        )
+        increment_batch_finalization_retry(result="scheduled")
+
+    async def finalize_with_retry(
+        self,
+        job,
+        *,
+        finalize_artifacts: Callable[[Any], Awaitable[None]] | None = None,
+    ) -> None:  # noqa: ANN001
+        started = perf_counter()
+        finalize = finalize_artifacts or self.finalize_artifacts
+        try:
+            await finalize(job)
+            observe_batch_finalize_latency(status="success", latency_seconds=perf_counter() - started)
+            return
+        except BatchArtifactValidationError as exc:
+            logger.warning(
+                "batch finalization permanently failed batch_id=%s error=%s",
+                job.batch_id,
+                exc,
+                exc_info=True,
+            )
+            try:
+                persisted = await self._persist_permanent_finalization_failure(job, reason=str(exc))
+            except Exception:
+                logger.warning(
+                    "batch finalization permanent-failure persistence failed batch_id=%s",
+                    job.batch_id,
+                    exc_info=True,
+                )
+            else:
+                if persisted:
+                    observe_batch_finalize_latency(status="error", latency_seconds=perf_counter() - started)
+                    return
+                logger.warning(
+                    "batch finalization permanent-failure persistence skipped after lease loss batch_id=%s",
+                    job.batch_id,
+                )
+        except Exception as exc:
+            logger.warning("batch finalization failed batch_id=%s error=%s", job.batch_id, exc, exc_info=True)
+            await self._schedule_finalization_retry(job)
+            observe_batch_finalize_latency(status="error", latency_seconds=perf_counter() - started)
+            return
+        await self._schedule_finalization_retry(job)
+        observe_batch_finalize_latency(status="error", latency_seconds=perf_counter() - started)
+
+    async def _cleanup_unattached_artifacts(self, artifacts: list[tuple[str, str]]) -> None:
+        for file_id, storage_key in artifacts:
+            with contextlib.suppress(Exception):
+                await self.storage.delete(storage_key)
+            with contextlib.suppress(Exception):
+                await self.repository.delete_file(file_id)
+
+    async def _iter_batch_items(self, batch_id: str) -> AsyncIterator[Any]:
+        if hasattr(self.repository, "list_items_page"):
+            after_line_number: int | None = None
+            while True:
+                page = await self.repository.list_items_page(
+                    batch_id=batch_id,
+                    limit=self.config.finalization_page_size,
+                    after_line_number=after_line_number,
+                )
+                if not page:
+                    break
+                for item in page:
+                    yield item
+                after_line_number = page[-1].line_number
+            return
+
+        for item in await self.repository.list_items(batch_id):
+            yield item
+
+    async def iter_output_lines(self, batch_id: str) -> AsyncIterator[str]:
+        async for item in self._iter_batch_items(batch_id):
+            if item.status == "completed":
+                yield json.dumps(self._serialize_completed_artifact_row(item))
+
+    async def iter_error_lines(self, batch_id: str) -> AsyncIterator[str]:
+        async for item in self._iter_batch_items(batch_id):
+            if item.status in {"failed", "cancelled"}:
+                yield json.dumps(self._serialize_failed_artifact_row(item))
+
+    async def finalize_artifacts(self, job) -> None:  # noqa: ANN001
+        storage_backend = getattr(self.storage, "backend_name", "local")
+        created_artifacts: list[tuple[str, str]] = []
+        output_file_id: str | None = None
+        error_file_id: str | None = None
+        final_status = self.resolve_final_status(job)
+        try:
+            if job.completed_items > 0:
+                key, size, checksum = await self.storage.write_lines_stream(
+                    purpose="batch_output",
+                    filename=f"{job.batch_id}-output.jsonl",
+                    lines=self.iter_output_lines(job.batch_id),
+                )
+                file_record = await self.repository.create_file(
+                    purpose="batch_output",
+                    filename=f"{job.batch_id}-output.jsonl",
+                    bytes_size=size,
+                    storage_backend=storage_backend,
+                    storage_key=key,
+                    checksum=checksum,
+                    created_by_api_key=job.created_by_api_key,
+                    created_by_user_id=job.created_by_user_id,
+                    created_by_team_id=job.created_by_team_id,
+                    created_by_organization_id=job.created_by_organization_id,
+                    expires_at=datetime.now(tz=UTC) + timedelta(days=self.config.completed_artifact_retention_days),
+                )
+                if file_record is None:
+                    increment_batch_artifact_failure(operation="create_record", backend=storage_backend)
+                    raise RuntimeError(f"Failed to create output artifact record for batch {job.batch_id}")
+                created_artifacts.append((file_record.file_id, key))
+                output_file_id = file_record.file_id
+
+            if job.failed_items > 0 or job.cancelled_items > 0:
+                key, size, checksum = await self.storage.write_lines_stream(
+                    purpose="batch_error",
+                    filename=f"{job.batch_id}-error.jsonl",
+                    lines=self.iter_error_lines(job.batch_id),
+                )
+                retention_days = (
+                    self.config.failed_artifact_retention_days
+                    if final_status in {BatchJobStatus.FAILED, BatchJobStatus.CANCELLED}
+                    else self.config.completed_artifact_retention_days
+                )
+                file_record = await self.repository.create_file(
+                    purpose="batch_error",
+                    filename=f"{job.batch_id}-error.jsonl",
+                    bytes_size=size,
+                    storage_backend=storage_backend,
+                    storage_key=key,
+                    checksum=checksum,
+                    created_by_api_key=job.created_by_api_key,
+                    created_by_user_id=job.created_by_user_id,
+                    created_by_team_id=job.created_by_team_id,
+                    created_by_organization_id=job.created_by_organization_id,
+                    expires_at=datetime.now(tz=UTC) + timedelta(days=retention_days),
+                )
+                if file_record is None:
+                    increment_batch_artifact_failure(operation="create_record", backend=storage_backend)
+                    raise RuntimeError(f"Failed to create error artifact record for batch {job.batch_id}")
+                created_artifacts.append((file_record.file_id, key))
+                error_file_id = file_record.file_id
+
+            finalized = await self.repository.attach_artifacts_and_finalize(
+                batch_id=job.batch_id,
+                output_file_id=output_file_id,
+                error_file_id=error_file_id,
+                final_status=final_status,
+                worker_id=self.config.worker_id,
+            )
+            if finalized is None:
+                raise RuntimeError(f"Failed to finalize batch {job.batch_id}")
+        except Exception:
+            increment_batch_artifact_failure(operation="write_or_finalize", backend=storage_backend)
+            await self._cleanup_unattached_artifacts(created_artifacts)
+            raise
+        logger.info(
+            "batch finalized id=%s status=%s completed=%s failed=%s",
+            job.batch_id,
+            final_status,
+            job.completed_items,
+            job.failed_items,
+        )

--- a/src/batch/worker_execution.py
+++ b/src/batch/worker_execution.py
@@ -1,0 +1,1032 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from datetime import UTC, datetime
+import json
+import logging
+from time import perf_counter
+from typing import Any, Awaitable, Callable
+
+import httpx
+
+from src.batch.embedding_microbatch import (
+    allocate_embedding_usage,
+    build_embedding_execution_signature,
+    classify_embedding_microbatch_request,
+    estimate_embedding_microbatch_weight,
+    resolve_effective_upstream_max_batch_inputs,
+)
+from src.batch.repository import BatchRepository
+from src.billing.cost import ModelPricing, completion_cost
+from src.metrics import (
+    increment_batch_microbatch_ineligible_item,
+    increment_batch_microbatch_inputs,
+    increment_batch_microbatch_isolation_fallback,
+    increment_batch_microbatch_requests,
+    observe_batch_microbatch_size,
+    set_batch_worker_saturation,
+)
+from src.models.requests import EmbeddingRequest
+from src.providers.resolution import resolve_provider
+from src.routers.routing_decision import route_failover_kwargs
+
+from src.batch.worker_types import _PreparedEmbeddingItem, _RequestShim, BatchWorkerConfig
+
+logger = logging.getLogger(__name__)
+_COMPLETION_OUTBOX_MAX_ATTEMPTS = 5
+
+
+class BatchExecutionEngine:
+    def __init__(
+        self,
+        *,
+        app: Any,
+        repository: BatchRepository,
+        config: BatchWorkerConfig,
+        normalize_persisted_embedding_response_body: Callable[..., dict[str, Any]],
+        execute_embedding: Callable[..., Awaitable[dict[str, Any]]],
+        record_router_usage: Callable[..., Awaitable[None]],
+        observe_item_execution_latency: Callable[..., None],
+        start_heartbeat: Callable[..., asyncio.Task[None]],
+        stop_heartbeat: Callable[[asyncio.Task[None]], Awaitable[None]],
+    ) -> None:
+        self.app = app
+        self.repository = repository
+        self.config = config
+        self._normalize_persisted_embedding_response_body = normalize_persisted_embedding_response_body
+        self._execute_embedding = execute_embedding
+        self._record_router_usage = record_router_usage
+        self._observe_batch_item_execution_latency = observe_item_execution_latency
+        self._start_heartbeat_fn = start_heartbeat
+        self._stop_heartbeat_fn = stop_heartbeat
+        self._prepared_item_overrides: dict[str, _PreparedEmbeddingItem] = {}
+
+    async def prepare_item_for_execution(self, job, item) -> _PreparedEmbeddingItem:  # noqa: ANN001
+        started_at_monotonic = perf_counter()
+        embedding_request = EmbeddingRequest.model_validate(item.request_body)
+        budget_service = getattr(self.app.state, "budget_service", None)
+        if budget_service is not None:
+            await budget_service.check_budgets(
+                api_key=job.created_by_api_key,
+                user_id=job.created_by_user_id,
+                team_id=job.created_by_team_id,
+                organization_id=job.created_by_organization_id,
+                model=embedding_request.model,
+            )
+
+        request_context: dict[str, Any] = {"metadata": {}, "user_id": "batch-worker"}
+        app_router = self.app.state.router
+        model_group = app_router.resolve_model_group(embedding_request.model)
+        primary_deployment = app_router.require_deployment(
+            model_group=model_group,
+            deployment=await app_router.select_deployment(model_group, request_context),
+        )
+        input_kind, microbatch_eligible, microbatch_ineligible_reason = classify_embedding_microbatch_request(
+            embedding_request
+        )
+        primary_deployment_id = str(getattr(primary_deployment, "deployment_id", None) or "")
+        return _PreparedEmbeddingItem(
+            item=item,
+            started_at_monotonic=started_at_monotonic,
+            payload=embedding_request,
+            model_name=embedding_request.model,
+            model_group=model_group,
+            primary_deployment=primary_deployment,
+            request_context=request_context,
+            failover_kwargs=route_failover_kwargs(request_context),
+            request_shim=_RequestShim(app=self.app),
+            effective_upstream_max_batch_inputs=resolve_effective_upstream_max_batch_inputs(
+                getattr(primary_deployment, "model_info", None)
+            ),
+            microbatch_eligible=microbatch_eligible,
+            microbatch_ineligible_reason=microbatch_ineligible_reason,
+            microbatch_weight=estimate_embedding_microbatch_weight(embedding_request) if microbatch_eligible else None,
+            execution_signature=build_embedding_execution_signature(
+                payload=embedding_request,
+                model_group=model_group,
+                primary_deployment_id=primary_deployment_id,
+                input_kind=input_kind,
+            ),
+        )
+
+    def _deployment_pricing(self, deployment) -> ModelPricing | None:  # noqa: ANN001
+        if deployment.input_cost_per_token or deployment.output_cost_per_token:
+            return ModelPricing(
+                input_cost_per_token=deployment.input_cost_per_token,
+                output_cost_per_token=deployment.output_cost_per_token,
+            )
+        return None
+
+    def _sanitize_embedding_response(self, data: dict[str, Any]) -> tuple[dict[str, Any], str | None, str | None]:
+        response_body = dict(data)
+        response_body.pop("_api_latency_ms", None)
+        api_base = response_body.pop("_api_base", None)
+        deployment_model = response_body.pop("_deployment_model", None)
+        return response_body, api_base, deployment_model
+
+    def _build_single_item_embedding_response_body(
+        self,
+        *,
+        chunk_response: dict[str, Any],
+        item_response: dict[str, Any],
+        usage: dict[str, Any],
+        api_provider: str,
+        model_fallback: str | None,
+    ) -> dict[str, Any]:
+        response_body: dict[str, Any] = {
+            "object": chunk_response.get("object") or "list",
+            "data": [dict(item_response)],
+        }
+        return self._normalize_persisted_embedding_response_body(
+            response_body=response_body,
+            usage=usage,
+            api_provider=api_provider,
+            model_fallback=model_fallback,
+        )
+
+    def _validate_embedding_microbatch_response(
+        self,
+        *,
+        response_body: dict[str, Any],
+        expected_count: int,
+    ) -> list[dict[str, Any]]:
+        data_rows = response_body.get("data")
+        if not isinstance(data_rows, list):
+            raise ValueError("microbatch response data is not a list")
+        if len(data_rows) != expected_count:
+            raise ValueError(
+                f"microbatch response length mismatch expected={expected_count} actual={len(data_rows)}"
+            )
+
+        normalized_rows: list[dict[str, Any] | None] = [None] * expected_count
+        for row_number, row in enumerate(data_rows):
+            if not isinstance(row, dict):
+                raise ValueError(f"microbatch response item {row_number} is not an object")
+            if "embedding" not in row:
+                raise ValueError(f"microbatch response item {row_number} is missing embedding")
+
+            response_index = row.get("index")
+            if type(response_index) is not int:
+                raise ValueError(f"microbatch response item {row_number} has invalid index")
+            if response_index < 0 or response_index >= expected_count:
+                raise ValueError(
+                    f"microbatch response item {row_number} index out of range index={response_index}"
+                )
+            if normalized_rows[response_index] is not None:
+                raise ValueError(f"microbatch response contains duplicate index={response_index}")
+            normalized_rows[response_index] = dict(row)
+
+        if any(row is None for row in normalized_rows):
+            raise ValueError("microbatch response is missing one or more expected indexes")
+
+        return [row for row in normalized_rows if row is not None]
+
+    def _build_microbatch_request(self, prepared_items: list[_PreparedEmbeddingItem]):  # noqa: ANN001
+        if not prepared_items:
+            raise ValueError("cannot build microbatch request without items")
+        request_data = prepared_items[0].payload.model_dump(exclude_none=True)
+        request_data["input"] = [prepared.payload.input for prepared in prepared_items]
+        return EmbeddingRequest.model_validate(request_data)
+
+    def _microbatch_group_key(self, prepared: _PreparedEmbeddingItem) -> tuple[Any, str]:
+        return (
+            prepared.execution_signature,
+            json.dumps(prepared.failover_kwargs, sort_keys=True, default=str),
+        )
+
+    async def _mark_item_failed(
+        self,
+        *,
+        job,
+        item,
+        model_name: str,
+        exc: Exception,
+        deployment_id: str | None,
+        started_at_monotonic: float,
+    ) -> None:
+        batch_id = job.batch_id
+        retryable = self._is_retryable(exc) and item.attempts < self.config.max_attempts
+        error_payload = {"message": str(exc), "type": exc.__class__.__name__}
+        retry_delay = min(30, max(1, item.attempts * 2))
+        updated = await self.repository.mark_item_failed(
+            item_id=item.item_id,
+            worker_id=self.config.worker_id,
+            error_body=error_payload,
+            last_error=str(exc),
+            retryable=retryable,
+            retry_delay_seconds=retry_delay,
+        )
+        if not updated:
+            logger.warning("batch item failure update skipped after lease loss batch_id=%s item_id=%s", batch_id, item.item_id)
+            return
+        await self.repository.refresh_job_progress(batch_id)
+        await self._record_failure_runtime_hooks(
+            job=job,
+            item=item,
+            batch_id=batch_id,
+            model_name=model_name,
+            exc=exc,
+            deployment_id=deployment_id,
+        )
+        self._observe_item_execution_latency(
+            status="error",
+            latency_seconds=perf_counter() - started_at_monotonic,
+            reference=item.item_id,
+        )
+
+    def _observe_item_execution_latency(self, *, status: str, latency_seconds: float, reference: str) -> None:
+        try:
+            self._observe_batch_item_execution_latency(status=status, latency_seconds=latency_seconds)
+        except Exception as exc:
+            logger.warning(
+                "batch item latency metric publish failed reference=%s status=%s error=%s",
+                reference,
+                status,
+                exc,
+            )
+
+    async def _renew_item_lease_once(self, item_id: str) -> bool:
+        try:
+            return await self.repository.renew_item_lease(
+                item_id=item_id,
+                worker_id=self.config.worker_id,
+                lease_seconds=self.config.item_lease_seconds,
+            )
+        except Exception as exc:
+            logger.warning(
+                "batch item lease renewal before persistence failed item_id=%s error=%s",
+                item_id,
+                exc,
+                exc_info=True,
+            )
+            return False
+
+    def _build_completion_outbox_payload(
+        self,
+        *,
+        job,
+        prepared: _PreparedEmbeddingItem,
+        usage: dict[str, Any],
+        api_provider: str,
+        billed_cost: float,
+        provider_cost: float,
+        api_base: str | None,
+        deployment_model: str | None,
+    ) -> dict[str, Any]:
+        return {
+            "request_id": f"batch:{job.batch_id}:{prepared.item.item_id}",
+            "batch_id": job.batch_id,
+            "item_id": prepared.item.item_id,
+            "api_key": job.created_by_api_key,
+            "user_id": job.created_by_user_id,
+            "team_id": job.created_by_team_id,
+            "organization_id": job.created_by_organization_id,
+            "model": prepared.payload.model,
+            "call_type": "embedding_batch",
+            "usage": dict(usage),
+            "billed_cost": billed_cost,
+            "provider_cost": provider_cost,
+            "api_provider": api_provider,
+            "api_base": api_base,
+            "deployment_model": deployment_model,
+            "execution_mode": job.execution_mode,
+            "completed_at": datetime.now(tz=UTC).isoformat(),
+        }
+
+    async def _persist_completion_rows_with_outbox(
+        self,
+        *,
+        items: list[dict[str, Any]],
+        item_ids: list[str],
+        context_label: str,
+    ) -> bool:
+        for attempt in range(2):
+            try:
+                result = await self.repository.complete_items_with_outbox_bulk(
+                    items=items,
+                    worker_id=self.config.worker_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "batch completion persistence attempt failed context=%s item_ids=%s attempt=%s error=%s",
+                    context_label,
+                    item_ids,
+                    attempt + 1,
+                    exc,
+                    exc_info=True,
+                )
+                continue
+
+            if result in {"completed", "already_completed"}:
+                return True
+            if result == "not_owned":
+                logger.warning(
+                    "batch completion persistence lost ownership context=%s item_ids=%s",
+                    context_label,
+                    item_ids,
+                )
+                return False
+
+        try:
+            requeued_item_ids = await self.repository.release_items_for_retry(
+                item_ids=item_ids,
+                worker_id=self.config.worker_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "batch completion persistence requeue failed context=%s item_ids=%s error=%s",
+                context_label,
+                item_ids,
+                exc,
+                exc_info=True,
+            )
+            return False
+
+        expected_ids = set(item_ids)
+        if set(requeued_item_ids) != expected_ids:
+            logger.warning(
+                "batch completion persistence requeue incomplete context=%s item_ids=%s requeued_item_ids=%s",
+                context_label,
+                item_ids,
+                requeued_item_ids,
+            )
+            return False
+        logger.warning(
+            "batch completion persistence requeued context=%s item_ids=%s",
+            context_label,
+            item_ids,
+        )
+        return False
+
+    async def _execute_prepared_item(self, job, prepared: _PreparedEmbeddingItem) -> None:  # noqa: ANN001
+        item_heartbeat: asyncio.Task[None] | None = None
+        try:
+            item_heartbeat = self._start_heartbeat_fn(
+                renew=lambda: self.repository.renew_item_lease(
+                    item_id=prepared.item.item_id,
+                    worker_id=self.config.worker_id,
+                    lease_seconds=self.config.item_lease_seconds,
+                ),
+                label=f"item:{prepared.item.item_id}",
+            )
+            data, served_deployment = await self.app.state.failover_manager.execute_with_failover(
+                primary_deployment=prepared.primary_deployment,
+                model_group=prepared.model_group,
+                execute=lambda dep: self._execute_embedding(prepared.request_shim, prepared.payload, dep),
+                return_deployment=True,
+                **prepared.failover_kwargs,
+            )
+            response_body, api_base, deployment_model = self._sanitize_embedding_response(data)
+            usage_allocations = allocate_embedding_usage(response_body.get("usage"), item_weights=[1])
+            usage = dict(usage_allocations[0] if usage_allocations else {})
+            api_provider = resolve_provider(served_deployment.deltallm_params)
+            api_base = api_base or served_deployment.deltallm_params.get("api_base")
+            deployment_model = deployment_model or (str(served_deployment.deltallm_params.get("model") or "") or None)
+            response_body = self._normalize_persisted_embedding_response_body(
+                response_body=response_body,
+                usage=usage,
+                api_provider=api_provider,
+                model_fallback=deployment_model,
+            )
+            deployment_pricing = self._deployment_pricing(served_deployment)
+            model_info = served_deployment.model_info or {}
+            billed_cost = completion_cost(
+                model=prepared.payload.model,
+                usage=usage,
+                cache_hit=False,
+                custom_pricing=deployment_pricing,
+                pricing_tier="batch",
+                model_info=model_info,
+            )
+            provider_cost = completion_cost(
+                model=prepared.payload.model,
+                usage=usage,
+                cache_hit=False,
+                custom_pricing=deployment_pricing,
+                pricing_tier="sync",
+                model_info=model_info,
+            )
+            served_deployment_id = str(
+                getattr(served_deployment, "deployment_id", None)
+                or getattr(prepared.primary_deployment, "deployment_id", None)
+                or ""
+            )
+            await self._record_upstream_success_runtime_hooks(
+                batch_id=job.batch_id,
+                deployment_id=served_deployment_id,
+                usage=usage,
+                reference=prepared.item.item_id,
+            )
+            await self._renew_item_lease_once(prepared.item.item_id)
+            if item_heartbeat is not None:
+                await self._stop_heartbeat_fn(item_heartbeat)
+                item_heartbeat = None
+            persisted = await self._persist_completion_rows_with_outbox(
+                items=[
+                    {
+                        "item_id": prepared.item.item_id,
+                        "response_body": response_body,
+                        "usage": usage,
+                        "provider_cost": provider_cost,
+                        "billed_cost": billed_cost,
+                        "outbox_payload": self._build_completion_outbox_payload(
+                            job=job,
+                            prepared=prepared,
+                            usage=usage,
+                            api_provider=api_provider,
+                            billed_cost=billed_cost,
+                            provider_cost=provider_cost,
+                            api_base=api_base,
+                            deployment_model=deployment_model,
+                        ),
+                        "outbox_max_attempts": _COMPLETION_OUTBOX_MAX_ATTEMPTS,
+                    }
+                ],
+                item_ids=[prepared.item.item_id],
+                context_label="single",
+            )
+            if persisted:
+                self._observe_item_execution_latency(
+                    status="success",
+                    latency_seconds=perf_counter() - prepared.started_at_monotonic,
+                    reference=prepared.item.item_id,
+                )
+        except Exception as exc:
+            await self._mark_item_failed(
+                job=job,
+                item=prepared.item,
+                model_name=prepared.model_name,
+                exc=exc,
+                deployment_id=str(getattr(prepared.primary_deployment, "deployment_id", None) or "") or None,
+                started_at_monotonic=prepared.started_at_monotonic,
+            )
+            return
+        finally:
+            if item_heartbeat is not None:
+                await self._stop_heartbeat_fn(item_heartbeat)
+
+    async def _process_item_with_prepared_override(
+        self,
+        job,
+        prepared: _PreparedEmbeddingItem,
+        *,
+        process_item: Callable[[Any, Any], Awaitable[None]],
+    ) -> None:  # noqa: ANN001
+        self._prepared_item_overrides[prepared.item.item_id] = prepared
+        try:
+            await process_item(job, prepared.item)
+        finally:
+            self._prepared_item_overrides.pop(prepared.item.item_id, None)
+
+    async def _execute_prepared_microbatch_chunk(
+        self,
+        job,
+        prepared_items: list[_PreparedEmbeddingItem],
+        *,
+        process_item: Callable[[Any, Any], Awaitable[None]],
+    ) -> None:
+        if len(prepared_items) <= 1:
+            await self._execute_prepared_item(job, prepared_items[0])
+            return
+
+        batch_id = job.batch_id
+        chunk_size = len(prepared_items)
+        first_item = prepared_items[0]
+        item_ids = [prepared.item.item_id for prepared in prepared_items]
+        item_heartbeats: dict[str, asyncio.Task[None]] = {}
+        served_deployment = None
+
+        try:
+            for prepared in prepared_items:
+                item_heartbeats[prepared.item.item_id] = self._start_heartbeat_fn(
+                    renew=lambda item_id=prepared.item.item_id: self.repository.renew_item_lease(
+                        item_id=item_id,
+                        worker_id=self.config.worker_id,
+                        lease_seconds=self.config.item_lease_seconds,
+                    ),
+                    label=f"item:{prepared.item.item_id}",
+                )
+            chunk_payload = self._build_microbatch_request(prepared_items)
+            logger.info(
+                "batch embedding microbatch started batch_id=%s deployment_id=%s size=%s item_ids=%s",
+                batch_id,
+                getattr(first_item.primary_deployment, "deployment_id", None),
+                chunk_size,
+                item_ids,
+            )
+            increment_batch_microbatch_requests()
+            increment_batch_microbatch_inputs(count=chunk_size)
+            observe_batch_microbatch_size(batch_size=chunk_size)
+            data, served_deployment = await self.app.state.failover_manager.execute_with_failover(
+                primary_deployment=first_item.primary_deployment,
+                model_group=first_item.model_group,
+                execute=lambda dep: self._execute_embedding(first_item.request_shim, chunk_payload, dep),
+                return_deployment=True,
+                **first_item.failover_kwargs,
+            )
+            response_body, api_base, deployment_model = self._sanitize_embedding_response(data)
+            item_responses = self._validate_embedding_microbatch_response(
+                response_body=response_body,
+                expected_count=chunk_size,
+            )
+            usage_allocations = allocate_embedding_usage(
+                response_body.get("usage"),
+                item_weights=[prepared.microbatch_weight or 1 for prepared in prepared_items],
+            )
+        except Exception as exc:
+            await self._record_upstream_failure_runtime_hook(
+                batch_id=batch_id,
+                deployment_id=str(
+                    getattr(served_deployment, "deployment_id", None)
+                    or getattr(first_item.primary_deployment, "deployment_id", None)
+                    or ""
+                )
+                or None,
+                exc=exc,
+                reference=",".join(item_ids),
+            )
+            if isinstance(exc, ValueError):
+                logger.warning(
+                    "batch embedding microbatch response mismatch batch_id=%s deployment_id=%s size=%s error=%s",
+                    batch_id,
+                    getattr(served_deployment or first_item.primary_deployment, "deployment_id", None),
+                    chunk_size,
+                    exc,
+                )
+            increment_batch_microbatch_isolation_fallback()
+            logger.warning(
+                "batch embedding microbatch isolated batch_id=%s deployment_id=%s size=%s item_ids=%s error=%s",
+                batch_id,
+                getattr(served_deployment or first_item.primary_deployment, "deployment_id", None),
+                chunk_size,
+                item_ids,
+                exc,
+            )
+            for prepared in prepared_items:
+                item_heartbeat = item_heartbeats.pop(prepared.item.item_id, None)
+                if item_heartbeat is not None:
+                    await self._stop_heartbeat_fn(item_heartbeat)
+                await process_item(job, prepared.item)
+            return
+
+        try:
+            api_provider = resolve_provider(served_deployment.deltallm_params)
+            api_base = api_base or served_deployment.deltallm_params.get("api_base")
+            deployment_model = deployment_model or (str(served_deployment.deltallm_params.get("model") or "") or None)
+            deployment_pricing = self._deployment_pricing(served_deployment)
+            model_info = served_deployment.model_info or {}
+            served_deployment_id = str(
+                getattr(served_deployment, "deployment_id", None)
+                or getattr(first_item.primary_deployment, "deployment_id", None)
+                or ""
+            )
+            await self._record_upstream_success_runtime_hooks(
+                batch_id=batch_id,
+                deployment_id=served_deployment_id,
+                usage=dict(response_body.get("usage") or {}),
+                reference=",".join(item_ids),
+            )
+            completion_rows: list[dict[str, Any]] = []
+            for prepared, item_response, usage in zip(prepared_items, item_responses, usage_allocations, strict=False):
+                normalized_response_body = self._build_single_item_embedding_response_body(
+                    chunk_response=response_body,
+                    item_response=item_response,
+                    usage=usage,
+                    api_provider=api_provider,
+                    model_fallback=deployment_model,
+                )
+                billed_cost = completion_cost(
+                    model=prepared.payload.model,
+                    usage=usage,
+                    cache_hit=False,
+                    custom_pricing=deployment_pricing,
+                    pricing_tier="batch",
+                    model_info=model_info,
+                )
+                provider_cost = completion_cost(
+                    model=prepared.payload.model,
+                    usage=usage,
+                    cache_hit=False,
+                    custom_pricing=deployment_pricing,
+                    pricing_tier="sync",
+                    model_info=model_info,
+                )
+                completion_rows.append(
+                    {
+                        "prepared": prepared,
+                        "response_body": normalized_response_body,
+                        "usage": usage,
+                        "provider_cost": provider_cost,
+                        "billed_cost": billed_cost,
+                    }
+                )
+
+            for item_id in item_ids:
+                await self._renew_item_lease_once(item_id)
+            await self._stop_heartbeat_tasks(item_heartbeats.values())
+            item_heartbeats.clear()
+
+            persisted = await self._persist_completion_rows_with_outbox(
+                items=[
+                    {
+                        "item_id": row["prepared"].item.item_id,
+                        "response_body": row["response_body"],
+                        "usage": row["usage"],
+                        "provider_cost": row["provider_cost"],
+                        "billed_cost": row["billed_cost"],
+                        "outbox_payload": self._build_completion_outbox_payload(
+                            job=job,
+                            prepared=row["prepared"],
+                            usage=row["usage"],
+                            api_provider=api_provider,
+                            billed_cost=row["billed_cost"],
+                            provider_cost=row["provider_cost"],
+                            api_base=api_base,
+                            deployment_model=deployment_model,
+                        ),
+                        "outbox_max_attempts": _COMPLETION_OUTBOX_MAX_ATTEMPTS,
+                    }
+                    for row in completion_rows
+                ],
+                item_ids=item_ids,
+                context_label=(
+                    f"microbatch:{served_deployment_id or getattr(first_item.primary_deployment, 'deployment_id', None) or 'unknown'}"
+                ),
+            )
+            if not persisted:
+                return
+
+            for row in completion_rows:
+                self._observe_item_execution_latency(
+                    status="success",
+                    latency_seconds=perf_counter() - row["prepared"].started_at_monotonic,
+                    reference=row["prepared"].item.item_id,
+                )
+            logger.info(
+                "batch embedding microbatch succeeded batch_id=%s primary_deployment_id=%s served_deployment_id=%s size=%s item_ids=%s",
+                batch_id,
+                getattr(first_item.primary_deployment, "deployment_id", None),
+                served_deployment_id,
+                chunk_size,
+                item_ids,
+            )
+        finally:
+            await self._stop_heartbeat_tasks(item_heartbeats.values())
+
+    async def process_item(
+        self,
+        job,
+        item,
+        *,
+        prepare_item: Callable[[Any, Any], Awaitable[_PreparedEmbeddingItem]] | None = None,
+    ) -> None:  # noqa: ANN001
+        request_body = item.request_body if isinstance(item.request_body, dict) else {}
+        model_name = str(request_body.get("model") or job.model or "")
+        started_at_monotonic = perf_counter()
+        prepared = self._prepared_item_overrides.get(item.item_id)
+        prepare_item_fn = prepare_item or self.prepare_item_for_execution
+        try:
+            if prepared is None:
+                prepared = await prepare_item_fn(job, item)
+        except Exception as exc:
+            await self._mark_item_failed(
+                job=job,
+                item=item,
+                model_name=model_name,
+                exc=exc,
+                deployment_id=None,
+                started_at_monotonic=started_at_monotonic,
+            )
+            return
+        await self._execute_prepared_item(job, prepared)
+
+    async def _stop_heartbeat_tasks(self, tasks) -> None:  # noqa: ANN001
+        for task in tasks:
+            await self._stop_heartbeat_fn(task)
+
+    async def process_items(
+        self,
+        job,
+        items,
+        *,
+        prepare_item: Callable[[Any, Any], Awaitable[_PreparedEmbeddingItem]] | None = None,
+        process_item: Callable[[Any, Any], Awaitable[None]] | None = None,
+    ) -> None:  # noqa: ANN001
+        if not items:
+            set_batch_worker_saturation(worker_id=self.config.worker_id, active=0, capacity=self.config.worker_concurrency)
+            return
+
+        prepare_item_fn = prepare_item or self.prepare_item_for_execution
+        if process_item is None:
+            async def process_item_fn(job, item) -> None:  # noqa: ANN001
+                await self.process_item(job, item, prepare_item=prepare_item_fn)
+        else:
+            process_item_fn = process_item
+
+        raw_items: deque[Any] = deque(items)
+        deferred_grouped_raw_items: deque[Any] = deque()
+        prepared_backlog: deque[_PreparedEmbeddingItem] = deque()
+        planned_work_units: deque[Any] = deque()
+        planning_lock = asyncio.Lock()
+        grouped_chunk_available = asyncio.Event()
+        grouped_chunk_available.set()
+        grouped_chunk_in_flight = False
+        grouped_chunk_blocked = object()
+        active = 0
+
+        logger.info(
+            "batch embedding microbatch planner started batch_id=%s claimed_items=%s",
+            job.batch_id,
+            len(items),
+        )
+
+        def _requeue_prepared_candidates(candidates: list[_PreparedEmbeddingItem]) -> None:
+            for candidate in reversed(candidates):
+                prepared_backlog.appendleft(candidate)
+
+        def _requeue_grouped_raw_items(candidates: list[Any]) -> None:
+            for candidate in reversed(candidates):
+                deferred_grouped_raw_items.appendleft(candidate)
+
+        def _requeue_deferred_candidates(candidates: list[_PreparedEmbeddingItem]) -> None:
+            prepared_candidates: list[_PreparedEmbeddingItem] = []
+            grouped_candidates: list[Any] = []
+            for candidate in candidates:
+                if candidate.microbatch_eligible and candidate.effective_upstream_max_batch_inputs > 1:
+                    grouped_candidates.append(candidate.item)
+                else:
+                    prepared_candidates.append(candidate)
+            _requeue_prepared_candidates(prepared_candidates)
+            _requeue_grouped_raw_items(grouped_candidates)
+
+        def _queue_preparation_failure(item, model_name: str, exc: Exception, started_at_monotonic: float) -> None:
+            planned_work_units.append(
+                lambda item=item, model_name=model_name, exc=exc, started_at_monotonic=started_at_monotonic: self._mark_item_failed(
+                    job=job,
+                    item=item,
+                    model_name=model_name,
+                    exc=exc,
+                    deployment_id=None,
+                    started_at_monotonic=started_at_monotonic,
+                )
+            )
+
+        async def _prepare_candidate_item(item) -> _PreparedEmbeddingItem | None:  # noqa: ANN001
+            started_at_monotonic = perf_counter()
+            request_body = item.request_body if isinstance(item.request_body, dict) else {}
+            model_name = str(request_body.get("model") or job.model or "")
+            try:
+                prepared = await prepare_item_fn(job, item)
+            except Exception as exc:
+                _queue_preparation_failure(item, model_name, exc, started_at_monotonic)
+                return None
+            if not prepared.microbatch_eligible:
+                increment_batch_microbatch_ineligible_item(reason=prepared.microbatch_ineligible_reason or "unknown")
+            return prepared
+
+        def _raw_item_looks_groupable(item) -> bool:  # noqa: ANN001
+            payload = EmbeddingRequest.model_validate(item.request_body)
+            _, microbatch_eligible, _ = classify_embedding_microbatch_request(payload)
+            return microbatch_eligible
+
+        async def _pop_next_candidate(*, allow_grouped_chunks: bool) -> _PreparedEmbeddingItem | object | None:
+            while True:
+                if allow_grouped_chunks and deferred_grouped_raw_items:
+                    prepared = await _prepare_candidate_item(deferred_grouped_raw_items.popleft())
+                    if prepared is None:
+                        continue
+                    return prepared
+
+                if prepared_backlog:
+                    return prepared_backlog.popleft()
+
+                if not raw_items:
+                    if deferred_grouped_raw_items and not allow_grouped_chunks:
+                        return grouped_chunk_blocked
+                    return None
+
+                item = raw_items.popleft()
+                if not allow_grouped_chunks:
+                    started_at_monotonic = perf_counter()
+                    request_body = item.request_body if isinstance(item.request_body, dict) else {}
+                    model_name = str(request_body.get("model") or job.model or "")
+                    try:
+                        if _raw_item_looks_groupable(item):
+                            deferred_grouped_raw_items.append(item)
+                            continue
+                    except Exception as exc:
+                        _queue_preparation_failure(item, model_name, exc, started_at_monotonic)
+                        continue
+                prepared = await _prepare_candidate_item(item)
+                if prepared is None:
+                    continue
+                grouped_chunk_candidate = prepared.microbatch_eligible and prepared.effective_upstream_max_batch_inputs > 1
+                if grouped_chunk_candidate and not allow_grouped_chunks:
+                    deferred_grouped_raw_items.append(prepared.item)
+                    continue
+                return prepared
+
+        async def _run_grouped_chunk(chunk: list[_PreparedEmbeddingItem]) -> None:
+            nonlocal grouped_chunk_in_flight
+            try:
+                await self._execute_prepared_microbatch_chunk(job, chunk, process_item=process_item_fn)
+            finally:
+                async with planning_lock:
+                    grouped_chunk_in_flight = False
+                    grouped_chunk_available.set()
+
+        async def _wait_for_grouped_chunk_slot() -> None:
+            await grouped_chunk_available.wait()
+
+        async def _plan_next_work_unit():
+            nonlocal grouped_chunk_in_flight
+            async with planning_lock:
+                if planned_work_units:
+                    return planned_work_units.popleft()
+
+                seed = await _pop_next_candidate(allow_grouped_chunks=not grouped_chunk_in_flight)
+                while seed is None:
+                    if planned_work_units:
+                        return planned_work_units.popleft()
+                    return None
+                if seed is grouped_chunk_blocked:
+                    return _wait_for_grouped_chunk_slot
+
+                if not seed.microbatch_eligible or seed.effective_upstream_max_batch_inputs <= 1:
+                    return lambda seed=seed: self._process_item_with_prepared_override(
+                        job,
+                        seed,
+                        process_item=process_item_fn,
+                    )
+
+                chunk = [seed]
+                chunk_key = self._microbatch_group_key(seed)
+                deferred_candidates: list[_PreparedEmbeddingItem] = []
+
+                while len(chunk) < seed.effective_upstream_max_batch_inputs:
+                    candidate = await _pop_next_candidate(allow_grouped_chunks=True)
+                    if candidate is None:
+                        break
+                    if candidate is grouped_chunk_blocked:
+                        break
+
+                    candidate_matches_chunk = (
+                        candidate.microbatch_eligible
+                        and candidate.effective_upstream_max_batch_inputs > 1
+                        and candidate.effective_upstream_max_batch_inputs == seed.effective_upstream_max_batch_inputs
+                        and self._microbatch_group_key(candidate) == chunk_key
+                    )
+                    if candidate_matches_chunk:
+                        chunk.append(candidate)
+                    else:
+                        deferred_candidates.append(candidate)
+
+                _requeue_deferred_candidates(deferred_candidates)
+                grouped_chunk_in_flight = True
+                grouped_chunk_available.clear()
+                return lambda chunk=list(chunk): _run_grouped_chunk(chunk)
+
+        async def _runner() -> None:
+            nonlocal active
+            while True:
+                work_unit = await _plan_next_work_unit()
+                if work_unit is None:
+                    return
+
+                active += 1
+                set_batch_worker_saturation(
+                    worker_id=self.config.worker_id,
+                    active=active,
+                    capacity=self.config.worker_concurrency,
+                )
+                try:
+                    await work_unit()
+                finally:
+                    active -= 1
+                    set_batch_worker_saturation(
+                        worker_id=self.config.worker_id,
+                        active=active,
+                        capacity=self.config.worker_concurrency,
+                    )
+
+        runner_count = min(max(1, self.config.worker_concurrency), len(items))
+        async with asyncio.TaskGroup() as task_group:
+            for _ in range(runner_count):
+                task_group.create_task(_runner())
+
+    async def _record_upstream_success_runtime_hooks(
+        self,
+        *,
+        batch_id: str,
+        deployment_id: str,
+        usage: dict[str, Any],
+        reference: str,
+    ) -> None:
+        passive_health_tracker = getattr(self.app.state, "passive_health_tracker", None)
+        if passive_health_tracker is not None and deployment_id:
+            try:
+                await passive_health_tracker.record_request_outcome(deployment_id, success=True)
+            except Exception as exc:
+                logger.warning(
+                    "batch passive health success hook failed batch_id=%s reference=%s deployment_id=%s error=%s",
+                    batch_id,
+                    reference,
+                    deployment_id,
+                    exc,
+                )
+        router_state_backend = getattr(self.app.state, "router_state_backend", None)
+        if router_state_backend is not None and deployment_id:
+            try:
+                await self._record_router_usage(
+                    router_state_backend,
+                    deployment_id,
+                    mode="embedding",
+                    usage=usage,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "batch router usage hook failed batch_id=%s reference=%s deployment_id=%s error=%s",
+                    batch_id,
+                    reference,
+                    deployment_id,
+                    exc,
+                )
+
+    async def _record_upstream_failure_runtime_hook(
+        self,
+        *,
+        batch_id: str,
+        deployment_id: str | None,
+        exc: Exception,
+        reference: str,
+    ) -> None:
+        passive_health_tracker = getattr(self.app.state, "passive_health_tracker", None)
+        if passive_health_tracker is None or deployment_id is None:
+            return
+        try:
+            await passive_health_tracker.record_request_outcome(deployment_id, success=False, error=str(exc))
+        except Exception as hook_exc:
+            logger.warning(
+                "batch passive health upstream failure hook failed batch_id=%s reference=%s deployment_id=%s error=%s",
+                batch_id,
+                reference,
+                deployment_id,
+                hook_exc,
+            )
+
+    async def _record_failure_runtime_hooks(
+        self,
+        *,
+        job,
+        item,
+        batch_id: str,
+        model_name: str,
+        exc: Exception,
+        deployment_id: str | None,
+    ) -> None:
+        passive_health_tracker = getattr(self.app.state, "passive_health_tracker", None)
+        if passive_health_tracker is not None and deployment_id is not None:
+            try:
+                await passive_health_tracker.record_request_outcome(deployment_id, success=False, error=str(exc))
+            except Exception as hook_exc:
+                logger.warning(
+                    "batch passive health failure hook failed batch_id=%s item_id=%s deployment_id=%s error=%s",
+                    batch_id,
+                    item.item_id,
+                    deployment_id,
+                    hook_exc,
+                )
+        spend_tracking_service = getattr(self.app.state, "spend_tracking_service", None)
+        if job.created_by_api_key and spend_tracking_service is not None:
+            try:
+                await spend_tracking_service.log_request_failure(
+                    request_id=f"batch:{batch_id}:{item.item_id}",
+                    api_key=job.created_by_api_key,
+                    user_id=job.created_by_user_id,
+                    team_id=job.created_by_team_id,
+                    organization_id=job.created_by_organization_id,
+                    end_user_id=None,
+                    model=model_name,
+                    call_type="embedding_batch",
+                    metadata={"batch_id": batch_id, "batch_item_id": item.item_id},
+                    cache_hit=False,
+                    start_time=None,
+                    end_time=datetime.now(tz=UTC),
+                    exc=exc,
+                )
+            except Exception as hook_exc:
+                logger.warning(
+                    "batch failure logging hook failed batch_id=%s item_id=%s error=%s",
+                    batch_id,
+                    item.item_id,
+                    hook_exc,
+                )
+
+    def _is_retryable(self, exc: Exception) -> bool:
+        if isinstance(exc, httpx.TimeoutException):
+            return True
+        if isinstance(exc, httpx.HTTPStatusError):
+            status_code = exc.response.status_code
+            return status_code == 429 or status_code >= 500
+        return False

--- a/src/batch/worker_types.py
+++ b/src/batch/worker_types.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.batch.embedding_microbatch import _ExecutionSignature
+from src.models.requests import EmbeddingRequest
+
+
+class BatchArtifactValidationError(ValueError):
+    """Raised when a completed batch artifact payload cannot be safely exposed."""
+
+
+@dataclass
+class BatchWorkerConfig:
+    worker_id: str
+    poll_interval_seconds: float = 1.0
+    heartbeat_interval_seconds: float = 15.0
+    job_lease_seconds: int = 120
+    item_lease_seconds: int = 360
+    finalization_retry_delay_seconds: int = 60
+    worker_concurrency: int = 4
+    item_buffer_multiplier: int = 2
+    finalization_page_size: int = 500
+    item_claim_limit: int = 20
+    max_attempts: int = 3
+    completed_artifact_retention_days: int = 7
+    failed_artifact_retention_days: int = 14
+
+
+@dataclass
+class _RequestShim:
+    app: Any
+
+
+@dataclass(slots=True)
+class _PreparedEmbeddingItem:
+    item: Any
+    started_at_monotonic: float
+    payload: EmbeddingRequest
+    model_name: str
+    model_group: str
+    primary_deployment: Any
+    request_context: dict[str, Any]
+    failover_kwargs: dict[str, Any]
+    request_shim: _RequestShim
+    effective_upstream_max_batch_inputs: int
+    microbatch_eligible: bool
+    microbatch_ineligible_reason: str | None
+    microbatch_weight: int | None
+    execution_signature: _ExecutionSignature

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -12,7 +12,7 @@ from fastapi import HTTPException
 
 from src.batch.models import BatchItemRecord, BatchJobRecord, BatchJobStatus, encode_operator_failed_reason
 from src.batch.service import BatchService
-from src.batch.worker import BatchExecutorWorker, BatchWorkerConfig
+from src.batch.worker import BatchArtifactValidationError, BatchExecutorWorker, BatchWorkerConfig
 from src.models.responses import UserAPIKeyAuth
 
 
@@ -90,6 +90,16 @@ class _FakeStorage:
     async def delete(self, storage_key: str) -> None:  # pragma: no cover
         del storage_key
         raise AssertionError("unexpected artifact delete in this test")
+
+
+def _valid_embedding_artifact_response_body() -> dict[str, object]:
+    return {
+        "object": "list",
+        "data": [{"index": 0, "embedding": [0.1, 0.2]}],
+        "model": "provider-embedding-model",
+        "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        "_provider": "openai",
+    }
 
 
 @pytest.mark.asyncio
@@ -217,6 +227,283 @@ async def test_batch_worker_logs_batch_pricing_and_spend(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_batch_worker_uses_post_construction_hook_patches(monkeypatch):
+    execute_inputs: list[object] = []
+    router_usage_calls: list[tuple[str, str, dict[str, int]]] = []
+    metric_statuses: list[str] = []
+
+    deployment = SimpleNamespace(
+        deployment_id="dep-1",
+        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.0,
+        model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
+    )
+
+    class _RouterStateBackend:
+        async def increment_usage_counters(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+            return None
+
+    class _Router:
+        def resolve_model_group(self, model: str) -> str:
+            return model
+
+        async def select_deployment(self, model_group: str, request_context: dict) -> str:
+            del model_group, request_context
+            return "dep-1"
+
+        def require_deployment(self, model_group: str, deployment: str):
+            del model_group, deployment
+            return deployment_obj
+
+    class _Failover:
+        async def execute_with_failover(
+            self,
+            *,
+            primary_deployment,
+            model_group,
+            execute,
+            return_deployment=False,
+            **kwargs,
+        ):
+            del model_group, kwargs
+            data = await execute(primary_deployment)
+            if return_deployment:
+                return data, primary_deployment
+            return data
+
+    deployment_obj = deployment
+    repo = _FakeRepository()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(),
+            failover_manager=_Failover(),
+            spend_tracking_service=None,
+            passive_health_tracker=None,
+            router_state_backend=_RouterStateBackend(),
+        )
+    )
+    worker = BatchExecutorWorker(
+        app=app,
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    async def _patched_execute_embedding(request, payload, deployment):
+        del request, deployment
+        execute_inputs.append(payload.input)
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+
+    async def _patched_record_router_usage(state_backend, deployment_id: str, *, mode: str, usage: dict):
+        del state_backend
+        router_usage_calls.append((deployment_id, mode, dict(usage)))
+
+    def _patched_observe_batch_item_execution_latency(*, status: str, latency_seconds: float) -> None:
+        assert latency_seconds >= 0
+        metric_statuses.append(status)
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _patched_execute_embedding)
+    monkeypatch.setattr("src.batch.worker.record_router_usage", _patched_record_router_usage)
+    monkeypatch.setattr(
+        "src.batch.worker.observe_batch_item_execution_latency",
+        _patched_observe_batch_item_execution_latency,
+    )
+
+    now = datetime.now(tz=UTC)
+    job = BatchJobRecord(
+        batch_id="b1",
+        endpoint="/v1/embeddings",
+        status=BatchJobStatus.IN_PROGRESS,
+        execution_mode="managed_internal",
+        input_file_id="f1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m-1",
+        metadata={},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=1,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="tok-1",
+        created_by_user_id="u1",
+        created_by_team_id="t1",
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+        expires_at=None,
+    )
+    item = BatchItemRecord(
+        item_id="i1",
+        batch_id="b1",
+        line_number=1,
+        custom_id="c1",
+        status="in_progress",
+        request_body={"model": "m-1", "input": "hello"},
+        response_body=None,
+        error_body=None,
+        usage=None,
+        provider_cost=0.0,
+        billed_cost=0.0,
+        attempts=0,
+        last_error=None,
+        locked_by="w1",
+        lease_expires_at=now,
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+    )
+
+    await worker._process_item(job, item)
+
+    assert execute_inputs == ["hello"]
+    assert router_usage_calls == [
+        ("dep-1", "embedding", {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5})
+    ]
+    assert metric_statuses == ["success"]
+    assert len(repo.completed_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_process_item_uses_worker_prepare_override(monkeypatch):
+    async def _fake_execute_embedding(request, payload, deployment):
+        del request, deployment
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
+
+    deployment = SimpleNamespace(
+        deployment_id="dep-1",
+        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.0,
+        model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
+    )
+
+    class _Router:
+        def resolve_model_group(self, model: str) -> str:
+            return model
+
+        async def select_deployment(self, model_group: str, request_context: dict) -> str:
+            del model_group, request_context
+            return "dep-1"
+
+        def require_deployment(self, model_group: str, deployment: str):
+            del model_group, deployment
+            return deployment_obj
+
+    class _Failover:
+        async def execute_with_failover(
+            self,
+            *,
+            primary_deployment,
+            model_group,
+            execute,
+            return_deployment=False,
+            **kwargs,
+        ):
+            del model_group, kwargs
+            data = await execute(primary_deployment)
+            if return_deployment:
+                return data, primary_deployment
+            return data
+
+    deployment_obj = deployment
+    repo = _FakeRepository()
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=None)),
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    prepare_calls: list[str] = []
+    original_prepare_item = worker._prepare_item_for_execution
+
+    async def _prepare_item_override(job, item):  # noqa: ANN001
+        prepare_calls.append(item.item_id)
+        return await original_prepare_item(job, item)
+
+    worker._prepare_item_for_execution = _prepare_item_override  # type: ignore[assignment]
+
+    now = datetime.now(tz=UTC)
+    job = BatchJobRecord(
+        batch_id="b1",
+        endpoint="/v1/embeddings",
+        status=BatchJobStatus.IN_PROGRESS,
+        execution_mode="managed_internal",
+        input_file_id="f1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m-1",
+        metadata={},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=1,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="tok-1",
+        created_by_user_id="u1",
+        created_by_team_id="t1",
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+        expires_at=None,
+        created_by_organization_id="org-1",
+    )
+    item = BatchItemRecord(
+        item_id="i1",
+        batch_id="b1",
+        line_number=1,
+        custom_id="c1",
+        status="in_progress",
+        request_body={"model": "m-1", "input": "hello"},
+        response_body=None,
+        error_body=None,
+        usage=None,
+        provider_cost=0.0,
+        billed_cost=0.0,
+        attempts=0,
+        last_error=None,
+        locked_by="w1",
+        lease_expires_at=now,
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+    )
+
+    await worker._process_item(job, item)
+
+    assert prepare_calls == ["i1"]
+    assert len(repo.completed_calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_batch_worker_normalizes_single_item_embedding_usage(monkeypatch):
     async def _fake_execute_embedding(request, payload, deployment):
         del request, payload, deployment
@@ -318,7 +605,69 @@ async def test_batch_worker_normalizes_single_item_embedding_usage(monkeypatch):
 
     await worker._process_item(job, item)
 
+    assert repo.completed_calls[0]["response_body"] == {
+        "object": "list",
+        "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+        "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+        "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        "_provider": "vllm",
+    }
     assert repo.completed_calls[0]["usage"] == {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}
+
+    artifact_now = datetime.now(tz=UTC)
+
+    class _ArtifactRepo:
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b1"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="c1",
+                    status="completed",
+                    request_body=item.request_body,
+                    response_body=repo.completed_calls[0]["response_body"],
+                    error_body=None,
+                    usage=repo.completed_calls[0]["usage"],
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=artifact_now,
+                    started_at=artifact_now,
+                    completed_at=artifact_now,
+                )
+            ]
+
+    artifact_worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_ArtifactRepo(),  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    rows = [json.loads(line) async for line in artifact_worker._iter_output_lines("b1")]
+
+    assert rows == [
+        {
+            "id": "batch_req_i1",
+            "custom_id": "c1",
+            "response": {
+                "status_code": 200,
+                "request_id": "req_batch_i1",
+                "body": {
+                    "object": "list",
+                    "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+                    "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+                },
+            },
+            "error": None,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -336,13 +685,7 @@ async def test_batch_worker_iter_output_lines_emit_openai_batch_success_rows():
                     custom_id="req-1",
                     status="completed",
                     request_body={},
-                    response_body={
-                        "object": "list",
-                        "data": [{"index": 0, "embedding": [0.1, 0.2]}],
-                        "model": "provider-embedding-model",
-                        "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
-                        "_provider": "openai",
-                    },
+                    response_body=_valid_embedding_artifact_response_body(),
                     error_body=None,
                     usage=None,
                     provider_cost=0.0,
@@ -422,7 +765,7 @@ async def test_batch_worker_iter_output_lines_reject_missing_response_body_for_c
         config=BatchWorkerConfig(worker_id="w1"),
     )
 
-    with pytest.raises(ValueError, match="missing an embedding response body"):
+    with pytest.raises(BatchArtifactValidationError, match="missing an embedding response body"):
         _ = [json.loads(line) async for line in worker._iter_output_lines("b1")]
 
 
@@ -468,7 +811,147 @@ async def test_batch_worker_iter_output_lines_reject_malformed_embedding_payload
         config=BatchWorkerConfig(worker_id="w1"),
     )
 
-    with pytest.raises(ValueError, match="missing embedding"):
+    with pytest.raises(BatchArtifactValidationError, match="missing embedding"):
+        _ = [json.loads(line) async for line in worker._iter_output_lines("b1")]
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_iter_output_lines_backfill_legacy_model_and_usage_from_item_fields():
+    now = datetime.now(tz=UTC)
+
+    class _ArtifactRepo:
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b1"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="completed",
+                    request_body={"model": "request-model", "input": "hello"},
+                    response_body={
+                        "object": "list",
+                        "data": [{"index": 0, "embedding": [0.1, 0.2]}],
+                        "usage": {"prompt_tokens": 5, "total_tokens": 5},
+                        "_provider": "openai",
+                    },
+                    error_body=None,
+                    usage={"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                )
+            ]
+
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_ArtifactRepo(),  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    rows = [json.loads(line) async for line in worker._iter_output_lines("b1")]
+
+    assert rows == [
+        {
+            "id": "batch_req_i1",
+            "custom_id": "req-1",
+            "response": {
+                "status_code": 200,
+                "request_id": "req_batch_i1",
+                "body": {
+                    "object": "list",
+                    "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                    "model": "request-model",
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+                },
+            },
+            "error": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        pytest.param(lambda body: body.pop("model"), "missing a valid model", id="missing-model"),
+        pytest.param(lambda body: body.__setitem__("model", " "), "missing a valid model", id="blank-model"),
+        pytest.param(lambda body: body.pop("usage"), "usage is not an object", id="missing-usage"),
+        pytest.param(lambda body: body.__setitem__("usage", "invalid"), "usage is not an object", id="non-object-usage"),
+        pytest.param(
+            lambda body: body.__setitem__("usage", {"completion_tokens": 0, "total_tokens": 5}),
+            "invalid prompt_tokens",
+            id="missing-prompt-tokens",
+        ),
+        pytest.param(
+            lambda body: body.__setitem__("usage", {"prompt_tokens": 5, "total_tokens": 5}),
+            "invalid completion_tokens",
+            id="missing-completion-tokens",
+        ),
+        pytest.param(
+            lambda body: body.__setitem__("usage", {"prompt_tokens": 5, "completion_tokens": 0}),
+            "invalid total_tokens",
+            id="missing-total-tokens",
+        ),
+        pytest.param(
+            lambda body: body.__setitem__("usage", {"prompt_tokens": "five", "completion_tokens": 0, "total_tokens": 5}),
+            "invalid prompt_tokens",
+            id="non-int-prompt-tokens",
+        ),
+        pytest.param(
+            lambda body: body.__setitem__("usage", {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": -1}),
+            "negative total_tokens",
+            id="negative-total-tokens",
+        ),
+    ],
+)
+async def test_batch_worker_iter_output_lines_reject_invalid_success_body_fields(mutate, match):
+    now = datetime.now(tz=UTC)
+    response_body = _valid_embedding_artifact_response_body()
+    mutate(response_body)
+
+    class _ArtifactRepo:
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b1"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="completed",
+                    request_body={},
+                    response_body=response_body,
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                )
+            ]
+
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_ArtifactRepo(),  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    with pytest.raises(BatchArtifactValidationError, match=match):
         _ = [json.loads(line) async for line in worker._iter_output_lines("b1")]
 
 
@@ -2201,7 +2684,7 @@ async def test_batch_worker_retries_finalizing_job_after_storage_failure(caplog:
                     custom_id="req-1",
                     status="completed",
                     request_body={},
-                    response_body={"ok": True},
+                    response_body=_valid_embedding_artifact_response_body(),
                     error_body=None,
                     usage=None,
                     provider_cost=0.0,
@@ -2306,6 +2789,146 @@ async def test_batch_worker_retries_finalizing_job_after_storage_failure(caplog:
 
 
 @pytest.mark.asyncio
+async def test_batch_worker_marks_invalid_completed_artifacts_failed_without_retry(
+    caplog: pytest.LogCaptureFixture,
+):
+    now = datetime.now(tz=UTC)
+
+    class _FinalizingRepo:
+        def __init__(self) -> None:
+            self.claim_count = 0
+            self.attach_calls: list[dict] = []
+            self.provider_error_calls: list[dict] = []
+            self.rescheduled: list[int] = []
+            self.released = 0
+            self.job = BatchJobRecord(
+                batch_id="b-finalize",
+                endpoint="/v1/embeddings",
+                status=BatchJobStatus.FINALIZING,
+                execution_mode="managed_internal",
+                input_file_id="f-1",
+                output_file_id=None,
+                error_file_id=None,
+                model="m-1",
+                metadata={},
+                provider_batch_id=None,
+                provider_status=None,
+                provider_error=None,
+                provider_last_sync_at=None,
+                total_items=1,
+                in_progress_items=0,
+                completed_items=1,
+                failed_items=0,
+                cancelled_items=0,
+                locked_by="w1",
+                lease_expires_at=now,
+                cancel_requested_at=None,
+                status_last_updated_at=now,
+                created_by_api_key="tok-1",
+                created_by_user_id="u1",
+                created_by_team_id="t1",
+                created_at=now,
+                started_at=now,
+                completed_at=None,
+                expires_at=None,
+                created_by_organization_id="org-1",
+            )
+
+        async def claim_next_job(self, *, worker_id: str, lease_seconds: int = 30):
+            del worker_id, lease_seconds
+            self.claim_count += 1
+            if self.claim_count > 1:
+                return None
+            return self.job
+
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b-finalize"
+            invalid_body = _valid_embedding_artifact_response_body()
+            invalid_body.pop("model")
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="completed",
+                    request_body={},
+                    response_body=invalid_body,
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                )
+            ]
+
+        async def attach_artifacts_and_finalize(self, **kwargs):
+            self.attach_calls.append(kwargs)
+            return self.job
+
+        async def set_provider_error(self, **kwargs):
+            self.provider_error_calls.append(kwargs)
+            return self.job
+
+        async def reschedule_finalization(self, *, batch_id: str, worker_id: str, retry_delay_seconds: int) -> bool:
+            assert batch_id == "b-finalize"
+            assert worker_id == "w1"
+            self.rescheduled.append(retry_delay_seconds)
+            return True
+
+        async def release_job_lease(self, *, batch_id: str, worker_id: str) -> None:
+            assert batch_id == "b-finalize"
+            assert worker_id == "w1"
+            self.released += 1
+
+    class _StreamingStorage:
+        backend_name = "local"
+
+        async def write_lines_stream(self, *, purpose: str, filename: str, lines):  # noqa: ANN001
+            assert purpose == "batch_output"
+            assert filename == "b-finalize-output.jsonl"
+            _ = [line async for line in lines]
+            raise AssertionError("expected artifact validation failure before write completion")
+
+    repo = _FinalizingRepo()
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=repo,  # type: ignore[arg-type]
+        storage=_StreamingStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        did_work = await worker.process_once()
+
+    assert did_work is True
+    assert repo.attach_calls == [
+        {
+            "batch_id": "b-finalize",
+            "output_file_id": None,
+            "error_file_id": None,
+            "final_status": BatchJobStatus.FAILED,
+            "worker_id": "w1",
+        }
+    ]
+    assert repo.provider_error_calls == [
+        {
+            "batch_id": "b-finalize",
+            "provider_error": "artifact_validation_failed: completed batch item embedding response is missing a valid model",
+        }
+    ]
+    assert repo.rescheduled == []
+    assert repo.released == 1
+    assert "batch finalization permanently failed batch_id=b-finalize" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows():
     now = datetime.now(tz=UTC)
 
@@ -2324,13 +2947,7 @@ async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows():
                     custom_id="req-1",
                     status="completed",
                     request_body={},
-                    response_body={
-                        "object": "list",
-                        "data": [{"index": 0, "embedding": [0.1, 0.2]}],
-                        "model": "provider-embedding-model",
-                        "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
-                        "_provider": "openai",
-                    },
+                    response_body=_valid_embedding_artifact_response_body(),
                     error_body=None,
                     usage=None,
                     provider_cost=0.0,

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -322,131 +322,154 @@ async def test_batch_worker_normalizes_single_item_embedding_usage(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_batch_worker_serializes_single_item_embedding_artifact_row_in_openai_batch_shape(monkeypatch):
-    async def _fake_execute_embedding(request, payload, deployment):
-        del request, payload, deployment
-        return {
-            "object": "list",
-            "data": [{"index": 0, "embedding": [0.1, 0.2]}],
-            "model": "provider-embedding-model",
-            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
-        }
+async def test_batch_worker_iter_output_lines_emit_openai_batch_success_rows():
+    now = datetime.now(tz=UTC)
 
-    monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
+    class _ArtifactRepo:
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b1"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="completed",
+                    request_body={},
+                    response_body={
+                        "object": "list",
+                        "data": [{"index": 0, "embedding": [0.1, 0.2]}],
+                        "model": "provider-embedding-model",
+                        "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+                        "_provider": "openai",
+                    },
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                )
+            ]
 
-    deployment = SimpleNamespace(
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
-        input_cost_per_token=0.001,
-        output_cost_per_token=0.0,
-        model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
-    )
-
-    class _Router:
-        def resolve_model_group(self, model: str) -> str:
-            return model
-
-        async def select_deployment(self, model_group: str, request_context: dict) -> str:
-            del model_group, request_context
-            return "dep-1"
-
-        def require_deployment(self, model_group: str, deployment: str):
-            del model_group, deployment
-            return deployment_obj
-
-    class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
-            del model_group, kwargs
-            data = await execute(primary_deployment)
-            if return_deployment:
-                return data, primary_deployment
-            return data
-
-    deployment_obj = deployment
-    repo = _FakeRepository()
-    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=_SpendRecorder()))
     worker = BatchExecutorWorker(
-        app=app,
-        repository=repo,  # type: ignore[arg-type]
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_ArtifactRepo(),  # type: ignore[arg-type]
         storage=_FakeStorage(),  # type: ignore[arg-type]
         config=BatchWorkerConfig(worker_id="w1"),
     )
 
-    now = datetime.now(tz=UTC)
-    job = BatchJobRecord(
-        batch_id="b1",
-        endpoint="/v1/embeddings",
-        status=BatchJobStatus.IN_PROGRESS,
-        execution_mode="managed_internal",
-        input_file_id="f1",
-        output_file_id=None,
-        error_file_id=None,
-        model="m-1",
-        metadata={},
-        provider_batch_id=None,
-        provider_status=None,
-        provider_error=None,
-        provider_last_sync_at=None,
-        total_items=1,
-        in_progress_items=1,
-        completed_items=0,
-        failed_items=0,
-        cancelled_items=0,
-        locked_by="w1",
-        lease_expires_at=now,
-        cancel_requested_at=None,
-        status_last_updated_at=now,
-        created_by_api_key="key-1",
-        created_by_user_id="user-1",
-        created_by_team_id="team-1",
-        created_by_organization_id="org-1",
-        created_at=now,
-        started_at=now,
-        completed_at=None,
-        expires_at=None,
-    )
-    item = BatchItemRecord(
-        item_id="i1",
-        batch_id="b1",
-        line_number=1,
-        custom_id="c1",
-        status="in_progress",
-        request_body={"model": "m-1", "input": "hello"},
-        response_body=None,
-        error_body=None,
-        usage=None,
-        provider_cost=0.0,
-        billed_cost=0.0,
-        attempts=0,
-        last_error=None,
-        locked_by="w1",
-        lease_expires_at=now,
-        created_at=now,
-        started_at=now,
-        completed_at=None,
-    )
+    rows = [json.loads(line) async for line in worker._iter_output_lines("b1")]
 
-    await worker._process_item(job, item)
-
-    completed = repo.completed_calls[0]
-    artifact_row = worker._serialize_completed_artifact_row(
-        SimpleNamespace(item_id=item.item_id, custom_id=item.custom_id, response_body=completed["response_body"])
-    )
-
-    assert artifact_row == {
-        "id": "batch_req_i1",
-        "custom_id": "c1",
-        "response": {
-            "status_code": 200,
-            "request_id": "req_batch_i1",
-            "body": {
-                "object": "list",
-                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
-                "model": "provider-embedding-model",
-                "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+    assert rows == [
+        {
+            "id": "batch_req_i1",
+            "custom_id": "req-1",
+            "response": {
+                "status_code": 200,
+                "request_id": "req_batch_i1",
+                "body": {
+                    "object": "list",
+                    "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                    "model": "provider-embedding-model",
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+                },
             },
-        },
-        "error": None,
-    }
+            "error": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_iter_output_lines_reject_missing_response_body_for_completed_items():
+    now = datetime.now(tz=UTC)
+
+    class _ArtifactRepo:
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b1"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="completed",
+                    request_body={},
+                    response_body=None,
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                )
+            ]
+
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_ArtifactRepo(),  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    with pytest.raises(ValueError, match="missing an embedding response body"):
+        _ = [json.loads(line) async for line in worker._iter_output_lines("b1")]
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_iter_output_lines_reject_malformed_embedding_payload_for_completed_items():
+    now = datetime.now(tz=UTC)
+
+    class _ArtifactRepo:
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b1"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="completed",
+                    request_body={},
+                    response_body={
+                        "object": "list",
+                        "data": [{"index": 0}],
+                        "model": "provider-embedding-model",
+                        "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+                    },
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                )
+            ]
+
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_ArtifactRepo(),  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    with pytest.raises(ValueError, match="missing embedding"):
+        _ = [json.loads(line) async for line in worker._iter_output_lines("b1")]
 
 
 @pytest.mark.asyncio
@@ -2280,6 +2303,169 @@ async def test_batch_worker_retries_finalizing_job_after_storage_failure(caplog:
     assert repo.released == 2
     assert repo.created_file_calls
     assert all(call["created_by_organization_id"] == "org-1" for call in repo.created_file_calls)
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows():
+    now = datetime.now(tz=UTC)
+
+    class _FinalizingRepo:
+        def __init__(self) -> None:
+            self.attach_calls: list[dict] = []
+            self.created_file_calls: list[dict] = []
+
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b-finalize"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="completed",
+                    request_body={},
+                    response_body={
+                        "object": "list",
+                        "data": [{"index": 0, "embedding": [0.1, 0.2]}],
+                        "model": "provider-embedding-model",
+                        "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+                        "_provider": "openai",
+                    },
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                ),
+                BatchItemRecord(
+                    item_id="i2",
+                    batch_id=batch_id,
+                    line_number=2,
+                    custom_id="req-2",
+                    status="failed",
+                    request_body={},
+                    response_body=None,
+                    error_body={"message": "boom"},
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error="boom",
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                ),
+            ]
+
+        async def create_file(self, **kwargs):
+            self.created_file_calls.append(kwargs)
+            purpose = kwargs["purpose"]
+            return SimpleNamespace(file_id=f"{purpose}-file", storage_key=kwargs["storage_key"])
+
+        async def attach_artifacts_and_finalize(self, **kwargs):
+            self.attach_calls.append(kwargs)
+            return SimpleNamespace(batch_id=kwargs["batch_id"])
+
+    class _CapturingStorage:
+        backend_name = "local"
+
+        def __init__(self) -> None:
+            self.writes: dict[str, dict[str, object]] = {}
+
+        async def write_lines_stream(self, *, purpose: str, filename: str, lines):  # noqa: ANN001
+            captured_lines = [line async for line in lines]
+            self.writes[purpose] = {"filename": filename, "lines": captured_lines}
+            size = sum(len(line) + 1 for line in captured_lines)
+            return f"{purpose}/{filename}", size, "checksum"
+
+    repo = _FinalizingRepo()
+    storage = _CapturingStorage()
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=repo,  # type: ignore[arg-type]
+        storage=storage,  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+    job = BatchJobRecord(
+        batch_id="b-finalize",
+        endpoint="/v1/embeddings",
+        status=BatchJobStatus.FINALIZING,
+        execution_mode="managed_internal",
+        input_file_id="f-1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m-1",
+        metadata={},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=2,
+        in_progress_items=0,
+        completed_items=1,
+        failed_items=1,
+        cancelled_items=0,
+        locked_by="w1",
+        lease_expires_at=now,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="tok-1",
+        created_by_user_id="u1",
+        created_by_team_id="t1",
+        created_by_organization_id="org-1",
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+        expires_at=None,
+    )
+
+    await worker._finalize_artifacts(job)
+
+    output_rows = [json.loads(line) for line in storage.writes["batch_output"]["lines"]]
+    error_rows = [json.loads(line) for line in storage.writes["batch_error"]["lines"]]
+
+    assert output_rows == [
+        {
+            "id": "batch_req_i1",
+            "custom_id": "req-1",
+            "response": {
+                "status_code": 200,
+                "request_id": "req_batch_i1",
+                "body": {
+                    "object": "list",
+                    "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                    "model": "provider-embedding-model",
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+                },
+            },
+            "error": None,
+        }
+    ]
+    assert error_rows == [
+        {
+            "id": "batch_req_i2",
+            "custom_id": "req-2",
+            "response": None,
+            "error": {"message": "boom", "type": "BatchItemError"},
+        }
+    ]
+    assert repo.attach_calls == [
+        {
+            "batch_id": "b-finalize",
+            "output_file_id": "batch_output-file",
+            "error_file_id": "batch_error-file",
+            "final_status": BatchJobStatus.COMPLETED,
+            "worker_id": "w1",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+import json
 import logging
 from types import SimpleNamespace
 
@@ -318,6 +319,209 @@ async def test_batch_worker_normalizes_single_item_embedding_usage(monkeypatch):
     await worker._process_item(job, item)
 
     assert repo.completed_calls[0]["usage"] == {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_serializes_single_item_embedding_artifact_row_in_openai_batch_shape(monkeypatch):
+    async def _fake_execute_embedding(request, payload, deployment):
+        del request, payload, deployment
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1, 0.2]}],
+            "model": "provider-embedding-model",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
+
+    deployment = SimpleNamespace(
+        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.0,
+        model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
+    )
+
+    class _Router:
+        def resolve_model_group(self, model: str) -> str:
+            return model
+
+        async def select_deployment(self, model_group: str, request_context: dict) -> str:
+            del model_group, request_context
+            return "dep-1"
+
+        def require_deployment(self, model_group: str, deployment: str):
+            del model_group, deployment
+            return deployment_obj
+
+    class _Failover:
+        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+            del model_group, kwargs
+            data = await execute(primary_deployment)
+            if return_deployment:
+                return data, primary_deployment
+            return data
+
+    deployment_obj = deployment
+    repo = _FakeRepository()
+    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=_SpendRecorder()))
+    worker = BatchExecutorWorker(
+        app=app,
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    now = datetime.now(tz=UTC)
+    job = BatchJobRecord(
+        batch_id="b1",
+        endpoint="/v1/embeddings",
+        status=BatchJobStatus.IN_PROGRESS,
+        execution_mode="managed_internal",
+        input_file_id="f1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m-1",
+        metadata={},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=1,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by="w1",
+        lease_expires_at=now,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="key-1",
+        created_by_user_id="user-1",
+        created_by_team_id="team-1",
+        created_by_organization_id="org-1",
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+        expires_at=None,
+    )
+    item = BatchItemRecord(
+        item_id="i1",
+        batch_id="b1",
+        line_number=1,
+        custom_id="c1",
+        status="in_progress",
+        request_body={"model": "m-1", "input": "hello"},
+        response_body=None,
+        error_body=None,
+        usage=None,
+        provider_cost=0.0,
+        billed_cost=0.0,
+        attempts=0,
+        last_error=None,
+        locked_by="w1",
+        lease_expires_at=now,
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+    )
+
+    await worker._process_item(job, item)
+
+    completed = repo.completed_calls[0]
+    artifact_row = worker._serialize_completed_artifact_row(
+        SimpleNamespace(item_id=item.item_id, custom_id=item.custom_id, response_body=completed["response_body"])
+    )
+
+    assert artifact_row == {
+        "id": "batch_req_i1",
+        "custom_id": "c1",
+        "response": {
+            "status_code": 200,
+            "request_id": "req_batch_i1",
+            "body": {
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                "model": "provider-embedding-model",
+                "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+            },
+        },
+        "error": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_iter_error_lines_emit_openai_batch_error_rows():
+    now = datetime.now(tz=UTC)
+
+    class _ArtifactRepo:
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b1"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="failed",
+                    request_body={},
+                    response_body=None,
+                    error_body={"message": "boom"},
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error="boom",
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                ),
+                BatchItemRecord(
+                    item_id="i2",
+                    batch_id=batch_id,
+                    line_number=2,
+                    custom_id="req-2",
+                    status="cancelled",
+                    request_body={},
+                    response_body=None,
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                ),
+            ]
+
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_ArtifactRepo(),  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    rows = [json.loads(line) async for line in worker._iter_error_lines("b1")]
+
+    assert rows == [
+        {
+            "id": "batch_req_i1",
+            "custom_id": "req-1",
+            "response": None,
+            "error": {"message": "boom", "type": "BatchItemError"},
+        },
+        {
+            "id": "batch_req_i2",
+            "custom_id": "req-2",
+            "response": None,
+            "error": {"message": "Batch request cancelled", "type": "BatchItemCancelled"},
+        },
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_worker_microbatch.py
+++ b/tests/test_batch_worker_microbatch.py
@@ -552,6 +552,44 @@ async def test_worker_fans_out_grouped_embedding_responses_into_single_item_rows
     assert first["usage"] == {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4}
     assert second["usage"] == {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4}
 
+    first_artifact_row = worker._serialize_completed_artifact_row(
+        SimpleNamespace(item_id="i1", custom_id="custom-i1", response_body=first["response_body"])
+    )
+    second_artifact_row = worker._serialize_completed_artifact_row(
+        SimpleNamespace(item_id="i2", custom_id="custom-i2", response_body=second["response_body"])
+    )
+
+    assert first_artifact_row == {
+        "id": "batch_req_i1",
+        "custom_id": "custom-i1",
+        "response": {
+            "status_code": 200,
+            "request_id": "req_batch_i1",
+            "body": {
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                "model": "provider-embedding-model",
+                "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
+            },
+        },
+        "error": None,
+    }
+    assert second_artifact_row == {
+        "id": "batch_req_i2",
+        "custom_id": "custom-i2",
+        "response": {
+            "status_code": 200,
+            "request_id": "req_batch_i2",
+            "body": {
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.3, 0.4]}],
+                "model": "provider-embedding-model",
+                "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
+            },
+        },
+        "error": None,
+    }
+
 
 @pytest.mark.asyncio
 async def test_worker_isolates_duplicate_response_indexes_back_to_single_item_execution(monkeypatch):

--- a/tests/test_batch_worker_microbatch.py
+++ b/tests/test_batch_worker_microbatch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -552,43 +553,94 @@ async def test_worker_fans_out_grouped_embedding_responses_into_single_item_rows
     assert first["usage"] == {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4}
     assert second["usage"] == {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4}
 
-    first_artifact_row = worker._serialize_completed_artifact_row(
-        SimpleNamespace(item_id="i1", custom_id="custom-i1", response_body=first["response_body"])
-    )
-    second_artifact_row = worker._serialize_completed_artifact_row(
-        SimpleNamespace(item_id="i2", custom_id="custom-i2", response_body=second["response_body"])
-    )
+    artifact_now = datetime.now(tz=UTC)
 
-    assert first_artifact_row == {
-        "id": "batch_req_i1",
-        "custom_id": "custom-i1",
-        "response": {
-            "status_code": 200,
-            "request_id": "req_batch_i1",
-            "body": {
-                "object": "list",
-                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
-                "model": "provider-embedding-model",
-                "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
+    class _ArtifactRepo:
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b1"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="custom-i1",
+                    status="completed",
+                    request_body={},
+                    response_body=first["response_body"],
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=artifact_now,
+                    started_at=artifact_now,
+                    completed_at=artifact_now,
+                ),
+                BatchItemRecord(
+                    item_id="i2",
+                    batch_id=batch_id,
+                    line_number=2,
+                    custom_id="custom-i2",
+                    status="completed",
+                    request_body={},
+                    response_body=second["response_body"],
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=artifact_now,
+                    started_at=artifact_now,
+                    completed_at=artifact_now,
+                ),
+            ]
+
+    artifact_worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_ArtifactRepo(),  # type: ignore[arg-type]
+        storage=_Storage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+    artifact_rows = [json.loads(line) async for line in artifact_worker._iter_output_lines("b1")]
+
+    assert artifact_rows == [
+        {
+            "id": "batch_req_i1",
+            "custom_id": "custom-i1",
+            "response": {
+                "status_code": 200,
+                "request_id": "req_batch_i1",
+                "body": {
+                    "object": "list",
+                    "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                    "model": "provider-embedding-model",
+                    "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
+                },
             },
+            "error": None,
         },
-        "error": None,
-    }
-    assert second_artifact_row == {
-        "id": "batch_req_i2",
-        "custom_id": "custom-i2",
-        "response": {
-            "status_code": 200,
-            "request_id": "req_batch_i2",
-            "body": {
-                "object": "list",
-                "data": [{"object": "embedding", "index": 0, "embedding": [0.3, 0.4]}],
-                "model": "provider-embedding-model",
-                "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
+        {
+            "id": "batch_req_i2",
+            "custom_id": "custom-i2",
+            "response": {
+                "status_code": 200,
+                "request_id": "req_batch_i2",
+                "body": {
+                    "object": "list",
+                    "data": [{"object": "embedding", "index": 0, "embedding": [0.3, 0.4]}],
+                    "model": "provider-embedding-model",
+                    "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
+                },
             },
+            "error": None,
         },
-        "error": None,
-    }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_worker_microbatch.py
+++ b/tests/test_batch_worker_microbatch.py
@@ -393,6 +393,44 @@ async def test_prepare_item_for_execution_returns_reusable_metadata_without_exec
 
 
 @pytest.mark.asyncio
+async def test_worker_process_items_uses_worker_prepare_override(monkeypatch):
+    async def _fake_execute_embedding(request, payload, deployment):
+        del request, deployment
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
+
+    worker, repo, _, _, failover = _build_worker(deployment_model_info={"upstream_max_batch_inputs": 1})
+    worker.config.worker_concurrency = 1
+
+    prepare_calls: list[str] = []
+    original_prepare_item = worker._prepare_item_for_execution
+
+    async def _prepare_item_override(job, item):  # noqa: ANN001
+        prepare_calls.append(item.item_id)
+        return await original_prepare_item(job, item)
+
+    worker._prepare_item_for_execution = _prepare_item_override  # type: ignore[assignment]
+
+    await worker._process_items(
+        _build_job(),
+        [
+            _build_item(item_id="i1", input_value="hello"),
+            _build_item(item_id="i2", input_value="world"),
+        ],
+    )
+
+    assert prepare_calls == ["i1", "i2"]
+    assert len(repo.completed_calls) == 2
+    assert repo.failed_calls == []
+    assert len(failover.calls) == 2
+
+
+@pytest.mark.asyncio
 async def test_worker_groups_eligible_items_into_upstream_microbatch_chunks(monkeypatch):
     execute_inputs: list[object] = []
 
@@ -517,7 +555,6 @@ async def test_worker_fans_out_grouped_embedding_responses_into_single_item_rows
                 {"index": 1, "embedding": [0.3, 0.4]},
                 {"index": 0, "embedding": [0.1, 0.2]},
             ],
-            "model": "provider-embedding-model",
             "usage": {"prompt_tokens": 8, "total_tokens": 8},
         }
 
@@ -538,15 +575,15 @@ async def test_worker_fans_out_grouped_embedding_responses_into_single_item_rows
     first, second = repo.completed_calls
     assert first["response_body"] == {
         "object": "list",
-        "data": [{"index": 0, "embedding": [0.1, 0.2]}],
-        "model": "provider-embedding-model",
+        "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+        "model": "openai/text-embedding-3-small",
         "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
         "_provider": "openai",
     }
     assert second["response_body"] == {
         "object": "list",
-        "data": [{"index": 0, "embedding": [0.3, 0.4]}],
-        "model": "provider-embedding-model",
+        "data": [{"object": "embedding", "index": 0, "embedding": [0.3, 0.4]}],
+        "model": "openai/text-embedding-3-small",
         "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
         "_provider": "openai",
     }
@@ -619,7 +656,7 @@ async def test_worker_fans_out_grouped_embedding_responses_into_single_item_rows
                 "body": {
                     "object": "list",
                     "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
-                    "model": "provider-embedding-model",
+                    "model": "openai/text-embedding-3-small",
                     "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
                 },
             },
@@ -634,7 +671,7 @@ async def test_worker_fans_out_grouped_embedding_responses_into_single_item_rows
                 "body": {
                     "object": "list",
                     "data": [{"object": "embedding", "index": 0, "embedding": [0.3, 0.4]}],
-                    "model": "provider-embedding-model",
+                    "model": "openai/text-embedding-3-small",
                     "usage": {"prompt_tokens": 4, "completion_tokens": 0, "total_tokens": 4},
                 },
             },
@@ -751,6 +788,86 @@ async def test_worker_isolates_upstream_exception_back_to_single_item_execution(
     )
 
     assert execute_inputs == [["hello", "world"], "hello", "world"]
+    assert len(failover.calls) == 3
+    assert len(repo.completed_calls) == 2
+    assert repo.failed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_worker_grouped_fallback_uses_worker_process_item_override(monkeypatch):
+    async def _fake_execute_embedding(request, payload, deployment):
+        del request, deployment
+        if payload.input == ["hello", "world"]:
+            raise RuntimeError("upstream exploded")
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+
+    worker, repo, _, _, failover = _build_worker(deployment_model_info={"upstream_max_batch_inputs": 4})
+    worker.config.worker_concurrency = 1
+
+    overridden_item_ids: list[str] = []
+
+    async def _process_item_override(job, item):  # noqa: ANN001
+        del job
+        overridden_item_ids.append(item.item_id)
+
+    worker._process_item = _process_item_override  # type: ignore[assignment]
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
+
+    await worker._process_items(
+        _build_job(),
+        [
+            _build_item(item_id="i1", input_value="hello"),
+            _build_item(item_id="i2", input_value="world"),
+        ],
+    )
+
+    assert overridden_item_ids == ["i1", "i2"]
+    assert len(failover.calls) == 1
+    assert repo.completed_calls == []
+    assert repo.failed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_worker_grouped_fallback_reprepares_items_before_isolated_retries(monkeypatch):
+    async def _fake_execute_embedding(request, payload, deployment):
+        del request, deployment
+        if payload.input == ["hello", "world"]:
+            raise RuntimeError("upstream exploded")
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+
+    monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
+
+    worker, repo, _, router, failover = _build_worker(deployment_model_info={"upstream_max_batch_inputs": 4})
+    worker.config.worker_concurrency = 1
+
+    prepare_calls: list[str] = []
+    original_prepare_item = worker._prepare_item_for_execution
+
+    async def _prepare_item_override(job, item):  # noqa: ANN001
+        prepare_calls.append(item.item_id)
+        return await original_prepare_item(job, item)
+
+    worker._prepare_item_for_execution = _prepare_item_override  # type: ignore[assignment]
+
+    await worker._process_items(
+        _build_job(),
+        [
+            _build_item(item_id="i1", input_value="hello"),
+            _build_item(item_id="i2", input_value="world"),
+        ],
+    )
+
+    assert prepare_calls == ["i1", "i2", "i1", "i2"]
+    assert len(router.select_calls) == 4
     assert len(failover.calls) == 3
     assert len(repo.completed_calls) == 2
     assert repo.failed_calls == []


### PR DESCRIPTION
## Summary

This PR fixes the batch embeddings output compatibility work tracked in #95 and packages the batch worker into smaller internal modules so the logic is easier to maintain.

## What Changed

- fixed batch embedding artifact output to use the OpenAI Batch-style wrapper shape
- hardened completed artifact validation so malformed completed payloads fail closed instead of producing synthetic success rows
- stopped permanently malformed completed payloads from retrying forever during finalization
- normalized new completed embedding rows before persistence and backfilled legacy rows during artifact serialization
- split the batch worker into focused modules:
  - `src/batch/worker.py` as orchestrator
  - `src/batch/worker_execution.py` for execution and microbatching
  - `src/batch/worker_artifacts.py` for artifact shaping and finalization
  - `src/batch/worker_types.py` for shared worker types
- preserved the existing worker seams used by tests and monkeypatch-based behavior
- added regression coverage for artifact output, fallback routing, dynamic hooks, and the refactored worker seams

## Why

The original batch output was not OpenAI Batch-compatible at the artifact boundary, and the worker implementation had grown large enough that compatibility fixes were becoming cross-cutting and hard to review safely.

## Impact

- batch embedding output artifacts are now substantially closer to OpenAI Batch expectations
- malformed completed payloads now terminate cleanly instead of cycling in finalization retries
- batch worker behavior is covered by stronger seam-focused tests after the internal split

## Follow-ups Not Included

These are intentionally left for later PRs:
- #97 batch artifact strict OpenAI compatibility follow-up
- #98 `/v1/embeddings` strict OpenAI compatibility follow-up

## Validation

- `uv run pytest tests/test_batch_worker.py -q`
- `uv run pytest tests/test_batch_worker_microbatch.py -q`
- `uv run ruff check src/batch/worker.py src/batch/worker_types.py src/batch/worker_execution.py src/batch/worker_artifacts.py tests/test_batch_worker.py tests/test_batch_worker_microbatch.py`

Closes #95