### PR TITLE
PR1: Add batch retry classifier and no-healthy error contract

### DIFF
--- a/src/batch/retry.py
+++ b/src/batch/retry.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+import httpx
+
+from src.models.errors import (
+    BudgetExceededError,
+    InvalidRequestError,
+    ModelNotFoundError,
+    NO_HEALTHY_DEPLOYMENTS_CODE,
+    PermissionDeniedError,
+    RateLimitError,
+    ServiceUnavailableError,
+    TimeoutError,
+    parse_retry_after_header,
+)
+
+_NO_HEALTHY_DEPLOYMENTS_MARKER = "no healthy deployments available"
+
+
+class BatchResponseShapeError(ValueError):
+    """Raised when an upstream microbatch response violates the expected contract."""
+
+
+class BatchRetryCategory(StrEnum):
+    RATE_LIMIT = "rate_limit"
+    TIMEOUT = "timeout"
+    TRANSPORT = "transport"
+    UPSTREAM_5XX = "upstream_5xx"
+    SERVICE_UNAVAILABLE = "service_unavailable"
+    NO_HEALTHY_DEPLOYMENTS = "no_healthy_deployments"
+    INVALID_REQUEST = "invalid_request"
+    RESPONSE_SHAPE = "response_shape"
+    BUDGET = "budget"
+    MISSING_MODEL = "missing_model"
+    PERMISSION = "permission"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class BatchRetryDecision:
+    retryable: bool
+    category: BatchRetryCategory
+    retry_after_seconds: int | None = None
+    terminal_reason: str | None = None
+
+
+def classify_batch_retry(exc: Exception) -> BatchRetryDecision:
+    if isinstance(exc, RateLimitError):
+        return BatchRetryDecision(
+            retryable=True,
+            category=BatchRetryCategory.RATE_LIMIT,
+            retry_after_seconds=_proxy_retry_after(exc),
+        )
+
+    if isinstance(exc, (httpx.TimeoutException, TimeoutError)):
+        return BatchRetryDecision(retryable=True, category=BatchRetryCategory.TIMEOUT)
+
+    if isinstance(exc, httpx.TransportError):
+        return BatchRetryDecision(retryable=True, category=BatchRetryCategory.TRANSPORT)
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        return _classify_http_status_error(exc)
+
+    if isinstance(exc, ServiceUnavailableError):
+        if getattr(exc, "code", None) == NO_HEALTHY_DEPLOYMENTS_CODE:
+            return BatchRetryDecision(retryable=True, category=BatchRetryCategory.NO_HEALTHY_DEPLOYMENTS)
+        return BatchRetryDecision(retryable=True, category=BatchRetryCategory.SERVICE_UNAVAILABLE)
+
+    if isinstance(exc, BudgetExceededError):
+        return BatchRetryDecision(
+            retryable=False,
+            category=BatchRetryCategory.BUDGET,
+            terminal_reason="not_retryable",
+        )
+
+    if isinstance(exc, InvalidRequestError):
+        return BatchRetryDecision(
+            retryable=False,
+            category=BatchRetryCategory.INVALID_REQUEST,
+            terminal_reason="not_retryable",
+        )
+
+    if isinstance(exc, PermissionDeniedError):
+        return BatchRetryDecision(
+            retryable=False,
+            category=BatchRetryCategory.PERMISSION,
+            terminal_reason="not_retryable",
+        )
+
+    if isinstance(exc, ModelNotFoundError):
+        if _has_no_healthy_deployments_message(exc):
+            return BatchRetryDecision(retryable=True, category=BatchRetryCategory.NO_HEALTHY_DEPLOYMENTS)
+        return BatchRetryDecision(
+            retryable=False,
+            category=BatchRetryCategory.MISSING_MODEL,
+            terminal_reason="not_retryable",
+        )
+
+    if isinstance(exc, BatchResponseShapeError):
+        return BatchRetryDecision(
+            retryable=False,
+            category=BatchRetryCategory.RESPONSE_SHAPE,
+            terminal_reason="not_retryable",
+        )
+
+    return BatchRetryDecision(
+        retryable=False,
+        category=BatchRetryCategory.UNKNOWN,
+        terminal_reason="not_retryable",
+    )
+
+
+def _classify_http_status_error(exc: httpx.HTTPStatusError) -> BatchRetryDecision:
+    status_code = exc.response.status_code
+    retry_after_seconds = parse_retry_after_header(exc.response.headers.get("Retry-After"))
+
+    if status_code == 429:
+        return BatchRetryDecision(
+            retryable=True,
+            category=BatchRetryCategory.RATE_LIMIT,
+            retry_after_seconds=retry_after_seconds,
+        )
+    if status_code == 408:
+        return BatchRetryDecision(
+            retryable=True,
+            category=BatchRetryCategory.TIMEOUT,
+            retry_after_seconds=retry_after_seconds,
+        )
+    if status_code >= 500:
+        return BatchRetryDecision(
+            retryable=True,
+            category=BatchRetryCategory.UPSTREAM_5XX,
+            retry_after_seconds=retry_after_seconds,
+        )
+    return BatchRetryDecision(
+        retryable=False,
+        category=BatchRetryCategory.INVALID_REQUEST,
+        terminal_reason="not_retryable",
+    )
+
+
+def _proxy_retry_after(exc: RateLimitError) -> int | None:
+    retry_after = getattr(exc, "retry_after", None)
+    if retry_after is None:
+        return None
+    try:
+        return max(0, int(retry_after))
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _has_no_healthy_deployments_message(exc: Exception) -> bool:
+    return _NO_HEALTHY_DEPLOYMENTS_MARKER in str(exc).lower()

