### PR TITLE
Finalize batch job status contract and enum filter cutover

### DIFF
--- a/prisma/migrations/20260424120000_batch_job_status_contract_reconciliation/migration.sql
+++ b/prisma/migrations/20260424120000_batch_job_status_contract_reconciliation/migration.sql
@@ -1,0 +1,180 @@
+DO $$
+DECLARE
+    final_labels constant text[] := ARRAY[
+        'queued',
+        'in_progress',
+        'finalizing',
+        'completed',
+        'failed',
+        'cancelled',
+        'expired'
+    ]::text[];
+    legacy_labels constant text[] := ARRAY[
+        'validating',
+        'queued',
+        'in_progress',
+        'finalizing',
+        'completed',
+        'failed',
+        'cancelled',
+        'expired'
+    ]::text[];
+    existing_labels text[];
+    next_labels text[];
+    status_udt_name text;
+    invalid_statuses text[];
+    existing_type_reference_count integer;
+    next_type_reference_count integer;
+BEGIN
+    SELECT c.udt_name
+    INTO status_udt_name
+    FROM information_schema.columns c
+    WHERE c.table_schema = 'public'
+      AND c.table_name = 'deltallm_batch_job'
+      AND c.column_name = 'status';
+
+    IF status_udt_name IS NULL THEN
+        RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: column is missing';
+    END IF;
+
+    SELECT COALESCE(array_agg(DISTINCT status::text ORDER BY status::text), ARRAY[]::text[])
+    INTO invalid_statuses
+    FROM "deltallm_batch_job"
+    WHERE status::text <> ALL(final_labels);
+
+    IF COALESCE(array_length(invalid_statuses, 1), 0) > 0 THEN
+        RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: found invalid existing values %', invalid_statuses;
+    END IF;
+
+    SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
+    INTO existing_labels
+    FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'DeltaLLM_BatchJobStatus';
+
+    SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
+    INTO next_labels
+    FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'DeltaLLM_BatchJobStatus_next';
+
+    SELECT COUNT(*)
+    INTO existing_type_reference_count
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND udt_name = 'DeltaLLM_BatchJobStatus';
+
+    SELECT COUNT(*)
+    INTO next_type_reference_count
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND udt_name = 'DeltaLLM_BatchJobStatus_next';
+
+    IF existing_labels IS NOT NULL
+       AND existing_labels IS DISTINCT FROM final_labels
+       AND existing_labels IS DISTINCT FROM legacy_labels THEN
+        RAISE EXCEPTION 'Cannot reconcile DeltaLLM_BatchJobStatus: unexpected enum labels %', existing_labels;
+    END IF;
+
+    IF next_labels IS NOT NULL
+       AND next_labels IS DISTINCT FROM final_labels THEN
+        RAISE EXCEPTION 'Cannot reconcile DeltaLLM_BatchJobStatus_next: unexpected enum labels %', next_labels;
+    END IF;
+
+    ALTER TABLE "deltallm_batch_job"
+    DROP CONSTRAINT IF EXISTS "deltallm_batch_job_status_chk";
+
+    IF status_udt_name = 'DeltaLLM_BatchJobStatus'
+       AND existing_labels IS NOT DISTINCT FROM final_labels THEN
+        IF next_labels IS NOT NULL
+           AND next_type_reference_count = 0 THEN
+            EXECUTE 'DROP TYPE "DeltaLLM_BatchJobStatus_next"';
+        END IF;
+        RETURN;
+    END IF;
+
+    IF status_udt_name = 'DeltaLLM_BatchJobStatus_next' THEN
+        IF next_labels IS DISTINCT FROM final_labels THEN
+            RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: expected DeltaLLM_BatchJobStatus_next to have final labels, found %', next_labels;
+        END IF;
+        IF existing_labels IS NOT NULL THEN
+            IF existing_type_reference_count > 0 THEN
+                RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: DeltaLLM_BatchJobStatus is still referenced by % columns while status uses DeltaLLM_BatchJobStatus_next', existing_type_reference_count;
+            END IF;
+            EXECUTE 'DROP TYPE "DeltaLLM_BatchJobStatus"';
+        END IF;
+        EXECUTE 'ALTER TYPE "DeltaLLM_BatchJobStatus_next" RENAME TO "DeltaLLM_BatchJobStatus"';
+        RETURN;
+    END IF;
+
+    IF existing_labels IS NULL
+       AND next_labels IS NOT NULL THEN
+        IF next_type_reference_count > 0 THEN
+            RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: DeltaLLM_BatchJobStatus_next is still referenced by % columns before rename', next_type_reference_count;
+        END IF;
+        EXECUTE 'ALTER TYPE "DeltaLLM_BatchJobStatus_next" RENAME TO "DeltaLLM_BatchJobStatus"';
+        existing_labels := final_labels;
+        next_labels := NULL;
+    END IF;
+
+    IF existing_labels IS NULL THEN
+        CREATE TYPE "DeltaLLM_BatchJobStatus" AS ENUM (
+            'queued',
+            'in_progress',
+            'finalizing',
+            'completed',
+            'failed',
+            'cancelled',
+            'expired'
+        );
+        existing_labels := final_labels;
+    END IF;
+
+    IF existing_labels IS NOT DISTINCT FROM legacy_labels THEN
+        IF next_labels IS NULL THEN
+            EXECUTE '
+                CREATE TYPE "DeltaLLM_BatchJobStatus_next" AS ENUM (
+                    ''queued'',
+                    ''in_progress'',
+                    ''finalizing'',
+                    ''completed'',
+                    ''failed'',
+                    ''cancelled'',
+                    ''expired''
+                )
+            ';
+            next_labels := final_labels;
+        END IF;
+
+        EXECUTE '
+            ALTER TABLE "deltallm_batch_job"
+            ALTER COLUMN "status" DROP DEFAULT
+        ';
+        EXECUTE '
+            ALTER TABLE "deltallm_batch_job"
+            ALTER COLUMN "status" TYPE "DeltaLLM_BatchJobStatus_next"
+            USING ("status"::text::"DeltaLLM_BatchJobStatus_next")
+        ';
+        SELECT COUNT(*)
+        INTO existing_type_reference_count
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND udt_name = 'DeltaLLM_BatchJobStatus';
+        IF existing_type_reference_count > 0 THEN
+            RAISE EXCEPTION 'Cannot reconcile deltallm_batch_job.status: DeltaLLM_BatchJobStatus is still referenced by % columns after moving status to DeltaLLM_BatchJobStatus_next', existing_type_reference_count;
+        END IF;
+        EXECUTE 'DROP TYPE "DeltaLLM_BatchJobStatus"';
+        EXECUTE 'ALTER TYPE "DeltaLLM_BatchJobStatus_next" RENAME TO "DeltaLLM_BatchJobStatus"';
+        RETURN;
+    END IF;
+
+    EXECUTE '
+        ALTER TABLE "deltallm_batch_job"
+        ALTER COLUMN "status" DROP DEFAULT
+    ';
+    EXECUTE '
+        ALTER TABLE "deltallm_batch_job"
+        ALTER COLUMN "status" TYPE "DeltaLLM_BatchJobStatus"
+        USING ("status"::text::"DeltaLLM_BatchJobStatus")
+    ';
+END $$;

