### PR TITLE
Standardize Prisma migration orchestration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,10 @@ Thank you for your interest in contributing to DeltaLLM! This document provides 
    ```bash
    cp config.example.yaml config.yaml
    uv run prisma generate --schema=./prisma/schema.prisma
-   uv run prisma db push --schema=./prisma/schema.prisma
+   uv run prisma migrate deploy --schema=./prisma/schema.prisma
    ```
+
+   If you are changing the Prisma schema itself, use `uv run prisma migrate dev` to create a migration rather than papering over failures with `db push`.
 
 6. **Start the development servers**
    

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,14 @@ ENV PYTHONUNBUFFERED=1
 ENV DELTALLM_CONFIG_PATH=/app/config/config.yaml
 ENV HOST=0.0.0.0
 ENV PORT=4000
+ENV DELTALLM_PRISMA_STARTUP_MODE=deploy
+ENV DELTALLM_PRISMA_SCHEMA_PATH=./prisma/schema.prisma
+ENV DELTALLM_PRISMA_MAX_ATTEMPTS=30
+ENV DELTALLM_PRISMA_SLEEP_SECONDS=2
 
 EXPOSE 4000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD curl -fsS "http://localhost:${PORT}/health/liveliness" || exit 1
 
-CMD ["sh", "-c", "python -m src.prisma_bootstrap --schema ./prisma/schema.prisma --max-attempts 30 --sleep-seconds 2 && exec uvicorn src.main:app --host ${HOST} --port ${PORT}"]
+CMD ["sh", "-c", "python -m src.prisma_bootstrap --mode \"${DELTALLM_PRISMA_STARTUP_MODE}\" --schema \"${DELTALLM_PRISMA_SCHEMA_PATH}\" --max-attempts \"${DELTALLM_PRISMA_MAX_ATTEMPTS}\" --sleep-seconds \"${DELTALLM_PRISMA_SLEEP_SECONDS}\" && exec uvicorn src.main:app --host ${HOST} --port ${PORT}"]

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ The sample config uses `OPENAI_API_KEY`. If you want a different provider, edit 
 ### 4. Start DeltaLLM
 
 ```bash
-docker compose --profile single up -d --build
+docker compose up -d --build
 ```
 
 If you want the full Presidio engine for guardrails instead of the default regex fallback:
 
 ```bash
-INSTALL_PRESIDIO=true docker compose --profile single up -d --build
+INSTALL_PRESIDIO=true docker compose up -d --build
 ```
 
 This starts:
@@ -285,8 +285,10 @@ general_settings:
 ```bash
 uv run prisma generate --schema=./prisma/schema.prisma
 uv run prisma py fetch
-uv run prisma db push --schema=./prisma/schema.prisma
+uv run prisma migrate deploy --schema=./prisma/schema.prisma
 ```
+
+If you are intentionally changing the schema during development, use `uv run prisma migrate dev` to create and apply a migration instead of reaching for `db push`.
 
 ### 5. Start the backend
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,34 @@
 services:
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        INSTALL_PRESIDIO: ${INSTALL_PRESIDIO:-false}
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/deltallm
+    command:
+      - python
+      - -m
+      - src.prisma_bootstrap
+      - --mode
+      - deploy
+      - --schema
+      - ./prisma/schema.prisma
+      - --max-attempts
+      - "30"
+      - --sleep-seconds
+      - "2"
+    depends_on:
+      db:
+        condition: service_healthy
+
   deltallm:
     build:
       context: .
       dockerfile: Dockerfile
       args:
         INSTALL_PRESIDIO: ${INSTALL_PRESIDIO:-false}
-    profiles: ["single"]
     ports:
       - "4002:4000"
     environment:
@@ -23,9 +46,12 @@ services:
       DELTALLM_REDIS_URL: redis://redis:6379/0
       REDIS_URL: redis://redis:6379/0
       DELTALLM_SALT_KEY: ${DELTALLM_SALT_KEY:-change-me}
+      DELTALLM_PRISMA_STARTUP_MODE: verify
     volumes:
       - ./config.yaml:/app/config/config.yaml:ro
     depends_on:
+      migrate:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
       redis:
@@ -60,9 +86,12 @@ services:
       REDIS_URL: redis://redis:6379/0
       DELTALLM_SALT_KEY: ${DELTALLM_SALT_KEY:-change-me}
       INSTANCE_ID: instance-1
+      DELTALLM_PRISMA_STARTUP_MODE: verify
     volumes:
       - ./config.yaml:/app/config/config.yaml:ro
     depends_on:
+      migrate:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
       redis:
@@ -91,9 +120,12 @@ services:
       REDIS_URL: redis://redis:6379/0
       DELTALLM_SALT_KEY: ${DELTALLM_SALT_KEY:-change-me}
       INSTANCE_ID: instance-2
+      DELTALLM_PRISMA_STARTUP_MODE: verify
     volumes:
       - ./config.yaml:/app/config/config.yaml:ro
     depends_on:
+      migrate:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
       redis:

--- a/docs/admin-ui/guardrails.md
+++ b/docs/admin-ui/guardrails.md
@@ -61,7 +61,7 @@ When you open the Guardrails page:
 To enable the full Presidio engine in Docker:
 
 ```bash
-INSTALL_PRESIDIO=true docker compose --profile single up -d --build
+INSTALL_PRESIDIO=true docker compose up -d --build
 ```
 
 ## What the user experiences

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,82 +1,28 @@
 # Docker Deployment
 
-See the [Getting Started: Docker](../getting-started/docker.md) guide for basic Docker setup.
+See the [Getting Started: Docker](../getting-started/docker.md) guide for the basic local flow.
 
-## Production Docker Compose
+## Repository Compose File
 
-A production-ready `docker-compose.yml`:
+The checked-in [docker-compose.yaml](../../docker-compose.yaml) is the supported local, evaluation, and demo Compose path. It runs:
 
-```yaml
-version: "3.8"
+- a one-shot `migrate` service that applies pending Prisma migrations with `prisma migrate deploy`
+- the default `deltallm` service in Prisma verification mode
+- bundled PostgreSQL and Redis services with local-development defaults
+- optional HA services behind Nginx through the `ha` profile
 
-services:
-  deltallm:
-    build: .
-    ports:
-      - "4002:4000"
-    environment:
-      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/deltallm
-      - REDIS_URL=redis://redis:6379/0
-      - DELTALLM_CONFIG_PATH=/app/config/config.yaml
-      - DELTALLM_MASTER_KEY=${DELTALLM_MASTER_KEY}
-      - DELTALLM_SALT_KEY=${DELTALLM_SALT_KEY}
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - PLATFORM_BOOTSTRAP_ADMIN_EMAIL=${ADMIN_EMAIL}
-      - PLATFORM_BOOTSTRAP_ADMIN_PASSWORD=${ADMIN_PASSWORD}
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    volumes:
-      - ./config.yaml:/app/config/config.yaml:ro
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4000/health/liveliness"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: deltallm
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  redis:
-    image: redis:7-alpine
-    volumes:
-      - redisdata:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-volumes:
-  pgdata:
-  redisdata:
-```
+It is not a production deployment template: it hardcodes bundled infrastructure and local credentials for convenience.
 
 ## Environment File
 
-Create a `.env` file alongside `docker-compose.yml`:
+Create a `.env` file in the repository root and set at least:
 
 ```bash
-POSTGRES_PASSWORD=strong-random-password
 DELTALLM_MASTER_KEY=replace-me
 DELTALLM_SALT_KEY=replace-me
 OPENAI_API_KEY=sk-...
-ADMIN_EMAIL=admin@company.com
-ADMIN_PASSWORD=initial-admin-password
+PLATFORM_BOOTSTRAP_ADMIN_EMAIL=admin@company.com
+PLATFORM_BOOTSTRAP_ADMIN_PASSWORD=initial-admin-password
 ```
 
 Generate working values for the master key and salt key with:
@@ -91,10 +37,10 @@ The generated master key always satisfies DeltaLLM's validator: it is longer tha
 ## Starting
 
 ```bash
-docker compose up -d
+docker compose up -d --build
 ```
 
-With this host mapping, the Docker deployment is reachable at `http://localhost:4002`.
+With the default host mapping, DeltaLLM is reachable at `http://localhost:4002`.
 
 ## Upgrading
 
@@ -103,4 +49,21 @@ docker compose pull
 docker compose up -d --build
 ```
 
-The application container runs the shared database bootstrap script on startup before launching the API. It prefers `prisma migrate deploy` and falls back to `prisma db push` for legacy or unbaselined databases.
+The `migrate` service runs before the API container starts, and the API container then verifies the migration state before serving traffic.
+
+## Production Docker Pattern
+
+For production Docker deployments, use the image as a building block rather than the checked-in Compose file:
+
+- run a one-shot migration container with `python -m src.prisma_bootstrap --mode deploy`
+- run the long-lived API containers with `DELTALLM_PRISMA_STARTUP_MODE=verify`
+- point both at external PostgreSQL and Redis instances managed outside the container stack
+- supply real secrets through your orchestrator or secret manager instead of the repo `.env` defaults
+
+## High Availability
+
+```bash
+docker compose --profile ha up -d --build nginx
+```
+
+Targeting `nginx` starts the HA stack and its dependencies without also launching the default single-instance `deltallm` service.

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -480,20 +480,26 @@ prometheus:
     enabled: true
 ```
 
-## Optional migration job
+## Migration job
 
-The current container image still bootstraps Prisma on startup by default.
+The image supports explicit Prisma startup modes. For shared Kubernetes environments, prefer a dedicated migration step over letting every app pod attempt schema writes on startup.
 
-The chart also exposes an optional `migrationJob` for teams that want a separate Kubernetes job for explicit migration control:
+The chart exposes a `migrationJob` for that purpose, and the released eval and production value overlays enable it:
 
 ```yaml
 migrationJob:
   enabled: true
-  hook:
-    enabled: true
 ```
 
-Use that only if your rollout process is intentionally built around a separate migration step. If you want the application pods to stop using the image default bootstrap path, set `command` and `args` explicitly for the app container.
+When `migrationJob.enabled=true`, the chart automatically resolves app startup to `prismaStartup.mode=verify`, so serving pods stop performing write-side migrations on startup. The migration job remains in `deploy` mode and is recreated on each Helm revision.
+
+The chart also renders a small migration-identity ConfigMap for the current release instance. The migration Job records successful completion in a runtime-owned Kubernetes Lease named after the release, and that Lease is owner-linked to the identity ConfigMap. Because the Lease itself is not rendered by Helm, GitOps or Helm reconciliation cannot reset the recorded revision back to an empty or stale value, and uninstall/reinstall with the same release name does not trust stale Lease state from an older release instance.
+
+By default, the Deployment adds a `wait-for-migration-job` init container. It waits for the migration-state Lease to report the current release revision for the current migration-identity ConfigMap and uses the current revision's migration Job only for progress and failure reporting. That keeps later pod restarts and scale-ups working even after Kubernetes garbage-collects finished Jobs. The chart renders a minimal Role and RoleBinding so the Job and init container can read the migration-identity ConfigMap, manage the named Lease, and read the current revision's Job. RBAC and token projection errors fail fast instead of timing out behind repeated retries.
+
+If you override `migrationJob.command` or `migrationJob.args`, keep `src.k8s_migration_state deploy-and-mark` as the entrypoint so the durable migration-state contract remains intact.
+
+For the supported rollout path, use `helm install` and `helm upgrade` with `--wait --wait-for-jobs`. That lets Helm wait on both the migration Job and the gated app rollout before considering the release healthy.
 
 ## S3 request logging
 