--- a/src/batch/worker_execution.py
+++ b/src/batch/worker_execution.py
@@ -10,8 +10,6 @@ import random
 from time import perf_counter
 from typing import Any, Awaitable, Callable
 
-import httpx
-
 from src.batch.embedding_microbatch import (
     allocate_embedding_usage,
     build_embedding_execution_signature,
@@ -19,6 +17,7 @@ from src.batch.embedding_microbatch import (
     estimate_embedding_microbatch_weight,
     resolve_effective_upstream_max_batch_inputs,
 )
+from src.batch.retry import BatchResponseShapeError, BatchRetryDecision, classify_batch_retry
 from src.batch.repository import BatchRepository
 from src.billing.cost import ModelPricing, completion_cost
 from src.metrics import (
@@ -29,13 +28,6 @@ from src.metrics import (
     observe_batch_microbatch_size,
     set_batch_worker_saturation,
 )
-from src.models.errors import (
-    ModelNotFoundError,
-    RateLimitError,
-    ServiceUnavailableError,
-    TimeoutError,
-    parse_retry_after_header,
-)
 from src.models.requests import EmbeddingRequest
 from src.providers.resolution import resolve_provider
 from src.routers.routing_decision import route_failover_kwargs
@@ -44,7 +36,6 @@ from src.batch.worker_types import _PreparedEmbeddingItem, _RequestShim, BatchWo
 
 logger = logging.getLogger(__name__)
 _COMPLETION_OUTBOX_MAX_ATTEMPTS = 5
-_NO_HEALTHY_DEPLOYMENTS_MARKER = "no healthy deployments available"
 
 
 class BatchExecutionEngine:
@@ -163,32 +154,32 @@ class BatchExecutionEngine:
     ) -> list[dict[str, Any]]:
         data_rows = response_body.get("data")
         if not isinstance(data_rows, list):
-            raise ValueError("microbatch response data is not a list")
+            raise BatchResponseShapeError("microbatch response data is not a list")
         if len(data_rows) != expected_count:
-            raise ValueError(
+            raise BatchResponseShapeError(
                 f"microbatch response length mismatch expected={expected_count} actual={len(data_rows)}"
             )
 
         normalized_rows: list[dict[str, Any] | None] = [None] * expected_count
         for row_number, row in enumerate(data_rows):
             if not isinstance(row, dict):
-                raise ValueError(f"microbatch response item {row_number} is not an object")
+                raise BatchResponseShapeError(f"microbatch response item {row_number} is not an object")
             if "embedding" not in row:
-                raise ValueError(f"microbatch response item {row_number} is missing embedding")
+                raise BatchResponseShapeError(f"microbatch response item {row_number} is missing embedding")
 
             response_index = row.get("index")
             if type(response_index) is not int:
-                raise ValueError(f"microbatch response item {row_number} has invalid index")
+                raise BatchResponseShapeError(f"microbatch response item {row_number} has invalid index")
             if response_index < 0 or response_index >= expected_count:
-                raise ValueError(
+                raise BatchResponseShapeError(
                     f"microbatch response item {row_number} index out of range index={response_index}"
                 )
             if normalized_rows[response_index] is not None:
-                raise ValueError(f"microbatch response contains duplicate index={response_index}")
+                raise BatchResponseShapeError(f"microbatch response contains duplicate index={response_index}")
             normalized_rows[response_index] = dict(row)
 
         if any(row is None for row in normalized_rows):
-            raise ValueError("microbatch response is missing one or more expected indexes")
+            raise BatchResponseShapeError("microbatch response is missing one or more expected indexes")
 
         return [row for row in normalized_rows if row is not None]
 
@@ -216,9 +207,10 @@ class BatchExecutionEngine:
         started_at_monotonic: float,
     ) -> None:
         batch_id = job.batch_id
-        retryable = self._is_retryable(exc) and item.attempts < self.config.max_attempts
+        retry_decision = classify_batch_retry(exc)
+        retryable = retry_decision.retryable and item.attempts < self.config.max_attempts
         error_payload = {"message": str(exc), "type": exc.__class__.__name__}
-        retry_delay = self._retry_delay_seconds(item_attempts=item.attempts, exc=exc) if retryable else 0
+        retry_delay = self._retry_delay_seconds(item_attempts=item.attempts, decision=retry_decision) if retryable else 0
         updated = await self.repository.mark_item_failed(
             item_id=item.item_id,
             worker_id=self.config.worker_id,
@@ -556,7 +548,7 @@ class BatchExecutionEngine:
                 exc=exc,
                 reference=",".join(item_ids),
             )
-            if isinstance(exc, ValueError):
+            if isinstance(exc, BatchResponseShapeError):
                 logger.warning(
                     "batch embedding microbatch response mismatch batch_id=%s deployment_id=%s size=%s error=%s",
                     batch_id,
@@ -1043,11 +1035,11 @@ class BatchExecutionEngine:
                     hook_exc,
                 )
 
-    def _retry_delay_seconds(self, *, item_attempts: int, exc: Exception) -> int:
+    def _retry_delay_seconds(self, *, item_attempts: int, decision: BatchRetryDecision) -> int:
         initial = max(1, int(self.config.retry_initial_seconds))
         max_delay = max(initial, int(self.config.retry_max_seconds))
         multiplier = max(1.0, float(self.config.retry_multiplier))
-        retry_after = self._retry_after_seconds(exc)
+        retry_after = decision.retry_after_seconds
         provider_delay = min(max_delay, retry_after) if retry_after is not None else None
 
         exponent = max(0, item_attempts - 1)
@@ -1058,27 +1050,3 @@ class BatchExecutionEngine:
 
         lower_bound = max(1, provider_delay or 0, ceil(target_delay / 2))
         return random.randint(lower_bound, target_delay)
-
-    def _retry_after_seconds(self, exc: Exception) -> int | None:
-        if isinstance(exc, RateLimitError):
-            retry_after = getattr(exc, "retry_after", None)
-            if retry_after is None:
-                return None
-            return max(0, int(retry_after))
-
-        if isinstance(exc, httpx.HTTPStatusError):
-            return parse_retry_after_header(exc.response.headers.get("Retry-After"))
-        return None
-
-    def _has_no_healthy_deployments_message(self, exc: Exception) -> bool:
-        return _NO_HEALTHY_DEPLOYMENTS_MARKER in str(exc).lower()
-
-    def _is_retryable(self, exc: Exception) -> bool:
-        if isinstance(exc, (httpx.TimeoutException, httpx.TransportError, TimeoutError, RateLimitError, ServiceUnavailableError)):
-            return True
-        if isinstance(exc, ModelNotFoundError):
-            return self._has_no_healthy_deployments_message(exc)
-        if isinstance(exc, httpx.HTTPStatusError):
-            status_code = exc.response.status_code
-            return status_code == 429 or status_code >= 500
-        return False

--- a/src/models/errors.py
+++ b/src/models/errors.py
@@ -5,6 +5,9 @@ from email.utils import parsedate_to_datetime
 from math import ceil
 
 
+NO_HEALTHY_DEPLOYMENTS_CODE = "no_healthy_deployments"
+
+
 def parse_retry_after_header(value: str | None) -> int | None:
     if value is None:
         return None

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -12,6 +12,7 @@ import httpx
 
 from src.models.errors import (
     InvalidRequestError,
+    NO_HEALTHY_DEPLOYMENTS_CODE,
     ProxyError,
     RateLimitError,
     ServiceUnavailableError,
@@ -431,7 +432,10 @@ class FailoverManager:
             raise last_error
         if last_error is not None:
             raise ServiceUnavailableError(message=f"All deployments exhausted: {last_error}")
-        raise ServiceUnavailableError(message="No healthy deployments available")
+        raise ServiceUnavailableError(
+            message="No healthy deployments available",
+            code=NO_HEALTHY_DEPLOYMENTS_CODE,
+        )
 
     def _get_classified_fallbacks(
         self,

--- a/src/router/router.py
+++ b/src/router/router.py
@@ -5,7 +5,7 @@ from enum import Enum
 import logging
 from typing import Any
 
-from src.models.errors import ModelNotFoundError
+from src.models.errors import ModelNotFoundError, NO_HEALTHY_DEPLOYMENTS_CODE, ServiceUnavailableError
 from src.router.state import DeploymentStateBackend
 from src.router.strategies import (
     CostBasedStrategy,
@@ -288,7 +288,12 @@ class Router:
 
     def require_deployment(self, model_group: str, deployment: Deployment | None) -> Deployment:
         if deployment is None:
-            raise ModelNotFoundError(message=f"No healthy deployments available for model '{model_group}'")
+            if self.deployment_registry.get(model_group):
+                raise ServiceUnavailableError(
+                    message=f"No healthy deployments available for model '{model_group}'",
+                    code=NO_HEALTHY_DEPLOYMENTS_CODE,
+                )
+            raise ModelNotFoundError(message=f"Model '{model_group}' is not configured", code="model_not_found")
         return deployment
 
 

--- a/tests/test_batch_retry.py
+++ b/tests/test_batch_retry.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.batch.retry import BatchResponseShapeError, BatchRetryCategory, classify_batch_retry
+from src.models.errors import (
+    BudgetExceededError,
+    InvalidRequestError,
+    ModelNotFoundError,
+    NO_HEALTHY_DEPLOYMENTS_CODE,
+    PermissionDeniedError,
+    RateLimitError,
+    ServiceUnavailableError,
+    TimeoutError,
+)
+
+
+def _http_status_error(status_code: int, *, retry_after: str | None = None) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://example.com/v1/embeddings")
+    headers = {"Retry-After": retry_after} if retry_after is not None else {}
+    response = httpx.Response(status_code, headers=headers, request=request)
+    return httpx.HTTPStatusError("upstream failed", request=request, response=response)
+
+
+@pytest.mark.parametrize(
+    ("exc", "category", "retryable", "retry_after"),
+    [
+        (RateLimitError(message="rate limited", retry_after=30), BatchRetryCategory.RATE_LIMIT, True, 30),
+        (_http_status_error(429, retry_after="17"), BatchRetryCategory.RATE_LIMIT, True, 17),
+        (_http_status_error(408), BatchRetryCategory.TIMEOUT, True, None),
+        (_http_status_error(500), BatchRetryCategory.UPSTREAM_5XX, True, None),
+        (_http_status_error(504), BatchRetryCategory.UPSTREAM_5XX, True, None),
+        (httpx.ReadTimeout("slow upstream"), BatchRetryCategory.TIMEOUT, True, None),
+        (httpx.ReadError("connection reset"), BatchRetryCategory.TRANSPORT, True, None),
+        (TimeoutError(message="request timeout"), BatchRetryCategory.TIMEOUT, True, None),
+        (ServiceUnavailableError(message="overloaded"), BatchRetryCategory.SERVICE_UNAVAILABLE, True, None),
+        (
+            ServiceUnavailableError(
+                message="No healthy deployments available for model 'text-embedding-3-small'",
+                code=NO_HEALTHY_DEPLOYMENTS_CODE,
+            ),
+            BatchRetryCategory.NO_HEALTHY_DEPLOYMENTS,
+            True,
+            None,
+        ),
+        (
+            ModelNotFoundError(message="No healthy deployments available for model 'text-embedding-3-small'"),
+            BatchRetryCategory.NO_HEALTHY_DEPLOYMENTS,
+            True,
+            None,
+        ),
+        (BudgetExceededError(message="Budget exceeded"), BatchRetryCategory.BUDGET, False, None),
+        (InvalidRequestError(message="bad request"), BatchRetryCategory.INVALID_REQUEST, False, None),
+        (PermissionDeniedError(message="forbidden"), BatchRetryCategory.PERMISSION, False, None),
+        (ModelNotFoundError(message="Model 'missing' is not configured"), BatchRetryCategory.MISSING_MODEL, False, None),
+        (BatchResponseShapeError("microbatch response length mismatch"), BatchRetryCategory.RESPONSE_SHAPE, False, None),
+        (RuntimeError("local bug"), BatchRetryCategory.UNKNOWN, False, None),
+    ],
+)
+def test_classify_batch_retry_matrix(
+    exc: Exception,
+    category: BatchRetryCategory,
+    retryable: bool,
+    retry_after: int | None,
+) -> None:
+    decision = classify_batch_retry(exc)
+
+    assert decision.category is category
+    assert decision.retryable is retryable
+    assert decision.retry_after_seconds == retry_after
+    if not retryable:
+        assert decision.terminal_reason == "not_retryable"
+
+
+def test_classify_batch_retry_treats_http_400_as_terminal_invalid_request() -> None:
+    decision = classify_batch_retry(_http_status_error(400))
+
+    assert decision.retryable is False
+    assert decision.category is BatchRetryCategory.INVALID_REQUEST
+    assert decision.terminal_reason == "not_retryable"
+
+
+def test_classify_batch_retry_does_not_treat_plain_value_error_as_response_shape() -> None:
+    decision = classify_batch_retry(ValueError("local request validation failed"))
+
+    assert decision.retryable is False
+    assert decision.category is BatchRetryCategory.UNKNOWN
+    assert decision.terminal_reason == "not_retryable"

--- a/tests/test_batch_worker_microbatch.py
+++ b/tests/test_batch_worker_microbatch.py
@@ -16,7 +16,13 @@ from src.batch.embedding_microbatch import (
 )
 from src.batch.models import BatchItemRecord, BatchJobRecord, BatchJobStatus
 from src.batch.worker import BatchExecutorWorker, BatchWorkerConfig
-from src.models.errors import BudgetExceededError, ModelNotFoundError, RateLimitError, ServiceUnavailableError
+from src.models.errors import (
+    BudgetExceededError,
+    ModelNotFoundError,
+    NO_HEALTHY_DEPLOYMENTS_CODE,
+    RateLimitError,
+    ServiceUnavailableError,
+)
 from src.models.requests import EmbeddingRequest
 
 
@@ -234,7 +240,10 @@ async def test_batch_retries_no_healthy_deployments_with_backoff(monkeypatch):
         job=_build_job(),
         item=item,
         model_name=item.request_body["model"],
-        exc=ModelNotFoundError(message="No healthy deployments available for model 'text-embedding-3-small'"),
+        exc=ServiceUnavailableError(
+            message="No healthy deployments available for model 'text-embedding-3-small'",
+            code=NO_HEALTHY_DEPLOYMENTS_CODE,
+        ),
         deployment_id=None,
         started_at_monotonic=0.0,
     )
@@ -245,7 +254,7 @@ async def test_batch_retries_no_healthy_deployments_with_backoff(monkeypatch):
             "worker_id": "w1",
             "error_body": {
                 "message": "No healthy deployments available for model 'text-embedding-3-small'",
-                "type": "ModelNotFoundError",
+                "type": "ServiceUnavailableError",
             },
             "last_error": "No healthy deployments available for model 'text-embedding-3-small'",
             "retryable": True,

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -7,7 +7,14 @@ from email.utils import format_datetime
 import httpx
 import pytest
 
-from src.models.errors import InvalidRequestError, RateLimitError, ServiceUnavailableError, TimeoutError, parse_retry_after_header
+from src.models.errors import (
+    InvalidRequestError,
+    NO_HEALTHY_DEPLOYMENTS_CODE,
+    RateLimitError,
+    ServiceUnavailableError,
+    TimeoutError,
+    parse_retry_after_header,
+)
 from src.router import CooldownManager, FallbackConfig, FailoverManager, PassiveHealthTracker, RedisStateBackend
 from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
@@ -301,6 +308,32 @@ async def test_failover_transport_error_maps_to_health_affecting_service_unavail
 
     assert exc_info.value.affects_deployment_health is True
     assert await state.is_cooled_down(primary.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_failover_returns_structured_no_healthy_deployments_error_when_all_candidates_cooled_down():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    await state.set_cooldown(primary.deployment_id, 30, "manual")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
+    )
+
+    async def run(_deployment: Deployment) -> str:
+        return "unreachable"
+
+    with pytest.raises(ServiceUnavailableError) as exc_info:
+        await manager.execute_with_failover(
+            primary_deployment=primary,
+            model_group="group-a",
+            execute=run,
+        )
+
+    assert exc_info.value.code == NO_HEALTHY_DEPLOYMENTS_CODE
+    assert exc_info.value.status_code == 503
 
 
 @pytest.mark.asyncio

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from src.models.errors import ServiceUnavailableError
+from src.models.errors import ModelNotFoundError, NO_HEALTHY_DEPLOYMENTS_CODE, ServiceUnavailableError
 import src.router.strategies as strategies_module
 from src.router import (
     HealthEndpointHandler,
@@ -263,6 +263,38 @@ async def test_cooldown_batch_uses_local_fallback_state():
     cooldowns = await state.get_cooldown_batch(["dep-a", "dep-b"])
 
     assert cooldowns == {"dep-a": True, "dep-b": False}
+
+
+def test_require_deployment_raises_service_unavailable_when_group_exists_but_none_healthy():
+    router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=RedisStateBackend(redis=None),
+        config=RouterConfig(),
+        deployment_registry=build_deployment_registry(
+            {"gpt-4o-mini": [{"deployment_id": "dep-a", "deltallm_params": {"model": "openai/gpt-4o-mini"}}]}
+        ),
+    )
+
+    with pytest.raises(ServiceUnavailableError) as exc_info:
+        router.require_deployment("gpt-4o-mini", None)
+
+    assert exc_info.value.code == NO_HEALTHY_DEPLOYMENTS_CODE
+    assert exc_info.value.status_code == 503
+
+
+def test_require_deployment_raises_model_not_found_for_missing_group():
+    router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=RedisStateBackend(redis=None),
+        config=RouterConfig(),
+        deployment_registry=build_deployment_registry({}),
+    )
+
+    with pytest.raises(ModelNotFoundError) as exc_info:
+        router.require_deployment("missing-model", None)
+
+    assert exc_info.value.code == "model_not_found"
+    assert exc_info.value.status_code == 404
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a centralized batch retry classifier with typed retry categories and retry-after handling
- return structured `no_healthy_deployments` service-unavailable errors when model groups exist but no healthy deployment can serve
- narrow response-shape classification to explicit upstream microbatch response contract failures

## Validation
- `uv run --extra dev python -m pytest tests/test_batch_retry.py tests/test_batch_worker_microbatch.py -q`
- `uv run --extra dev python -m pytest tests/test_batch_worker.py tests/test_embeddings.py tests/test_chat.py -q`
- `uv run --extra dev ruff check src/batch/retry.py src/batch/worker_execution.py tests/test_batch_retry.py tests/test_batch_worker_microbatch.py`
- `git diff --check`