### PR TITLE
Refactor batch status Python contract

### DIFF
--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -13,7 +13,7 @@ from src.auth.roles import Permission
 from src.api.admin.endpoints.common import db_or_503, emit_admin_mutation_audit, to_json_value, get_auth_scope
 from src.audit.actions import AuditAction
 from src.batch.repository import BatchRepository
-from src.batch.models import decode_operator_failed_reason, encode_operator_failed_reason
+from src.batch.models import BATCH_JOB_STATUS_SET, decode_operator_failed_reason, encode_operator_failed_reason
 from src.metrics import (
     increment_batch_repair_action,
     publish_batch_runtime_summary,
@@ -23,7 +23,6 @@ from src.services.ui_authorization import build_batch_capabilities
 
 router = APIRouter(tags=["Admin Batches"])
 logger = logging.getLogger(__name__)
-FILTERABLE_BATCH_STATUSES = frozenset({"queued", "in_progress", "finalizing", "completed", "failed", "cancelled", "expired"})
 
 
 class MarkBatchFailedRequest(BaseModel):
@@ -149,7 +148,7 @@ async def list_batches(
         params.append(f"%{search}%")
         clauses.append(f"(j.batch_id ILIKE ${len(params)} OR j.model ILIKE ${len(params)})")
 
-    if status_filter and status_filter in FILTERABLE_BATCH_STATUSES:
+    if status_filter and status_filter in BATCH_JOB_STATUS_SET:
         params.append(status_filter)
         clauses.append(f"j.status::text = ${len(params)}")
 

--- a/src/batch/models.py
+++ b/src/batch/models.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from enum import StrEnum
 from typing import Any
 
 
-class BatchJobStatus:
+class BatchJobStatus(StrEnum):
     QUEUED = "queued"
     IN_PROGRESS = "in_progress"
     FINALIZING = "finalizing"
@@ -15,23 +16,19 @@ class BatchJobStatus:
     EXPIRED = "expired"
 
 
-BATCH_JOB_STATUSES = (
-    BatchJobStatus.QUEUED,
-    BatchJobStatus.IN_PROGRESS,
-    BatchJobStatus.FINALIZING,
-    BatchJobStatus.COMPLETED,
-    BatchJobStatus.FAILED,
-    BatchJobStatus.CANCELLED,
-    BatchJobStatus.EXPIRED,
-)
-_BATCH_JOB_STATUS_SET = frozenset(BATCH_JOB_STATUSES)
+BATCH_JOB_STATUSES = tuple(BatchJobStatus)
+BATCH_JOB_STATUS_VALUES = tuple(status.value for status in BatchJobStatus)
+BATCH_JOB_STATUS_SET = frozenset(BATCH_JOB_STATUS_VALUES)
 
 
-def normalize_batch_job_status(status: str) -> str:
+def normalize_batch_job_status(status: str | BatchJobStatus) -> BatchJobStatus:
+    if isinstance(status, BatchJobStatus):
+        return status
     normalized = str(status or "").strip()
-    if normalized not in _BATCH_JOB_STATUS_SET:
-        raise ValueError("batch job status must be one of: " + ", ".join(BATCH_JOB_STATUSES))
-    return normalized
+    try:
+        return BatchJobStatus(normalized)
+    except ValueError as exc:
+        raise ValueError("batch job status must be one of: " + ", ".join(BATCH_JOB_STATUS_VALUES)) from exc
 
 
 class BatchItemStatus:
@@ -91,7 +88,7 @@ class BatchFileRecord:
 class BatchJobRecord:
     batch_id: str
     endpoint: str
-    status: str
+    status: BatchJobStatus
     execution_mode: str
     input_file_id: str
     output_file_id: str | None

--- a/src/batch/repositories/job_repository.py
+++ b/src/batch/repositories/job_repository.py
@@ -48,7 +48,7 @@ class BatchJobRepository:
         created_by_organization_id: str | None = None,
         expires_at: datetime | None = None,
         execution_mode: str = "managed_internal",
-        status: str = BatchJobStatus.QUEUED,
+        status: str | BatchJobStatus = BatchJobStatus.QUEUED,
         total_items: int = 0,
     ) -> BatchJobRecord | None:
         if self.prisma is None:
@@ -81,7 +81,7 @@ class BatchJobRepository:
             """,
             batch_id,
             endpoint,
-            normalized_status,
+            normalized_status.value,
             execution_mode,
             input_file_id,
             model,
@@ -245,7 +245,7 @@ class BatchJobRepository:
             RETURNING *
             """,
             batch_id,
-            BatchJobStatus.QUEUED,
+            BatchJobStatus.QUEUED.value,
             total_items,
         )
         if not rows:
@@ -419,7 +419,7 @@ class BatchJobRepository:
         batch_id: str,
         output_file_id: str | None,
         error_file_id: str | None,
-        final_status: str,
+        final_status: str | BatchJobStatus,
         worker_id: str | None = None,
     ) -> BatchJobRecord | None:
         if self.prisma is None:
@@ -442,7 +442,7 @@ class BatchJobRepository:
                 batch_id,
                 output_file_id,
                 error_file_id,
-                normalized_final_status,
+                normalized_final_status.value,
             )
         else:
             rows = await self.prisma.query_raw(
@@ -464,7 +464,7 @@ class BatchJobRepository:
                 worker_id,
                 output_file_id,
                 error_file_id,
-                normalized_final_status,
+                normalized_final_status.value,
             )
         if not rows:
             return None