@@ -576,4 +582,6 @@ helm dependency build ./helm
 | App cannot connect to Redis | Wrong Redis URL or missing Redis auth password | Check `runtime.redis.*` or bundled `redis.auth.password` |
 | Provider calls fail immediately | Missing provider env vars | Add them via `envFrom` / `env` |
 | Config change did not roll pods | External secret changed outside Helm | Restart the deployment or rotate through your secret operator |
-| Migration job fails | DB not reachable or migration command not appropriate | Inspect `kubectl logs job/<release>-migrate` and adjust `migrationJob.args` |
+| Pod is stuck in `Init` | The current revision is not yet recorded in the migration-state Lease for the current release identity | Inspect `kubectl logs deploy/<release>-deltallm -c wait-for-migration-job`, `kubectl get configmap/<release>-deltallm-migration-identity -o yaml`, `kubectl get lease/<release>-deltallm-migration-state -o yaml`, and the latest migration Job selected by `app.kubernetes.io/component=migration` |
+| Migration job fails | DB not reachable or migration command not appropriate | Inspect the latest migration Job selected by `app.kubernetes.io/component=migration` and adjust `migrationJob.args` |
+| Migration wait/job fails with access denied | Missing Role/RoleBinding permission or projected token issue | Inspect the migration Role/RoleBinding, ServiceAccount, and projected `migration-api-access` volume |

--- a/docs/features/guardrails.md
+++ b/docs/features/guardrails.md
@@ -176,7 +176,7 @@ Regex fallback supports this smaller entity set:
 To enable the full Presidio engine in Docker:
 
 ```bash
-INSTALL_PRESIDIO=true docker compose --profile single up -d --build
+INSTALL_PRESIDIO=true docker compose up -d --build
 ```
 
 For local development from source:

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -9,7 +9,7 @@ Run DeltaLLM with Docker for a quick, reproducible setup.
 
 ## Using Docker Compose (Recommended)
 
-The project includes a `docker-compose.yaml` with two deployment profiles: **single** (one instance) and **ha** (high availability with load balancing).
+The project includes a `docker-compose.yaml` with a default single-instance stack and an optional `ha` profile for load-balanced multi-instance deployments.
 
 ## Before You Start
 
@@ -42,24 +42,24 @@ The fastest way to get everything running:
 ```bash
 # Edit config.yaml with your API keys and settings
 
-docker compose --profile single up -d --build
+docker compose up -d --build
 ```
 
 If you want the full Presidio engine for guardrails instead of the default regex fallback:
 
 ```bash
-INSTALL_PRESIDIO=true docker compose --profile single up -d --build
+INSTALL_PRESIDIO=true docker compose up -d --build
 ```
 
 Run the command from the repository root so Compose can read the project `.env` file automatically.
 
-On startup, the DeltaLLM container applies the Prisma schema with:
+Compose runs a one-shot migration service that applies pending Prisma migrations with:
 
 ```bash
-prisma db push --schema=./prisma/schema.prisma --accept-data-loss
+prisma migrate deploy --schema=./prisma/schema.prisma
 ```
 
-Then it starts the API server.
+After that succeeds, the DeltaLLM API container starts in verification mode and refuses to serve if the database migration state is not healthy.
 
 This starts:
 - DeltaLLM on port **4002** on the host (`4000` inside the container)
@@ -77,10 +77,12 @@ Once a model is available, see [Quick Start](quickstart.md) for `curl`, Python, 
 Run two DeltaLLM instances behind an Nginx load balancer:
 
 ```bash
-docker compose --profile ha up -d --build
+docker compose --profile ha up -d --build nginx
 ```
 
-Each DeltaLLM container applies the Prisma schema with `prisma db push --schema=./prisma/schema.prisma --accept-data-loss` before starting the API.
+Compose runs the shared migration service once, then each DeltaLLM API container starts in verification mode instead of trying to write schema changes independently.
+
+Targeting `nginx` starts the HA stack and its dependencies without also launching the default single-instance `deltallm` service.
 
 This starts:
 - 2 DeltaLLM instances (load balanced)
@@ -155,7 +157,7 @@ The starter config keeps the common optional features commented out with guidanc
 - JWT auth: optional bearer-token validation for proxy traffic
 - Guardrails and S3 callbacks: enable only when the related provider credentials are configured
 
-The container applies the Prisma schema automatically on boot, so you do not need a separate schema initialization step for the default Compose setup.
+The default Compose setup already includes the dedicated `migrate` service, so you do not need to run a separate manual schema initialization step.
 
 ## Custom Config
 
@@ -184,7 +186,7 @@ To build an image with the full Presidio engine:
 docker build --build-arg INSTALL_PRESIDIO=true -t deltallm .
 ```
 
-The image runs `prisma db push --schema=./prisma/schema.prisma --accept-data-loss` before starting `uvicorn`, so the target database must be reachable when the container starts.
+The image runs the Prisma startup bootstrap before starting `uvicorn`. By default that bootstrap uses `prisma migrate deploy`, so the target database must be reachable when the container starts. In shared or multi-instance environments, prefer a dedicated migration step and run app containers in verification mode.
 
 ## Health Check
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -133,8 +133,10 @@ Generate the Prisma client artifacts, fetch the required binaries, and apply the
 ```bash
 uv run prisma generate --schema=./prisma/schema.prisma
 uv run prisma py fetch
