### PR TITLE
hotfix: make audit detail lookup text-safe

### DIFF
--- a/src/api/admin/endpoints/audit.py
+++ b/src/api/admin/endpoints/audit.py
@@ -165,7 +165,7 @@ async def get_audit_event(
         scope=scope,
     )
     params.append(event_id)
-    event_clause = f"event_id = ${len(params)}::uuid"
+    event_clause = f"event_id::text = ${len(params)}"
     if where_sql:
         where_sql = f"{where_sql} AND {event_clause}"
     else:
@@ -190,7 +190,7 @@ async def get_audit_event(
         """
         SELECT payload_id, event_id, kind, storage_mode, content_json, storage_uri, content_sha256, size_bytes, redacted, created_at
         FROM deltallm_auditpayload
-        WHERE event_id = $1::uuid
+        WHERE event_id::text = $1
         ORDER BY created_at ASC
         """,
         event_id,

--- a/tests/test_audit_api.py
+++ b/tests/test_audit_api.py
@@ -19,6 +19,8 @@ class FakeAuditDB:
         if "from deltallm_auditpayload" in normalized:
             return [{"payload_id": "pl-1", "event_id": "evt-1", "kind": "request", "content_json": {"foo": "bar"}}]
         if "limit 1" in normalized and "from deltallm_auditevent" in normalized:
+            if params[-1] == "missing":
+                return []
             return [{"event_id": "evt-1", "action": "AUTH_INTERNAL_LOGIN", "organization_id": "org-1"}]
         if "from deltallm_auditevent" in normalized:
             return [
@@ -67,11 +69,29 @@ async def test_audit_event_detail_includes_payloads(client, test_app):
     assert payload["event_id"] == "evt-1"
     assert payload["payloads"][0]["payload_id"] == "pl-1"
     event_query, event_params = fake_db.calls[0]
-    assert "event_id = $1::uuid" in event_query or "event_id = $2::uuid" in event_query
+    assert "event_id::text" in event_query
+    assert "::uuid" not in event_query
     assert event_params[-1] == "evt-1"
     payload_query, payload_params = fake_db.calls[1]
-    assert "where event_id = $1::uuid" in " ".join(payload_query.lower().split())
+    assert "where event_id::text = $1" in " ".join(payload_query.lower().split())
+    assert "::uuid" not in payload_query
     assert payload_params == ("evt-1",)
+
+
+@pytest.mark.asyncio
+async def test_audit_event_detail_missing_event_returns_404(client, test_app):
+    fake_db = FakeAuditDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.settings.master_key = "mk-test"
+
+    response = await client.get("/ui/api/audit/events/missing", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 404
+    assert len(fake_db.calls) == 1
+    event_query, event_params = fake_db.calls[0]
+    assert "event_id::text" in event_query
+    assert "::uuid" not in event_query
+    assert event_params[-1] == "missing"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #112.

This hotfix makes the audit event detail endpoint compatible with deployments whose audit ID columns are stored as `text` instead of PostgreSQL `uuid`.

## Root Cause

The audit list endpoint worked, but the detail endpoint used UUID-only raw SQL comparisons:

```sql
event_id = $1::uuid
```

In the live `bunyan-misc` deployment, `deltallm_auditevent.event_id` and `deltallm_auditpayload.event_id` are `text`, so Postgres raised:

```text
operator does not exist: text = uuid
```

## What Changed

- Compare audit event IDs through `event_id::text = $n` in the detail event lookup
- Compare payload event IDs through `event_id::text = $1` in the payload lookup
- Update audit API tests to prevent reintroducing `::uuid` in this detail path
- Add a 404 regression check for missing audit events

## Impact

Audit detail drawers should load again for existing text-backed deployments while remaining compatible with UUID-backed columns.

## Validation

- `uv run --extra dev python -m pytest tests/test_audit_api.py -q`
- `uv run --extra dev python -m pytest tests/test_audit_api.py tests/test_audit_api_authorization.py -q`
- `uv run --extra dev ruff check src/api/admin/endpoints/audit.py tests/test_audit_api.py`