### PR TITLE
Reconcile batch job status schema contract

### DIFF
--- a/prisma/migrations/20260424120000_batch_job_status_contract_reconciliation/migration.sql
+++ b/prisma/migrations/20260424120000_batch_job_status_contract_reconciliation/migration.sql
@@ -1,0 +1,180 @@
+DO $$
+DECLARE
+    final_labels constant text[] := ARRAY[
+        'queued',
+        'in_progress',
+        'finalizing',
+        'completed',
+        'failed',
+        'cancelled',
+        'expired'
+    ]::text[];
+    legacy_labels constant text[] := ARRAY[
+        'validating',
+        'queued',
+        'in_progress',
+        'finalizing',
+        'completed',
+        'failed',
+        'cancelled',
+        'expired'
+    ]::text[];
+    existing_labels text[];
+    next_labels text[];
+    status_udt_name text;
+    invalid_statuses text[];
+    existing_type_reference_count integer;
+    next_type_reference_count integer;
+BEGIN
+    SELECT c.udt_name
+    INTO status_udt_name
+    FROM information_schema.columns c
+    WHERE c.table_schema = 'public'
+      AND c.table_name = 'deltallm_batch_job'
+      AND c.column_name = 'status';
+
+    IF status_udt_name IS NULL THEN
+        RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: column is missing';
+    END IF;
+
+    SELECT COALESCE(array_agg(DISTINCT status::text ORDER BY status::text), ARRAY[]::text[])
+    INTO invalid_statuses
+    FROM "deltallm_batch_job"
+    WHERE status::text <> ALL(final_labels);
+
+    IF COALESCE(array_length(invalid_statuses, 1), 0) > 0 THEN
+        RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: found invalid existing values %', invalid_statuses;
+    END IF;
+
+    SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
+    INTO existing_labels
+    FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'DeltaLLM_BatchJobStatus';
+
+    SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
+    INTO next_labels
+    FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'DeltaLLM_BatchJobStatus_next';
+
+    SELECT COUNT(*)
+    INTO existing_type_reference_count
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND udt_name = 'DeltaLLM_BatchJobStatus';
+
+    SELECT COUNT(*)
+    INTO next_type_reference_count
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND udt_name = 'DeltaLLM_BatchJobStatus_next';
+
+    IF existing_labels IS NOT NULL
+       AND existing_labels IS DISTINCT FROM final_labels
+       AND existing_labels IS DISTINCT FROM legacy_labels THEN
+        RAISE EXCEPTION 'Cannot reconcile DeltaLLM_BatchJobStatus: unexpected enum labels %', existing_labels;
+    END IF;
+
+    IF next_labels IS NOT NULL
+       AND next_labels IS DISTINCT FROM final_labels THEN
+        RAISE EXCEPTION 'Cannot reconcile DeltaLLM_BatchJobStatus_next: unexpected enum labels %', next_labels;
+    END IF;
+
+    ALTER TABLE "deltallm_batch_job"
+    DROP CONSTRAINT IF EXISTS "deltallm_batch_job_status_chk";
+
+    IF status_udt_name = 'DeltaLLM_BatchJobStatus'
+       AND existing_labels IS NOT DISTINCT FROM final_labels THEN
+        IF next_labels IS NOT NULL
+           AND next_type_reference_count = 0 THEN
+            EXECUTE 'DROP TYPE "DeltaLLM_BatchJobStatus_next"';
+        END IF;
+        RETURN;
+    END IF;
+
+    IF status_udt_name = 'DeltaLLM_BatchJobStatus_next' THEN
+        IF next_labels IS DISTINCT FROM final_labels THEN
+            RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: expected DeltaLLM_BatchJobStatus_next to have final labels, found %', next_labels;
+        END IF;
+        IF existing_labels IS NOT NULL THEN
+            IF existing_type_reference_count > 0 THEN
+                RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: DeltaLLM_BatchJobStatus is still referenced by % columns while status uses DeltaLLM_BatchJobStatus_next', existing_type_reference_count;
+            END IF;
+            EXECUTE 'DROP TYPE "DeltaLLM_BatchJobStatus"';
+        END IF;
+        EXECUTE 'ALTER TYPE "DeltaLLM_BatchJobStatus_next" RENAME TO "DeltaLLM_BatchJobStatus"';
+        RETURN;
+    END IF;
+
+    IF existing_labels IS NULL
+       AND next_labels IS NOT NULL THEN
+        IF next_type_reference_count > 0 THEN
+            RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: DeltaLLM_BatchJobStatus_next is still referenced by % columns before rename', next_type_reference_count;
+        END IF;
+        EXECUTE 'ALTER TYPE "DeltaLLM_BatchJobStatus_next" RENAME TO "DeltaLLM_BatchJobStatus"';
+        existing_labels := final_labels;
+        next_labels := NULL;
+    END IF;
+
+    IF existing_labels IS NULL THEN
+        CREATE TYPE "DeltaLLM_BatchJobStatus" AS ENUM (
+            'queued',
+            'in_progress',
+            'finalizing',
+            'completed',
+            'failed',
+            'cancelled',
+            'expired'
+        );
+        existing_labels := final_labels;
+    END IF;
+
+    IF existing_labels IS NOT DISTINCT FROM legacy_labels THEN
+        IF next_labels IS NULL THEN
+            EXECUTE '
+                CREATE TYPE "DeltaLLM_BatchJobStatus_next" AS ENUM (
+                    ''queued'',
+                    ''in_progress'',
+                    ''finalizing'',
+                    ''completed'',
+                    ''failed'',
+                    ''cancelled'',
+                    ''expired''
+                )
+            ';
+            next_labels := final_labels;
+        END IF;
+
+        EXECUTE '
+            ALTER TABLE "deltallm_batch_job"
+            ALTER COLUMN "status" DROP DEFAULT
+        ';
+        EXECUTE '
+            ALTER TABLE "deltallm_batch_job"
+            ALTER COLUMN "status" TYPE "DeltaLLM_BatchJobStatus_next"
+            USING ("status"::text::"DeltaLLM_BatchJobStatus_next")
+        ';
+        SELECT COUNT(*)
+        INTO existing_type_reference_count
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND udt_name = 'DeltaLLM_BatchJobStatus';
+        IF existing_type_reference_count > 0 THEN
+            RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: DeltaLLM_BatchJobStatus is still referenced by % columns after moving status to DeltaLLM_BatchJobStatus_next', existing_type_reference_count;
+        END IF;
+        EXECUTE 'DROP TYPE "DeltaLLM_BatchJobStatus"';
+        EXECUTE 'ALTER TYPE "DeltaLLM_BatchJobStatus_next" RENAME TO "DeltaLLM_BatchJobStatus"';
+        RETURN;
+    END IF;
+
+    EXECUTE '
+        ALTER TABLE "deltallm_batch_job"
+        ALTER COLUMN "status" DROP DEFAULT
+    ';
+    EXECUTE '
+        ALTER TABLE "deltallm_batch_job"
+        ALTER COLUMN "status" TYPE "DeltaLLM_BatchJobStatus"
+        USING ("status"::text::"DeltaLLM_BatchJobStatus")
+    ';
+END $$;

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -26,7 +26,7 @@ from src.batch.create import (
 )
 from src.batch.create.service import BatchCreateSessionService
 from src.batch.cleanup import BatchCleanupConfig, BatchRetentionCleanupWorker