-uv run prisma db push --schema=./prisma/schema.prisma
+uv run prisma migrate deploy --schema=./prisma/schema.prisma
 ```
+
+When you are actively changing the schema, use `uv run prisma migrate dev` to generate and apply a migration in your local development database.
 
 ## 6. Start the backend API
 

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -17,4 +17,10 @@ Health endpoints:
   /health/readiness
 
 If you enabled a migration job:
-  kubectl logs job/{{ include "deltallm.fullname" . }}-migrate -n {{ .Release.Namespace }}
+  kubectl get jobs -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=migration -n {{ .Release.Namespace }}
+  kubectl logs job/{{ include "deltallm.migrationJobName" . }} -n {{ .Release.Namespace }}
+  kubectl get configmap/{{ include "deltallm.migrationIdentityConfigMapName" . }} -o yaml -n {{ .Release.Namespace }}
+  kubectl get lease/{{ include "deltallm.migrationStateLeaseName" . }} -o yaml -n {{ .Release.Namespace }}
+  kubectl logs deploy/{{ include "deltallm.fullname" . }} -c wait-for-migration-job -n {{ .Release.Namespace }}
+  App pods wait in the wait-for-migration-job init container until the runtime-owned migration-state Lease records the current release revision and matches the current migration-identity ConfigMap.
+  Prefer helm install/upgrade --wait --wait-for-jobs so Helm waits on both the migration job and the gated app rollout.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -78,3 +78,35 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "redis://%s:6379/0" (include "deltallm.redisHost" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "deltallm.prismaStartupMode" -}}
+{{- $mode := default "auto" .Values.prismaStartup.mode | trim | lower -}}
+{{- if eq $mode "auto" -}}
+{{- if .Values.migrationJob.enabled -}}verify{{- else -}}deploy{{- end -}}
+{{- else if and .Values.migrationJob.enabled (eq $mode "deploy") -}}
+{{- fail "prismaStartup.mode=deploy cannot be used when migrationJob.enabled=true; use auto, verify, or skip" -}}
+{{- else if or (eq $mode "deploy") (eq $mode "verify") (eq $mode "skip") -}}
+{{- $mode -}}
+{{- else -}}
+{{- fail "prismaStartup.mode must be one of: auto, deploy, verify, skip" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "deltallm.migrationJobName" -}}
+{{- $suffix := printf "-migrate-r%d" .Release.Revision -}}
+{{- $nameLimit := int (sub 63 (len $suffix)) -}}
+{{- $baseName := include "deltallm.fullname" . | trunc $nameLimit | trimSuffix "-" -}}
+{{- printf "%s%s" $baseName $suffix | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "deltallm.migrationStateLeaseName" -}}
+{{- printf "%s-migration-state" (include "deltallm.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "deltallm.migrationIdentityConfigMapName" -}}
+{{- printf "%s-migration-identity" (include "deltallm.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "deltallm.migrationAccessRoleName" -}}
+{{- printf "%s-migration-access" (include "deltallm.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -4,6 +4,10 @@
 {{- $hasGeneratedAppSecret := not .Values.secret.existingSecret -}}
 {{- $hasGeneratedS3Secret := and .Values.s3.enabled (not .Values.s3.existingSecret.name) (or .Values.s3.accessKeyId .Values.s3.secretAccessKey) -}}
 {{- $hasRuntimeDependencies := or $dbSecretName .Values.runtime.database.url .Values.postgresql.enabled $redisSecretName .Values.runtime.redis.url .Values.redis.enabled -}}
+{{- $prismaStartupMode := include "deltallm.prismaStartupMode" . -}}
+{{- $waitForMigrationJob := and .Values.migrationJob.enabled .Values.migrationJob.waitForCompletion.enabled -}}
+{{- $migrationStateLeaseName := include "deltallm.migrationStateLeaseName" . -}}
+{{- $migrationIdentityConfigMapName := include "deltallm.migrationIdentityConfigMapName" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,8 +65,42 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if and .Values.dependencyWait.enabled $hasRuntimeDependencies }}
+      {{- if or $waitForMigrationJob (and .Values.dependencyWait.enabled $hasRuntimeDependencies) }}
       initContainers:
+        {{- if $waitForMigrationJob }}
+        - name: wait-for-migration-job
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            - python
+            - -m
+            - src.k8s_migration_state
+            - wait
+          env:
+            - name: DELTALLM_MIGRATION_IDENTITY_CONFIGMAP_NAME
+              value: {{ $migrationIdentityConfigMapName | quote }}
+            - name: DELTALLM_MIGRATION_STATE_LEASE_NAME
+              value: {{ $migrationStateLeaseName | quote }}
+            - name: DELTALLM_MIGRATION_JOB_NAME
+              value: {{ include "deltallm.migrationJobName" . | quote }}
+            - name: DELTALLM_RELEASE_REVISION
+              value: {{ .Release.Revision | quote }}
+            - name: DELTALLM_MIGRATION_WAIT_TIMEOUT_SECONDS
+              value: {{ .Values.migrationJob.waitForCompletion.timeoutSeconds | quote }}
+            - name: DELTALLM_MIGRATION_WAIT_PERIOD_SECONDS
+              value: {{ .Values.migrationJob.waitForCompletion.periodSeconds | quote }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: migration-api-access
+              mountPath: /var/run/secrets/deltallm-migration
+              readOnly: true
+        {{- end }}
+        {{- if and .Values.dependencyWait.enabled $hasRuntimeDependencies }}
         - name: wait-for-runtime-dependencies
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -131,6 +169,7 @@ spec:
               value: {{ include "deltallm.bundledRedisUrl" . | quote }}
               {{- end }}
             {{- end }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -155,6 +194,8 @@ spec:
               value: "0.0.0.0"
             - name: PORT
               value: {{ .Values.service.port | quote }}
+            - name: DELTALLM_PRISMA_STARTUP_MODE
+              value: {{ $prismaStartupMode | quote }}
             - name: DELTALLM_CONFIG_PATH
               value: /app/config/config.yaml
             - name: DELTALLM_MASTER_KEY
@@ -269,8 +310,21 @@ spec:
         - name: config
           configMap:
             name: {{ include "deltallm.fullname" . }}-config
+        {{- if $waitForMigrationJob }}
+        - name: migration-api-access
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+        {{- end }}
         {{- with .Values.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/templates/migration-identity-configmap.yaml
+++ b/helm/templates/migration-identity-configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.migrationJob.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "deltallm.migrationIdentityConfigMapName" . }}
+  labels:
+    {{- include "deltallm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migration
+data: {}
+{{- end }}

--- a/helm/templates/migration-job-reader-role.yaml
+++ b/helm/templates/migration-job-reader-role.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.migrationJob.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "deltallm.migrationAccessRoleName" . }}
+  labels:
+    {{- include "deltallm.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames:
+      - {{ include "deltallm.migrationIdentityConfigMapName" . }}
+    verbs: ["get"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames:
+      - {{ include "deltallm.migrationStateLeaseName" . }}
+    verbs: ["get", "update"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    resourceNames:
+      - {{ include "deltallm.migrationJobName" . }}
+    verbs: ["get"]
+{{- end }}

--- a/helm/templates/migration-job-reader-rolebinding.yaml
+++ b/helm/templates/migration-job-reader-rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.migrationJob.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "deltallm.migrationAccessRoleName" . }}
+  labels:
+    {{- include "deltallm.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "deltallm.migrationAccessRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "deltallm.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/templates/migration-job.yaml
+++ b/helm/templates/migration-job.yaml
@@ -2,21 +2,18 @@
 {{- $dbSecretName := .Values.runtime.database.existingSecret.name -}}
 {{- $redisSecretName := .Values.runtime.redis.existingSecret.name -}}
 {{- $s3SecretName := include "deltallm.s3SecretName" . -}}
+{{- $migrationStateLeaseName := include "deltallm.migrationStateLeaseName" . -}}
+{{- $migrationIdentityConfigMapName := include "deltallm.migrationIdentityConfigMapName" . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "deltallm.fullname" . }}-migrate
+  name: {{ include "deltallm.migrationJobName" . }}
   labels:
     {{- include "deltallm.labels" . | nindent 4 }}
-  {{- if or .Values.migrationJob.annotations .Values.migrationJob.hook.enabled }}
+    app.kubernetes.io/component: migration
+  {{- with .Values.migrationJob.annotations }}
   annotations:
-    {{- with .Values.migrationJob.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- if .Values.migrationJob.hook.enabled }}
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: {{ .Values.migrationJob.hook.deletePolicy }}
-    {{- end }}
   {{- end }}
 spec:
   backoffLimit: {{ .Values.migrationJob.backoffLimit }}
@@ -26,6 +23,7 @@ spec:
     metadata:
       labels:
         {{- include "deltallm.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migration
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "deltallm.serviceAccountName" . }}
@@ -47,6 +45,16 @@ spec:
           args:
             {{- toYaml .Values.migrationJob.args | nindent 12 }}
           env:
+            - name: DELTALLM_MIGRATION_IDENTITY_CONFIGMAP_NAME
+              value: {{ $migrationIdentityConfigMapName | quote }}
+            - name: DELTALLM_MIGRATION_STATE_LEASE_NAME
+              value: {{ $migrationStateLeaseName | quote }}
+            - name: DELTALLM_RELEASE_REVISION
+              value: {{ .Release.Revision | quote }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DELTALLM_CONFIG_PATH
               value: /app/config/config.yaml
             - name: DELTALLM_MASTER_KEY
@@ -127,6 +135,9 @@ spec:
             - name: config
               mountPath: /app/config
               readOnly: true
+            - name: migration-api-access
+              mountPath: /var/run/secrets/deltallm-migration
+              readOnly: true
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -136,6 +147,17 @@ spec:
         - name: config
           configMap:
             name: {{ include "deltallm.fullname" . }}-config
+        - name: migration-api-access
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/values-eval.yaml
+++ b/helm/values-eval.yaml
@@ -6,6 +6,9 @@ autoscaling:
 podDisruptionBudget:
   enabled: false
 
+migrationJob:
+  enabled: true
+
 postgresql:
   enabled: true
   auth:

--- a/helm/values-production.yaml
+++ b/helm/values-production.yaml
@@ -19,6 +19,9 @@ podDisruptionBudget:
   enabled: true
   minAvailable: 2
 
+migrationJob:
+  enabled: true
+
 topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: kubernetes.io/hostname

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -75,6 +75,16 @@
     },
     "env": { "type": "array" },
     "envFrom": { "type": "array" },
+    "prismaStartup": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["auto", "deploy", "verify", "skip"]
+        }
+      }
+    },
     "dependencyWait": {
       "type": "object",
       "additionalProperties": true,
@@ -205,17 +215,18 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "annotations": { "type": "object" },
-        "hook": {
+        "backoffLimit": { "type": "integer", "minimum": 0 },
+        "activeDeadlineSeconds": { "type": "integer", "minimum": 1 },
+        "ttlSecondsAfterFinished": { "type": "integer", "minimum": 0 },
+        "waitForCompletion": {
           "type": "object",
           "additionalProperties": true,
           "properties": {
             "enabled": { "type": "boolean" },
-            "deletePolicy": { "type": "string" }
+            "timeoutSeconds": { "type": "integer", "minimum": 1 },
+            "periodSeconds": { "type": "integer", "minimum": 1 }
           }
         },
-        "backoffLimit": { "type": "integer", "minimum": 0 },
-        "activeDeadlineSeconds": { "type": "integer", "minimum": 1 },
-        "ttlSecondsAfterFinished": { "type": "integer", "minimum": 0 },
         "command": { "type": "array" },
         "args": { "type": "array" }
       }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -100,6 +100,9 @@ envFrom: []
 extraVolumes: []
 extraVolumeMounts: []
 
+prismaStartup:
+  mode: auto
+
 dependencyWait:
   enabled: true
   timeoutSeconds: 180
@@ -185,19 +188,26 @@ prometheus:
 migrationJob:
   enabled: false
   annotations: {}
-  hook:
-    enabled: false
-    deletePolicy: before-hook-creation,hook-succeeded
   backoffLimit: 4
   activeDeadlineSeconds: 600
   ttlSecondsAfterFinished: 300
+  waitForCompletion:
+    enabled: true
+    timeoutSeconds: 900
+    periodSeconds: 2
   resources: {}
   command:
-    - sh
-    - -c
+    - python
+    - -m
+    - src.k8s_migration_state
   args:
-    - |
-      prisma migrate deploy --schema=./prisma/schema.prisma || prisma db push --schema=./prisma/schema.prisma --accept-data-loss
+    - deploy-and-mark
+    - --schema
+    - ./prisma/schema.prisma
+    - --max-attempts
+    - "30"
+    - --sleep-seconds
+    - "2"
 
 postgresql:
   enabled: false

--- a/scripts/e2e_budget_threshold_notifications.sh
+++ b/scripts/e2e_budget_threshold_notifications.sh
@@ -47,7 +47,7 @@ BODY=""
 
 cleanup() {
   set +e
-  docker compose --profile single up -d deltallm >/dev/null 2>&1 || true
+  docker compose up -d deltallm >/dev/null 2>&1 || true
   rm -f "$TMP_CONFIG" "$TMP_OVERRIDE"
 }
 trap cleanup EXIT
@@ -148,7 +148,7 @@ KEY_NAME="budget-alert-key-${RUN_ID}"
 echo "== Step 1: Start Docker app with test-only budget notification config =="
 write_temp_config
 write_temp_override
-docker compose -f docker-compose.yaml -f "$TMP_OVERRIDE" --profile single up -d --build deltallm
+docker compose -f docker-compose.yaml -f "$TMP_OVERRIDE" up -d --build deltallm
 wait_for_http_200 "$BASE/health/liveliness" "app health check"
 
 request "${AUTH_HEADER[@]}" "$BASE/v1/models"

--- a/scripts/measure_embedding_batch_load.py
+++ b/scripts/measure_embedding_batch_load.py
@@ -103,7 +103,7 @@ def peak_rss_mib() -> float:
 async def ensure_batch_schema(db: Any) -> None:
     rows = await db.query_raw("SELECT to_regclass('public.deltallm_batch_job')::text AS name")
     if not rows or dict(rows[0]).get("name") is None:
-        raise RuntimeError("Batch tables are missing. Run `uv run prisma db push --schema=./prisma/schema.prisma` first.")
+        raise RuntimeError("Batch tables are missing. Run `uv run prisma migrate deploy --schema=./prisma/schema.prisma` first.")
 
 
 def validate_database_url(database_url: str, *, force: bool) -> None:

--- a/src/k8s_migration_state.py
+++ b/src/k8s_migration_state.py
@@ -1,0 +1,869 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, TextIO
+from urllib.parse import quote
+
+from src.prisma_bootstrap import (
+    DEFAULT_PRISMA_BOOTSTRAP_ATTEMPTS,
+    DEFAULT_PRISMA_BOOTSTRAP_SLEEP_SECONDS,
+    DEFAULT_PRISMA_SCHEMA_PATH,
+    run_prisma_bootstrap,
+)
+
+DEFAULT_KUBERNETES_TOKEN_PATH = "/var/run/secrets/deltallm-migration/token"
+DEFAULT_KUBERNETES_CA_PATH = "/var/run/secrets/deltallm-migration/ca.crt"
+DEFAULT_KUBERNETES_REQUEST_TIMEOUT_SECONDS = 10.0
+DEFAULT_MIGRATION_WAIT_TIMEOUT_SECONDS = 900.0
+DEFAULT_MIGRATION_WAIT_PERIOD_SECONDS = 2.0
+DEFAULT_MIGRATION_STATE_UPDATE_ATTEMPTS = 30
+DEFAULT_MIGRATION_STATE_UPDATE_SLEEP_SECONDS = 2.0
+
+_DEFAULT_NAMESPACE_ENV = "POD_NAMESPACE"
+_DEFAULT_RELEASE_REVISION_ENV = "DELTALLM_RELEASE_REVISION"
+_DEFAULT_MIGRATION_IDENTITY_ENV = "DELTALLM_MIGRATION_IDENTITY_CONFIGMAP_NAME"
+_DEFAULT_MIGRATION_LEASE_ENV = "DELTALLM_MIGRATION_STATE_LEASE_NAME"
+_DEFAULT_MIGRATION_JOB_ENV = "DELTALLM_MIGRATION_JOB_NAME"
+_DEFAULT_WAIT_TIMEOUT_ENV = "DELTALLM_MIGRATION_WAIT_TIMEOUT_SECONDS"
+_DEFAULT_WAIT_PERIOD_ENV = "DELTALLM_MIGRATION_WAIT_PERIOD_SECONDS"
+
+_AUTHORIZATION_STATUS_CODES = {401, 403}
+_TRANSIENT_STATUS_CODES = {409, 429, 500, 502, 503, 504}
+
+
+class MigrationStateError(RuntimeError):
+    pass
+
+
+class KubernetesApiError(RuntimeError):
+    pass
+
+
+class KubernetesApiNotFoundError(KubernetesApiError):
+    pass
+
+
+class KubernetesApiAuthorizationError(KubernetesApiError):
+    pass
+
+
+class KubernetesApiTransientError(KubernetesApiError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReleaseIdentity:
+    name: str
+    uid: str
+
+
+@dataclass(frozen=True)
+class MigrationLeaseState:
+    holder_identity: str
+    revision: int
+    renew_time: str
+
+
+@dataclass(frozen=True)
+class KubernetesApiClient:
+    base_url: str
+    namespace: str
+    token: str
+    ssl_context: ssl.SSLContext
+    request_timeout_seconds: float = DEFAULT_KUBERNETES_REQUEST_TIMEOUT_SECONDS
+
+    @classmethod
+    def from_cluster(
+        cls,
+        *,
+        namespace: str,
+        token_path: str = DEFAULT_KUBERNETES_TOKEN_PATH,
+        ca_path: str = DEFAULT_KUBERNETES_CA_PATH,
+        api_host: str | None = None,
+        api_port: str | None = None,
+    ) -> KubernetesApiClient:
+        normalized_namespace = _required_argument(namespace, "namespace")
+        host = str(api_host or os.getenv("KUBERNETES_SERVICE_HOST", "")).strip()
+        if not host:
+            raise MigrationStateError("KUBERNETES_SERVICE_HOST is not set")
+        port = str(api_port or os.getenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")).strip() or "443"
+
+        try:
+            with open(token_path, "r", encoding="utf-8") as handle:
+                token = handle.read().strip()
+        except OSError as exc:
+            raise MigrationStateError(f"Failed to read Kubernetes API token: {exc}") from exc
+        if not token:
+            raise MigrationStateError("Kubernetes API token is empty")
+
+        try:
+            ssl_context = ssl.create_default_context(cafile=ca_path)
+        except OSError as exc:
+            raise MigrationStateError(f"Failed to read Kubernetes API CA bundle: {exc}") from exc
+
+        return cls(
+            base_url=f"https://{host}:{port}",
+            namespace=normalized_namespace,
+            token=token,
+            ssl_context=ssl_context,
+        )
+
+    def get_configmap(self, name: str) -> dict[str, Any]:
+        normalized_name = _required_argument(name, "configmap name")
+        return self._request_json(
+            method="GET",
+            path=f"/api/v1/namespaces/{quote(self.namespace, safe='')}/configmaps/{quote(normalized_name, safe='')}",
+        )
+
+    def get_lease(self, name: str) -> dict[str, Any]:
+        normalized_name = _required_argument(name, "lease name")
+        return self._request_json(
+            method="GET",
+            path=(
+                f"/apis/coordination.k8s.io/v1/namespaces/{quote(self.namespace, safe='')}/leases/"
+                f"{quote(normalized_name, safe='')}"
+            ),
+        )
+
+    def create_lease(
+        self,
+        name: str,
+        *,
+        holder_identity: str,
+        renew_time: str,
+        owner_reference: dict[str, str],
+    ) -> dict[str, Any]:
+        normalized_name = _required_argument(name, "lease name")
+        body = json.dumps(
+            _build_lease_document(
+                name=normalized_name,
+                namespace=self.namespace,
+                holder_identity=holder_identity,
+                renew_time=renew_time,
+                owner_reference=owner_reference,
+            )
+        ).encode("utf-8")
+        return self._request_json(
+            method="POST",
+            path=f"/apis/coordination.k8s.io/v1/namespaces/{quote(self.namespace, safe='')}/leases",
+            body=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+    def replace_lease(self, lease: dict[str, Any]) -> dict[str, Any]:
+        metadata = lease.get("metadata") or {}
+        normalized_name = _required_argument(metadata.get("name"), "lease name")
+        body = json.dumps(lease).encode("utf-8")
+        return self._request_json(
+            method="PUT",
+            path=(
+                f"/apis/coordination.k8s.io/v1/namespaces/{quote(self.namespace, safe='')}/leases/"
+                f"{quote(normalized_name, safe='')}"
+            ),
+            body=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+    def get_job(self, name: str) -> dict[str, Any]:
+        normalized_name = _required_argument(name, "job name")
+        return self._request_json(
+            method="GET",
+            path=f"/apis/batch/v1/namespaces/{quote(self.namespace, safe='')}/jobs/{quote(normalized_name, safe='')}",
+        )
+
+    def _request_json(
+        self,
+        *,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        request_headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.token}",
+        }
+        if headers:
+            request_headers.update(headers)
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers=request_headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(
+                request,
+                context=self.ssl_context,
+                timeout=self.request_timeout_seconds,
+            ) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            body_text = exc.read().decode("utf-8", errors="replace").strip()
+            message = f"Kubernetes API {method} {path} failed with HTTP {exc.code}"
+            if body_text:
+                message = f"{message}: {body_text}"
+            if exc.code == 404:
+                raise KubernetesApiNotFoundError(message) from exc
+            if exc.code in _AUTHORIZATION_STATUS_CODES:
+                raise KubernetesApiAuthorizationError(message) from exc
+            if exc.code in _TRANSIENT_STATUS_CODES:
+                raise KubernetesApiTransientError(message) from exc
+            raise KubernetesApiError(message) from exc
+        except OSError as exc:
+            raise KubernetesApiTransientError(f"Failed to contact the Kubernetes API: {exc}") from exc
+
+
+def wait_for_migration_completion(
+    *,
+    client: KubernetesApiClient,
+    identity_configmap_name: str,
+    lease_name: str,
+    expected_revision: str,
+    job_name: str,
+    timeout_seconds: float = DEFAULT_MIGRATION_WAIT_TIMEOUT_SECONDS,
+    period_seconds: float = DEFAULT_MIGRATION_WAIT_PERIOD_SECONDS,
+    sleeper: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    stdout: TextIO | None = None,
+) -> None:
+    normalized_identity_configmap_name = _required_argument(
+        identity_configmap_name,
+        "migration identity configmap name",
+    )
+    normalized_lease_name = _required_argument(lease_name, "lease name")
+    normalized_expected_revision, expected_revision_number = _parse_revision(expected_revision, label="release revision")
+    normalized_job_name = _required_argument(job_name, "job name")
+    out_stream = stdout if stdout is not None else sys.stdout
+    delay = max(0.0, float(period_seconds))
+    deadline = monotonic() + max(1.0, float(timeout_seconds))
+
+    while True:
+        state_message = ""
+        try:
+            release_identity = _load_release_identity(
+                client=client,
+                identity_configmap_name=normalized_identity_configmap_name,
+            )
+        except KubernetesApiAuthorizationError as exc:
+            raise _authorization_error(
+                action="reading",
+                resource_kind="migration identity ConfigMap",
+                resource_name=normalized_identity_configmap_name,
+                exc=exc,
+            ) from exc
+        except KubernetesApiNotFoundError as exc:
+            raise MigrationStateError(
+                f"Migration identity ConfigMap {normalized_identity_configmap_name} was not found: {exc}"
+            ) from exc
+        except KubernetesApiTransientError as exc:
+            state_message = (
+                f"migration identity ConfigMap {normalized_identity_configmap_name} is temporarily unavailable ({exc})"
+            )
+        except KubernetesApiError as exc:
+            raise MigrationStateError(
+                f"Failed to read migration identity ConfigMap {normalized_identity_configmap_name}: {exc}"
+            ) from exc
+        else:
+            try:
+                lease = client.get_lease(normalized_lease_name)
+            except KubernetesApiNotFoundError as exc:
+                state_message = f"migration state lease {normalized_lease_name} is not available yet ({exc})"
+            except KubernetesApiAuthorizationError as exc:
+                raise _authorization_error(
+                    action="reading",
+                    resource_kind="migration state Lease",
+                    resource_name=normalized_lease_name,
+                    exc=exc,
+                ) from exc
+            except KubernetesApiTransientError as exc:
+                state_message = f"migration state lease {normalized_lease_name} is temporarily unavailable ({exc})"
+            except KubernetesApiError as exc:
+                raise MigrationStateError(str(exc)) from exc
+            else:
+                owner_uid = _lease_owner_uid(lease, identity_name=release_identity.name)
+                if owner_uid == release_identity.uid:
+                    lease_state = _parse_migration_lease_state(lease, lease_name=normalized_lease_name)
+                    if lease_state.revision >= expected_revision_number:
+                        print(
+                            (
+                                f"Migration state lease {normalized_lease_name} confirms revision {lease_state.revision} "
+                                f"for expected revision {normalized_expected_revision}"
+                            ),
+                            file=out_stream,
+                            flush=True,
+                        )
+                        return
+                    state_message = (
+                        f"migration state lease revision={lease_state.revision} "
+                        f"renewTime={_display_value(lease_state.renew_time)}"
+                    )
+                elif owner_uid:
+                    state_message = (
+                        f"migration state lease {normalized_lease_name} belongs to stale release identity uid {owner_uid}"
+                    )
+                else:
+                    state_message = (
+                        f"migration state lease {normalized_lease_name} is missing the current release identity owner reference"
+                    )
+
+        try:
+            job = client.get_job(normalized_job_name)
+        except KubernetesApiNotFoundError as exc:
+            job_message = f"migration job {normalized_job_name} is not available yet ({exc})"
+        except KubernetesApiAuthorizationError as exc:
+            raise _authorization_error(
+                action="reading",
+                resource_kind="migration Job",
+                resource_name=normalized_job_name,
+                exc=exc,
+            ) from exc
+        except KubernetesApiTransientError as exc:
+            job_message = f"migration job {normalized_job_name} is temporarily unavailable ({exc})"
+        except KubernetesApiError as exc:
+            raise MigrationStateError(str(exc)) from exc
+        else:
+            conditions = _job_conditions(job)
+            if conditions.get("Failed") == "True":
+                raise MigrationStateError(
+                    f"Migration job {normalized_job_name} failed before revision {normalized_expected_revision} was recorded"
+                )
+            if conditions.get("Complete") == "True":
+                job_message = (
+                    f"migration job {normalized_job_name} completed and is waiting to record "
+                    f"revision {normalized_expected_revision} in lease {normalized_lease_name}"
+                )
+            else:
+                job_message = f"migration job {normalized_job_name} status {_job_status_summary(job)}"
+
+        if monotonic() >= deadline:
+            raise MigrationStateError(
+                (
+                    f"Timed out waiting for migration revision {normalized_expected_revision}: "
+                    f"{state_message}; {job_message}"
+                )
+            )
+
+        print(
+            f"Waiting for migration revision {normalized_expected_revision}: {state_message}; {job_message}",
+            file=out_stream,
+            flush=True,
+        )
+        sleeper(delay)
+
+
+def mark_migration_complete(
+    *,
+    client: KubernetesApiClient,
+    identity_configmap_name: str,
+    lease_name: str,
+    expected_revision: str,
+    completed_at: str | None = None,
+    max_attempts: int = DEFAULT_MIGRATION_STATE_UPDATE_ATTEMPTS,
+    sleep_seconds: float = DEFAULT_MIGRATION_STATE_UPDATE_SLEEP_SECONDS,
+    sleeper: Callable[[float], None] = time.sleep,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> None:
+    normalized_identity_configmap_name = _required_argument(
+        identity_configmap_name,
+        "migration identity configmap name",
+    )
+    normalized_lease_name = _required_argument(lease_name, "lease name")
+    normalized_expected_revision, expected_revision_number = _parse_revision(expected_revision, label="release revision")
+    out_stream = stdout if stdout is not None else sys.stdout
+    err_stream = stderr if stderr is not None else sys.stderr
+    attempts = max(1, int(max_attempts))
+    delay = max(0.0, float(sleep_seconds))
+    completed_timestamp = completed_at or current_timestamp()
+
+    for attempt in range(1, attempts + 1):
+        try:
+            release_identity = _load_release_identity(
+                client=client,
+                identity_configmap_name=normalized_identity_configmap_name,
+            )
+        except KubernetesApiAuthorizationError as exc:
+            raise _authorization_error(
+                action="reading",
+                resource_kind="migration identity ConfigMap",
+                resource_name=normalized_identity_configmap_name,
+                exc=exc,
+            ) from exc
+        except KubernetesApiNotFoundError as exc:
+            raise MigrationStateError(
+                f"Migration identity ConfigMap {normalized_identity_configmap_name} was not found: {exc}"
+            ) from exc
+        except KubernetesApiTransientError as exc:
+            if attempt >= attempts:
+                raise MigrationStateError(
+                    (
+                        f"Failed to read migration identity ConfigMap {normalized_identity_configmap_name} "
+                        f"after {attempts} attempts: {exc}"
+                    )
+                ) from exc
+            print(
+                (
+                    f"Waiting to read migration identity ConfigMap {normalized_identity_configmap_name} "
+                    f"({attempt}/{attempts}): {exc}"
+                ),
+                file=err_stream,
+                flush=True,
+            )
+            sleeper(delay)
+            continue
+        except KubernetesApiError as exc:
+            raise MigrationStateError(
+                f"Failed to read migration identity ConfigMap {normalized_identity_configmap_name}: {exc}"
+            ) from exc
+
+        owner_reference = _build_identity_owner_reference(release_identity)
+        try:
+            lease = client.get_lease(normalized_lease_name)
+        except KubernetesApiNotFoundError:
+            try:
+                client.create_lease(
+                    normalized_lease_name,
+                    holder_identity=normalized_expected_revision,
+                    renew_time=completed_timestamp,
+                    owner_reference=owner_reference,
+                )
+            except KubernetesApiAuthorizationError as exc:
+                raise _authorization_error(
+                    action="creating",
+                    resource_kind="migration state Lease",
+                    resource_name=normalized_lease_name,
+                    exc=exc,
+                ) from exc
+            except KubernetesApiTransientError as exc:
+                if attempt >= attempts:
+                    raise MigrationStateError(
+                        (
+                            f"Failed to record migration revision {normalized_expected_revision} in lease "
+                            f"{normalized_lease_name} after {attempts} attempts: {exc}"
+                        )
+                    ) from exc
+                print(
+                    f"Waiting to create migration state lease {normalized_lease_name} ({attempt}/{attempts}): {exc}",
+                    file=err_stream,
+                    flush=True,
+                )
+                sleeper(delay)
+                continue
+            except KubernetesApiError as exc:
+                raise MigrationStateError(
+                    f"Failed to create migration state lease {normalized_lease_name}: {exc}"
+                ) from exc
+            print(
+                f"Recorded migration revision {normalized_expected_revision} in lease {normalized_lease_name}",
+                file=out_stream,
+                flush=True,
+            )
+            return
+        except KubernetesApiAuthorizationError as exc:
+            raise _authorization_error(
+                action="reading",
+                resource_kind="migration state Lease",
+                resource_name=normalized_lease_name,
+                exc=exc,
+            ) from exc
+        except KubernetesApiTransientError as exc:
+            if attempt >= attempts:
+                raise MigrationStateError(
+                    (
+                        f"Failed to record migration revision {normalized_expected_revision} in lease "
+                        f"{normalized_lease_name} after {attempts} attempts: {exc}"
+                    )
+                ) from exc
+            print(
+                f"Waiting to read migration state lease {normalized_lease_name} ({attempt}/{attempts}): {exc}",
+                file=err_stream,
+                flush=True,
+            )
+            sleeper(delay)
+            continue
+        except KubernetesApiError as exc:
+            raise MigrationStateError(
+                f"Failed to record migration revision {normalized_expected_revision} in lease {normalized_lease_name}: {exc}"
+            ) from exc
+
+        owner_uid = _lease_owner_uid(lease, identity_name=release_identity.name)
+        if owner_uid == release_identity.uid:
+            lease_state = _parse_migration_lease_state(lease, lease_name=normalized_lease_name)
+            if lease_state.revision > expected_revision_number:
+                print(
+                    (
+                        f"Migration state lease {normalized_lease_name} already records newer revision "
+                        f"{lease_state.revision}; skipping stale revision {normalized_expected_revision}"
+                    ),
+                    file=out_stream,
+                    flush=True,
+                )
+                return
+            if lease_state.revision == expected_revision_number:
+                print(
+                    f"Migration state lease {normalized_lease_name} already records revision {normalized_expected_revision}",
+                    file=out_stream,
+                    flush=True,
+                )
+                return
+
+        updated_lease = _updated_lease_document(
+            lease,
+            lease_name=normalized_lease_name,
+            holder_identity=normalized_expected_revision,
+            renew_time=completed_timestamp,
+            owner_reference=owner_reference,
+        )
+        try:
+            client.replace_lease(updated_lease)
+        except KubernetesApiAuthorizationError as exc:
+            raise _authorization_error(
+                action="updating",
+                resource_kind="migration state Lease",
+                resource_name=normalized_lease_name,
+                exc=exc,
+            ) from exc
+        except KubernetesApiTransientError as exc:
+            if attempt >= attempts:
+                raise MigrationStateError(
+                    (
+                        f"Failed to advance migration revision {normalized_expected_revision} in lease "
+                        f"{normalized_lease_name} after {attempts} attempts: {exc}"
+                    )
+                ) from exc
+            print(
+                f"Waiting to update migration state lease {normalized_lease_name} ({attempt}/{attempts}): {exc}",
+                file=err_stream,
+                flush=True,
+            )
+            sleeper(delay)
+            continue
+        except KubernetesApiError as exc:
+            raise MigrationStateError(
+                f"Failed to advance migration revision {normalized_expected_revision} in lease {normalized_lease_name}: {exc}"
+            ) from exc
+
+        print(
+            f"Recorded migration revision {normalized_expected_revision} in lease {normalized_lease_name}",
+            file=out_stream,
+            flush=True,
+        )
+        return
+
+
+def deploy_and_mark_migration_complete(
+    *,
+    client: KubernetesApiClient,
+    identity_configmap_name: str,
+    lease_name: str,
+    expected_revision: str,
+    schema_path: str = DEFAULT_PRISMA_SCHEMA_PATH,
+    max_attempts: int = DEFAULT_PRISMA_BOOTSTRAP_ATTEMPTS,
+    sleep_seconds: float = DEFAULT_PRISMA_BOOTSTRAP_SLEEP_SECONDS,
+    state_max_attempts: int = DEFAULT_MIGRATION_STATE_UPDATE_ATTEMPTS,
+    state_sleep_seconds: float = DEFAULT_MIGRATION_STATE_UPDATE_SLEEP_SECONDS,
+    bootstrap_runner: Callable[..., None] = run_prisma_bootstrap,
+    completed_at_factory: Callable[[], str] | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> None:
+    bootstrap_runner(
+        mode="deploy",
+        schema_path=schema_path,
+        max_attempts=max_attempts,
+        sleep_seconds=sleep_seconds,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    mark_migration_complete(
+        client=client,
+        identity_configmap_name=identity_configmap_name,
+        lease_name=lease_name,
+        expected_revision=expected_revision,
+        completed_at=(completed_at_factory or current_timestamp)(),
+        max_attempts=state_max_attempts,
+        sleep_seconds=state_sleep_seconds,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def current_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_release_identity(
+    *,
+    client: KubernetesApiClient,
+    identity_configmap_name: str,
+) -> ReleaseIdentity:
+    normalized_name = _required_argument(identity_configmap_name, "migration identity configmap name")
+    configmap = client.get_configmap(normalized_name)
+    return _parse_release_identity(configmap, identity_configmap_name=normalized_name)
+
+
+def _authorization_error(
+    *,
+    action: str,
+    resource_kind: str,
+    resource_name: str,
+    exc: KubernetesApiAuthorizationError,
+) -> MigrationStateError:
+    return MigrationStateError(
+        (
+            f"Access denied while {action} {resource_kind} {resource_name}: {exc}. "
+            "Check the migration Role/RoleBinding and projected service-account token configuration."
+        )
+    )
+
+
+def _build_lease_document(
+    *,
+    name: str,
+    namespace: str,
+    holder_identity: str,
+    renew_time: str,
+    owner_reference: dict[str, str],
+    resource_version: str | None = None,
+    spec: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "name": _required_argument(name, "lease name"),
+        "namespace": _required_argument(namespace, "namespace"),
+        "ownerReferences": [dict(owner_reference)],
+    }
+    if resource_version:
+        metadata["resourceVersion"] = resource_version
+    lease_spec = dict(spec or {})
+    lease_spec["holderIdentity"] = _required_argument(holder_identity, "lease holderIdentity")
+    lease_spec["renewTime"] = _required_argument(renew_time, "lease renewTime")
+    return {
+        "apiVersion": "coordination.k8s.io/v1",
+        "kind": "Lease",
+        "metadata": metadata,
+        "spec": lease_spec,
+    }
+
+
+def _build_identity_owner_reference(release_identity: ReleaseIdentity) -> dict[str, str]:
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "name": release_identity.name,
+        "uid": release_identity.uid,
+    }
+
+
+def _parse_release_identity(
+    configmap: dict[str, Any],
+    *,
+    identity_configmap_name: str,
+) -> ReleaseIdentity:
+    metadata = configmap.get("metadata") or {}
+    uid = _required_argument(
+        metadata.get("uid"),
+        f"migration identity ConfigMap {identity_configmap_name} metadata.uid",
+    )
+    return ReleaseIdentity(name=identity_configmap_name, uid=uid)
+
+
+def _parse_migration_lease_state(lease: dict[str, Any], *, lease_name: str) -> MigrationLeaseState:
+    spec = lease.get("spec") or {}
+    holder_identity, revision = _parse_revision(
+        spec.get("holderIdentity"),
+        label=f"migration state lease {lease_name} holderIdentity",
+    )
+    renew_time = str(spec.get("renewTime", "")).strip()
+    return MigrationLeaseState(
+        holder_identity=holder_identity,
+        revision=revision,
+        renew_time=renew_time,
+    )
+
+
+def _lease_owner_uid(lease: dict[str, Any], *, identity_name: str) -> str:
+    metadata = lease.get("metadata") or {}
+    owner_references = metadata.get("ownerReferences") or []
+    for owner_reference in owner_references:
+        if (
+            str(owner_reference.get("apiVersion", "")).strip() == "v1"
+            and str(owner_reference.get("kind", "")).strip() == "ConfigMap"
+            and str(owner_reference.get("name", "")).strip() == identity_name
+        ):
+            return str(owner_reference.get("uid", "")).strip()
+    return ""
+
+
+def _updated_lease_document(
+    lease: dict[str, Any],
+    *,
+    lease_name: str,
+    holder_identity: str,
+    renew_time: str,
+    owner_reference: dict[str, str],
+) -> dict[str, Any]:
+    metadata = lease.get("metadata") or {}
+    resource_version = str(metadata.get("resourceVersion", "")).strip()
+    if not resource_version:
+        raise MigrationStateError(
+            f"Migration state lease {lease_name} is missing metadata.resourceVersion"
+        )
+    namespace = _required_argument(
+        metadata.get("namespace"),
+        f"migration state lease {lease_name} metadata.namespace",
+    )
+    return _build_lease_document(
+        name=lease_name,
+        namespace=namespace,
+        holder_identity=holder_identity,
+        renew_time=renew_time,
+        owner_reference=owner_reference,
+        resource_version=resource_version,
+        spec=lease.get("spec") or {},
+    )
+
+
+def _job_conditions(job: dict[str, Any]) -> dict[str, str]:
+    conditions = {}
+    for condition in (job.get("status") or {}).get("conditions") or []:
+        condition_type = str(condition.get("type", "")).strip()
+        if condition_type:
+            conditions[condition_type] = str(condition.get("status", "")).strip()
+    return conditions
+
+
+def _job_status_summary(job: dict[str, Any]) -> str:
+    status = job.get("status") or {}
+    active = int(status.get("active", 0) or 0)
+    succeeded = int(status.get("succeeded", 0) or 0)
+    failed = int(status.get("failed", 0) or 0)
+    return f"active={active} succeeded={succeeded} failed={failed}"
+
+
+def _display_value(value: str) -> str:
+    return value if value else "<empty>"
+
+
+def _required_argument(value: object, label: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise MigrationStateError(f"{label} is required")
+    return normalized
+
+
+def _parse_revision(value: object, *, label: str) -> tuple[str, int]:
+    normalized = _required_argument(value, label)
+    try:
+        revision = int(normalized)
+    except ValueError as exc:
+        raise MigrationStateError(f"{label} must be a positive integer") from exc
+    if revision < 1:
+        raise MigrationStateError(f"{label} must be a positive integer")
+    return normalized, revision
+
+
+def _env_float(name: str, default: float) -> float:
+    raw_value = str(os.getenv(name, default)).strip()
+    try:
+        return float(raw_value)
+    except ValueError as exc:
+        raise MigrationStateError(f"{name} must be a number") from exc
+
+
+def _add_cluster_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--namespace", default=os.getenv(_DEFAULT_NAMESPACE_ENV, ""))
+    parser.add_argument("--token-path", default=DEFAULT_KUBERNETES_TOKEN_PATH)
+    parser.add_argument("--ca-path", default=DEFAULT_KUBERNETES_CA_PATH)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Coordinate durable Kubernetes migration state for DeltaLLM releases.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    wait_parser = subparsers.add_parser("wait", help="Wait for the current release revision to be marked as migrated.")
+    _add_cluster_arguments(wait_parser)
+    wait_parser.add_argument("--identity-configmap-name", default=os.getenv(_DEFAULT_MIGRATION_IDENTITY_ENV, ""))
+    wait_parser.add_argument("--lease-name", default=os.getenv(_DEFAULT_MIGRATION_LEASE_ENV, ""))
+    wait_parser.add_argument("--job-name", default=os.getenv(_DEFAULT_MIGRATION_JOB_ENV, ""))
+    wait_parser.add_argument("--revision", default=os.getenv(_DEFAULT_RELEASE_REVISION_ENV, ""))
+    wait_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=_env_float(_DEFAULT_WAIT_TIMEOUT_ENV, DEFAULT_MIGRATION_WAIT_TIMEOUT_SECONDS),
+    )
+    wait_parser.add_argument(
+        "--period-seconds",
+        type=float,
+        default=_env_float(_DEFAULT_WAIT_PERIOD_ENV, DEFAULT_MIGRATION_WAIT_PERIOD_SECONDS),
+    )
+
+    deploy_parser = subparsers.add_parser(
+        "deploy-and-mark",
+        help="Run prisma migrate deploy and mark the current release revision as complete.",
+    )
+    _add_cluster_arguments(deploy_parser)
+    deploy_parser.add_argument("--identity-configmap-name", default=os.getenv(_DEFAULT_MIGRATION_IDENTITY_ENV, ""))
+    deploy_parser.add_argument("--lease-name", default=os.getenv(_DEFAULT_MIGRATION_LEASE_ENV, ""))
+    deploy_parser.add_argument("--revision", default=os.getenv(_DEFAULT_RELEASE_REVISION_ENV, ""))
+    deploy_parser.add_argument("--schema", default=DEFAULT_PRISMA_SCHEMA_PATH)
+    deploy_parser.add_argument("--max-attempts", type=int, default=DEFAULT_PRISMA_BOOTSTRAP_ATTEMPTS)
+    deploy_parser.add_argument("--sleep-seconds", type=float, default=DEFAULT_PRISMA_BOOTSTRAP_SLEEP_SECONDS)
+    deploy_parser.add_argument("--state-max-attempts", type=int, default=DEFAULT_MIGRATION_STATE_UPDATE_ATTEMPTS)
+    deploy_parser.add_argument(
+        "--state-sleep-seconds",
+        type=float,
+        default=DEFAULT_MIGRATION_STATE_UPDATE_SLEEP_SECONDS,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        client = KubernetesApiClient.from_cluster(
+            namespace=args.namespace,
+            token_path=args.token_path,
+            ca_path=args.ca_path,
+        )
+        if args.command == "wait":
+            wait_for_migration_completion(
+                client=client,
+                identity_configmap_name=args.identity_configmap_name,
+                lease_name=args.lease_name,
+                expected_revision=args.revision,
+                job_name=args.job_name,
+                timeout_seconds=args.timeout_seconds,
+                period_seconds=args.period_seconds,
+            )
+            return 0
+        if args.command == "deploy-and-mark":
+            deploy_and_mark_migration_complete(
+                client=client,
+                identity_configmap_name=args.identity_configmap_name,
+                lease_name=args.lease_name,
+                expected_revision=args.revision,
+                schema_path=args.schema,
+                max_attempts=args.max_attempts,
+                sleep_seconds=args.sleep_seconds,
+                state_max_attempts=args.state_max_attempts,
+                state_sleep_seconds=args.state_sleep_seconds,
+            )
+            return 0
+        raise AssertionError(f"Unhandled command: {args.command}")
+    except (MigrationStateError, KeyboardInterrupt) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prisma_bootstrap.py
+++ b/src/prisma_bootstrap.py
@@ -10,6 +10,13 @@ from typing import TextIO
 DEFAULT_PRISMA_BOOTSTRAP_ATTEMPTS = 30
 DEFAULT_PRISMA_BOOTSTRAP_SLEEP_SECONDS = 2.0
 DEFAULT_PRISMA_SCHEMA_PATH = "./prisma/schema.prisma"
+DEFAULT_PRISMA_BOOTSTRAP_MODE = "deploy"
+
+_PRISMA_BOOTSTRAP_MODES = ("deploy", "verify", "skip")
+_PRISMA_COMMAND_LABELS = {
+    "deploy": "Prisma migrate deploy",
+    "verify": "Prisma migrate status",
+}
 
 _RETRYABLE_CONNECTIVITY_MARKERS = (
     "p1001",
@@ -30,6 +37,14 @@ class PrismaBootstrapError(RuntimeError):
         self.retryable = bool(retryable)
 
 
+def normalize_prisma_bootstrap_mode(mode: str) -> str:
+    normalized = str(mode or DEFAULT_PRISMA_BOOTSTRAP_MODE).strip().lower()
+    if normalized not in _PRISMA_BOOTSTRAP_MODES:
+        allowed = ", ".join(_PRISMA_BOOTSTRAP_MODES)
+        raise ValueError(f"Prisma bootstrap mode must be one of: {allowed}")
+    return normalized
+
+
 def classify_prisma_failure(output: str) -> str:
     normalized = str(output or "").lower()
     if any(marker in normalized for marker in _RETRYABLE_CONNECTIVITY_MARKERS):
@@ -44,8 +59,17 @@ def _emit_command_output(*, stdout: str, stderr: str, out: TextIO, err: TextIO) 
         print(stderr, file=err, end="" if stderr.endswith("\n") else "\n")
 
 
+def _build_prisma_command(*, mode: str, schema_path: str) -> list[str]:
+    if mode == "deploy":
+        return ["prisma", "migrate", "deploy", "--schema", schema_path]
+    if mode == "verify":
+        return ["prisma", "migrate", "status", "--schema", schema_path]
+    raise ValueError(f"Unsupported Prisma bootstrap mode: {mode}")
+
+
 def run_prisma_bootstrap(
     *,
+    mode: str = DEFAULT_PRISMA_BOOTSTRAP_MODE,
     schema_path: str = DEFAULT_PRISMA_SCHEMA_PATH,
     max_attempts: int = DEFAULT_PRISMA_BOOTSTRAP_ATTEMPTS,
     sleep_seconds: float = DEFAULT_PRISMA_BOOTSTRAP_SLEEP_SECONDS,
@@ -54,7 +78,11 @@ def run_prisma_bootstrap(
     stdout: TextIO | None = None,
     stderr: TextIO | None = None,
 ) -> None:
-    command = ["prisma", "migrate", "deploy", "--schema", schema_path]
+    normalized_mode = normalize_prisma_bootstrap_mode(mode)
+    if normalized_mode == "skip":
+        return
+    command = _build_prisma_command(mode=normalized_mode, schema_path=schema_path)
+    command_label = _PRISMA_COMMAND_LABELS[normalized_mode]
     attempts = max(1, int(max_attempts))
     delay = max(0.0, float(sleep_seconds))
     out_stream = stdout if stdout is not None else sys.stdout
@@ -79,7 +107,7 @@ def run_prisma_bootstrap(
         if failure_type == "retryable_connectivity" and attempt < attempts:
             _emit_command_output(stdout=result.stdout, stderr=result.stderr, out=out_stream, err=err_stream)
             print(
-                f"Waiting for database before Prisma migrate deploy... ({attempt}/{attempts})",
+                f"Waiting for database before {command_label}... ({attempt}/{attempts})",
                 file=err_stream,
             )
             sleeper(delay)
@@ -88,14 +116,15 @@ def run_prisma_bootstrap(
         _emit_command_output(stdout=result.stdout, stderr=result.stderr, out=out_stream, err=err_stream)
         if failure_type == "retryable_connectivity":
             raise PrismaBootstrapError(
-                f"Prisma migrate deploy did not succeed after {attempts} attempts",
+                f"{command_label} did not succeed after {attempts} attempts",
                 retryable=True,
             )
-        raise PrismaBootstrapError("Prisma migrate deploy failed with a non-retryable error", retryable=False)
+        raise PrismaBootstrapError(f"{command_label} failed with a non-retryable error", retryable=False)
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run Prisma migrate deploy with connectivity retries.")
+    parser = argparse.ArgumentParser(description="Run Prisma bootstrap commands with connectivity retries.")
+    parser.add_argument("--mode", choices=_PRISMA_BOOTSTRAP_MODES, default=DEFAULT_PRISMA_BOOTSTRAP_MODE)
     parser.add_argument("--schema", default=DEFAULT_PRISMA_SCHEMA_PATH)
     parser.add_argument("--max-attempts", type=int, default=DEFAULT_PRISMA_BOOTSTRAP_ATTEMPTS)
     parser.add_argument("--sleep-seconds", type=float, default=DEFAULT_PRISMA_BOOTSTRAP_SLEEP_SECONDS)
@@ -106,6 +135,7 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
         run_prisma_bootstrap(
+            mode=args.mode,
             schema_path=args.schema,
             max_attempts=args.max_attempts,
             sleep_seconds=args.sleep_seconds,

--- a/tests/bootstrap/test_k8s_migration_state.py
+++ b/tests/bootstrap/test_k8s_migration_state.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+import importlib
+import io
+
+import pytest
+
+
+def _migration_state_module():
+    return importlib.import_module("src.k8s_migration_state")
+
+
+class _FakeKubernetesApiClient:
+    def __init__(
+        self,
+        *,
+        configmaps: list[dict[str, object] | Exception] | None = None,
+        leases: list[dict[str, object] | Exception] | None = None,
+        jobs: list[dict[str, object] | Exception] | None = None,
+        create_side_effects: list[object] | None = None,
+        replace_side_effects: list[object] | None = None,
+    ) -> None:
+        self._configmaps = list(configmaps or [])
+        self._leases = list(leases or [])
+        self._jobs = list(jobs or [])
+        self._create_side_effects = list(create_side_effects or [])
+        self._replace_side_effects = list(replace_side_effects or [])
+        self.create_requests: list[dict[str, object]] = []
+        self.replace_requests: list[dict[str, object]] = []
+        self.get_configmap_calls = 0
+        self.get_job_calls = 0
+
+    def get_configmap(self, name: str) -> dict[str, object]:
+        assert name
+        self.get_configmap_calls += 1
+        if not self._configmaps:
+            raise AssertionError("unexpected configmap lookup")
+        if len(self._configmaps) == 1:
+            value = self._configmaps[0]
+        else:
+            value = self._configmaps.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def get_lease(self, name: str) -> dict[str, object]:
+        assert name
+        if not self._leases:
+            raise AssertionError("unexpected lease lookup")
+        value = self._leases.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def create_lease(
+        self,
+        name: str,
+        *,
+        holder_identity: str,
+        renew_time: str,
+        owner_reference: dict[str, str],
+    ) -> dict[str, object]:
+        assert name
+        self.create_requests.append(
+            {
+                "name": name,
+                "holder_identity": holder_identity,
+                "renew_time": renew_time,
+                "owner_reference": dict(owner_reference),
+            }
+        )
+        if self._create_side_effects:
+            side_effect = self._create_side_effects.pop(0)
+            if isinstance(side_effect, Exception):
+                raise side_effect
+            return side_effect
+        return _lease(revision=holder_identity, owner_uid=owner_reference["uid"], renew_time=renew_time, resource_version="1")
+
+    def replace_lease(self, lease: dict[str, object]) -> dict[str, object]:
+        self.replace_requests.append(lease)
+        if self._replace_side_effects:
+            side_effect = self._replace_side_effects.pop(0)
+            if isinstance(side_effect, Exception):
+                raise side_effect
+            return side_effect
+        return lease
+
+    def get_job(self, name: str) -> dict[str, object]:
+        assert name
+        self.get_job_calls += 1
+        if not self._jobs:
+            raise AssertionError("unexpected job lookup")
+        value = self._jobs.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+def _configmap(
+    *,
+    uid: str = "uid-current",
+    name: str = "release-migration-identity",
+) -> dict[str, object]:
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": name,
+            "namespace": "default",
+            "uid": uid,
+        },
+    }
+
+
+def _lease(
+    *,
+    revision: str | int,
+    owner_uid: str | None = "uid-current",
+    owner_name: str = "release-migration-identity",
+    renew_time: str = "2026-04-18T00:00:00Z",
+    resource_version: str = "12",
+) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "name": "release-migration-state",
+        "namespace": "default",
+        "resourceVersion": resource_version,
+    }
+    if owner_uid is not None:
+        metadata["ownerReferences"] = [
+            {
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "name": owner_name,
+                "uid": owner_uid,
+            }
+        ]
+    return {
+        "apiVersion": "coordination.k8s.io/v1",
+        "kind": "Lease",
+        "metadata": metadata,
+        "spec": {
+            "holderIdentity": str(revision),
+            "renewTime": renew_time,
+        },
+    }
+
+
+def _job(*, active: int = 0, succeeded: int = 0, failed: int = 0, failed_condition: bool = False) -> dict[str, object]:
+    conditions: list[dict[str, str]] = []
+    if failed_condition:
+        conditions.append({"type": "Failed", "status": "True"})
+    return {
+        "status": {
+            "active": active,
+            "succeeded": succeeded,
+            "failed": failed,
+            "conditions": conditions,
+        }
+    }
+
+
+def test_wait_for_migration_completion_returns_when_matching_lease_revision_is_already_ahead() -> None:
+    module = _migration_state_module()
+    stdout = io.StringIO()
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[_lease(revision=9, owner_uid="uid-current")],
+    )
+
+    module.wait_for_migration_completion(
+        client=client,
+        identity_configmap_name="release-migration-identity",
+        lease_name="release-migration-state",
+        expected_revision="8",
+        job_name="release-migrate-r8",
+        stdout=stdout,
+    )
+
+    assert "confirms revision 9 for expected revision 8" in stdout.getvalue()
+    assert client.get_configmap_calls == 1
+    assert client.get_job_calls == 0
+
+
+def test_wait_for_migration_completion_ignores_stale_owner_until_current_identity_records_state() -> None:
+    module = _migration_state_module()
+    stdout = io.StringIO()
+    sleeps: list[float] = []
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[
+            _lease(revision=20, owner_uid="uid-old"),
+            _lease(revision=9, owner_uid="uid-current"),
+        ],
+        jobs=[_job(active=1)],
+    )
+
+    module.wait_for_migration_completion(
+        client=client,
+        identity_configmap_name="release-migration-identity",
+        lease_name="release-migration-state",
+        expected_revision="9",
+        job_name="release-migrate-r9",
+        timeout_seconds=30,
+        period_seconds=1.5,
+        sleeper=sleeps.append,
+        monotonic=lambda: 0.0,
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert "belongs to stale release identity uid uid-old" in output
+    assert "status active=1 succeeded=0 failed=0" in output
+    assert "confirms revision 9 for expected revision 9" in output
+    assert sleeps == [1.5]
+    assert client.get_job_calls == 1
+
+
+def test_wait_for_migration_completion_fails_fast_when_the_job_has_failed() -> None:
+    module = _migration_state_module()
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[_lease(revision=9, owner_uid="uid-current")],
+        jobs=[_job(failed=1, failed_condition=True)],
+    )
+
+    with pytest.raises(module.MigrationStateError, match="failed before revision 10 was recorded"):
+        module.wait_for_migration_completion(
+            client=client,
+            identity_configmap_name="release-migration-identity",
+            lease_name="release-migration-state",
+            expected_revision="10",
+            job_name="release-migrate-r10",
+            monotonic=lambda: 0.0,
+        )
+
+
+def test_wait_for_migration_completion_fails_on_malformed_lease_state() -> None:
+    module = _migration_state_module()
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[_lease(revision="bad-revision", owner_uid="uid-current")],
+    )
+
+    with pytest.raises(module.MigrationStateError, match="holderIdentity must be a positive integer"):
+        module.wait_for_migration_completion(
+            client=client,
+            identity_configmap_name="release-migration-identity",
+            lease_name="release-migration-state",
+            expected_revision="10",
+            job_name="release-migrate-r10",
+        )
+
+
+def test_wait_for_migration_completion_fails_fast_on_identity_access_denied() -> None:
+    module = _migration_state_module()
+    client = _FakeKubernetesApiClient(
+        configmaps=[module.KubernetesApiAuthorizationError("forbidden")],
+    )
+
+    with pytest.raises(module.MigrationStateError, match="Check the migration Role/RoleBinding"):
+        module.wait_for_migration_completion(
+            client=client,
+            identity_configmap_name="release-migration-identity",
+            lease_name="release-migration-state",
+            expected_revision="10",
+            job_name="release-migrate-r10",
+        )
+
+
+def test_wait_for_migration_completion_retries_when_identity_lookup_is_transient() -> None:
+    module = _migration_state_module()
+    stdout = io.StringIO()
+    sleeps: list[float] = []
+    client = _FakeKubernetesApiClient(
+        configmaps=[
+            module.KubernetesApiTransientError("temporarily unavailable"),
+            _configmap(uid="uid-current"),
+        ],
+        leases=[_lease(revision=10, owner_uid="uid-current")],
+        jobs=[_job(active=1)],
+    )
+
+    module.wait_for_migration_completion(
+        client=client,
+        identity_configmap_name="release-migration-identity",
+        lease_name="release-migration-state",
+        expected_revision="10",
+        job_name="release-migrate-r10",
+        timeout_seconds=30,
+        period_seconds=1.25,
+        sleeper=sleeps.append,
+        monotonic=lambda: 0.0,
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert "migration identity ConfigMap release-migration-identity is temporarily unavailable" in output
+    assert "status active=1 succeeded=0 failed=0" in output
+    assert "confirms revision 10 for expected revision 10" in output
+    assert sleeps == [1.25]
+
+
+def test_mark_migration_complete_creates_a_missing_lease_with_current_identity_owner() -> None:
+    module = _migration_state_module()
+    stdout = io.StringIO()
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[module.KubernetesApiNotFoundError("lease missing")],
+    )
+
+    module.mark_migration_complete(
+        client=client,
+        identity_configmap_name="release-migration-identity",
+        lease_name="release-migration-state",
+        expected_revision="11",
+        completed_at="2026-04-18T00:00:00Z",
+        stdout=stdout,
+    )
+
+    assert "Recorded migration revision 11 in lease release-migration-state" in stdout.getvalue()
+    assert client.create_requests == [
+        {
+            "name": "release-migration-state",
+            "holder_identity": "11",
+            "renew_time": "2026-04-18T00:00:00Z",
+            "owner_reference": {
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "name": "release-migration-identity",
+                "uid": "uid-current",
+            },
+        }
+    ]
+    assert client.replace_requests == []
+
+
+def test_mark_migration_complete_advances_lower_matching_lease_revision_with_replace() -> None:
+    module = _migration_state_module()
+    stdout = io.StringIO()
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[_lease(revision=11, owner_uid="uid-current", resource_version="42")],
+    )
+
+    module.mark_migration_complete(
+        client=client,
+        identity_configmap_name="release-migration-identity",
+        lease_name="release-migration-state",
+        expected_revision="12",
+        completed_at="2026-04-18T12:00:00Z",
+        stdout=stdout,
+    )
+
+    assert "Recorded migration revision 12 in lease release-migration-state" in stdout.getvalue()
+    assert client.create_requests == []
+    assert client.replace_requests == [
+        {
+            "apiVersion": "coordination.k8s.io/v1",
+            "kind": "Lease",
+            "metadata": {
+                "name": "release-migration-state",
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "name": "release-migration-identity",
+                        "uid": "uid-current",
+                    }
+                ],
+                "resourceVersion": "42",
+            },
+            "spec": {
+                "holderIdentity": "12",
+                "renewTime": "2026-04-18T12:00:00Z",
+            },
+        }
+    ]
+
+
+def test_mark_migration_complete_repairs_stale_owner_even_when_old_revision_is_newer() -> None:
+    module = _migration_state_module()
+    stdout = io.StringIO()
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[_lease(revision=25, owner_uid="uid-old", resource_version="42")],
+    )
+
+    module.mark_migration_complete(
+        client=client,
+        identity_configmap_name="release-migration-identity",
+        lease_name="release-migration-state",
+        expected_revision="1",
+        completed_at="2026-04-18T12:00:00Z",
+        stdout=stdout,
+    )
+
+    assert "Recorded migration revision 1 in lease release-migration-state" in stdout.getvalue()
+    assert client.create_requests == []
+    assert client.replace_requests == [
+        {
+            "apiVersion": "coordination.k8s.io/v1",
+            "kind": "Lease",
+            "metadata": {
+                "name": "release-migration-state",
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "name": "release-migration-identity",
+                        "uid": "uid-current",
+                    }
+                ],
+                "resourceVersion": "42",
+            },
+            "spec": {
+                "holderIdentity": "1",
+                "renewTime": "2026-04-18T12:00:00Z",
+            },
+        }
+    ]
+
+
+def test_mark_migration_complete_does_not_downgrade_matching_newer_lease_revision() -> None:
+    module = _migration_state_module()
+    stdout = io.StringIO()
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[_lease(revision=13, owner_uid="uid-current")],
+    )
+
+    module.mark_migration_complete(
+        client=client,
+        identity_configmap_name="release-migration-identity",
+        lease_name="release-migration-state",
+        expected_revision="12",
+        stdout=stdout,
+    )
+
+    assert "already records newer revision 13; skipping stale revision 12" in stdout.getvalue()
+    assert client.create_requests == []
+    assert client.replace_requests == []
+
+
+def test_mark_migration_complete_retries_conflict_then_succeeds() -> None:
+    module = _migration_state_module()
+    stderr = io.StringIO()
+    stdout = io.StringIO()
+    sleeps: list[float] = []
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[
+            _lease(revision=11, owner_uid="uid-current", resource_version="42"),
+            _lease(revision=11, owner_uid="uid-current", resource_version="43"),
+        ],
+        replace_side_effects=[
+            module.KubernetesApiTransientError("lease update conflict"),
+            _lease(revision=12, owner_uid="uid-current", resource_version="44"),
+        ],
+    )
+
+    module.mark_migration_complete(
+        client=client,
+        identity_configmap_name="release-migration-identity",
+        lease_name="release-migration-state",
+        expected_revision="12",
+        completed_at="2026-04-18T12:00:00Z",
+        max_attempts=2,
+        sleep_seconds=0.25,
+        sleeper=sleeps.append,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert sleeps == [0.25]
+    assert "Waiting to update migration state lease release-migration-state (1/2)" in stderr.getvalue()
+    assert "Recorded migration revision 12 in lease release-migration-state" in stdout.getvalue()
+    assert len(client.replace_requests) == 2
+    assert client.replace_requests[0]["metadata"]["resourceVersion"] == "42"
+    assert client.replace_requests[1]["metadata"]["resourceVersion"] == "43"
+
+
+def test_mark_migration_complete_fails_fast_on_identity_access_denied() -> None:
+    module = _migration_state_module()
+    client = _FakeKubernetesApiClient(
+        configmaps=[module.KubernetesApiAuthorizationError("forbidden")],
+    )
+
+    with pytest.raises(module.MigrationStateError, match="Check the migration Role/RoleBinding"):
+        module.mark_migration_complete(
+            client=client,
+            identity_configmap_name="release-migration-identity",
+            lease_name="release-migration-state",
+            expected_revision="12",
+        )
+
+
+def test_deploy_and_mark_migration_complete_runs_prisma_then_records_state() -> None:
+    module = _migration_state_module()
+    client = _FakeKubernetesApiClient(
+        configmaps=[_configmap(uid="uid-current")],
+        leases=[module.KubernetesApiNotFoundError("lease missing")],
+    )
+    bootstrap_calls: list[dict[str, object]] = []
+
+    def fake_bootstrap_runner(**kwargs: object) -> None:
+        bootstrap_calls.append(kwargs)
+
+    module.deploy_and_mark_migration_complete(
+        client=client,
+        identity_configmap_name="release-migration-identity",
+        lease_name="release-migration-state",
+        expected_revision="12",
+        schema_path="./prisma/schema.prisma",
+        max_attempts=7,
+        sleep_seconds=0.75,
+        state_max_attempts=4,
+        state_sleep_seconds=0.5,
+        bootstrap_runner=fake_bootstrap_runner,
+        completed_at_factory=lambda: "2026-04-18T12:00:00Z",
+    )
+
+    assert bootstrap_calls == [
+        {
+            "mode": "deploy",
+            "schema_path": "./prisma/schema.prisma",
+            "max_attempts": 7,
+            "sleep_seconds": 0.75,
+            "stdout": None,
+            "stderr": None,
+        }
+    ]
+    assert client.create_requests == [
+        {
+            "name": "release-migration-state",
+            "holder_identity": "12",
+            "renew_time": "2026-04-18T12:00:00Z",
+            "owner_reference": {
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "name": "release-migration-identity",
+                "uid": "uid-current",
+            },
+        }
+    ]

--- a/tests/bootstrap/test_prisma_bootstrap.py
+++ b/tests/bootstrap/test_prisma_bootstrap.py
@@ -7,9 +7,15 @@ import sys
 import pytest
 
 
-def _completed_process(*, returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+def _completed_process(
+    *,
+    returncode: int,
+    stdout: str = "",
+    stderr: str = "",
+    args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(
-        args=["prisma", "migrate", "deploy"],
+        args=args or ["prisma", "migrate", "deploy"],
         returncode=returncode,
         stdout=stdout,
         stderr=stderr,
@@ -40,7 +46,33 @@ def test_classify_prisma_failure_marks_connectivity_errors_retryable() -> None:
     assert module.classify_prisma_failure("migration failed because type already exists") == "fatal"
 
 
-def test_run_prisma_bootstrap_retries_retryable_connectivity_errors_then_succeeds(capsys: pytest.CaptureFixture[str]) -> None:
+def test_normalize_prisma_bootstrap_mode_rejects_invalid_mode() -> None:
+    module = _prisma_bootstrap_module()
+
+    with pytest.raises(ValueError, match="Prisma bootstrap mode must be one of"):
+        module.normalize_prisma_bootstrap_mode("migrate")
+
+
+def test_run_prisma_bootstrap_skip_mode_returns_without_running_commands() -> None:
+    module = _prisma_bootstrap_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return _completed_process(returncode=0)
+
+    module.run_prisma_bootstrap(
+        mode="skip",
+        runner=fake_runner,
+        sleeper=lambda _: None,
+    )
+
+    assert calls == []
+
+
+def test_run_prisma_bootstrap_deploy_mode_retries_retryable_connectivity_errors_then_succeeds(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     module = _prisma_bootstrap_module()
     calls: list[list[str]] = []
     sleeps: list[float] = []
@@ -56,6 +88,7 @@ def test_run_prisma_bootstrap_retries_retryable_connectivity_errors_then_succeed
         return next(results)
 
     module.run_prisma_bootstrap(
+        mode="deploy",
         schema_path="./prisma/schema.prisma",
         max_attempts=3,
         sleep_seconds=0.25,
@@ -73,6 +106,30 @@ def test_run_prisma_bootstrap_retries_retryable_connectivity_errors_then_succeed
     assert "Prisma migrate deploy completed" in captured.out
 
 
+def test_run_prisma_bootstrap_verify_mode_uses_migrate_status(capsys: pytest.CaptureFixture[str]) -> None:
+    module = _prisma_bootstrap_module()
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return _completed_process(
+            returncode=0,
+            stdout="Database schema is up to date",
+            args=command,
+        )
+
+    module.run_prisma_bootstrap(
+        mode="verify",
+        schema_path="./prisma/schema.prisma",
+        runner=fake_runner,
+        sleeper=lambda _: None,
+    )
+
+    captured = capsys.readouterr()
+    assert calls == [["prisma", "migrate", "status", "--schema", "./prisma/schema.prisma"]]
+    assert "Database schema is up to date" in captured.out
+
+
 def test_run_prisma_bootstrap_raises_immediately_on_fatal_error(capsys: pytest.CaptureFixture[str]) -> None:
     module = _prisma_bootstrap_module()
     calls: list[list[str]] = []
@@ -83,6 +140,7 @@ def test_run_prisma_bootstrap_raises_immediately_on_fatal_error(capsys: pytest.C
 
     with pytest.raises(module.PrismaBootstrapError, match="non-retryable"):
         module.run_prisma_bootstrap(
+            mode="deploy",
             max_attempts=5,
             runner=fake_runner,
             sleeper=lambda _: None,
@@ -103,6 +161,7 @@ def test_run_prisma_bootstrap_raises_after_retry_budget_exhausted(capsys: pytest
 
     with pytest.raises(module.PrismaBootstrapError, match="did not succeed after 2 attempts") as exc_info:
         module.run_prisma_bootstrap(
+            mode="deploy",
             max_attempts=2,
             sleep_seconds=1.5,
             runner=fake_runner,
@@ -113,3 +172,55 @@ def test_run_prisma_bootstrap_raises_after_retry_budget_exhausted(capsys: pytest
     assert exc_info.value.retryable is True
     assert sleeps == [1.5]
     assert "Waiting for database before Prisma migrate deploy... (1/2)" in captured.err
+
+
+def test_run_prisma_bootstrap_verify_mode_retries_connectivity_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    module = _prisma_bootstrap_module()
+    calls: list[list[str]] = []
+    sleeps: list[float] = []
+    results = iter(
+        [
+            _completed_process(returncode=1, stderr="Error: P1001: Can't reach database server"),
+            _completed_process(returncode=0, stdout="No pending migrations to apply"),
+        ]
+    )
+
+    def fake_runner(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return next(results)
+
+    module.run_prisma_bootstrap(
+        mode="verify",
+        max_attempts=3,
+        sleep_seconds=0.5,
+        runner=fake_runner,
+        sleeper=sleeps.append,
+    )
+
+    captured = capsys.readouterr()
+    assert calls == [
+        ["prisma", "migrate", "status", "--schema", "./prisma/schema.prisma"],
+        ["prisma", "migrate", "status", "--schema", "./prisma/schema.prisma"],
+    ]
+    assert sleeps == [0.5]
+    assert "Waiting for database before Prisma migrate status... (1/3)" in captured.err
+
+
+def test_run_prisma_bootstrap_verify_mode_fails_on_pending_or_broken_state(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _prisma_bootstrap_module()
+
+    def fake_runner(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        del command
+        return _completed_process(returncode=1, stderr="Following migration have not yet been applied")
+
+    with pytest.raises(module.PrismaBootstrapError, match="Prisma migrate status failed with a non-retryable error"):
+        module.run_prisma_bootstrap(
+            mode="verify",
+            runner=fake_runner,
+            sleeper=lambda _: None,
+        )
+
+    captured = capsys.readouterr()
+    assert "Following migration have not yet been applied" in captured.err


### PR DESCRIPTION
## Summary
- split Prisma startup into explicit deploy, verify, and skip modes and align Docker/local/Compose usage around that contract
- add a strict Helm migration workflow with a dedicated migration job, gated app startup, and durable Kubernetes migration state tied to the current release identity
- update docs and local workflows to use Prisma migrations instead of `db push` for supported upgradeable environments

## Validation
- `uv run pytest tests/bootstrap/test_prisma_bootstrap.py tests/bootstrap/test_k8s_migration_state.py -q`
- `helm lint ./helm --set secret.values.masterKey=StrongMasterKey2026SecureValue99 --set secret.values.saltKey=unique-salt-2026`
- `helm lint ./helm -f helm/values-eval.yaml --set secret.values.masterKey=StrongMasterKey2026SecureValue99 --set secret.values.saltKey=unique-salt-2026`
- `helm lint ./helm -f helm/values-production.yaml --set secret.existingSecret=deltallm-app-secrets --set runtime.database.existingSecret.name=deltallm-runtime-secrets --set runtime.redis.existingSecret.name=deltallm-runtime-secrets --set ingress.enabled=true --set 'ingress.hosts[0].host=llm-gateway.example.com' --set 'ingress.hosts[0].paths[0].path=/' --set 'ingress.hosts[0].paths[0].pathType=Prefix'`
- `helm template deltallm ./helm --set secret.values.masterKey=StrongMasterKey2026SecureValue99 --set secret.values.saltKey=unique-salt-2026`
- `helm template deltallm ./helm --set migrationJob.enabled=true --set secret.values.masterKey=StrongMasterKey2026SecureValue99 --set secret.values.saltKey=unique-salt-2026`
- `git diff --check`

## Notes
- this PR targets the stacked branch `feature/issue94-prisma-upgrade-path`
- live Kubernetes install/upgrade/uninstall smoke testing has not been run in this PR