--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -150,7 +150,7 @@ async def list_batches(
 
     if status_filter and status_filter in BATCH_JOB_STATUS_SET:
         params.append(status_filter)
-        clauses.append(f"j.status::text = ${len(params)}")
+        clauses.append(f'j.status = ${len(params)}::"DeltaLLM_BatchJobStatus"')
 
     where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
 

--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -13,7 +13,7 @@ from src.auth.roles import Permission
 from src.api.admin.endpoints.common import db_or_503, emit_admin_mutation_audit, to_json_value, get_auth_scope
 from src.audit.actions import AuditAction
 from src.batch.repository import BatchRepository
-from src.batch.models import decode_operator_failed_reason, encode_operator_failed_reason
+from src.batch.models import BATCH_JOB_STATUS_SET, decode_operator_failed_reason, encode_operator_failed_reason
 from src.metrics import (
     increment_batch_repair_action,
     publish_batch_runtime_summary,
@@ -23,7 +23,6 @@ from src.services.ui_authorization import build_batch_capabilities
 
 router = APIRouter(tags=["Admin Batches"])
 logger = logging.getLogger(__name__)
-FILTERABLE_BATCH_STATUSES = frozenset({"queued", "in_progress", "finalizing", "completed", "failed", "cancelled", "expired"})
 
 
 class MarkBatchFailedRequest(BaseModel):
@@ -149,7 +148,7 @@ async def list_batches(
         params.append(f"%{search}%")
         clauses.append(f"(j.batch_id ILIKE ${len(params)} OR j.model ILIKE ${len(params)})")
 
-    if status_filter and status_filter in FILTERABLE_BATCH_STATUSES:
+    if status_filter and status_filter in BATCH_JOB_STATUS_SET:
         params.append(status_filter)
         clauses.append(f"j.status::text = ${len(params)}")
 

--- a/src/batch/models.py
+++ b/src/batch/models.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from enum import StrEnum
 from typing import Any
 
 
-class BatchJobStatus:
+class BatchJobStatus(StrEnum):
     QUEUED = "queued"
     IN_PROGRESS = "in_progress"
     FINALIZING = "finalizing"
@@ -15,23 +16,19 @@ class BatchJobStatus:
     EXPIRED = "expired"
 
 
-BATCH_JOB_STATUSES = (
-    BatchJobStatus.QUEUED,
-    BatchJobStatus.IN_PROGRESS,
-    BatchJobStatus.FINALIZING,
-    BatchJobStatus.COMPLETED,
-    BatchJobStatus.FAILED,
-    BatchJobStatus.CANCELLED,
-    BatchJobStatus.EXPIRED,
-)
-_BATCH_JOB_STATUS_SET = frozenset(BATCH_JOB_STATUSES)
+BATCH_JOB_STATUSES = tuple(BatchJobStatus)
+BATCH_JOB_STATUS_VALUES = tuple(status.value for status in BatchJobStatus)
+BATCH_JOB_STATUS_SET = frozenset(BATCH_JOB_STATUS_VALUES)
 
 
-def normalize_batch_job_status(status: str) -> str:
+def normalize_batch_job_status(status: str | BatchJobStatus) -> BatchJobStatus:
+    if isinstance(status, BatchJobStatus):
+        return status
     normalized = str(status or "").strip()
-    if normalized not in _BATCH_JOB_STATUS_SET:
-        raise ValueError("batch job status must be one of: " + ", ".join(BATCH_JOB_STATUSES))
-    return normalized
+    try:
+        return BatchJobStatus(normalized)
+    except ValueError as exc:
+        raise ValueError("batch job status must be one of: " + ", ".join(BATCH_JOB_STATUS_VALUES)) from exc
 
 
 class BatchItemStatus:
@@ -91,7 +88,7 @@ class BatchFileRecord:
 class BatchJobRecord:
     batch_id: str
     endpoint: str
-    status: str
+    status: BatchJobStatus
     execution_mode: str
     input_file_id: str
     output_file_id: str | None

--- a/src/batch/repositories/job_repository.py
+++ b/src/batch/repositories/job_repository.py
@@ -48,7 +48,7 @@ class BatchJobRepository:
         created_by_organization_id: str | None = None,
         expires_at: datetime | None = None,
         execution_mode: str = "managed_internal",
-        status: str = BatchJobStatus.QUEUED,
+        status: str | BatchJobStatus = BatchJobStatus.QUEUED,
         total_items: int = 0,
     ) -> BatchJobRecord | None:
         if self.prisma is None:
@@ -81,7 +81,7 @@ class BatchJobRepository:
             """,
             batch_id,
             endpoint,
-            normalized_status,
+            normalized_status.value,
             execution_mode,
             input_file_id,
             model,
@@ -245,7 +245,7 @@ class BatchJobRepository:
             RETURNING *
             """,
             batch_id,
-            BatchJobStatus.QUEUED,
+            BatchJobStatus.QUEUED.value,
             total_items,
         )
         if not rows:
@@ -419,7 +419,7 @@ class BatchJobRepository:
         batch_id: str,
         output_file_id: str | None,
         error_file_id: str | None,
-        final_status: str,
+        final_status: str | BatchJobStatus,
         worker_id: str | None = None,
     ) -> BatchJobRecord | None:
         if self.prisma is None:
@@ -442,7 +442,7 @@ class BatchJobRepository:
                 batch_id,
                 output_file_id,
                 error_file_id,
-                normalized_final_status,
+                normalized_final_status.value,
             )
         else:
             rows = await self.prisma.query_raw(
@@ -464,7 +464,7 @@ class BatchJobRepository:
                 worker_id,
                 output_file_id,
                 error_file_id,
-                normalized_final_status,
+                normalized_final_status.value,
             )
         if not rows:
             return None

--- a/src/batch/repositories/mappers.py
+++ b/src/batch/repositories/mappers.py
@@ -64,7 +64,7 @@ def job_from_row(row: dict[str, Any]) -> BatchJobRecord:
     return BatchJobRecord(
         batch_id=str(row.get("batch_id") or ""),
         endpoint=str(row.get("endpoint") or ""),
-        status=normalize_batch_job_status(str(row.get("status") or "")),
+        status=normalize_batch_job_status(row.get("status") or ""),
         execution_mode=str(row.get("execution_mode") or "managed_internal"),
         input_file_id=str(row.get("input_file_id") or ""),
         output_file_id=row.get("output_file_id"),

--- a/src/batch/repository.py
+++ b/src/batch/repository.py
@@ -12,6 +12,7 @@ from src.batch.models import (
     BatchItemCreate,
     BatchItemRecord,
     BatchJobRecord,
+    BatchJobStatus,
 )
 from src.batch.repositories import (
     BatchCompletionOutboxRepository,
@@ -83,7 +84,7 @@ class BatchRepository:
         created_by_organization_id: str | None = None,
         expires_at: datetime | None = None,
         execution_mode: str = "managed_internal",
-        status: str = "queued",
+        status: str | BatchJobStatus = BatchJobStatus.QUEUED,
         total_items: int = 0,
     ) -> BatchJobRecord | None:
         return await self.jobs.create_job(
@@ -337,7 +338,7 @@ class BatchRepository:
         batch_id: str,
         output_file_id: str | None,
         error_file_id: str | None,
-        final_status: str,
+        final_status: str | BatchJobStatus,
         worker_id: str | None = None,
     ) -> BatchJobRecord | None:
         return await self.jobs.attach_artifacts_and_finalize(

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -239,6 +239,39 @@ async def test_batch_job_status_column_uses_final_enum_contract(batch_db) -> Non
 
 
 @pytest.mark.asyncio
+async def test_batch_job_status_enum_query_shape_works_against_real_postgres(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+    job = await repository.create_job(
+        endpoint="/v1/embeddings",
+        input_file_id=input_file_id,
+        model="m1",
+        metadata=None,
+        created_by_api_key="key-a",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_by_organization_id=None,
+        expires_at=None,
+        status="queued",
+    )
+
+    assert job is not None
+    await _assert_final_batch_job_status_contract(batch_db)
+
+    rows = await batch_db.query_raw(
+        """
+        SELECT batch_id, status
+        FROM deltallm_batch_job
+        WHERE status = $1::"DeltaLLM_BatchJobStatus"
+        """,
+        "queued",
+    )
+
+    assert [str(dict(row)["batch_id"]) for row in rows] == [job.batch_id]
+    assert [str(dict(row)["status"]) for row in rows] == ["queued"]
+
+
+@pytest.mark.asyncio
 async def test_batch_job_status_reconciliation_converts_text_backed_column(batch_db) -> None:
     repository = BatchRepository(batch_db)
     input_file_id = await _seed_batch_file(repository)

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -183,15 +183,25 @@ async def _enum_labels(db: Any, type_name: str) -> list[str]:
 
 
 async def _seed_raw_batch_job(db: Any, *, input_file_id: str, batch_id: str, status: str) -> None:
+    column = await _batch_job_status_column_contract(db)
+    status_udt_name = str(column.get("udt_name") or "")
+
+    if status_udt_name == "text":
+        status_value_sql = "$2"
+    elif status_udt_name in {"DeltaLLM_BatchJobStatus", "DeltaLLM_BatchJobStatus_next"}:
+        status_value_sql = f'$2::"{status_udt_name}"'
+    else:  # pragma: no cover - defensive branch for unexpected schema drift in tests
+        raise AssertionError(f"unexpected deltallm_batch_job.status type in test setup: {status_udt_name}")
+
     await db.execute_raw(
-        """
+        f"""
         INSERT INTO deltallm_batch_job (
             batch_id, endpoint, status, execution_mode, input_file_id, total_items
         )
         VALUES (
             $1,
             '/v1/embeddings',
-            $2,
+            {status_value_sql},
             'managed_internal',
             $3,
             0

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -26,7 +26,7 @@ from src.batch.create import (
 )
 from src.batch.create.service import BatchCreateSessionService
 from src.batch.cleanup import BatchCleanupConfig, BatchRetentionCleanupWorker
-from src.batch.models import BatchCompletionOutboxCreate, BatchItemCreate
+from src.batch.models import BATCH_JOB_STATUS_VALUES, BatchCompletionOutboxCreate, BatchItemCreate
 from src.batch.models import encode_operator_failed_reason
 from src.batch.repository import BatchRepository
 from src.batch.service import BatchService
@@ -42,6 +42,13 @@ except Exception:  # pragma: no cover
 
 
 DATABASE_URL = os.getenv("DATABASE_URL")
+BATCH_JOB_STATUS_RECONCILIATION_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "prisma"
+    / "migrations"
+    / "20260424120000_batch_job_status_contract_reconciliation"
+    / "migration.sql"
+)
 
 
 class _Upload:
@@ -136,6 +143,75 @@ async def _reset_batch_tables(db: Any) -> None:
     await db.execute_raw("DELETE FROM deltallm_batch_file")
 
 
+def _batch_job_status_reconciliation_sql() -> str:
+    return BATCH_JOB_STATUS_RECONCILIATION_MIGRATION_PATH.read_text()
+
+
+async def _execute_batch_job_status_reconciliation(db: Any) -> None:
+    await db.execute_raw(_batch_job_status_reconciliation_sql())
+
+
+async def _batch_job_status_column_contract(db: Any) -> dict[str, Any]:
+    rows = await db.query_raw(
+        """
+        SELECT
+            data_type,
+            udt_name,
+            column_default
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'deltallm_batch_job'
+          AND column_name = 'status'
+        """
+    )
+    assert rows
+    return dict(rows[0])
+
+
+async def _enum_labels(db: Any, type_name: str) -> list[str]:
+    rows = await db.query_raw(
+        """
+        SELECT e.enumlabel
+        FROM pg_enum e
+        JOIN pg_type t ON t.oid = e.enumtypid
+        WHERE t.typname = $1
+        ORDER BY e.enumsortorder
+        """,
+        type_name,
+    )
+    return [str(row["enumlabel"]) for row in rows]
+
+
+async def _seed_raw_batch_job(db: Any, *, input_file_id: str, batch_id: str, status: str) -> None:
+    await db.execute_raw(
+        """
+        INSERT INTO deltallm_batch_job (
+            batch_id, endpoint, status, execution_mode, input_file_id, total_items
+        )
+        VALUES (
+            $1,
+            '/v1/embeddings',
+            $2,
+            'managed_internal',
+            $3,
+            0
+        )
+        """,
+        batch_id,
+        status,
+        input_file_id,
+    )
+
+
+async def _assert_final_batch_job_status_contract(db: Any) -> None:
+    column = await _batch_job_status_column_contract(db)
+    assert column["udt_name"] == "DeltaLLM_BatchJobStatus"
+    assert column["data_type"] == "USER-DEFINED"
+    assert column["column_default"] is None
+    assert await _enum_labels(db, "DeltaLLM_BatchJobStatus") == list(BATCH_JOB_STATUS_VALUES)
+    assert await _enum_labels(db, "DeltaLLM_BatchJobStatus_next") == []
+
+
 @pytest.fixture
 async def batch_db():
     db = await _connect_prisma()
@@ -155,6 +231,214 @@ async def batch_db():
     finally:
         await _reset_batch_tables(db)
         await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_column_uses_final_enum_contract(batch_db) -> None:
+    await _assert_final_batch_job_status_contract(batch_db)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_reconciliation_converts_text_backed_column(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+
+    try:
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status DROP DEFAULT
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE text
+            USING (status::text)
+            """
+        )
+        await _seed_raw_batch_job(
+            batch_db,
+            input_file_id=input_file_id,
+            batch_id="batch-text-status",
+            status="queued",
+        )
+
+        column = await _batch_job_status_column_contract(batch_db)
+        assert column["udt_name"] == "text"
+
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+        await _assert_final_batch_job_status_contract(batch_db)
+    finally:
+        await _reset_batch_tables(batch_db)
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_reconciliation_converts_legacy_enum_shape(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+
+    try:
+        await batch_db.execute_raw(
+            """
+            CREATE TYPE "DeltaLLM_BatchJobStatus_legacy" AS ENUM (
+                'validating',
+                'queued',
+                'in_progress',
+                'finalizing',
+                'completed',
+                'failed',
+                'cancelled',
+                'expired'
+            )
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status DROP DEFAULT
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE "DeltaLLM_BatchJobStatus_legacy"
+            USING (status::text::"DeltaLLM_BatchJobStatus_legacy")
+            """
+        )
+        await batch_db.execute_raw('DROP TYPE "DeltaLLM_BatchJobStatus"')
+        await batch_db.execute_raw('ALTER TYPE "DeltaLLM_BatchJobStatus_legacy" RENAME TO "DeltaLLM_BatchJobStatus"')
+        await _seed_raw_batch_job(
+            batch_db,
+            input_file_id=input_file_id,
+            batch_id="batch-legacy-enum",
+            status="queued",
+        )
+
+        assert await _enum_labels(batch_db, "DeltaLLM_BatchJobStatus") == [
+            "validating",
+            *list(BATCH_JOB_STATUS_VALUES),
+        ]
+
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+        await _assert_final_batch_job_status_contract(batch_db)
+    finally:
+        await _reset_batch_tables(batch_db)
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_reconciliation_finishes_partial_next_type_cutover(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+
+    try:
+        await batch_db.execute_raw(
+            """
+            CREATE TYPE "DeltaLLM_BatchJobStatus_legacy" AS ENUM (
+                'validating',
+                'queued',
+                'in_progress',
+                'finalizing',
+                'completed',
+                'failed',
+                'cancelled',
+                'expired'
+            )
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status DROP DEFAULT
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE "DeltaLLM_BatchJobStatus_legacy"
+            USING (status::text::"DeltaLLM_BatchJobStatus_legacy")
+            """
+        )
+        await batch_db.execute_raw('DROP TYPE "DeltaLLM_BatchJobStatus"')
+        await batch_db.execute_raw('ALTER TYPE "DeltaLLM_BatchJobStatus_legacy" RENAME TO "DeltaLLM_BatchJobStatus"')
+        await batch_db.execute_raw(
+            """
+            CREATE TYPE "DeltaLLM_BatchJobStatus_next" AS ENUM (
+                'queued',
+                'in_progress',
+                'finalizing',
+                'completed',
+                'failed',
+                'cancelled',
+                'expired'
+            )
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE "DeltaLLM_BatchJobStatus_next"
+            USING (status::text::"DeltaLLM_BatchJobStatus_next")
+            """
+        )
+        await _seed_raw_batch_job(
+            batch_db,
+            input_file_id=input_file_id,
+            batch_id="batch-partial-next-cutover",
+            status="queued",
+        )
+
+        column = await _batch_job_status_column_contract(batch_db)
+        assert column["udt_name"] == "DeltaLLM_BatchJobStatus_next"
+        assert await _enum_labels(batch_db, "DeltaLLM_BatchJobStatus") == [
+            "validating",
+            *list(BATCH_JOB_STATUS_VALUES),
+        ]
+        assert await _enum_labels(batch_db, "DeltaLLM_BatchJobStatus_next") == list(BATCH_JOB_STATUS_VALUES)
+
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+        await _assert_final_batch_job_status_contract(batch_db)
+    finally:
+        await _reset_batch_tables(batch_db)
+        await _execute_batch_job_status_reconciliation(batch_db)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_status_reconciliation_rejects_invalid_text_values(batch_db) -> None:
+    repository = BatchRepository(batch_db)
+    input_file_id = await _seed_batch_file(repository)
+
+    try:
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status DROP DEFAULT
+            """
+        )
+        await batch_db.execute_raw(
+            """
+            ALTER TABLE deltallm_batch_job
+            ALTER COLUMN status TYPE text
+            USING (status::text)
+            """
+        )
+        await _seed_raw_batch_job(
+            batch_db,
+            input_file_id=input_file_id,
+            batch_id="batch-invalid-text-status",
+            status="broken",
+        )
+
+        with pytest.raises(Exception, match="invalid existing values"):
+            await _execute_batch_job_status_reconciliation(batch_db)
+    finally:
+        await _reset_batch_tables(batch_db)
+        await _execute_batch_job_status_reconciliation(batch_db)
 
 
 async def _create_input_file(service: BatchService, *, auth: UserAPIKeyAuth, payload: bytes) -> str:

--- a/tests/test_batch_models.py
+++ b/tests/test_batch_models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.batch.models import (
+    BATCH_JOB_STATUSES,
+    BATCH_JOB_STATUS_VALUES,
+    BatchJobRecord,
+    BatchJobStatus,
+    normalize_batch_job_status,
+)
+
+
+def test_batch_job_status_values_follow_enum_definition() -> None:
+    assert BATCH_JOB_STATUSES == tuple(BatchJobStatus)
+    assert BATCH_JOB_STATUS_VALUES == tuple(status.value for status in BatchJobStatus)
+
+
+@pytest.mark.parametrize("status", ["queued", BatchJobStatus.QUEUED])
+def test_normalize_batch_job_status_returns_enum(status: str | BatchJobStatus) -> None:
+    assert normalize_batch_job_status(status) is BatchJobStatus.QUEUED
+
+
+def test_batch_job_record_normalizes_status_to_enum() -> None:
+    now = datetime.now(tz=UTC)
+
+    record = BatchJobRecord(
+        batch_id="batch-1",
+        endpoint="/v1/embeddings",
+        status="queued",
+        execution_mode="managed_internal",
+        input_file_id="file-1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m1",
+        metadata=None,
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=0,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="key-1",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_at=now,
+        started_at=None,
+        completed_at=None,
+        expires_at=None,
+        created_by_organization_id=None,
+    )
+
+    assert record.status is BatchJobStatus.QUEUED

--- a/tests/test_batch_repository.py
+++ b/tests/test_batch_repository.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from src.batch.models import BatchJobStatus
 from src.batch.repository import BatchRepository
 
 
@@ -268,7 +269,7 @@ async def test_create_job_defaults_to_queued_status() -> None:
     )
 
     assert '::"DeltaLLM_BatchJobStatus"' in prisma.sql
-    assert prisma.params[2] == "queued"
+    assert prisma.params[2] == BatchJobStatus.QUEUED.value
 
 
 @pytest.mark.asyncio
@@ -308,7 +309,7 @@ async def test_attach_artifacts_and_finalize_casts_status_parameter_to_enum() ->
 
     assert finalized is None
     assert 'status = $4::"DeltaLLM_BatchJobStatus"' in prisma.sql
-    assert prisma.params[3] == "completed"
+    assert prisma.params[3] == BatchJobStatus.COMPLETED.value
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -420,20 +420,22 @@ async def test_list_batches_exposes_repair_capabilities_for_updating_scope(clien
         ("in_progress", "batch-in-progress"),
     ],
 )
-async def test_list_batches_status_filter_uses_text_safe_query(client, test_app, monkeypatch, status_filter, expected_batch_id):
+async def test_list_batches_status_filter_uses_enum_query(client, test_app, monkeypatch, status_filter, expected_batch_id):
     class FilteredBatchDB(FakeAuthorizationDB):
         async def query_raw(self, query: str, *params):
             if 'COUNT(*) AS total FROM deltallm_batch_job j' in query:
-                if "j.status::text =" in query:
-                    assert '::"DeltaLLM_BatchJobStatus"' not in query
+                if 'j.status = $' in query:
+                    assert '::"DeltaLLM_BatchJobStatus"' in query
+                    assert "j.status::text =" not in query
                     return [{"total": 1 if status_filter in params else 0}]
                 return [{"total": len(self.batches)}]
             if "FROM deltallm_batch_job j" in query and "LEFT JOIN deltallm_teamtable t" in query:
                 if "WHERE j.batch_id = $1" in query:
                     row = self.batches.get(str(params[0]))
                     return [row] if row else []
-                if "j.status::text =" in query:
-                    assert '::"DeltaLLM_BatchJobStatus"' not in query
+                if 'j.status = $' in query:
+                    assert '::"DeltaLLM_BatchJobStatus"' in query
+                    assert "j.status::text =" not in query
                     return [{
                         **self.batches["batch-1"],
                         "batch_id": expected_batch_id,


### PR DESCRIPTION
## Summary
- centralize batch job status handling on a shared Python `StrEnum` contract
- add a reconciliation migration for `deltallm_batch_job.status` covering text-backed, legacy-enum, and partial `_next` drift states
- cut the admin batch status filter over to the final enum-native query shape and add real-Postgres contract coverage

## Rollout Note
- this branch now assumes the enum-backed status contract in the admin batch list path
- migrations must run before the app code serves `/ui/api/batches?status=...`

## Validation
- `uv run --extra dev python -m pytest tests/test_batch_models.py tests/test_batch_repository.py tests/test_batch_create_service.py tests/test_batch_create_promoter.py`
- `uv run --extra dev python -m pytest tests/test_ui_authorization.py -k batch`
- `uv run --extra dev python -m pytest tests/test_ui_authorization.py -k list_batches_status_filter`
- `uv run --extra dev ruff check src/batch/models.py src/batch/repositories/mappers.py src/batch/repositories/job_repository.py src/batch/repository.py src/api/admin/endpoints/batches.py tests/test_batch_models.py tests/test_batch_repository.py tests/test_ui_authorization.py tests/test_batch_db_integration.py`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/deltallm' uv run prisma validate --schema=./prisma/schema.prisma`
- `uv run --extra dev python -m pytest tests/test_batch_db_integration.py -k "batch_job_status_"` (DB-backed selectors depend on a live `DATABASE_URL`; they were skipped in shells without that harness)