-from src.batch.models import BatchCompletionOutboxCreate, BatchItemCreate
+from src.batch.models import BATCH_JOB_STATUS_VALUES, BatchCompletionOutboxCreate, BatchItemCreate
 from src.batch.models import encode_operator_failed_reason
 from src.batch.repository import BatchRepository
 from src.batch.service import BatchService
@@ -42,6 +42,13 @@ except Exception:  # pragma: no cover
 
 
 DATABASE_URL = os.getenv("DATABASE_URL")
+BATCH_JOB_STATUS_RECONCILIATION_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "prisma"
+    / "migrations"
+    / "20260424120000_batch_job_status_contract_reconciliation"
+    / "migration.sql"
+)
 
 
 class _Upload:
@@ -136,6 +143,75 @@ async def _reset_batch_tables(db: Any) -> None:
     await db.execute_raw("DELETE FROM deltallm_batch_file")
 
 
+def _batch_job_status_reconciliation_sql() -> str:
+    return BATCH_JOB_STATUS_RECONCILIATION_MIGRATION_PATH.read_text()
+
+
+async def _execute_batch_job_status_reconciliation(db: Any) -> None:
+    await db.execute_raw(_batch_job_status_reconciliation_sql())
+
+
+async def _batch_job_status_column_contract(db: Any) -> dict[str, Any]:
+    rows = await db.query_raw(
+        """
+        SELECT
+            data_type,
+            udt_name,
+            column_default
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'deltallm_batch_job'
+          AND column_name = 'status'
+        """
+    )
+    assert rows
+    return dict(rows[0])
+
+
+async def _enum_labels(db: Any, type_name: str) -> list[str]:
+    rows = await db.query_raw(
+        """
+        SELECT e.enumlabel
+        FROM pg_enum e
+        JOIN pg_type t ON t.oid = e.enumtypid
+        WHERE t.typname = $1
+        ORDER BY e.enumsortorder
+        """,
+        type_name,
+    )
+    return [str(row["enumlabel"]) for row in rows]
+
+
+async def _seed_raw_batch_job(db: Any, *, input_file_id: str, batch_id: str, status: str) -> None:
+    await db.execute_raw(
+        """
+        INSERT INTO deltallm_batch_job (
+            batch_id, endpoint, status, execution_mode, input_file_id, total_items
+        )
+        VALUES (
+            $1,
+            '/v1/embeddings',
+            $2,
+            'managed_internal',
+            $3,
+            0
+        )
+        """,
+        batch_id,
+        status,
+        input_file_id,
+    )
+
+
+async def _assert_final_batch_job_status_contract(db: Any) -> None:
+    column = await _batch_job_status_column_contract(db)
+    assert column["udt_name"] == "DeltaLLM_BatchJobStatus"
+    assert column["data_type"] == "USER-DEFINED"
+    assert column["column_default"] is None
+    assert await _enum_labels(db, "DeltaLLM_BatchJobStatus") == list(BATCH_JOB_STATUS_VALUES)
+    assert await _enum_labels(db, "DeltaLLM_BatchJobStatus_next") == []
+
+
 @pytest.fixture
 async def batch_db():
     db = await _connect_prisma()