--- a/src/batch/repositories/mappers.py
+++ b/src/batch/repositories/mappers.py
@@ -64,7 +64,7 @@ def job_from_row(row: dict[str, Any]) -> BatchJobRecord:
     return BatchJobRecord(
         batch_id=str(row.get("batch_id") or ""),
         endpoint=str(row.get("endpoint") or ""),
-        status=normalize_batch_job_status(str(row.get("status") or "")),
+        status=normalize_batch_job_status(row.get("status") or ""),
         execution_mode=str(row.get("execution_mode") or "managed_internal"),
         input_file_id=str(row.get("input_file_id") or ""),
         output_file_id=row.get("output_file_id"),

--- a/src/batch/repository.py
+++ b/src/batch/repository.py
@@ -12,6 +12,7 @@ from src.batch.models import (
     BatchItemCreate,
     BatchItemRecord,
     BatchJobRecord,
+    BatchJobStatus,
 )
 from src.batch.repositories import (
     BatchCompletionOutboxRepository,
@@ -83,7 +84,7 @@ class BatchRepository:
         created_by_organization_id: str | None = None,
         expires_at: datetime | None = None,
         execution_mode: str = "managed_internal",
-        status: str = "queued",
+        status: str | BatchJobStatus = BatchJobStatus.QUEUED,
         total_items: int = 0,
     ) -> BatchJobRecord | None:
         return await self.jobs.create_job(
@@ -337,7 +338,7 @@ class BatchRepository:
         batch_id: str,
         output_file_id: str | None,
         error_file_id: str | None,
-        final_status: str,
+        final_status: str | BatchJobStatus,
         worker_id: str | None = None,
     ) -> BatchJobRecord | None:
         return await self.jobs.attach_artifacts_and_finalize(

--- a/tests/test_batch_models.py
+++ b/tests/test_batch_models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.batch.models import (
+    BATCH_JOB_STATUSES,
+    BATCH_JOB_STATUS_VALUES,
+    BatchJobRecord,
+    BatchJobStatus,
+    normalize_batch_job_status,
+)
+
+
+def test_batch_job_status_values_follow_enum_definition() -> None:
+    assert BATCH_JOB_STATUSES == tuple(BatchJobStatus)
+    assert BATCH_JOB_STATUS_VALUES == tuple(status.value for status in BatchJobStatus)
+
+
+@pytest.mark.parametrize("status", ["queued", BatchJobStatus.QUEUED])
+def test_normalize_batch_job_status_returns_enum(status: str | BatchJobStatus) -> None:
+    assert normalize_batch_job_status(status) is BatchJobStatus.QUEUED
+
+
+def test_batch_job_record_normalizes_status_to_enum() -> None:
+    now = datetime.now(tz=UTC)
+
+    record = BatchJobRecord(
+        batch_id="batch-1",
+        endpoint="/v1/embeddings",
+        status="queued",
+        execution_mode="managed_internal",
+        input_file_id="file-1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m1",
+        metadata=None,
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=0,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="key-1",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_at=now,
+        started_at=None,
+        completed_at=None,
+        expires_at=None,
+        created_by_organization_id=None,
+    )
+
+    assert record.status is BatchJobStatus.QUEUED

--- a/tests/test_batch_repository.py
+++ b/tests/test_batch_repository.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from src.batch.models import BatchJobStatus
 from src.batch.repository import BatchRepository
 
 
@@ -268,7 +269,7 @@ async def test_create_job_defaults_to_queued_status() -> None:
     )
 
     assert '::"DeltaLLM_BatchJobStatus"' in prisma.sql
-    assert prisma.params[2] == "queued"
+    assert prisma.params[2] == BatchJobStatus.QUEUED.value
 
 
 @pytest.mark.asyncio
@@ -308,7 +309,7 @@ async def test_attach_artifacts_and_finalize_casts_status_parameter_to_enum() ->
 
     assert finalized is None
     assert 'status = $4::"DeltaLLM_BatchJobStatus"' in prisma.sql
-    assert prisma.params[3] == "completed"
+    assert prisma.params[3] == BatchJobStatus.COMPLETED.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace the batch job status string constant holder with a real Python `StrEnum`
- centralize the shared batch status values/set in `src.batch.models`
- update the batch repository and admin batch filter path to reuse the shared status contract while keeping the current hotfix query behavior unchanged
- add focused tests for status normalization and repository parameter binding

## Why
The batch status hotfix fixed the live admin failure, but the Python-side status contract was still duplicated and loosely typed. The codebase had:
- a plain class of string constants instead of a real enum
- a duplicate status allowlist in the admin endpoint
- repository methods accepting raw strings without an explicit shared type contract

This PR handles the Python-only cleanup portion first, without changing the database contract yet.

## Impact
- `BatchJobStatus` is now a typed `StrEnum`
- `BatchJobRecord.status` now normalizes to `BatchJobStatus`
- repository entry points accept either `str` or `BatchJobStatus`, then bind the normalized enum value explicitly into SQL parameters
- the admin batch status filter now reuses the shared batch status set from `src.batch.models`
- the current compatibility query `j.status::text = $n` remains in place intentionally for the hotfix path

## Scope Notes
This PR does not:
- change the Prisma schema
- change the PostgreSQL enum contract
- remove the temporary text-safe admin query

Those steps are intentionally left for the later schema reconciliation and cutover PRs.

## Validation
- `uv run --extra dev python -m pytest tests/test_batch_models.py tests/test_batch_repository.py tests/test_batch_create_service.py tests/test_batch_create_promoter.py`
- `uv run --extra dev python -m pytest tests/test_ui_authorization.py -k batch`
- `uv run --extra dev ruff check src/batch/models.py src/batch/repositories/mappers.py src/batch/repositories/job_repository.py src/batch/repository.py src/api/admin/endpoints/batches.py tests/test_batch_models.py tests/test_batch_repository.py`