### PR TITLE
Raise default unhealthy threshold to three failures

### DIFF
--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -18,6 +18,8 @@ router_settings:
 
 That is enough for most first deployments.
 
+Tip: check the effective `allowed_fails` value in the config your deployment actually loads. Depending on how you run DeltaLLM, the source of truth is usually your `config.yaml` from `DELTALLM_CONFIG_PATH`, your Helm `values.yaml`, or the rendered Kubernetes ConfigMap.
+
 ## Reference
 
 | Setting | Default | What it controls |

--- a/docs/features/routing.md
+++ b/docs/features/routing.md
@@ -362,6 +362,8 @@ router_settings:
 - `cooldown_time`: how long a failing deployment stays out of rotation
 - `allowed_fails`: how many failures are allowed before cooldown starts
 
+Tip: verify the effective `allowed_fails` value in the config your environment actually applies. In practice that usually means your mounted `config.yaml`, your Helm `values.yaml`, or the rendered ConfigMap in the cluster.
+
 When you publish a route-group policy, that group can override timeout and retry behavior without changing the global config.
 
 ## Fallback Chains

--- a/src/config.py
+++ b/src/config.py
@@ -162,7 +162,7 @@ class RouterSettings(BaseModel):
     retry_after: float = 0
     timeout: float = 600
     cooldown_time: int = 60
-    allowed_fails: int = 0
+    allowed_fails: int = 2
     enable_pre_call_checks: bool = False
     model_group_alias: dict[str, str] = Field(default_factory=dict)
     route_groups: list[RouteGroupConfig] = Field(default_factory=list)

--- a/src/router/cooldown.py
+++ b/src/router/cooldown.py
@@ -12,7 +12,7 @@ class CooldownManager:
         self,
         state_backend: DeploymentStateBackend,
         cooldown_time: int = 60,
-        allowed_fails: int = 0,
+        allowed_fails: int = 2,
         alert_callback: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
     ):
         self.state = state_backend

--- a/src/router/router.py
+++ b/src/router/router.py
@@ -60,7 +60,7 @@ class RouterConfig:
     retry_after: float = 0.0
     timeout: float = 600.0
     cooldown_time: int = 60
-    allowed_fails: int = 0
+    allowed_fails: int = 2
     enable_pre_call_checks: bool = False
     model_group_alias: dict[str, str] = field(default_factory=dict)
     route_group_policies: dict[str, "RouteGroupPolicy"] = field(default_factory=dict)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -685,7 +685,11 @@ async def test_chat_upstream_rate_limit_returns_429(client, test_app):
         "param": None,
         "code": None,
     }
-    assert await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 2
+    assert health.get("last_error") == "provider quota exhausted"
+    assert not await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -89,7 +89,11 @@ async def test_embeddings_upstream_rate_limit_returns_429(client, test_app):
     assert response.status_code == 429
     assert response.headers.get("Retry-After") == "11"
     assert response.json()["error"]["type"] == "rate_limit_error"
-    assert await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 2
+    assert health.get("last_error") == "provider quota exhausted"
+    assert not await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
 
 
 @pytest.mark.asyncio
@@ -107,11 +111,11 @@ async def test_embeddings_upstream_service_unavailable_updates_passive_health(cl
     response = await client.post("/v1/embeddings", headers=headers, json=body)
 
     assert response.status_code == 503
-    assert await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
     health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
-    assert health.get("healthy") == "false"
+    assert health.get("healthy", "true") != "false"
     assert int(health.get("consecutive_failures", 0) or 0) == 2
     assert health.get("last_error") == "Upstream embedding call failed with status 503"
+    assert not await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -228,7 +228,7 @@ async def test_failover_http_429_maps_to_rate_limit_error():
         config=FallbackConfig(num_retries=0, timeout=1.0),
         deployment_registry={"group-a": [primary]},
         state_backend=state,
-        cooldown_manager=CooldownManager(state),
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
 
     async def run(_deployment: Deployment) -> str:
@@ -257,7 +257,7 @@ async def test_failover_http_503_maps_to_health_affecting_service_unavailable_er
         config=FallbackConfig(num_retries=0, timeout=1.0),
         deployment_registry={"group-a": [primary]},
         state_backend=state,
-        cooldown_manager=CooldownManager(state),
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
 
     async def run(_deployment: Deployment) -> str:
@@ -286,7 +286,7 @@ async def test_failover_transport_error_maps_to_health_affecting_service_unavail
         config=FallbackConfig(num_retries=0, timeout=1.0),
         deployment_registry={"group-a": [primary]},
         state_backend=state,
-        cooldown_manager=CooldownManager(state),
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
 
     async def run(_deployment: Deployment) -> str:
@@ -311,7 +311,7 @@ async def test_failover_http_timeout_maps_to_timeout_error():
         config=FallbackConfig(num_retries=0, timeout=1.0),
         deployment_registry={"group-a": [primary]},
         state_backend=state,
-        cooldown_manager=CooldownManager(state),
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
 
     async def run(_deployment: Deployment) -> str:
@@ -413,7 +413,7 @@ async def test_failover_classified_fallback_continues_after_upstream_service_una
         ),
         deployment_registry={"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
         state_backend=state,
-        cooldown_manager=CooldownManager(state),
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
     attempts: list[str] = []
 

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -78,6 +78,31 @@ async def test_failover_applies_timeout_override():
         )
 
 
+@pytest.mark.asyncio
+async def test_cooldown_manager_default_marks_unhealthy_on_third_failure():
+    state = RedisStateBackend(redis=None)
+    cooldown = CooldownManager(state)
+
+    first = await cooldown.record_failure("dep-a", "boom-1")
+    second = await cooldown.record_failure("dep-a", "boom-2")
+
+    assert first is False
+    assert second is False
+    assert not await state.is_cooled_down("dep-a")
+    health = await state.get_health("dep-a")
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 2
+
+    third = await cooldown.record_failure("dep-a", "boom-3")
+
+    assert third is True
+    assert await state.is_cooled_down("dep-a")
+    health = await state.get_health("dep-a")
+    assert health.get("healthy") == "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 3
+    assert health.get("last_error") == "boom-3"
+
+
 @pytest.mark.parametrize(
     ("exc", "expected"),
     [


### PR DESCRIPTION
## Summary
- change the default cooldown threshold so deployments become unhealthy after the third consecutive failure instead of the first
- add a regression test covering the default `CooldownManager` behavior
- add docs notes telling operators to verify the effective `allowed_fails` value from their rendered config

## Why
The current default `allowed_fails=0` means the cooldown path marks a deployment unhealthy on the first failure. That is too aggressive for transient provider errors and does not match the desired operational behavior.

## Impact
- default behavior is now effectively `3` failures before cooldown/unhealthy state
- existing deployments can still override the value explicitly through `router_settings.allowed_fails`
- docs now point readers to the actual source of truth for their environment, including mounted config and Helm-rendered config

## Validation
- `uv run --extra dev python -m pytest tests/test_failover.py`
- `uv run --extra dev python -m pytest tests/bootstrap/test_routing_bootstrap.py tests/config/test_dynamic.py`
