### PR TITLE
Cut over batch status filter to enum contract

### DIFF
--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -150,7 +150,7 @@ async def list_batches(
 
     if status_filter and status_filter in BATCH_JOB_STATUS_SET:
         params.append(status_filter)
-        clauses.append(f"j.status::text = ${len(params)}")
+        clauses.append(f'j.status = ${len(params)}::"DeltaLLM_BatchJobStatus"')
 
     where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
 

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -239,6 +239,39 @@ async def test_batch_job_status_column_uses_final_enum_contract(batch_db) -> Non
 
 
 @pytest.mark.asyncio
+async def test_batch_job_status_enum_query_shape_works_against_real_postgres(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+    job = await repository.create_job(
+        endpoint="/v1/embeddings",
+        input_file_id=input_file_id,
+        model="m1",
+        metadata=None,
+        created_by_api_key="key-a",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_by_organization_id=None,
+        expires_at=None,
+        status="queued",
+    )
+
+    assert job is not None
+    await _assert_final_batch_job_status_contract(batch_db)
+
+    rows = await batch_db.query_raw(
+        """
+        SELECT batch_id, status
+        FROM deltallm_batch_job
+        WHERE status = $1::"DeltaLLM_BatchJobStatus"
+        """,
+        "queued",
+    )
+
+    assert [str(dict(row)["batch_id"]) for row in rows] == [job.batch_id]
+    assert [str(dict(row)["status"]) for row in rows] == ["queued"]
+
+
+@pytest.mark.asyncio
 async def test_batch_job_status_reconciliation_converts_text_backed_column(batch_db) -> None:
     repository = BatchRepository(batch_db)
     input_file_id = await _seed_batch_file(repository)

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -420,20 +420,22 @@ async def test_list_batches_exposes_repair_capabilities_for_updating_scope(clien
         ("in_progress", "batch-in-progress"),
     ],
 )
-async def test_list_batches_status_filter_uses_text_safe_query(client, test_app, monkeypatch, status_filter, expected_batch_id):
+async def test_list_batches_status_filter_uses_enum_query(client, test_app, monkeypatch, status_filter, expected_batch_id):
     class FilteredBatchDB(FakeAuthorizationDB):
         async def query_raw(self, query: str, *params):
             if 'COUNT(*) AS total FROM deltallm_batch_job j' in query:
-                if "j.status::text =" in query:
-                    assert '::"DeltaLLM_BatchJobStatus"' not in query
+                if 'j.status = $' in query:
+                    assert '::"DeltaLLM_BatchJobStatus"' in query
+                    assert "j.status::text =" not in query
                     return [{"total": 1 if status_filter in params else 0}]
                 return [{"total": len(self.batches)}]
             if "FROM deltallm_batch_job j" in query and "LEFT JOIN deltallm_teamtable t" in query:
                 if "WHERE j.batch_id = $1" in query:
                     row = self.batches.get(str(params[0]))
                     return [row] if row else []
-                if "j.status::text =" in query:
-                    assert '::"DeltaLLM_BatchJobStatus"' not in query
+                if 'j.status = $' in query:
+                    assert '::"DeltaLLM_BatchJobStatus"' in query
+                    assert "j.status::text =" not in query
                     return [{
                         **self.batches["batch-1"],
                         "batch_id": expected_batch_id,


### PR DESCRIPTION
## Summary
- switch the admin batch status filter to the final enum-native query shape
- update the route-level authorization test to assert the enum contract and removal of the temporary text-cast fallback
- add a real-Postgres integration test covering the final enum query shape against the reconciled schema

## Validation
- `uv run --extra dev python -m pytest tests/test_ui_authorization.py -k list_batches_status_filter`
- `uv run --extra dev ruff check src/api/admin/endpoints/batches.py tests/test_ui_authorization.py tests/test_batch_db_integration.py`
- `uv run --extra dev python -m pytest tests/test_batch_db_integration.py -k "batch_job_status_column_uses_final_enum_contract or batch_job_status_enum_query_shape_works_against_real_postgres"` (skipped in this shell because the DB-backed harness did not have a live `DATABASE_URL`)
