### PR TITLE
Fix deployment health classification for upstream request failures

### DIFF
--- a/scripts/measure_embedding_batch_load.py
+++ b/scripts/measure_embedding_batch_load.py
@@ -54,8 +54,15 @@ class NoopSpendTrackingService:
 
 
 class NoopPassiveHealthTracker:
-    async def record_request_outcome(self, deployment_id: str, success: bool, error: str | None = None) -> None:
-        del deployment_id, success, error
+    async def record_request_outcome(
+        self,
+        deployment_id: str,
+        success: bool,
+        error: str | None = None,
+        *,
+        exc: Exception | None = None,
+    ) -> None:
+        del deployment_id, success, error, exc
 
 
 class NoopRouterStateBackend:

--- a/src/batch/worker_execution.py
+++ b/src/batch/worker_execution.py
@@ -965,7 +965,12 @@ class BatchExecutionEngine:
         if passive_health_tracker is None or deployment_id is None:
             return
         try:
-            await passive_health_tracker.record_request_outcome(deployment_id, success=False, error=str(exc))
+            await passive_health_tracker.record_request_outcome(
+                deployment_id,
+                success=False,
+                error=str(exc),
+                exc=exc,
+            )
         except Exception as hook_exc:
             logger.warning(
                 "batch passive health upstream failure hook failed batch_id=%s reference=%s deployment_id=%s error=%s",
@@ -988,7 +993,12 @@ class BatchExecutionEngine:
         passive_health_tracker = getattr(self.app.state, "passive_health_tracker", None)
         if passive_health_tracker is not None and deployment_id is not None:
             try:
-                await passive_health_tracker.record_request_outcome(deployment_id, success=False, error=str(exc))
+                await passive_health_tracker.record_request_outcome(
+                    deployment_id,
+                    success=False,
+                    error=str(exc),
+                    exc=exc,
+                )
             except Exception as hook_exc:
                 logger.warning(
                     "batch passive health failure hook failed batch_id=%s item_id=%s deployment_id=%s error=%s",

--- a/src/chat/executor.py
+++ b/src/chat/executor.py
@@ -158,7 +158,10 @@ async def open_stream_with_first_chunk(
                 first_line = line
                 break
         if first_line is None:
-            raise ServiceUnavailableError(message="Provider stream ended before first chunk")
+            raise ServiceUnavailableError(
+                message="Provider stream ended before first chunk",
+                affects_deployment_health=True,
+            )
 
         return OpenedStream(
             context_manager=context_manager,

--- a/src/chat/telemetry.py
+++ b/src/chat/telemetry.py
@@ -19,6 +19,7 @@ from src.metrics import (
     observe_request_latency,
 )
 from src.providers.resolution import resolve_provider
+from src.router.health_policy import exception_status_code
 from src.telemetry.request_failures import enqueue_request_log_write
 from src.routers.routing_decision import attach_route_decision, resolve_failure_target
 from src.routers.utils import fire_and_forget
@@ -26,17 +27,6 @@ from src.routers.utils import fire_and_forget
 
 def _append_route_decision_metadata(request: Request, metadata: dict[str, Any]) -> dict[str, Any]:
     return attach_route_decision(metadata, request)
-
-
-def _exception_status_code(exc: Exception) -> int | None:
-    response = getattr(exc, "response", None)
-    raw_status = getattr(exc, "status_code", None)
-    if raw_status is None and response is not None:
-        raw_status = getattr(response, "status_code", None)
-    try:
-        return int(raw_status) if raw_status is not None else None
-    except (TypeError, ValueError):
-        return None
 
 
 def _resolve_failure_fields(
@@ -181,7 +171,7 @@ async def emit_stream_failure(
             cache_hit=cache_hit,
             start_time=callback_start,
             end_time=datetime.now(tz=UTC),
-            http_status_code=_exception_status_code(exc),
+            http_status_code=exception_status_code(exc),
             exc=exc,
         )
     )
@@ -190,6 +180,7 @@ async def emit_stream_failure(
             str(failure_fields["deployment_id"]),
             success=False,
             error=str(exc),
+            exc=exc,
         )
     callback_payload = build_standard_logging_payload(
         call_type="completion",
@@ -462,6 +453,7 @@ async def emit_nonstream_failure(
         str(failure_fields["deployment_id"] or primary_deployment.deployment_id),
         success=False,
         error=str(exc),
+        exc=exc,
     )
     increment_request(
         model=payload.model,

--- a/src/models/errors.py
+++ b/src/models/errors.py
@@ -1,15 +1,52 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from math import ceil
+
+
+def parse_retry_after_header(value: str | None) -> int | None:
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    if not normalized:
+        return None
+
+    try:
+        return max(0, ceil(float(normalized)))
+    except (OverflowError, TypeError, ValueError):
+        pass
+
+    try:
+        retry_at = parsedate_to_datetime(normalized)
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=UTC)
+
+    remaining = ceil((retry_at - datetime.now(tz=UTC)).total_seconds())
+    return max(0, remaining)
+
 
 class ProxyError(Exception):
     status_code: int = 500
     error_type: str = "server_error"
     message: str = "Internal server error"
 
-    def __init__(self, message: str | None = None, param: str | None = None, code: str | None = None):
+    def __init__(
+        self,
+        message: str | None = None,
+        param: str | None = None,
+        code: str | None = None,
+        *,
+        affects_deployment_health: bool | None = None,
+    ):
         self.message = message or self.message
         self.param = param
         self.code = code
+        self.affects_deployment_health = affects_deployment_health
         super().__init__(self.message)
 
 

--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -6,10 +6,9 @@ from typing import Any, AsyncIterator
 
 import httpx
 
-from src.models.errors import InvalidRequestError, ServiceUnavailableError, TimeoutError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter
+from src.providers.base import ProviderAdapter, map_standard_provider_error
 from src.providers.resolution import resolve_upstream_model
 
 
@@ -179,14 +178,12 @@ class AnthropicAdapter(ProviderAdapter):
         yield "data: [DONE]"
 
     def map_error(self, provider_error: Exception) -> Exception:
-        if isinstance(provider_error, httpx.TimeoutException):
-            return TimeoutError()
-        if isinstance(provider_error, httpx.HTTPStatusError):
-            status = provider_error.response.status_code
-            if status >= 500:
-                return ServiceUnavailableError(message=f"Provider error: {status}")
-            return InvalidRequestError(message=f"Provider rejected request: {status}")
-        return ServiceUnavailableError(message=str(provider_error))
+        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
+        return map_standard_provider_error(
+            provider_error,
+            invalid_request_message=f"Provider rejected request: {status}",
+            rate_limit_message=f"Provider rate limited request: {status}",
+        )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
         api_key = provider_config.get("api_key")

--- a/src/providers/azure.py
+++ b/src/providers/azure.py
@@ -5,10 +5,9 @@ from typing import Any, AsyncIterator
 
 import httpx
 
-from src.models.errors import InvalidRequestError, ServiceUnavailableError, TimeoutError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter
+from src.providers.base import ProviderAdapter, map_standard_provider_error
 from src.providers.resolution import normalize_openai_chat_payload, resolve_provider, resolve_upstream_model
 
 
@@ -40,14 +39,12 @@ class AzureOpenAIAdapter(ProviderAdapter):
             yield chunk
 
     def map_error(self, provider_error: Exception) -> Exception:
-        if isinstance(provider_error, httpx.TimeoutException):
-            return TimeoutError()
-        if isinstance(provider_error, httpx.HTTPStatusError):
-            status = provider_error.response.status_code
-            if status >= 500:
-                return ServiceUnavailableError(message=f"Provider error: {status}")
-            return InvalidRequestError(message=f"Provider rejected request: {status}")
-        return ServiceUnavailableError(message=str(provider_error))
+        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
+        return map_standard_provider_error(
+            provider_error,
+            invalid_request_message=f"Provider rejected request: {status}",
+            rate_limit_message=f"Provider rate limited request: {status}",
+        )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
         api_base = str(provider_config.get("api_base") or "").rstrip("/")

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -3,8 +3,51 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator
 
+import httpx
+
+from src.models.errors import (
+    InvalidRequestError,
+    RateLimitError,
+    ServiceUnavailableError,
+    TimeoutError,
+    parse_retry_after_header,
+)
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
+
+
+def map_standard_provider_error(
+    provider_error: Exception,
+    *,
+    invalid_request_message: str,
+    unavailable_message: str | None = None,
+    rate_limit_message: str | None = None,
+) -> Exception:
+    if isinstance(provider_error, httpx.TimeoutException):
+        return TimeoutError(affects_deployment_health=True)
+
+    if isinstance(provider_error, httpx.HTTPStatusError):
+        status = provider_error.response.status_code
+        if status == 429:
+            return RateLimitError(
+                message=rate_limit_message or invalid_request_message,
+                retry_after=parse_retry_after_header(provider_error.response.headers.get("retry-after")),
+                affects_deployment_health=True,
+            )
+        if status >= 500:
+            return ServiceUnavailableError(
+                message=f"Provider error: {status}",
+                affects_deployment_health=True,
+            )
+        return InvalidRequestError(
+            message=invalid_request_message,
+            affects_deployment_health=False,
+        )
+
+    return ServiceUnavailableError(
+        message=unavailable_message or str(provider_error),
+        affects_deployment_health=True,
+    )
 
 
 class ProviderAdapter(ABC):

--- a/src/providers/bedrock.py
+++ b/src/providers/bedrock.py
@@ -6,10 +6,10 @@ from typing import Any, AsyncIterator
 
 import httpx
 
-from src.models.errors import InvalidRequestError, ServiceUnavailableError, TimeoutError
+from src.models.errors import InvalidRequestError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter
+from src.providers.base import ProviderAdapter, map_standard_provider_error
 
 
 class BedrockAdapter(ProviderAdapter):
@@ -103,14 +103,12 @@ class BedrockAdapter(ProviderAdapter):
         raise InvalidRequestError(message="Bedrock streaming is not supported yet")
 
     def map_error(self, provider_error: Exception) -> Exception:
-        if isinstance(provider_error, httpx.TimeoutException):
-            return TimeoutError()
-        if isinstance(provider_error, httpx.HTTPStatusError):
-            status = provider_error.response.status_code
-            if status >= 500:
-                return ServiceUnavailableError(message=f"Provider error: {status}")
-            return InvalidRequestError(message=f"Provider rejected request: {status}")
-        return ServiceUnavailableError(message=str(provider_error))
+        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
+        return map_standard_provider_error(
+            provider_error,
+            invalid_request_message=f"Provider rejected request: {status}",
+            rate_limit_message=f"Provider rate limited request: {status}",
+        )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
         access_key = provider_config.get("aws_access_key_id")

--- a/src/providers/gemini.py
+++ b/src/providers/gemini.py
@@ -6,10 +6,10 @@ from typing import Any, AsyncIterator
 
 import httpx
 
-from src.models.errors import InvalidRequestError, ServiceUnavailableError, TimeoutError
+from src.models.errors import InvalidRequestError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter
+from src.providers.base import ProviderAdapter, map_standard_provider_error
 
 
 class GeminiAdapter(ProviderAdapter):
@@ -104,14 +104,12 @@ class GeminiAdapter(ProviderAdapter):
         raise InvalidRequestError(message="Gemini streaming is not supported yet")
 
     def map_error(self, provider_error: Exception) -> Exception:
-        if isinstance(provider_error, httpx.TimeoutException):
-            return TimeoutError()
-        if isinstance(provider_error, httpx.HTTPStatusError):
-            status = provider_error.response.status_code
-            if status >= 500:
-                return ServiceUnavailableError(message=f"Provider error: {status}")
-            return InvalidRequestError(message=f"Provider rejected request: {status}")
-        return ServiceUnavailableError(message=str(provider_error))
+        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
+        return map_standard_provider_error(
+            provider_error,
+            invalid_request_message=f"Provider rejected request: {status}",
+            rate_limit_message=f"Provider rate limited request: {status}",
+        )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
         api_base = str(provider_config.get("api_base") or "https://generativelanguage.googleapis.com/v1beta").rstrip("/")

--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -5,10 +5,9 @@ from typing import Any, AsyncIterator
 
 import httpx
 
-from src.models.errors import InvalidRequestError, ServiceUnavailableError, TimeoutError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter
+from src.providers.base import ProviderAdapter, map_standard_provider_error
 from src.providers.resolution import normalize_openai_chat_payload, resolve_provider, resolve_upstream_model
 from src.upstream_auth import build_openai_compatible_auth_headers
 
@@ -59,7 +58,7 @@ class OpenAIAdapter(ProviderAdapter):
         response = provider_error.response
         try:
             payload = response.json()
-        except ValueError:
+        except (AttributeError, ValueError):
             payload = None
         if isinstance(payload, dict):
             error = payload.get("error")
@@ -67,20 +66,24 @@ class OpenAIAdapter(ProviderAdapter):
                 message = str(error.get("message") or "").strip()
                 if message:
                     return message
-        body = response.text.strip()
+        body = str(getattr(response, "text", "") or "").strip()
         if body:
             return body
         return f"Provider rejected request: {response.status_code}"
 
     def map_error(self, provider_error: Exception) -> Exception:
-        if isinstance(provider_error, httpx.TimeoutException):
-            return TimeoutError()
-        if isinstance(provider_error, httpx.HTTPStatusError):
-            status = provider_error.response.status_code
-            if status >= 500:
-                return ServiceUnavailableError(message=f"Provider error: {status}")
-            return InvalidRequestError(message=self._http_error_message(provider_error))
-        return ServiceUnavailableError(message="Provider unavailable")
+        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
+        message = (
+            self._http_error_message(provider_error)
+            if isinstance(provider_error, httpx.HTTPStatusError) and status is not None and status < 500
+            else "Provider unavailable"
+        )
+        return map_standard_provider_error(
+            provider_error,
+            invalid_request_message=message,
+            unavailable_message="Provider unavailable",
+            rate_limit_message=message if status == 429 else None,
+        )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
         api_base = provider_config.get("api_base", "https://api.openai.com/v1")

--- a/src/router/cooldown.py
+++ b/src/router/cooldown.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from typing import Any, Awaitable, Callable
 
+from src.router.health_policy import affects_deployment_health
 from src.router.state import DeploymentStateBackend
 
 
@@ -19,7 +20,18 @@ class CooldownManager:
         self.allowed_fails = allowed_fails
         self.alert_callback = alert_callback
 
-    async def record_failure(self, deployment_id: str, error: str) -> bool:
+    async def record_failure(
+        self,
+        deployment_id: str,
+        error: str,
+        *,
+        exc: Exception | None = None,
+        affects_health: bool | None = None,
+    ) -> bool:
+        if affects_health is None and exc is not None:
+            affects_health = affects_deployment_health(exc)
+        if affects_health is False:
+            return False
         failure_count = await self.state.record_failure(deployment_id, error)
         if failure_count > self.allowed_fails:
             await self._enter_cooldown(deployment_id, error, failure_count)

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -10,8 +10,16 @@ from typing import Any, Awaitable, Callable
 
 import httpx
 
-from src.models.errors import InvalidRequestError, ProxyError, ServiceUnavailableError, TimeoutError
+from src.models.errors import (
+    InvalidRequestError,
+    ProxyError,
+    RateLimitError,
+    ServiceUnavailableError,
+    TimeoutError,
+    parse_retry_after_header,
+)
 from src.router.cooldown import CooldownManager
+from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
 from src.router.state import DeploymentStateBackend
 
@@ -228,6 +236,86 @@ class FailoverManager:
         except Exception:
             logger.warning("failover attempt callback failed", exc_info=True)
 
+    @staticmethod
+    def _http_error_message(error: httpx.HTTPError) -> str:
+        response = getattr(error, "response", None)
+        if response is None:
+            return str(error)
+
+        try:
+            payload = response.json()
+        except Exception:
+            payload = None
+
+        if isinstance(payload, dict):
+            nested_error = payload.get("error")
+            if isinstance(nested_error, dict):
+                for key in ("message", "detail"):
+                    message = nested_error.get(key)
+                    if isinstance(message, str) and message.strip():
+                        return message.strip()
+            if isinstance(nested_error, str) and nested_error.strip():
+                return nested_error.strip()
+            for key in ("message", "detail"):
+                message = payload.get(key)
+                if isinstance(message, str) and message.strip():
+                    return message.strip()
+
+        body = str(getattr(response, "text", "") or "").strip()
+        if body:
+            return body
+
+        content = getattr(response, "content", None)
+        if isinstance(content, bytes):
+            decoded = content.decode("utf-8", errors="replace").strip()
+            if decoded:
+                return decoded
+
+        return str(error)
+
+    def _normalize_http_error(self, error: httpx.HTTPError) -> ProxyError:
+        if isinstance(error, httpx.TimeoutException):
+            return TimeoutError(
+                message=str(error) or None,
+                affects_deployment_health=True,
+            )
+        response = getattr(error, "response", None)
+        status_code = getattr(response, "status_code", None)
+        if status_code == 429:
+            return RateLimitError(
+                message=self._http_error_message(error),
+                retry_after=parse_retry_after_header(response.headers.get("retry-after")),
+                affects_deployment_health=True,
+            )
+        if affects_deployment_health(error):
+            return ServiceUnavailableError(
+                message=str(error),
+                affects_deployment_health=True,
+            )
+        return InvalidRequestError(
+            message=self._http_error_message(error),
+            affects_deployment_health=False,
+        )
+
+    def _normalize_execution_error(
+        self,
+        error: Exception,
+        deployment: Deployment,
+    ) -> tuple[Exception, str, bool]:
+        if isinstance(error, asyncio.TimeoutError):
+            normalized = TimeoutError(message=f"Deployment '{deployment.deployment_id}' timed out")
+            return normalized, ErrorClassification.TIMEOUT, True
+
+        if isinstance(error, ProxyError):
+            return error, ErrorClassification.classify(error), True
+
+        if isinstance(error, httpx.HTTPError):
+            normalized = self._normalize_http_error(error)
+            return normalized, ErrorClassification.classify(normalized), True
+
+        normalized = ServiceUnavailableError(message=str(error))
+        return normalized, ErrorClassification.classify(normalized), False
+
     async def execute_with_failover(
         self,
         primary_deployment: Deployment,
@@ -283,132 +371,54 @@ class FailoverManager:
                     if return_deployment:
                         return result, deployment
                     return result
-                except asyncio.TimeoutError:
-                    last_error = TimeoutError(message=f"Deployment '{deployment.deployment_id}' timed out")
-                    classification = ErrorClassification.TIMEOUT
-                    await self.cooldown.record_failure(deployment.deployment_id, "timeout")
+                except Exception as exc:
+                    last_error, classification, allow_classified_fallbacks = self._normalize_execution_error(
+                        exc,
+                        deployment,
+                    )
+                    error_message = str(last_error)
+                    reason = "timeout" if classification == ErrorClassification.TIMEOUT else classification
+                    await self.cooldown.record_failure(
+                        deployment.deployment_id,
+                        error_message,
+                        exc=last_error,
+                    )
 
                     self._record_fallback_event(
                         model_group=model_group,
                         from_id=deployment.deployment_id,
                         to_id=None,
-                        reason="timeout",
+                        reason=reason,
                         classification=classification,
-                        error_msg=str(last_error),
+                        error_msg=error_message,
                         attempt=attempt,
                         success=False,
                     )
+
+                    if allow_classified_fallbacks:
+                        extra_chain = self._get_classified_fallbacks(classification, model_group)
+                        if extra_chain:
+                            extra_result = await self._try_classified_fallbacks(
+                                extra_chain,
+                                model_group,
+                                execute,
+                                deployment.deployment_id,
+                                classification,
+                                on_attempt=on_attempt,
+                                timeout_seconds=effective_timeout,
+                            )
+                            if extra_result is not None:
+                                if return_deployment:
+                                    result, served = extra_result
+                                    return result, served
+                                return extra_result[0]
+
+                    if not affects_deployment_health(last_error):
+                        if last_error is exc:
+                            raise
+                        raise last_error from exc
 
                     if self._should_retry(classification, last_error, effective_retry_classes) and attempt < effective_retries:
-                        await asyncio.sleep(self._compute_backoff(attempt))
-                except ProxyError as exc:
-                    last_error = exc
-                    classification = ErrorClassification.classify(exc)
-                    await self.cooldown.record_failure(deployment.deployment_id, str(exc))
-
-                    self._record_fallback_event(
-                        model_group=model_group,
-                        from_id=deployment.deployment_id,
-                        to_id=None,
-                        reason=classification,
-                        classification=classification,
-                        error_msg=str(exc),
-                        attempt=attempt,
-                        success=False,
-                    )
-
-                    extra_chain = self._get_classified_fallbacks(classification, model_group)
-                    if extra_chain:
-                        extra_result = await self._try_classified_fallbacks(
-                            extra_chain,
-                            model_group,
-                            execute,
-                            deployment.deployment_id,
-                            classification,
-                            on_attempt=on_attempt,
-                            timeout_seconds=effective_timeout,
-                        )
-                        if extra_result is not None:
-                            if return_deployment:
-                                result, served = extra_result
-                                return result, served
-                            return extra_result[0]
-
-                    if self._should_retry(classification, exc, effective_retry_classes) and attempt < effective_retries:
-                        await asyncio.sleep(self._compute_backoff(attempt))
-                        continue
-                    break
-                except httpx.HTTPError as exc:
-                    classification = ErrorClassification.classify(exc)
-                    last_error = ServiceUnavailableError(message=str(exc))
-                    await self.cooldown.record_failure(deployment.deployment_id, str(exc))
-
-                    self._record_fallback_event(
-                        model_group=model_group,
-                        from_id=deployment.deployment_id,
-                        to_id=None,
-                        reason=classification,
-                        classification=classification,
-                        error_msg=str(exc),
-                        attempt=attempt,
-                        success=False,
-                    )
-
-                    extra_chain = self._get_classified_fallbacks(classification, model_group)
-                    if extra_chain:
-                        extra_result = await self._try_classified_fallbacks(
-                            extra_chain,
-                            model_group,
-                            execute,
-                            deployment.deployment_id,
-                            classification,
-                            on_attempt=on_attempt,
-                            timeout_seconds=effective_timeout,
-                        )
-                        if extra_result is not None:
-                            if return_deployment:
-                                result, served = extra_result
-                                return result, served
-                            return extra_result[0]
-
-                    if self._should_retry(classification, exc, effective_retry_classes) and attempt < effective_retries:
-                        await asyncio.sleep(self._compute_backoff(attempt))
-                        continue
-                    break
-                except Exception as exc:
-                    classification = ErrorClassification.classify(exc)
-                    last_error = ServiceUnavailableError(message=str(exc))
-                    await self.cooldown.record_failure(deployment.deployment_id, str(exc))
-
-                    self._record_fallback_event(
-                        model_group=model_group,
-                        from_id=deployment.deployment_id,
-                        to_id=None,
-                        reason=classification,
-                        classification=classification,
-                        error_msg=str(exc),
-                        attempt=attempt,
-                        success=False,
-                    )
-
-                    extra_chain = self._get_classified_fallbacks(classification, model_group)
-                    if extra_chain:
-                        extra_result = await self._try_classified_fallbacks(
-                            extra_chain,
-                            model_group,
-                            execute,
-                            deployment.deployment_id,
-                            classification,
-                            on_attempt=on_attempt,
-                            timeout_seconds=effective_timeout,
-                        )
-                        if extra_result is not None:
-                            if return_deployment:
-                                result, served = extra_result
-                                return result, served
-                            return extra_result[0]
-
-                    if self._should_retry(classification, exc, effective_retry_classes) and attempt < effective_retries:
                         await asyncio.sleep(self._compute_backoff(attempt))
                         continue
                     break
@@ -491,17 +501,35 @@ class FailoverManager:
 
                 return result, deployment
             except Exception as exc:
-                await self.cooldown.record_failure(deployment.deployment_id, str(exc))
+                normalized_error, failure_classification, allow_classified_fallbacks = self._normalize_execution_error(
+                    exc,
+                    deployment,
+                )
+                error_message = str(normalized_error)
+                await self.cooldown.record_failure(
+                    deployment.deployment_id,
+                    error_message,
+                    exc=normalized_error,
+                )
                 self._record_fallback_event(
                     model_group=model_group,
                     from_id=from_deployment_id,
                     to_id=deployment.deployment_id,
                     reason=classification,
-                    classification=classification,
-                    error_msg=str(exc),
+                    classification=failure_classification,
+                    error_msg=error_message,
                     attempt=0,
                     success=False,
                 )
+                if not allow_classified_fallbacks:
+                    raise normalized_error from exc
+                if not affects_deployment_health(normalized_error) and failure_classification not in {
+                    ErrorClassification.CONTEXT_WINDOW,
+                    ErrorClassification.CONTENT_POLICY,
+                }:
+                    if normalized_error is exc:
+                        raise
+                    raise normalized_error from exc
             finally:
                 await self.state.decrement_active(deployment.deployment_id)
 

--- a/src/router/health.py
+++ b/src/router/health.py
@@ -13,6 +13,7 @@ from src.metrics import (
 )
 from src.models.errors import ServiceUnavailableError
 from src.providers.healthcheck import HealthProbeResult
+from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
 from src.router.state import DeploymentStateBackend
 
@@ -101,10 +102,23 @@ class PassiveHealthTracker:
         self.state = state_backend
         self.failure_threshold = failure_threshold
 
-    async def record_request_outcome(self, deployment_id: str, success: bool, error: str | None = None) -> None:
+    async def record_request_outcome(
+        self,
+        deployment_id: str,
+        success: bool,
+        error: str | None = None,
+        *,
+        exc: Exception | None = None,
+        affects_health: bool | None = None,
+    ) -> None:
         if success:
             await self.state.record_success(deployment_id)
             await self.state.set_health(deployment_id, True)
+            return
+
+        if affects_health is None and exc is not None:
+            affects_health = affects_deployment_health(exc)
+        if affects_health is False:
             return
 
         failures = await self.state.record_failure(deployment_id, error or "request_failed")

--- a/src/router/health_policy.py
+++ b/src/router/health_policy.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import httpx
+
+from src.models.errors import InvalidRequestError, ProxyError, TimeoutError
+
+
+def exception_status_code(exc: Exception) -> int | None:
+    response = getattr(exc, "response", None)
+    raw_status = getattr(exc, "status_code", None)
+    if raw_status is None and response is not None:
+        raw_status = getattr(response, "status_code", None)
+    try:
+        return int(raw_status) if raw_status is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def is_request_side_client_error(exc: Exception) -> bool:
+    explicit = getattr(exc, "affects_deployment_health", None)
+    if explicit is False:
+        return True
+
+    if isinstance(exc, InvalidRequestError):
+        return True
+
+    status_code = exception_status_code(exc)
+    return status_code is not None and 400 <= status_code < 500 and status_code != 429
+
+
+def affects_deployment_health(exc: Exception) -> bool:
+    explicit = getattr(exc, "affects_deployment_health", None)
+    if explicit is not None:
+        return bool(explicit)
+
+    if isinstance(exc, (httpx.TimeoutException, TimeoutError)):
+        return True
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        return not is_request_side_client_error(exc)
+
+    if isinstance(exc, httpx.TransportError):
+        return True
+
+    if isinstance(exc, ProxyError):
+        return False
+
+    status_code = exception_status_code(exc)
+    if status_code is not None:
+        return status_code == 429 or status_code >= 500
+
+    return True

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -292,7 +292,12 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
         increment_request(model=payload.model, api_provider=failure_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
         increment_request_failure(model=payload.model, api_provider=failure_provider, error_type=exc.__class__.__name__)
@@ -354,7 +359,12 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = int(getattr(exc, "status_code", 500) or 500)
         enqueue_request_log_write(
             request,

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -301,7 +301,12 @@ async def audio_transcriptions(
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
         increment_request(model=model, api_provider=failure_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
         increment_request_failure(model=model, api_provider=failure_provider, error_type=exc.__class__.__name__)
@@ -365,7 +370,12 @@ async def audio_transcriptions(
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = int(getattr(exc, "status_code", 500) or 500)
         enqueue_request_log_write(
             request,

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -368,7 +368,12 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
         increment_request(
             model=payload.model, api_provider=failure_provider,
@@ -435,7 +440,12 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = int(getattr(exc, "status_code", 500) or 500)
         callback_payload = build_standard_logging_payload(
             call_type="embedding", request_id=request_id, model=payload.model,

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -245,7 +245,12 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
         increment_request(model=payload.model, api_provider=failure_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
         increment_request_failure(model=payload.model, api_provider=failure_provider, error_type=exc.__class__.__name__)
@@ -307,7 +312,12 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = int(getattr(exc, "status_code", 500) or 500)
         enqueue_request_log_write(
             request,

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -238,7 +238,12 @@ async def rerank(request: Request, payload: RerankRequest):
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
         increment_request(model=payload.model, api_provider=failure_provider, api_key=auth.api_key, user=auth.user_id, team=auth.team_id, status_code=status_code)
         increment_request_failure(model=payload.model, api_provider=failure_provider, error_type=exc.__class__.__name__)
@@ -302,7 +307,12 @@ async def rerank(request: Request, payload: RerankRequest):
         failure_provider = str(failure_target.provider or api_provider)
         failure_api_base = failure_target.api_base or primary_api_base
         failure_deployment_model = failure_target.deployment_model or primary.deltallm_params.get("model")
-        await request.app.state.passive_health_tracker.record_request_outcome(failure_deployment_id, success=False, error=str(exc))
+        await request.app.state.passive_health_tracker.record_request_outcome(
+            failure_deployment_id,
+            success=False,
+            error=str(exc),
+            exc=exc,
+        )
         status_code = int(getattr(exc, "status_code", 500) or 500)
         enqueue_request_log_write(
             request,

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -104,8 +104,15 @@ class _NoopSpendTrackingService:
 
 
 class _NoopPassiveHealthTracker:
-    async def record_request_outcome(self, deployment_id: str, success: bool, error: str | None = None) -> None:
-        del deployment_id, success, error
+    async def record_request_outcome(
+        self,
+        deployment_id: str,
+        success: bool,
+        error: str | None = None,
+        *,
+        exc: Exception | None = None,
+    ) -> None:
+        del deployment_id, success, error, exc
 
 
 class _NoopRouterStateBackend:

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -35,7 +35,15 @@ class _PassiveHealthRecorder:
     def __init__(self) -> None:
         self.calls: list[tuple[str, bool, str | None]] = []
 
-    async def record_request_outcome(self, deployment_id: str, success: bool, error: str | None = None) -> None:
+    async def record_request_outcome(
+        self,
+        deployment_id: str,
+        success: bool,
+        error: str | None = None,
+        *,
+        exc: Exception | None = None,
+    ) -> None:
+        del exc
         self.calls.append((deployment_id, success, error))
 
 
@@ -1165,8 +1173,15 @@ async def test_batch_worker_keeps_completed_state_when_passive_health_success_ho
     )
 
     class _FailingPassiveHealth:
-        async def record_request_outcome(self, deployment_id: str, success: bool, error: str | None = None) -> None:
-            del deployment_id, success, error
+        async def record_request_outcome(
+            self,
+            deployment_id: str,
+            success: bool,
+            error: str | None = None,
+            *,
+            exc: Exception | None = None,
+        ) -> None:
+            del deployment_id, success, error, exc
             raise RuntimeError("health sink unavailable")
 
     class _RouterStateBackend:
@@ -1708,7 +1723,15 @@ async def test_batch_worker_keeps_failed_state_when_passive_health_failure_hook_
         def __init__(self) -> None:
             self.calls: list[tuple[str, bool, str | None]] = []
 
-        async def record_request_outcome(self, deployment_id: str, success: bool, error: str | None = None) -> None:
+        async def record_request_outcome(
+            self,
+            deployment_id: str,
+            success: bool,
+            error: str | None = None,
+            *,
+            exc: Exception | None = None,
+        ) -> None:
+            del exc
             self.calls.append((deployment_id, success, error))
             raise RuntimeError("health sink unavailable")
 

--- a/tests/test_batch_worker_microbatch.py
+++ b/tests/test_batch_worker_microbatch.py
@@ -879,7 +879,15 @@ async def test_worker_records_one_upstream_failure_before_isolation_fallback(mon
         def __init__(self) -> None:
             self.calls: list[tuple[str, bool, str | None]] = []
 
-        async def record_request_outcome(self, deployment_id: str, success: bool, error: str | None = None) -> None:
+        async def record_request_outcome(
+            self,
+            deployment_id: str,
+            success: bool,
+            error: str | None = None,
+            *,
+            exc: Exception | None = None,
+        ) -> None:
+            del exc
             self.calls.append((deployment_id, success, error))
 
     async def _fake_execute_embedding(request, payload, deployment):
@@ -922,7 +930,15 @@ async def test_worker_attributes_grouped_response_validation_failures_to_served_
         def __init__(self) -> None:
             self.calls: list[tuple[str, bool, str | None]] = []
 
-        async def record_request_outcome(self, deployment_id: str, success: bool, error: str | None = None) -> None:
+        async def record_request_outcome(
+            self,
+            deployment_id: str,
+            success: bool,
+            error: str | None = None,
+            *,
+            exc: Exception | None = None,
+        ) -> None:
+            del exc
             self.calls.append((deployment_id, success, error))
 
     async def _fake_execute_embedding(request, payload, deployment):
@@ -1001,7 +1017,15 @@ async def test_worker_salvages_grouped_chunk_when_bulk_completion_fails_without_
         def __init__(self) -> None:
             self.calls: list[tuple[str, bool, str | None]] = []
 
-        async def record_request_outcome(self, deployment_id: str, success: bool, error: str | None = None) -> None:
+        async def record_request_outcome(
+            self,
+            deployment_id: str,
+            success: bool,
+            error: str | None = None,
+            *,
+            exc: Exception | None = None,
+        ) -> None:
+            del exc
             self.calls.append((deployment_id, success, error))
 
     async def _fake_execute_embedding(request, payload, deployment):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -144,6 +144,12 @@ class _TimeoutMCPGateway(_FakeMCPGateway):
         raise MCPToolTimeoutError("MCP tool 'docs.search' exceeded the policy execution limit of 10 ms", timeout_ms=10)
 
 
+class _BuggyMCPGateway(_FakeMCPGateway):
+    async def list_visible_tools(self, auth):  # noqa: ANN001, ANN201
+        del auth
+        raise RuntimeError("local MCP bug")
+
+
 @pytest.mark.asyncio
 async def test_chat_completion_success(client, test_app):
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
@@ -504,6 +510,34 @@ async def test_chat_completion_with_mcp_tool_timeout_returns_503(client, test_ap
 
 
 @pytest.mark.asyncio
+async def test_chat_completion_with_local_mcp_gateway_error_does_not_affect_deployment_health(client, test_app):
+    test_app.state.mcp_gateway_service = _BuggyMCPGateway()
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del url, headers, json, timeout
+        raise AssertionError("upstream provider should not be called")
+
+    test_app.state.http_client.post = post
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "Search docs for DeltaLLM"}],
+        "tools": [{"type": "mcp", "server": "docs", "allowed_tools": ["search"], "require_approval": "never"}],
+    }
+
+    response = await client.post("/v1/chat/completions", headers=headers, json=body)
+
+    assert response.status_code == 503
+    assert response.json()["error"]["type"] == "service_unavailable"
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+    assert health.get("last_error") is None
+    assert not await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_without_mcp_tools_skips_mcp_gateway(client, test_app):
     test_app.state.mcp_gateway_service = _ExplodingMCPGateway()
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
@@ -622,6 +656,97 @@ async def test_chat_completion_runs_failure_callback(client, test_app):
     assert response.status_code == 503
     await asyncio.sleep(0.05)
     assert recorder.failure == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_upstream_rate_limit_returns_429(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        return httpx.Response(
+            429,
+            json={"error": {"message": "provider quota exhausted"}},
+            headers={"Retry-After": "17"},
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False}
+
+    response = await client.post("/v1/chat/completions", headers=headers, json=body)
+
+    assert response.status_code == 429
+    assert response.headers.get("Retry-After") == "17"
+    assert response.json()["error"] == {
+        "message": "provider quota exhausted",
+        "type": "rate_limit_error",
+        "param": None,
+        "code": None,
+    }
+    assert await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_chat_upstream_bad_request_does_not_mark_deployment_unhealthy(client, test_app):
+    registry = test_app.state.router.deployment_registry["gpt-4o-mini"]
+    deployment = registry[0]
+    deployment.deltallm_params["api_key"] = "provider-key"
+    registry.append(
+        type(deployment)(
+            deployment_id="gpt-4o-mini-fallback",
+            model_name="gpt-4o-mini",
+            deltallm_params={"model": "openai/gpt-4o-mini", "api_key": "provider-key-fallback"},
+            model_info={},
+        )
+    )
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return deployment
+
+    test_app.state.router.select_deployment = choose_primary
+    calls = {"count": 0}
+    attempted_auths: list[str | None] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del timeout
+        request = httpx.Request("POST", url)
+        attempted_auths.append(headers.get("Authorization"))
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return httpx.Response(400, json={"error": {"message": "bad input"}}, request=request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-ok",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "model": json["model"],
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+            request=request,
+        )
+
+    test_app.state.http_client.post = post
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False}
+
+    failure = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert failure.status_code == 400
+    assert attempted_auths == ["Bearer provider-key"]
+
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+    assert health.get("last_error") is None
+    assert not await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
+
+    success = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert success.status_code == 200
+    assert attempted_auths == ["Bearer provider-key", "Bearer provider-key"]
 
 
 class _StreamContext:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -68,6 +68,203 @@ async def test_embeddings_runs_failure_callback(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_embeddings_upstream_rate_limit_returns_429(client, test_app):
+    deployment = test_app.state.router.deployment_registry["text-embedding-3-small"][0]
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        return httpx.Response(
+            429,
+            json={"error": {"message": "provider quota exhausted"}},
+            headers={"Retry-After": "11"},
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "text-embedding-3-small", "input": "hello"}
+
+    response = await client.post("/v1/embeddings", headers=headers, json=body)
+
+    assert response.status_code == 429
+    assert response.headers.get("Retry-After") == "11"
+    assert response.json()["error"]["type"] == "rate_limit_error"
+    assert await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_embeddings_upstream_service_unavailable_updates_passive_health(client, test_app):
+    deployment = test_app.state.router.deployment_registry["text-embedding-3-small"][0]
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        return httpx.Response(503, json={"error": {"message": "provider unavailable"}}, request=httpx.Request("POST", url))
+
+    test_app.state.http_client.post = post
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "text-embedding-3-small", "input": "hello"}
+
+    response = await client.post("/v1/embeddings", headers=headers, json=body)
+
+    assert response.status_code == 503
+    assert await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert health.get("healthy") == "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 2
+    assert health.get("last_error") == "Upstream embedding call failed with status 503"
+
+
+@pytest.mark.asyncio
+async def test_embeddings_upstream_service_unavailable_retries_when_route_policy_allows(client, test_app):
+    deployment = test_app.state.router.deployment_registry["text-embedding-3-small"][0]
+    attempts = {"count": 0}
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group
+        request_context["route_policy"] = {"retry_max_attempts": 1}
+        return deployment
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            return httpx.Response(
+                503,
+                json={"error": {"message": "provider unavailable"}},
+                request=httpx.Request("POST", url),
+            )
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                "model": "text-embedding-3-small",
+                "usage": {"prompt_tokens": 2, "total_tokens": 2},
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.router.select_deployment = choose_primary
+    test_app.state.http_client.post = post
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "text-embedding-3-small", "input": "hello"}
+
+    response = await client.post("/v1/embeddings", headers=headers, json=body)
+
+    assert response.status_code == 200
+    assert attempts["count"] == 2
+    assert response.headers.get("x-deltallm-route-deployment") == deployment.deployment_id
+    assert response.headers.get("x-deltallm-route-fallback-used") == "false"
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_embeddings_upstream_timeout_retries_when_route_policy_targets_timeout(client, test_app):
+    deployment = test_app.state.router.deployment_registry["text-embedding-3-small"][0]
+    attempts = {"count": 0}
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group
+        request_context["route_policy"] = {
+            "retry_max_attempts": 1,
+            "retryable_error_classes": ["timeout"],
+        }
+        return deployment
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise httpx.ReadTimeout("upstream timed out", request=httpx.Request("POST", url))
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                "model": "text-embedding-3-small",
+                "usage": {"prompt_tokens": 2, "total_tokens": 2},
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.router.select_deployment = choose_primary
+    test_app.state.http_client.post = post
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "text-embedding-3-small", "input": "hello"}
+
+    response = await client.post("/v1/embeddings", headers=headers, json=body)
+
+    assert response.status_code == 200
+    assert attempts["count"] == 2
+    assert response.headers.get("x-deltallm-route-deployment") == deployment.deployment_id
+    assert response.headers.get("x-deltallm-route-fallback-used") == "false"
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_embeddings_upstream_bad_request_does_not_mark_deployment_unhealthy(client, test_app):
+    registry = test_app.state.router.deployment_registry["text-embedding-3-small"]
+    deployment = registry[0]
+    deployment.deltallm_params["api_key"] = "provider-key"
+    registry.append(
+        type(deployment)(
+            deployment_id="text-embedding-3-small-fallback",
+            model_name="text-embedding-3-small",
+            deltallm_params={"model": "openai/text-embedding-3-small", "api_key": "provider-key-fallback"},
+            model_info={},
+        )
+    )
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return deployment
+
+    test_app.state.router.select_deployment = choose_primary
+    calls = {"count": 0}
+    attempted_auths: list[str | None] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del timeout
+        request = httpx.Request("POST", url)
+        attempted_auths.append(headers.get("Authorization"))
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return httpx.Response(400, json={"error": {"message": "bad embedding input"}}, request=request)
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+                "model": json["model"],
+                "usage": {"prompt_tokens": 2, "total_tokens": 2},
+            },
+            request=request,
+        )
+
+    test_app.state.http_client.post = post
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "text-embedding-3-small", "input": "hello"}
+
+    failure = await client.post("/v1/embeddings", headers=headers, json=body)
+    assert failure.status_code == 400
+    assert attempted_auths == ["Bearer provider-key"]
+
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+    assert health.get("last_error") is None
+    assert not await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
+
+    success = await client.post("/v1/embeddings", headers=headers, json=body)
+    assert success.status_code == 200
+    assert attempted_auths == ["Bearer provider-key", "Bearer provider-key"]
+
+
+@pytest.mark.asyncio
 async def test_embeddings_use_custom_auth_headers_for_openai_compatible_provider(client, test_app):
     deployment = test_app.state.router.deployment_registry["text-embedding-3-small"][0]
     deployment.deltallm_params["provider"] = "vllm"

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
 
+import httpx
 import pytest
 
-from src.models.errors import TimeoutError
-from src.router import CooldownManager, FallbackConfig, FailoverManager, RedisStateBackend
+from src.models.errors import InvalidRequestError, RateLimitError, ServiceUnavailableError, TimeoutError, parse_retry_after_header
+from src.router import CooldownManager, FallbackConfig, FailoverManager, PassiveHealthTracker, RedisStateBackend
+from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
 
 
@@ -72,6 +76,445 @@ async def test_failover_applies_timeout_override():
             timeout_seconds=0.01,
             retry_max_attempts=0,
         )
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (InvalidRequestError(message="bad input"), False),
+        (ServiceUnavailableError(message="local service unavailable"), False),
+        (ServiceUnavailableError(message="provider unavailable", affects_deployment_health=True), True),
+        (TimeoutError(message="timed out"), True),
+        (
+            httpx.HTTPStatusError(
+                "bad request",
+                request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+                response=httpx.Response(400),
+            ),
+            False,
+        ),
+        (
+            httpx.HTTPStatusError(
+                "rate limited",
+                request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+                response=httpx.Response(429),
+            ),
+            True,
+        ),
+        (
+            httpx.HTTPStatusError(
+                "upstream unavailable",
+                request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+                response=httpx.Response(503),
+            ),
+            True,
+        ),
+        (httpx.ReadError("connection reset"), True),
+    ],
+)
+def test_affects_deployment_health_matrix(exc: Exception, expected: bool):
+    assert affects_deployment_health(exc) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("17", 17),
+        ("1.2", 2),
+        ("", None),
+        ("   ", None),
+        ("not-a-date", None),
+        ("1e309", None),
+    ],
+)
+def test_parse_retry_after_header_matrix(value: str, expected: int | None):
+    assert parse_retry_after_header(value) == expected
+
+
+def test_parse_retry_after_header_supports_http_dates():
+    retry_after = parse_retry_after_header(
+        format_datetime(datetime.now(tz=UTC) + timedelta(seconds=2), usegmt=True)
+    )
+
+    assert retry_after is not None
+    assert retry_after >= 0
+
+
+@pytest.mark.asyncio
+async def test_failover_does_not_cool_down_on_invalid_request_error():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+
+    async def run(_deployment: Deployment) -> str:
+        raise InvalidRequestError(message="bad input")
+
+    with pytest.raises(InvalidRequestError):
+        await manager.execute_with_failover(
+            primary_deployment=primary,
+            model_group="group-a",
+            execute=run,
+        )
+
+    assert not await state.is_cooled_down(primary.deployment_id)
+    health = await state.get_health(primary.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+    assert health.get("last_error") is None
+
+
+@pytest.mark.asyncio
+async def test_failover_invalid_request_stops_after_first_deployment():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback = _deployment("dep-b")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary, fallback]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        raise InvalidRequestError(message=f"bad input from {deployment.deployment_id}")
+
+    with pytest.raises(InvalidRequestError, match="bad input from dep-a"):
+        await manager.execute_with_failover(
+            primary_deployment=primary,
+            model_group="group-a",
+            execute=run,
+        )
+
+    assert attempts == ["dep-a"]
+
+
+@pytest.mark.asyncio
+async def test_failover_http_429_maps_to_rate_limit_error():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+
+    async def run(_deployment: Deployment) -> str:
+        raise httpx.HTTPStatusError(
+            "rate limited",
+            request=httpx.Request("POST", "https://example.com/v1/embeddings"),
+            response=httpx.Response(429, headers={"Retry-After": "7"}),
+        )
+
+    with pytest.raises(RateLimitError) as exc_info:
+        await manager.execute_with_failover(
+            primary_deployment=primary,
+            model_group="group-a",
+            execute=run,
+        )
+
+    assert exc_info.value.retry_after == 7
+    assert await state.is_cooled_down(primary.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_failover_http_503_maps_to_health_affecting_service_unavailable_error():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+
+    async def run(_deployment: Deployment) -> str:
+        raise httpx.HTTPStatusError(
+            "upstream unavailable",
+            request=httpx.Request("POST", "https://example.com/v1/embeddings"),
+            response=httpx.Response(503),
+        )
+
+    with pytest.raises(ServiceUnavailableError) as exc_info:
+        await manager.execute_with_failover(
+            primary_deployment=primary,
+            model_group="group-a",
+            execute=run,
+        )
+
+    assert exc_info.value.affects_deployment_health is True
+    assert await state.is_cooled_down(primary.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_failover_transport_error_maps_to_health_affecting_service_unavailable_error():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+
+    async def run(_deployment: Deployment) -> str:
+        raise httpx.ReadError("connection reset")
+
+    with pytest.raises(ServiceUnavailableError) as exc_info:
+        await manager.execute_with_failover(
+            primary_deployment=primary,
+            model_group="group-a",
+            execute=run,
+        )
+
+    assert exc_info.value.affects_deployment_health is True
+    assert await state.is_cooled_down(primary.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_failover_http_timeout_maps_to_timeout_error():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+
+    async def run(_deployment: Deployment) -> str:
+        raise httpx.ReadTimeout("upstream timed out")
+
+    with pytest.raises(TimeoutError, match="upstream timed out") as exc_info:
+        await manager.execute_with_failover(
+            primary_deployment=primary,
+            model_group="group-a",
+            execute=run,
+        )
+
+    assert exc_info.value.affects_deployment_health is True
+    assert await state.is_cooled_down(primary.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_failover_local_execution_error_does_not_affect_deployment_health_or_fallback():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback = _deployment("dep-b")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary, fallback]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        raise RuntimeError("local bug")
+
+    with pytest.raises(ServiceUnavailableError) as exc_info:
+        await manager.execute_with_failover(
+            primary_deployment=primary,
+            model_group="group-a",
+            execute=run,
+        )
+
+    assert str(exc_info.value) == "local bug"
+    assert affects_deployment_health(exc_info.value) is False
+    assert attempts == ["dep-a"]
+    assert not await state.is_cooled_down(primary.deployment_id)
+    health = await state.get_health(primary.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+    assert health.get("last_error") is None
+
+
+@pytest.mark.asyncio
+async def test_failover_classified_fallback_local_error_does_not_cool_down_or_try_next_fallback():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback_a = _deployment("dep-b")
+    fallback_b = _deployment("dep-c")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=0,
+            timeout=1.0,
+            context_window_fallbacks={"group-a": ["ctx-fallbacks"]},
+        ),
+        deployment_registry={"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment.deployment_id == "dep-a":
+            raise InvalidRequestError(message="maximum context length reached")
+        raise RuntimeError("local fallback bug")
+
+    with pytest.raises(ServiceUnavailableError, match="local fallback bug"):
+        await manager.execute_with_failover(
+            primary_deployment=primary,
+            model_group="group-a",
+            execute=run,
+        )
+
+    assert attempts == ["dep-a", "dep-b"]
+    assert not await state.is_cooled_down(primary.deployment_id)
+    assert not await state.is_cooled_down(fallback_a.deployment_id)
+    assert not await state.is_cooled_down(fallback_b.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_failover_classified_fallback_continues_after_upstream_service_unavailable():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback_a = _deployment("dep-b")
+    fallback_b = _deployment("dep-c")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=0,
+            timeout=1.0,
+            context_window_fallbacks={"group-a": ["ctx-fallbacks"]},
+        ),
+        deployment_registry={"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment.deployment_id == "dep-a":
+            raise InvalidRequestError(message="maximum context length reached")
+        if deployment.deployment_id == "dep-b":
+            raise httpx.HTTPStatusError(
+                "upstream unavailable",
+                request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+                response=httpx.Response(503),
+            )
+        return "ok"
+
+    data, served = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=run,
+        return_deployment=True,
+    )
+
+    assert data == "ok"
+    assert served.deployment_id == "dep-c"
+    assert attempts == ["dep-a", "dep-b", "dep-c"]
+    assert not await state.is_cooled_down(primary.deployment_id)
+    assert await state.is_cooled_down(fallback_a.deployment_id)
+    assert not await state.is_cooled_down(fallback_b.deployment_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "headers"),
+    [
+        (429, {"Retry-After": "7"}),
+        (503, {}),
+    ],
+)
+async def test_failover_retries_transient_raw_http_errors(status_code: int, headers: dict[str, str]):
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts = {"count": 0}
+
+    async def run(_deployment: Deployment) -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise httpx.HTTPStatusError(
+                f"upstream failed with status {status_code}",
+                request=httpx.Request("POST", "https://example.com/v1/embeddings"),
+                response=httpx.Response(status_code, headers=headers),
+            )
+        return "ok"
+
+    data, served = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=run,
+        return_deployment=True,
+        retry_max_attempts=1,
+    )
+
+    assert data == "ok"
+    assert served.deployment_id == "dep-a"
+    assert attempts["count"] == 2
+    health = await state.get_health(primary.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_failover_retries_raw_http_timeout_when_route_policy_targets_timeout():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts = {"count": 0}
+
+    async def run(_deployment: Deployment) -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise httpx.ReadTimeout("upstream timed out")
+        return "ok"
+
+    data, served = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=run,
+        return_deployment=True,
+        retry_max_attempts=1,
+        retryable_error_classes=["timeout"],
+    )
+
+    assert data == "ok"
+    assert served.deployment_id == "dep-a"
+    assert attempts["count"] == 2
+    health = await state.get_health(primary.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_passive_health_tracker_ignores_invalid_request_errors():
+    state = RedisStateBackend(redis=None)
+    tracker = PassiveHealthTracker(state_backend=state, failure_threshold=1)
+
+    await tracker.record_request_outcome(
+        "dep-a",
+        success=False,
+        error="bad request",
+        exc=InvalidRequestError(message="bad request"),
+    )
+
+    health = await state.get_health("dep-a")
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+    assert health.get("last_error") is None
 
 
 def test_failover_event_history_is_bounded_and_preserves_recent_order():


### PR DESCRIPTION
## Summary
- centralize deployment-health impact classification for upstream failures in the router failover path
- stop request-side upstream 4xx errors from cooling down deployments or poisoning passive health
- preserve retry and classified-fallback behavior for upstream 429s, 5xxs, and timeouts across direct-route and adapter-backed paths

## Root Cause
Issue #100 came from treating every upstream failure as a deployment-health failure. Upstream bad requests were being counted the same way as transport errors and service instability, which pushed healthy deployments into cooldown and passive unhealthy state.

## What Changed
- added a shared health-policy decision path and threaded the original exception into cooldown and passive health recording
- normalized upstream provider errors so 429s remain rate-limit failures, 5xx and transport failures remain health-affecting, and ordinary 4xx request errors stay non-health-affecting
- updated failover so non-health-affecting client errors fail fast instead of fanning out across sibling deployments
- aligned classified fallbacks and direct-route retry behavior with the same normalized error semantics
- restored timeout-specific retry classification for raw `httpx.TimeoutException` failures
- added regression coverage for bad requests, rate limits, service unavailability, local orchestration bugs, classified fallbacks, and timeout-targeted retry policy

## Impact
- malformed upstream requests no longer mark deployments unhealthy
- transient upstream failures still participate in cooldown, passive health, retries, and classified fallback behavior
- route policies that target `timeout` continue to work for direct-route endpoints

## Validation
```bash
uv run pytest tests/test_failover.py tests/test_embeddings.py tests/test_chat.py
uv run pytest tests/test_failover.py tests/test_chat.py tests/test_embeddings.py tests/test_batch_worker.py tests/test_batch_worker_microbatch.py tests/test_uniformity_hardening.py
```

Closes #100 