### PR TITLE
hotfix: make admin batch status filtering text-safe

### DIFF
--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -23,6 +23,7 @@ from src.services.ui_authorization import build_batch_capabilities
 
 router = APIRouter(tags=["Admin Batches"])
 logger = logging.getLogger(__name__)
+FILTERABLE_BATCH_STATUSES = frozenset({"queued", "in_progress", "finalizing", "completed", "failed", "cancelled", "expired"})
 
 
 class MarkBatchFailedRequest(BaseModel):
@@ -148,10 +149,9 @@ async def list_batches(
         params.append(f"%{search}%")
         clauses.append(f"(j.batch_id ILIKE ${len(params)} OR j.model ILIKE ${len(params)})")
 
-    valid_statuses = {"queued", "in_progress", "finalizing", "completed", "failed", "cancelled", "expired"}
-    if status_filter and status_filter in valid_statuses:
+    if status_filter and status_filter in FILTERABLE_BATCH_STATUSES:
         params.append(status_filter)
-        clauses.append(f'j.status = ${len(params)}::"DeltaLLM_BatchJobStatus"')
+        clauses.append(f"j.status::text = ${len(params)}")
 
     where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
 

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -413,27 +413,34 @@ async def test_list_batches_exposes_repair_capabilities_for_updating_scope(clien
 
 
 @pytest.mark.asyncio
-async def test_list_batches_status_filter_uses_enum_safe_query(client, test_app, monkeypatch):
+@pytest.mark.parametrize(
+    ("status_filter", "expected_batch_id"),
+    [
+        ("queued", "batch-queued"),
+        ("in_progress", "batch-in-progress"),
+    ],
+)
+async def test_list_batches_status_filter_uses_text_safe_query(client, test_app, monkeypatch, status_filter, expected_batch_id):
     class FilteredBatchDB(FakeAuthorizationDB):
         async def query_raw(self, query: str, *params):
             if 'COUNT(*) AS total FROM deltallm_batch_job j' in query:
-                if 'j.status =' in query:
-                    assert '::"DeltaLLM_BatchJobStatus"' in query
-                    return [{"total": 1 if "queued" in params else 0}]
+                if "j.status::text =" in query:
+                    assert '::"DeltaLLM_BatchJobStatus"' not in query
+                    return [{"total": 1 if status_filter in params else 0}]
                 return [{"total": len(self.batches)}]
             if "FROM deltallm_batch_job j" in query and "LEFT JOIN deltallm_teamtable t" in query:
                 if "WHERE j.batch_id = $1" in query:
                     row = self.batches.get(str(params[0]))
                     return [row] if row else []
-                if 'j.status =' in query:
-                    assert '::"DeltaLLM_BatchJobStatus"' in query
+                if "j.status::text =" in query:
+                    assert '::"DeltaLLM_BatchJobStatus"' not in query
                     return [{
                         **self.batches["batch-1"],
-                        "batch_id": "batch-queued",
-                        "status": "queued",
-                        "in_progress_items": 0,
-                        "completed_items": 0,
-                    }] if "queued" in params else []
+                        "batch_id": expected_batch_id,
+                        "status": status_filter,
+                        "in_progress_items": 0 if status_filter == "queued" else self.batches["batch-1"]["in_progress_items"],
+                        "completed_items": 0 if status_filter == "queued" else self.batches["batch-1"]["completed_items"],
+                    }] if status_filter in params else []
                 return [self.batches["batch-1"]]
             return await super().query_raw(query, *params)
 
@@ -451,13 +458,13 @@ async def test_list_batches_status_filter_uses_enum_safe_query(client, test_app,
         ),
     )
 
-    response = await client.get("/ui/api/batches?status=queued", headers={"Authorization": "Bearer mk-test"})
+    response = await client.get(f"/ui/api/batches?status={status_filter}", headers={"Authorization": "Bearer mk-test"})
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["pagination"]["total"] == 1
-    assert payload["data"][0]["batch_id"] == "batch-queued"
-    assert payload["data"][0]["status"] == "queued"
+    assert payload["data"][0]["batch_id"] == expected_batch_id
+    assert payload["data"][0]["status"] == status_filter
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This hotfix makes the admin batch list status filter tolerant of the live database contract currently running in production.

## Root Cause

The admin batch list endpoint was building a raw SQL filter using:

- `j.status = $n::"DeltaLLM_BatchJobStatus"`

In the live failing environment, `deltallm_batch_job.status` behaves as `text`, so Postgres rejected the comparison with:

- `operator does not exist: text = "DeltaLLM_BatchJobStatus"`

That caused requests such as `/ui/api/batches?status=queued` and `/ui/api/batches?status=in_progress` to return `500`.

## What Changed

- replace the admin batch list status predicate with a text-safe comparison: `j.status::text = $n`
- lift the allowed status values into a module-level constant for the endpoint
- update the route-level authorization tests to verify the text-safe query shape
- cover both `queued` and `in_progress`, which were the live failing cases

## Scope

This PR fixes the verified admin read-path failure only.

It does not reconcile the wider batch status schema contract yet. Repository SQL paths that still cast to `DeltaLLM_BatchJobStatus` remain follow-up work.

## Validation

- `uv run --extra dev python -m pytest tests/test_ui_authorization.py -k list_batches_status_filter`
- `uv run --extra dev python -m pytest tests/test_ui_authorization.py -k batch`
- `uv run --extra dev ruff check src/api/admin/endpoints/batches.py tests/test_ui_authorization.py`
