### PR TITLE
Include boto3 in runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "PyYAML>=6.0,<7.0",
   "httpx>=0.26,<1.0",
   "redis>=5.0,<6.0",
+  "boto3>=1.35,<2.0",
   "prisma>=0.12,<1.0",
   "prometheus-client>=0.20,<1.0",
   "PyJWT[crypto]>=2.8,<3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pydantic-settings>=2.1,<3.0
 PyYAML>=6.0,<7.0
 httpx>=0.26,<1.0
 redis>=5.0,<6.0
+boto3>=1.35,<2.0
 prisma>=0.12,<1.0
 prometheus-client>=0.20,<1.0
 PyJWT[crypto]>=2.8,<3.0

--- a/uv.lock
+++ b/uv.lock
@@ -445,6 +445,7 @@ name = "deltallm-core-api"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "prisma" },
@@ -474,6 +475,7 @@ guardrails-presidio = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.35,<2.0" },
     { name = "boto3", marker = "extra == 'batch-s3'", specifier = ">=1.35,<2.0" },
     { name = "fastapi", specifier = ">=0.109,<1.0" },
     { name = "httpx", specifier = ">=0.26,<1.0" },


### PR DESCRIPTION
## Summary

Adds `boto3` to the base Python runtime dependencies so the standard Docker image includes the package required by S3 batch artifact storage.

## Root Cause

The S3 batch storage path raises during application startup when `embeddings_batch_storage_backend` is set to `s3` and `boto3` is not installed. The released image installs from `requirements.txt`, but `boto3` was only available through the optional `batch-s3` extra, so Kubernetes deployments using S3 batch storage could crash on startup.

## Impact

The standard image can now boot with S3 batch storage enabled without relying on a chart-level dependency install workaround.

## Validation

- `uv lock --offline`
- `uv run python -c "import boto3; print(boto3.__version__)"`
- `uv run python -c "from src.batch.storage import BOTO3_AVAILABLE; print(BOTO3_AVAILABLE)"`
- `uv run --extra dev pytest tests/test_batch_storage.py tests/bootstrap/test_optional_bootstrap.py -q`