@@ -155,6 +231,214 @@ async def batch_db():
     finally:
         await _reset_batch_tables(db)
         await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_column_uses_final_enum_contract(batch_db) -> None:
+    await _assert_final_batch_job_status_contract(batch_db)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_reconciliation_converts_text_backed_column(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+
+    try:
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status DROP DEFAULT
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE text
+            USING (status::text)
+            """
+        )
+        await _seed_raw_batch_job(
+            batch_db,
+            input_file_id=input_file_id,
+            batch_id="batch-text-status",
+            status="queued",
+        )
+
+        column = await _batch_job_status_column_contract(batch_db)
+        assert column["udt_name"] == "text"
+
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+        await _assert_final_batch_job_status_contract(batch_db)
+    finally:
+        await _reset_batch_tables(batch_db)
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_reconciliation_converts_legacy_enum_shape(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+
+    try:
+        await batch_db.execute_raw(
+            """
+            CREATE TYPE "DeltaLLM_BatchJobStatus_legacy" AS ENUM (
+                'validating',
+                'queued',
+                'in_progress',
+                'finalizing',
+                'completed',
+                'failed',
+                'cancelled',
+                'expired'
+            )
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status DROP DEFAULT
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE "DeltaLLM_BatchJobStatus_legacy"
+            USING (status::text::"DeltaLLM_BatchJobStatus_legacy")
+            """
+        )
+        await batch_db.execute_raw('DROP TYPE "DeltaLLM_BatchJobStatus"')
+        await batch_db.execute_raw('ALTER TYPE "DeltaLLM_BatchJobStatus_legacy" RENAME TO "DeltaLLM_BatchJobStatus"')
+        await _seed_raw_batch_job(
+            batch_db,
+            input_file_id=input_file_id,
+            batch_id="batch-legacy-enum",
+            status="queued",
+        )
+
+        assert await _enum_labels(batch_db, "DeltaLLM_BatchJobStatus") == [
+            "validating",
+            *list(BATCH_JOB_STATUS_VALUES),
+        ]
+
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+        await _assert_final_batch_job_status_contract(batch_db)
+    finally:
+        await _reset_batch_tables(batch_db)
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_reconciliation_finishes_partial_next_type_cutover(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+
+    try:
+        await batch_db.execute_raw(
+            """
+            CREATE TYPE "DeltaLLM_BatchJobStatus_legacy" AS ENUM (
+                'validating',
+                'queued',
+                'in_progress',
+                'finalizing',
+                'completed',
+                'failed',
+                'cancelled',
+                'expired'
+            )
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status DROP DEFAULT
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE "DeltaLLM_BatchJobStatus_legacy"
+            USING (status::text::"DeltaLLM_BatchJobStatus_legacy")
+            """
+        )
+        await batch_db.execute_raw('DROP TYPE "DeltaLLM_BatchJobStatus"')
+        await batch_db.execute_raw('ALTER TYPE "DeltaLLM_BatchJobStatus_legacy" RENAME TO "DeltaLLM_BatchJobStatus"')
+        await batch_db.execute_raw(
+            """
+            CREATE TYPE "DeltaLLM_BatchJobStatus_next" AS ENUM (
+                'queued',
+                'in_progress',
+                'finalizing',
+                'completed',
+                'failed',
+                'cancelled',
+                'expired'
+            )
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE "DeltaLLM_BatchJobStatus_next"
+            USING (status::text::"DeltaLLM_BatchJobStatus_next")
+            """
+        )
+        await _seed_raw_batch_job(
+            batch_db,
+            input_file_id=input_file_id,
+            batch_id="batch-partial-next-cutover",
+            status="queued",
+        )
+
+        column = await _batch_job_status_column_contract(batch_db)
+        assert column["udt_name"] == "DeltaLLM_BatchJobStatus_next"
+        assert await _enum_labels(batch_db, "DeltaLLM_BatchJobStatus") == [
+            "validating",
+            *list(BATCH_JOB_STATUS_VALUES),
+        ]
+        assert await _enum_labels(batch_db, "DeltaLLM_BatchJobStatus_next") == list(BATCH_JOB_STATUS_VALUES)
+
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+        await _assert_final_batch_job_status_contract(batch_db)
+    finally:
+        await _reset_batch_tables(batch_db)
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_reconciliation_rejects_invalid_text_values(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+
+    try:
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status DROP DEFAULT
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE text
+            USING (status::text)
+            """
+        )
+        await _seed_raw_batch_job(
+            batch_db,
+            input_file_id=input_file_id,
+            batch_id="batch-invalid-text-status",
+            status="broken",
+        )
+
+        with pytest.raises(Exception, match="invalid existing values"):
+            await _execute_batch_job_status_reconciliation(batch_db)
+    finally:
+        await _reset_batch_tables(batch_db)
+        await _execute_batch_job_status_reconciliation(batch_db)
 
 
 async def _create_input_file(service: BatchService, *, auth: UserAPIKeyAuth, payload: bytes) -> str:


### PR DESCRIPTION
## Summary
- add a reconciliation migration for `deltallm_batch_job.status`
- handle the supported historical drift states explicitly: `text`, legacy enum with `validating`, and partial `_next` cutover
- add DB-backed migration-path coverage for the final contract, supported reconciliations, and invalid-data failure

## Why
The batch runtime and Prisma schema already assume `deltallm_batch_job.status` uses the `DeltaLLM_BatchJobStatus` enum, but production behavior showed at least one environment drifting away from that contract.

The first pass of this PR2 work surfaced two specific risks:
- a partially applied prior migration could leave the column on `DeltaLLM_BatchJobStatus_next`
- the tests only asserted the already-correct steady state, not the migration paths this PR is meant to support

This update fixes both.

## What Changed
- Added `prisma/migrations/20260424120000_batch_job_status_contract_reconciliation/migration.sql`
- The migration now:
  - validates live row values against the final seven allowed statuses
  - inspects both `DeltaLLM_BatchJobStatus` and `DeltaLLM_BatchJobStatus_next`
  - no-ops on already-correct final enum state
  - converts `text` safely to the final enum
  - completes a legacy enum cutover by moving through `_next`
  - completes a partial `_next` cutover without dropping an in-use type
  - fails loudly on unexpected enum shapes or invalid stored values
- Added DB-backed tests covering:
  - final steady-state contract
  - `text -> enum`
  - legacy enum -> final enum
  - partial `_next` cutover completion
  - invalid text value failure

## Scope Notes
This PR intentionally does not remove the current admin endpoint compatibility query. That cutover stays for the later PR after schema reconciliation is in place.

## Validation
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/deltallm' uv run prisma validate --schema=./prisma/schema.prisma`
- `uv run --extra dev ruff check tests/test_batch_db_integration.py`
- `uv run --extra dev python -m pytest tests/test_batch_db_integration.py -k "batch_job_status_"`

## Validation Notes
The DB-backed migration-path tests are included in this branch, but in this shell they skipped because the `DATABASE_URL`-backed integration harness was not available at runtime.