### PR TITLE
Add monthly organization budget reset

### DIFF
--- a/docs/features/budgets.md
+++ b/docs/features/budgets.md
@@ -99,7 +99,9 @@ general_settings:
 
 Budget notifications require email delivery to be configured first.
 
-If an entity has both `budget_duration` and `budget_reset_at`, the runtime can reset tracked spend automatically when the reset window is reached.
+If an entity has both `budget_duration` and `budget_reset_at`, the runtime can reset tracked spend automatically when the reset window is reached. Durations use a positive integer up to `10000` followed by `h`, `d`, or `mo`, for example `1h`, `7d`, `30d`, and `1mo`.
+
+Organization monthly reset is available from the organization create page, organization list edit modal, and organization detail settings. Monthly reset timestamps are UTC. Monthly reset is lazy: it runs when budget enforcement checks the organization after the configured reset time. It clears the tracked organization spend counter and advances the next reset by calendar month. The selected UTC day of month is preserved; if the next month is shorter, the reset clamps for that month only, for example January 30 -> February 28 -> March 30. It does not carry unused budget forward.
 
 ## Organization Soft Budgets
 

--- a/docs/internal/20260428-issue106-monthly-budget-reset-plan.md
+++ b/docs/internal/20260428-issue106-monthly-budget-reset-plan.md
@@ -1,0 +1,684 @@
+# Issue 106 Plan: Monthly Organization Budget Reset
+
+## Objective
+
+Expose and implement monthly budget reset for organizations.
+
+Target outcome:
+
+- organization admins can configure a monthly reset policy from the admin UI
+- org API responses include reset configuration and next reset time
+- runtime budget enforcement resets org spend when the configured reset boundary is reached
+- monthly reset uses calendar-month semantics instead of a fixed 30-day approximation
+- true unused-budget rollover remains out of scope and tracked separately
+
+Related issues:
+
+- [#106](https://github.com/deltawi/deltallm/issues/106): monthly reset
+- [#123](https://github.com/deltawi/deltallm/issues/123): true rollover
+
+Worktree:
+
+- `/Users/mehditantaoui/Documents/Challenges/deltallm-issue-106-monthly-reset`
+
+Branch:
+
+- `issue-106-monthly-reset`
+
+## Problem Statement
+
+Budget reset columns exist in the database, but organization management screens do not expose them. The backend also has partial reset behavior, but it does not support a true monthly duration.
+
+Current org UI can manage:
+
+- `max_budget`
+- `soft_budget`
+- RPM/TPM/RPH/RPD/TPD limits
+- audit content storage
+- asset access controls
+
+Current org UI cannot manage:
+
+- `budget_duration`
+- `budget_reset_at`
+
+This means operators can set hard and soft org budgets, but they cannot configure a recurring monthly budget cycle from the UI.
+
+## Current State
+
+### Data model
+
+The schema already includes budget reset columns on all major budget-bearing entities:
+
+- `DeltaLLM_VerificationToken`
+- `DeltaLLM_UserTable`
+- `DeltaLLM_TeamTable`
+- `DeltaLLM_OrganizationTable`
+
+Relevant org columns:
+
+```prisma
+max_budget      Float?
+soft_budget     Float?
+spend           Float    @default(0)
+budget_duration String?
+budget_reset_at DateTime?
+```
+
+No schema migration is required for the first org-only monthly reset slice.
+
+### Spend model
+
+Spend is maintained in two forms:
+
+1. append-only request events in `deltallm_spendlog_events`
+2. cumulative `spend` counters on key/user/team/org rows
+
+Budget enforcement uses the cumulative counters. Reporting uses the append-only event table.
+
+This issue should preserve that model.
+
+### Reset behavior
+
+`BudgetEnforcementService` checks budgets before requests. During budget checks, it calls `_check_budget_reset()`.
+
+Current reset behavior:
+
+- requires both `budget_duration` and `budget_reset_at`
+- only runs lazily when traffic arrives for that entity
+- if `budget_reset_at <= now`, it sets `spend = 0`
+- then it updates `budget_reset_at` to the next reset timestamp
+- supports positive integer `h` and `d` suffixes
+
+Current duration parser:
+
+- `1h`
+- `1d`
+- `7d`
+- `30d`
+
+Missing:
+
+- `1mo`
+- calendar-month date handling
+- durable monthly anchors for existing rows that predate the UI metadata
+- focused tests for reset behavior
+
+### Admin organization API
+
+Organization list/detail/create/update currently include budget amounts but not reset fields.
+
+Required API additions:
+
+- select `budget_duration`
+- select `budget_reset_at`
+- validate write payloads
+- persist write payloads
+- return reset fields in responses
+
+### Admin UI
+
+The org create drawer and org detail settings panel currently only expose budget amount and soft alert.
+
+Required UI additions:
+
+- monthly reset toggle or selector
+- next reset date/time input
+- current reset policy display
+- payload support for `budget_duration` and `budget_reset_at`
+
+## Scope
+
+In scope:
+
+1. Organization-level monthly budget reset.
+2. Admin API read/write support for org `budget_duration` and `budget_reset_at`.
+3. Runtime support for `1mo`.
+4. Calendar-safe next-month calculation.
+5. Admin UI controls for org create and org detail settings.
+6. Focused backend and frontend tests.
+7. Documentation of intended semantics in this plan and public budget docs if implementation changes user-visible behavior.
+
+Out of scope:
+
+1. True rollover of unused budget.
+2. Team/user/key reset UI.
+3. Background scheduler for proactive resets.
+4. New budget period ledger tables.
+5. Rewriting spend enforcement to query event windows.
+6. Recomputing historical cumulative counters from spend events.
+7. Per-model budget reset behavior.
+
+## Product Semantics
+
+### Monthly reset means reset, not rollover
+
+At the reset boundary:
+
+- org `spend` becomes `0`
+- `budget_reset_at` advances to the next monthly boundary
+- `max_budget` remains unchanged
+- `soft_budget` remains unchanged
+- request spend events remain unchanged
+
+Unused budget is not carried forward.
+
+### Effective duration value
+
+Use:
+
+```text
+1mo
+```
+
+Rationale:
+
+- internal planning docs already mention `1mo`
+- it is compact and consistent with existing `1h` and `1d`
+- it avoids ambiguous labels such as `monthly` in the stored DB field
+
+### Calendar-month calculation
+
+Monthly reset must add calendar months, not days.
+
+Examples:
+
+- `2026-01-15T00:00:00Z` -> `2026-02-15T00:00:00Z`
+- `2026-01-31T00:00:00Z` -> `2026-02-28T00:00:00Z`
+- `2028-01-31T00:00:00Z` -> `2028-02-29T00:00:00Z`
+- `2026-12-31T00:00:00Z` -> `2027-01-31T00:00:00Z`
+
+### Next reset anchoring
+
+For the first implementation, keep the existing service shape but improve the calculation.
+
+Recommended behavior:
+
+- if reset is due, advance from the previous `budget_reset_at`, not from `now`
+- if multiple monthly windows were missed, advance repeatedly until the next reset is in the future
+
+Reason:
+
+- advancing from `now` causes reset drift
+- advancing from the prior reset boundary preserves the operator-selected reset day/time
+
+Example:
+
+- previous `budget_reset_at`: `2026-01-01T00:00:00Z`
+- request arrives: `2026-04-28T09:00:00Z`
+- next reset should become `2026-05-01T00:00:00Z`
+
+### Initial next reset value
+
+The UI should ask for the next reset date/time when monthly reset is enabled.
+
+Rules:
+
+- `budget_duration = "1mo"` requires `budget_reset_at`
+- `budget_reset_at` must parse as ISO 8601
+- prefer future timestamps in validation
+- allow server-side normalization to UTC
+
+If product wants a shortcut later, we can add "first day of next month" as a UI helper, but the first slice should keep the stored behavior explicit.
+
+## Target API Contract
+
+### Organization response fields
+
+Organization list and detail responses should include:
+
+```json
+{
+  "budget_duration": "1mo",
+  "budget_reset_at": "2026-05-01T00:00:00Z"
+}
+```
+
+When reset is disabled:
+
+```json
+{
+  "budget_duration": null,
+  "budget_reset_at": null
+}
+```
+
+### Create organization payload
+
+Enabled:
+
+```json
+{
+  "organization_name": "Acme",
+  "max_budget": 5000,
+  "soft_budget": 4000,
+  "budget_duration": "1mo",
+  "budget_reset_at": "2026-05-01T00:00:00Z"
+}
+```
+
+Disabled:
+
+```json
+{
+  "organization_name": "Acme",
+  "max_budget": 5000,
+  "budget_duration": null,
+  "budget_reset_at": null
+}
+```
+
+### Update organization payload
+
+Enable or change reset:
+
+```json
+{
+  "budget_duration": "1mo",
+  "budget_reset_at": "2026-06-01T00:00:00Z"
+}
+```
+
+Disable reset:
+
+```json
+{
+  "budget_duration": null,
+  "budget_reset_at": null
+}
+```
+
+### Validation
+
+Accept:
+
+- `null`
+- positive integer duration strings from `1` through `10000` ending in `h`, `d`, or `mo`
+- examples: `"1h"`, `"7d"`, `"30d"`, `"1mo"`, `"3mo"`
+
+For issue #106 UI, only expose monthly reset. Backend can preserve existing hour/day compatibility.
+
+Reject:
+
+- unsupported units, for example `"1m"` or `"monthly"`
+- non-positive or out-of-range values
+
+### Create Upsert Semantics
+
+`POST /ui/api/organizations` already behaves as an upsert through `ON CONFLICT (organization_id) DO UPDATE`.
+
+Reset fields follow the same omitted-field contract as `PUT`:
+
+- omitted reset fields preserve existing `budget_duration`, `budget_reset_at`, and `_budget_reset` metadata on conflict
+- explicit `null` reset fields clear reset columns and remove `_budget_reset`
+- explicit reset values update reset columns and write or replace the monthly anchor metadata
+- missing `budget_reset_at` when `budget_duration` is set
+- `budget_reset_at` without `budget_duration`
+- invalid datetime strings
+
+## Implementation Plan
+
+### Phase 1: Backend reset semantics
+
+Files:
+
+- `src/billing/budget.py`
+- `tests/test_billing.py`
+
+Tasks:
+
+- [ ] replace `_next_reset(duration, now)` with a helper that can advance from an anchor timestamp
+- [ ] support `1mo`
+- [ ] preserve existing `h` and `d` behavior
+- [ ] advance repeated missed windows until next reset is in the future
+- [ ] add calendar-month helper without adding a new dependency
+- [ ] add tests for month-end and leap-year behavior
+- [ ] add tests for missed reset windows
+
+Recommended helper shape:
+
+```python
+def _next_reset_after(*, duration: str, previous_reset_at: datetime, now: datetime) -> datetime | None:
+    next_reset = _advance_reset(duration, previous_reset_at)
+    while next_reset <= now:
+        next_reset = _advance_reset(duration, next_reset)
+    return next_reset
+```
+
+Recommended month helper:
+
+```python
+def _add_months(value: datetime, months: int) -> datetime:
+    ...
+```
+
+Use `calendar.monthrange()` from the standard library to clamp day-of-month.
+
+Risk control:
+
+- keep helper functions pure and unit-test them directly
+- avoid broad service refactors
+
+### Phase 2: Organization API fields and validation
+
+Files:
+
+- `src/api/admin/endpoints/organizations.py`
+- `tests/test_ui_organizations_assets.py`
+- `tests/test_ui_rate_limits.py` if current fake DB coverage requires it
+
+Tasks:
+
+- [ ] add `budget_duration` and `budget_reset_at` to organization list SELECT
+- [ ] add both fields to organization detail SELECT
+- [ ] parse and validate both fields in create
+- [ ] insert both fields on create
+- [ ] preserve or update both fields on update
+- [ ] include both fields in returned payloads
+- [ ] update fake admin DB test utilities to store and return both fields
+- [ ] add tests for create persistence
+- [ ] add tests for update persistence
+- [ ] add tests for invalid duration
+- [ ] add tests for missing reset timestamp when duration is present
+- [ ] add tests for reset timestamp without duration
+
+Recommended helper names:
+
+- `_optional_budget_duration(value, field_name)`
+- `_optional_datetime(value, field_name)`
+- `_resolve_budget_reset_fields(payload, existing=None)`
+
+Important update semantics:
+
+- omitted fields should preserve existing values
+- explicit `null` should clear values
+- duration and reset timestamp should be validated as a pair after resolving omitted fields
+
+### Phase 3: UI type and payload support
+
+Files:
+
+- `ui/src/lib/api.ts`
+- `ui/src/pages/OrganizationCreate.tsx`
+- `ui/src/pages/OrganizationDetail.tsx`
+- possibly `ui/src/pages/Organizations.tsx`
+
+Tasks:
+
+- [ ] define or extend organization type fields if this page currently uses `any`
+- [ ] add form fields:
+  - `budget_reset_enabled`
+  - `budget_duration`
+  - `budget_reset_at`
+- [ ] on create, send `budget_duration: "1mo"` and ISO `budget_reset_at` only when enabled
+- [ ] on edit, initialize form from existing org reset fields
+- [ ] allow disabling reset by sending both fields as `null`
+- [ ] display current reset policy in org settings summary
+- [ ] keep the UI focused on monthly reset only
+
+Recommended UX:
+
+- add a "Monthly reset" toggle under budget limit controls
+- when enabled, show "Next reset" date/time input
+- store value as ISO string before sending to API
+- show summary text:
+  - `Monthly reset`
+  - `Next reset: May 1, 2026, 00:00 UTC`
+
+Avoid:
+
+- exposing hour/day duration options in the first UI pass
+- implying rollover or carry-forward
+- hiding reset settings outside the budget section
+
+### Phase 4: Documentation touch-up
+
+Files:
+
+- `docs/features/budgets.md`
+
+Tasks:
+
+- [ ] update "Soft Budgets and Resets" with supported duration values
+- [ ] mention monthly reset is reset-only, not rollover
+- [ ] mention UI support is org-level in this implementation
+- [ ] link or note that true rollover is separate future work if appropriate
+
+Keep this concise; the implementation plan remains the detailed internal source.
+
+### Phase 5: Verification
+
+Backend focused tests:
+
+```bash
+uv run pytest tests/test_billing.py tests/test_ui_organizations_assets.py tests/test_ui_rate_limits.py
+```
+
+Frontend validation:
+
+```bash
+npm run build --prefix ui
+```
+
+Optional broader checks:
+
+```bash
+uv run ruff check src/billing/budget.py src/api/admin/endpoints/organizations.py tests/test_billing.py tests/test_ui_organizations_assets.py
+```
+
+Manual smoke path:
+
+1. create org with budget enabled and monthly reset enabled
+2. verify detail page shows reset policy and next reset
+3. edit next reset timestamp
+4. disable reset
+5. confirm API returns `null` for both fields after disable
+
+## Efficient Delivery Order
+
+Do the work in this order:
+
+1. Backend pure reset helper tests first.
+2. Implement `1mo` runtime reset support.
+3. Add organization API validation and persistence tests.
+4. Implement organization API changes.
+5. Add UI form state and payload wiring.
+6. Add UI display text for existing reset policy.
+7. Run focused backend tests.
+8. Run UI build.
+9. Update public budget docs.
+
+Reasoning:
+
+- reset helper behavior is the riskiest logic and easiest to validate independently
+- API persistence must be stable before UI wiring
+- UI should not invent semantics that backend does not enforce
+- docs should reflect the final implementation, not the initial intent
+
+## Data Consistency Notes
+
+### Existing rows
+
+Existing orgs have `budget_duration = null` and `budget_reset_at = null`, so reset remains disabled.
+
+### Partial updates
+
+Organization update currently resolves omitted fields from the existing row. Preserve that pattern.
+
+Examples:
+
+- payload omits reset fields: keep existing reset config
+- payload sets both fields to `null`: disable reset
+- payload sets duration only: reject unless an existing or payload reset timestamp is available
+- payload sets reset timestamp only: reject unless an existing or payload duration is available
+
+### Timezone handling
+
+Backend should parse ISO 8601 values and normalize them to UTC. Naive timestamps are treated as UTC for backward compatibility.
+
+The database stores `budget_reset_at` as UTC-naive `TIMESTAMP(3)` because that is the existing schema shape. API responses must serialize `budget_reset_at` back as an explicit UTC ISO string ending in `Z`, so the UI never interprets offset-less values as browser-local time.
+
+UI reset controls should use UTC date/time helpers and label reset inputs as UTC.
+
+### Concurrency
+
+Reset remains lazy, but the reset write must be guarded against stale rows.
+
+This issue reduces drift but does not need a scheduler or full lock-based reset. However, the implementation should avoid making concurrency worse.
+
+Use an update guarded by the previous reset timestamp:
+
+```sql
+UPDATE ...
+SET spend = 0,
+    budget_reset_at = $1,
+    updated_at = NOW()
+WHERE organization_id = $2
+  AND budget_reset_at IS NOT DISTINCT FROM $3
+```
+
+If the guard updates zero rows, re-fetch or return without overwriting in-memory state. This prevents stale concurrent reset writes.
+
+Do not broaden this into a full budget service redesign.
+
+### Month-end semantics
+
+For `1mo`, preserve the selected UTC day of month using an internal anchor stored in organization metadata:
+
+```json
+{
+  "_budget_reset": {
+    "monthly_anchor_day": 30
+  }
+}
+```
+
+The anchor is derived from the submitted UTC `budget_reset_at` when monthly reset fields are created or changed. Omitted reset fields preserve the existing anchor. Clearing reset removes the private metadata key. If a monthly reset row has no anchor metadata, infer the anchor from the current `budget_reset_at` day and persist it during the guarded reset update.
+
+Examples:
+
+- anchor day 30: `2026-01-30T00:00:00Z` -> `2026-02-28T00:00:00Z` -> `2026-03-30T00:00:00Z`
+- anchor day 31: `2026-01-31T00:00:00Z` -> `2026-02-28T00:00:00Z` -> `2026-03-31T00:00:00Z`
+- anchor day 31 in leap year: `2028-01-31T00:00:00Z` -> `2028-02-29T00:00:00Z` -> `2028-03-31T00:00:00Z`
+
+Rows without anchor metadata use the previous fallback behavior.
+
+## Test Matrix
+
+### Budget helper tests
+
+- [ ] `1h` advances from previous reset
+- [ ] `1d` advances from previous reset
+- [ ] `30d` continues to work
+- [ ] `1mo` Jan 15 -> Feb 15
+- [ ] `1mo` Jan 31 -> Feb 28 in non-leap year
+- [ ] `1mo` Jan 31 -> Feb 29 in leap year
+- [ ] `1mo` Dec 31 -> Jan 31 next year
+- [ ] missed monthly windows advance until future
+- [ ] unsupported duration returns `None`
+- [ ] out-of-range duration returns `None`
+- [ ] very old hourly and monthly reset windows advance without repeated window-by-window loops
+
+### Budget enforcement tests
+
+- [ ] due org monthly reset sets spend to zero
+- [ ] after reset, hard budget check does not reject using stale pre-reset spend
+- [ ] not-due reset does not update the row
+- [ ] invalid reset config does not crash request path
+
+### Organization API tests
+
+- [ ] create org persists `budget_duration` and `budget_reset_at`
+- [ ] detail returns both fields
+- [ ] list returns both fields
+- [ ] update org changes both fields
+- [ ] update org clears both fields
+- [ ] create/upsert omitting reset fields preserves existing reset config
+- [ ] create/upsert explicit null reset fields clears existing reset config
+- [ ] invalid duration returns `400`
+- [ ] reset timestamp without duration returns `400`
+- [ ] duration without reset timestamp returns `400`
+- [ ] existing soft-budget validation still works
+
+### UI validation
+
+- [ ] create payload includes reset fields only when monthly reset is enabled
+- [ ] edit form initializes from existing reset fields
+- [ ] save sends explicit nulls when disabling reset
+- [ ] org detail displays current monthly reset policy
+- [ ] UI build passes
+
+## Rollout Plan
+
+This can ship as a backward-compatible feature:
+
+- no migration needed
+- existing orgs remain reset-disabled
+- existing API clients continue to work
+- new fields are additive in responses
+
+Recommended release note:
+
+> Organizations can now configure monthly budget resets from the admin UI. Monthly reset clears the tracked org spend counter at the configured reset time; unused budget does not roll over.
+
+## Risks and Mitigations
+
+### Risk: monthly reset drifts over time
+
+Mitigation:
+
+- calculate from previous reset boundary, not request time
+- add missed-window tests
+
+### Risk: month-end behavior is surprising
+
+Mitigation:
+
+- clamp to last valid day of target month
+- document examples in tests
+
+### Risk: UI implies rollover
+
+Mitigation:
+
+- use "Monthly reset" language
+- do not mention carry-forward in UI
+- keep rollover tracked in issue #123
+
+### Risk: concurrent reset request races
+
+Mitigation:
+
+- prefer guarded update using previous `budget_reset_at`
+- keep behavior lazy for now
+- leave scheduler/ledger changes out of scope
+
+### Risk: API null/omitted semantics regress existing update flows
+
+Mitigation:
+
+- preserve existing omitted-field behavior
+- test explicit null clearing
+
+## Definition of Done
+
+- [ ] org create API accepts and persists monthly reset settings
+- [ ] org update API accepts, changes, and clears monthly reset settings
+- [ ] org list/detail API returns reset settings
+- [ ] budget runtime supports `1mo`
+- [ ] monthly reset advances without drift
+- [ ] org create UI exposes monthly reset settings
+- [ ] org detail settings UI exposes and displays monthly reset settings
+- [ ] focused backend tests pass
+- [ ] UI build passes
+- [ ] public budget docs are updated
+
+## Follow-up Work
+
+Future issues:
+
+- true rollover with carry-forward balance
+- team/user/key reset UI
+- proactive reset scheduler
+- budget period ledger for auditability
+- reset history display in UI

--- a/src/api/admin/endpoints/organizations.py
+++ b/src/api/admin/endpoints/organizations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from datetime import UTC, datetime
 import json
 import secrets
 from time import perf_counter
@@ -45,6 +46,10 @@ from src.services.ui_authorization import build_organization_capabilities
 
 router = APIRouter(tags=["Admin Organizations"])
 
+_BUDGET_RESET_METADATA_KEY = "_budget_reset"
+_MONTHLY_ANCHOR_DAY_KEY = "monthly_anchor_day"
+_MAX_BUDGET_DURATION_AMOUNT = 10_000
+
 
 def _organization_response_payload(
     organization: dict[str, Any],
@@ -52,8 +57,10 @@ def _organization_response_payload(
     capabilities: dict[str, bool] | None = None,
 ) -> dict[str, Any]:
     payload = to_json_value(dict(organization))
-    if isinstance(payload, dict) and capabilities is not None:
-        payload["capabilities"] = capabilities
+    if isinstance(payload, dict):
+        payload["budget_reset_at"] = _serialize_budget_reset_at(organization.get("budget_reset_at"))
+        if capabilities is not None:
+            payload["capabilities"] = capabilities
     return payload
 
 
@@ -77,6 +84,149 @@ def _optional_float(value: Any, field_name: str) -> float | None:
     if parsed < 0:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be >= 0")
     return parsed
+
+
+def _optional_budget_duration(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if _parse_budget_duration(normalized) is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{field_name} must be a positive integer up to {_MAX_BUDGET_DURATION_AMOUNT} followed by h, d, or mo",
+        )
+    return normalized
+
+
+def _parse_budget_duration(value: str) -> tuple[int, str] | None:
+    if value.endswith("mo"):
+        amount_raw = value[:-2]
+        unit = "mo"
+    else:
+        amount_raw = value[:-1]
+        unit = value[-1:]
+    if not amount_raw.isdigit():
+        return None
+    amount = int(amount_raw)
+    if amount <= 0 or amount > _MAX_BUDGET_DURATION_AMOUNT or unit not in {"h", "d", "mo"}:
+        return None
+    return amount, unit
+
+
+def _budget_duration_unit(value: str | None) -> str | None:
+    if value is None:
+        return None
+    parsed = _parse_budget_duration(value)
+    return parsed[1] if parsed is not None else None
+
+
+def _optional_datetime(value: Any, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _as_utc_datetime(value)
+    if not isinstance(value, str):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be an ISO 8601 datetime")
+    normalized = value.strip()
+    if not normalized:
+        return None
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be an ISO 8601 datetime") from exc
+    return _as_utc_datetime(parsed)
+
+
+def _resolve_budget_reset_fields(
+    payload: dict[str, Any],
+    *,
+    existing: dict[str, Any] | None = None,
+) -> tuple[str | None, datetime | None]:
+    existing = existing or {}
+    reset_fields_provided = "budget_duration" in payload or "budget_reset_at" in payload
+    if not reset_fields_provided and existing:
+        duration = _existing_budget_duration(existing.get("budget_duration"))
+        reset_at = _coerce_budget_reset_datetime(existing.get("budget_reset_at"))
+        return duration, reset_at
+
+    duration_raw = payload["budget_duration"] if "budget_duration" in payload else existing.get("budget_duration")
+    reset_at_raw = payload["budget_reset_at"] if "budget_reset_at" in payload else existing.get("budget_reset_at")
+    duration = _optional_budget_duration(duration_raw, "budget_duration")
+    reset_at = _optional_datetime(reset_at_raw, "budget_reset_at")
+
+    if duration is None and reset_at is None:
+        return None, None
+    if duration is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="budget_duration is required when budget_reset_at is set")
+    if reset_at is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="budget_reset_at is required when budget_duration is set")
+    return duration, reset_at
+
+
+def _existing_budget_duration(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _as_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _budget_reset_storage_value(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return _as_utc_datetime(value).replace(tzinfo=None)
+
+
+def _serialize_budget_reset_at(value: Any) -> str | None:
+    parsed = _coerce_budget_reset_datetime(value)
+    if parsed is None:
+        return None
+    return _as_utc_datetime(parsed).isoformat().replace("+00:00", "Z")
+
+
+def _coerce_budget_reset_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _as_utc_datetime(value)
+    if isinstance(value, str):
+        try:
+            return _as_utc_datetime(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+
+def _apply_budget_reset_metadata(
+    metadata: dict[str, Any] | None,
+    *,
+    duration: str | None,
+    reset_at: datetime | None,
+    reset_fields_provided: bool,
+) -> dict[str, Any] | None:
+    if not reset_fields_provided:
+        return metadata
+
+    next_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    if _budget_duration_unit(duration) == "mo" and reset_at is not None:
+        raw_budget_reset_settings = next_metadata.get(_BUDGET_RESET_METADATA_KEY)
+        budget_reset_settings = dict(raw_budget_reset_settings) if isinstance(raw_budget_reset_settings, dict) else {}
+        budget_reset_settings[_MONTHLY_ANCHOR_DAY_KEY] = _as_utc_datetime(reset_at).day
+        next_metadata[_BUDGET_RESET_METADATA_KEY] = budget_reset_settings
+    else:
+        next_metadata.pop(_BUDGET_RESET_METADATA_KEY, None)
+    return next_metadata or None
 
 
 def _validate_model_limit_dict(value: Any, field_name: str) -> dict[str, int] | None:
@@ -449,7 +599,7 @@ async def list_organizations(
 
     where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
 
-    select_cols = """o.organization_id, o.organization_name, o.max_budget, o.soft_budget, o.spend, o.rpm_limit, o.tpm_limit,
+    select_cols = """o.organization_id, o.organization_name, o.max_budget, o.soft_budget, o.spend, o.budget_duration, o.budget_reset_at, o.rpm_limit, o.tpm_limit,
                    o.rph_limit, o.rpd_limit, o.tpd_limit,
                    o.model_rpm_limit, o.model_tpm_limit,
                    o.audit_content_storage_enabled, o.metadata, o.created_at, o.updated_at,
@@ -497,7 +647,7 @@ async def get_organization(
     db = db_or_503(request)
     rows = await db.query_raw(
         """
-        SELECT organization_id, organization_name, max_budget, soft_budget, spend, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
+        SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
         FROM deltallm_organizationtable
         WHERE organization_id = $1
         LIMIT 1
@@ -658,6 +808,9 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
     soft_budget = _optional_float(payload.get("soft_budget"), "soft_budget")
     if max_budget is not None and soft_budget is not None and soft_budget > max_budget:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="soft_budget must be less than or equal to max_budget")
+    reset_fields_provided = "budget_duration" in payload or "budget_reset_at" in payload
+    budget_duration, budget_reset_at = _resolve_budget_reset_fields(payload)
+    budget_reset_at_storage = _budget_reset_storage_value(budget_reset_at)
     rpm_limit = optional_int(payload.get("rpm_limit"), "rpm_limit")
     tpm_limit = optional_int(payload.get("tpm_limit"), "tpm_limit")
     rph_limit = optional_int(payload.get("rph_limit"), "rph_limit")
@@ -673,6 +826,12 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
         _audit_retention_metadata(payload),
         enabled=False,
     )
+    metadata = _apply_budget_reset_metadata(
+        metadata,
+        duration=budget_duration,
+        reset_at=budget_reset_at,
+        reset_fields_provided=True,
+    )
     route_group_bindings = _normalize_route_group_binding_payloads(payload.get("route_group_bindings"))
     callable_target_bindings = _normalize_callable_target_binding_payloads(payload.get("callable_target_bindings"))
     _validate_route_group_callable_target_overlap(route_group_bindings, callable_target_bindings)
@@ -685,7 +844,7 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
         catalog=catalog,
     )
 
-    async def _apply_create(db_client: Any, *, route_repository, callable_repository) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:  # noqa: ANN001
+    async def _apply_create(db_client: Any, *, route_repository, callable_repository) -> dict[str, Any]:  # noqa: ANN001
         await db_client.execute_raw(
             """
             INSERT INTO deltallm_organizationtable (
@@ -694,6 +853,8 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
                 organization_name,
                 max_budget,
                 soft_budget,
+                budget_duration,
+                budget_reset_at,
                 spend,
                 rpm_limit,
                 tpm_limit,
@@ -707,12 +868,20 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
                 created_at,
                 updated_at
             )
-            VALUES (gen_random_uuid(), $1, $2, $3, $4, 0, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12, $13::jsonb, NOW(), NOW())
+            VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6::timestamp, 0, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14, $15::jsonb, NOW(), NOW())
             ON CONFLICT (organization_id)
             DO UPDATE SET
                 organization_name = EXCLUDED.organization_name,
                 max_budget = EXCLUDED.max_budget,
                 soft_budget = EXCLUDED.soft_budget,
+                budget_duration = CASE
+                    WHEN $16::boolean THEN EXCLUDED.budget_duration
+                    ELSE deltallm_organizationtable.budget_duration
+                END,
+                budget_reset_at = CASE
+                    WHEN $16::boolean THEN EXCLUDED.budget_reset_at
+                    ELSE deltallm_organizationtable.budget_reset_at
+                END,
                 rpm_limit = EXCLUDED.rpm_limit,
                 tpm_limit = EXCLUDED.tpm_limit,
                 rph_limit = EXCLUDED.rph_limit,
@@ -721,13 +890,21 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
                 model_rpm_limit = EXCLUDED.model_rpm_limit,
                 model_tpm_limit = EXCLUDED.model_tpm_limit,
                 audit_content_storage_enabled = EXCLUDED.audit_content_storage_enabled,
-                metadata = COALESCE(EXCLUDED.metadata, deltallm_organizationtable.metadata),
+                metadata = CASE
+                    WHEN NOT $16::boolean
+                    THEN NULLIF(COALESCE(deltallm_organizationtable.metadata, '{}'::jsonb) || COALESCE(EXCLUDED.metadata, '{}'::jsonb), '{}'::jsonb)
+                    WHEN EXCLUDED.budget_duration IS NULL OR EXCLUDED.budget_duration NOT LIKE '%mo'
+                    THEN NULLIF((COALESCE(deltallm_organizationtable.metadata, '{}'::jsonb) || COALESCE(EXCLUDED.metadata, '{}'::jsonb)) - '_budget_reset', '{}'::jsonb)
+                    ELSE NULLIF(COALESCE(deltallm_organizationtable.metadata, '{}'::jsonb) || COALESCE(EXCLUDED.metadata, '{}'::jsonb), '{}'::jsonb)
+                END,
                 updated_at = NOW()
             """,
             organization_id,
             organization_name,
             max_budget,
             soft_budget,
+            budget_duration,
+            budget_reset_at_storage,
             rpm_limit,
             tpm_limit,
             rph_limit,
@@ -737,7 +914,20 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
             json.dumps(model_tpm_limit) if model_tpm_limit else None,
             bool(audit_content_storage_enabled) if audit_content_storage_enabled is not None else False,
             metadata if metadata is not None else None,
+            reset_fields_provided,
         )
+        persisted_rows = await db_client.query_raw(
+            """
+            SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
+            FROM deltallm_organizationtable
+            WHERE organization_id = $1
+            LIMIT 1
+            """,
+            organization_id,
+        )
+        if not persisted_rows:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+        response_payload = _organization_response_payload(dict(persisted_rows[0]))
         applied_route_group_bindings = (
             await _sync_org_route_group_bindings(
                 request,
@@ -762,40 +952,25 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
             if callable_target_bindings
             else []
         )
-        return applied_route_group_bindings, applied_callable_target_bindings
+        response_payload["route_group_bindings"] = applied_route_group_bindings
+        response_payload["callable_target_bindings"] = applied_callable_target_bindings
+        return response_payload
 
     if hasattr(db, "tx"):
         async with db.tx() as tx:
-            applied_route_group_bindings, applied_callable_target_bindings = await _apply_create(
+            response = await _apply_create(
                 tx,
                 route_repository=_route_group_repository_for_request(request, db_client=tx),
                 callable_repository=_callable_target_binding_repository_for_request(request, db_client=tx),
             )
     else:
-        applied_route_group_bindings, applied_callable_target_bindings = await _apply_create(
+        response = await _apply_create(
             db,
             route_repository=route_repo,
             callable_repository=callable_binding_repo,
         )
     if route_group_bindings or callable_target_bindings:
         await reload_callable_target_grants(request)
-    response = {
-        "organization_id": organization_id,
-        "organization_name": organization_name,
-        "max_budget": max_budget,
-        "soft_budget": soft_budget,
-        "rpm_limit": rpm_limit,
-        "tpm_limit": tpm_limit,
-        "rph_limit": rph_limit,
-        "rpd_limit": rpd_limit,
-        "tpd_limit": tpd_limit,
-        "model_rpm_limit": model_rpm_limit,
-        "model_tpm_limit": model_tpm_limit,
-        "audit_content_storage_enabled": bool(audit_content_storage_enabled) if audit_content_storage_enabled is not None else False,
-        "metadata": metadata or {},
-        "route_group_bindings": applied_route_group_bindings,
-        "callable_target_bindings": applied_callable_target_bindings,
-    }
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -821,7 +996,7 @@ async def update_organization(
     scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.ORG_UPDATE)
     rows = await db.query_raw(
         """
-        SELECT organization_id, organization_name, max_budget, soft_budget, spend, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
+        SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
         FROM deltallm_organizationtable
         WHERE organization_id = $1
         LIMIT 1
@@ -837,6 +1012,9 @@ async def update_organization(
     soft_budget = _optional_float(payload.get("soft_budget", existing.get("soft_budget")), "soft_budget")
     if max_budget is not None and soft_budget is not None and soft_budget > max_budget:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="soft_budget must be less than or equal to max_budget")
+    reset_fields_provided = "budget_duration" in payload or "budget_reset_at" in payload
+    budget_duration, budget_reset_at = _resolve_budget_reset_fields(payload, existing=existing)
+    budget_reset_at_storage = _budget_reset_storage_value(budget_reset_at)
     rpm_limit = optional_int(payload.get("rpm_limit", existing.get("rpm_limit")), "rpm_limit")
     tpm_limit = optional_int(payload.get("tpm_limit", existing.get("tpm_limit")), "tpm_limit")
     rph_limit = optional_int(payload.get("rph_limit", existing.get("rph_limit")), "rph_limit")
@@ -888,6 +1066,12 @@ async def update_organization(
             and callable_target_bindings is None
         ),
     )
+    metadata = _apply_budget_reset_metadata(
+        metadata,
+        duration=budget_duration,
+        reset_at=budget_reset_at,
+        reset_fields_provided=reset_fields_provided,
+    )
 
     async def _apply_update(db_client: Any, *, route_repository, callable_repository):  # noqa: ANN001, ANN202
         await db_client.execute_raw(
@@ -896,21 +1080,25 @@ async def update_organization(
             SET organization_name = $1,
                 max_budget = $2,
                 soft_budget = $3,
-                rpm_limit = $4,
-                tpm_limit = $5,
-                rph_limit = $6,
-                rpd_limit = $7,
-                tpd_limit = $8,
-                model_rpm_limit = $9::jsonb,
-                model_tpm_limit = $10::jsonb,
-                audit_content_storage_enabled = $11,
-                metadata = $12::jsonb,
+                budget_duration = $4,
+                budget_reset_at = $5::timestamp,
+                rpm_limit = $6,
+                tpm_limit = $7,
+                rph_limit = $8,
+                rpd_limit = $9,
+                tpd_limit = $10,
+                model_rpm_limit = $11::jsonb,
+                model_tpm_limit = $12::jsonb,
+                audit_content_storage_enabled = $13,
+                metadata = $14::jsonb,
                 updated_at = NOW()
-            WHERE organization_id = $13
+            WHERE organization_id = $15
             """,
             organization_name,
             max_budget,
             soft_budget,
+            budget_duration,
+            budget_reset_at_storage,
             rpm_limit,
             tpm_limit,
             rph_limit,
@@ -924,7 +1112,7 @@ async def update_organization(
         )
         updated_rows = await db_client.query_raw(
             """
-            SELECT organization_id, organization_name, max_budget, soft_budget, spend, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
+            SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
             FROM deltallm_organizationtable
             WHERE organization_id = $1
             LIMIT 1

--- a/src/billing/budget.py
+++ b/src/billing/budget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import calendar
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -8,6 +9,10 @@ from typing import Any
 from src.billing.alerts import AlertService
 
 logger = logging.getLogger(__name__)
+
+_BUDGET_RESET_METADATA_KEY = "_budget_reset"
+_MONTHLY_ANCHOR_DAY_KEY = "monthly_anchor_day"
+_MAX_BUDGET_DURATION_AMOUNT = 10_000
 
 
 @dataclass
@@ -128,19 +133,19 @@ class BudgetEnforcementService:
 
     async def _get_entity(self, entity_type: str, entity_id: str) -> dict[str, Any] | None:
         table_map = {
-            "key": ("deltallm_verificationtoken", "token", "NULL AS soft_budget"),
-            "user": ("deltallm_usertable", "user_id", "NULL AS soft_budget"),
-            "team": ("deltallm_teamtable", "team_id", "NULL AS soft_budget"),
-            "org": ("deltallm_organizationtable", "organization_id", "soft_budget"),
+            "key": ("deltallm_verificationtoken", "token", "NULL AS soft_budget", "metadata"),
+            "user": ("deltallm_usertable", "user_id", "NULL AS soft_budget", "metadata"),
+            "team": ("deltallm_teamtable", "team_id", "NULL AS soft_budget", "metadata"),
+            "org": ("deltallm_organizationtable", "organization_id", "soft_budget", "metadata"),
         }
         table_info = table_map.get(entity_type)
         if table_info is None:
             return None
 
-        table, column, soft_budget_expr = table_info
+        table, column, soft_budget_expr, metadata_expr = table_info
         rows = await self.db.query_raw(
             f"""
-            SELECT {column} AS entity_id, max_budget, {soft_budget_expr}, spend, budget_duration, budget_reset_at
+            SELECT {column} AS entity_id, max_budget, {soft_budget_expr}, spend, budget_duration, budget_reset_at, {metadata_expr} AS metadata
             FROM {table}
             WHERE {column} = $1
             LIMIT 1
@@ -165,7 +170,30 @@ class BudgetEnforcementService:
         if reset_at > now:
             return entity
 
-        next_reset = _next_reset(duration=duration, now=now)
+        monthly_anchor_day = _monthly_anchor_day(entity.get("metadata"))
+        inferred_monthly_anchor_day = None
+        if monthly_anchor_day is None and _duration_unit(duration) == "mo":
+            inferred_monthly_anchor_day = reset_at.day
+            monthly_anchor_day = inferred_monthly_anchor_day
+
+        try:
+            next_reset = _next_reset_after(
+                duration=duration,
+                previous_reset_at=reset_at,
+                now=now,
+                monthly_anchor_day=monthly_anchor_day,
+            )
+        except (OverflowError, ValueError) as exc:
+            logger.warning(
+                "failed to calculate budget reset",
+                extra={
+                    "entity_type": entity_type,
+                    "entity_id": entity.get("entity_id"),
+                    "budget_duration": duration,
+                    "error": str(exc),
+                },
+            )
+            return entity
         if next_reset is None:
             return entity
 
@@ -185,19 +213,42 @@ class BudgetEnforcementService:
             return entity
 
         try:
-            await self.db.query_raw(
+            updated_count = await self.db.execute_raw(
                 f"""
                 UPDATE {table}
                 SET spend = 0,
-                    budget_reset_at = $1,
+                    budget_reset_at = $1::timestamp,
+                    metadata = CASE
+                        WHEN $4::int IS NULL THEN metadata
+                        ELSE jsonb_set(
+                            COALESCE(metadata, '{{}}'::jsonb),
+                            '{{_budget_reset}}',
+                            CASE
+                                WHEN jsonb_typeof(metadata->'_budget_reset') = 'object'
+                                THEN metadata->'_budget_reset'
+                                ELSE '{{}}'::jsonb
+                            END
+                                || jsonb_build_object('monthly_anchor_day', $4::int),
+                            true
+                        )
+                    END,
                     updated_at = NOW()
                 WHERE {column} = $2
+                  AND budget_reset_at IS NOT DISTINCT FROM $3::timestamp
                 """,
-                next_reset,
+                _as_utc_naive(next_reset),
                 entity_id,
+                _as_utc_naive(reset_at),
+                inferred_monthly_anchor_day,
             )
+            if _affected_row_count(updated_count) <= 0:
+                refreshed = await self._get_entity(entity_type, str(entity_id))
+                return refreshed or entity
+
             entity["spend"] = 0
             entity["budget_reset_at"] = next_reset
+            if inferred_monthly_anchor_day is not None:
+                entity["metadata"] = _with_monthly_anchor_day(entity.get("metadata"), inferred_monthly_anchor_day)
         except Exception as exc:  # pragma: no cover - defensive logging
             logger.warning("failed to reset budget", extra={"entity_type": entity_type, "entity_id": entity_id, "error": str(exc)})
 
@@ -208,7 +259,7 @@ def _as_datetime(value: Any) -> datetime | None:
     if isinstance(value, datetime):
         if value.tzinfo is None:
             return value.replace(tzinfo=UTC)
-        return value
+        return value.astimezone(UTC)
     if isinstance(value, str):
         try:
             parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
@@ -216,25 +267,146 @@ def _as_datetime(value: Any) -> datetime | None:
             return None
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=UTC)
-        return parsed
+        return parsed.astimezone(UTC)
     return None
 
 
-def _next_reset(*, duration: str, now: datetime) -> datetime | None:
-    unit = duration[-1:]
-    value = duration[:-1]
+def _next_reset_after(
+    *,
+    duration: str,
+    previous_reset_at: datetime,
+    now: datetime,
+    monthly_anchor_day: int | None = None,
+) -> datetime | None:
+    parsed = _parse_duration(duration)
+    if parsed is None:
+        return None
+
+    amount, unit = parsed
+    try:
+        if unit in {"h", "d"}:
+            return _next_fixed_reset_after(
+                previous_reset_at,
+                amount=amount,
+                unit=unit,
+                now=now,
+            )
+        if unit == "mo":
+            return _next_month_reset_after(
+                previous_reset_at,
+                amount=amount,
+                now=now,
+                monthly_anchor_day=monthly_anchor_day,
+            )
+    except (OverflowError, ValueError):
+        return None
+    return None
+
+
+def _parse_duration(duration: Any) -> tuple[int, str] | None:
+    if not isinstance(duration, str):
+        return None
+    if duration.endswith("mo"):
+        unit = "mo"
+        value = duration[:-2]
+    else:
+        unit = duration[-1:]
+        value = duration[:-1]
+
     if not value.isdigit():
         return None
 
     amount = int(value)
-    if amount <= 0:
+    if amount <= 0 or amount > _MAX_BUDGET_DURATION_AMOUNT:
         return None
+    if unit not in {"h", "d", "mo"}:
+        return None
+    return amount, unit
 
+
+def _duration_unit(duration: Any) -> str | None:
+    parsed = _parse_duration(duration)
+    return parsed[1] if parsed is not None else None
+
+
+def _next_fixed_reset_after(value: datetime, *, amount: int, unit: str, now: datetime) -> datetime | None:
     if unit == "h":
-        return now + timedelta(hours=amount)
-    if unit == "d":
-        return now + timedelta(days=amount)
+        step = timedelta(hours=amount)
+    elif unit == "d":
+        step = timedelta(days=amount)
+    else:
+        return None
+    elapsed_intervals = max(0, (now - value) // step)
+    return value + step * (elapsed_intervals + 1)
+
+
+def _next_month_reset_after(
+    value: datetime,
+    *,
+    amount: int,
+    now: datetime,
+    monthly_anchor_day: int | None,
+) -> datetime:
+    elapsed_months = max(0, (now.year - value.year) * 12 + (now.month - value.month))
+    elapsed_intervals = max(1, elapsed_months // amount)
+    next_reset = _add_months(value, amount * elapsed_intervals, anchor_day=monthly_anchor_day)
+    while next_reset <= now:
+        elapsed_intervals += 1
+        next_reset = _add_months(value, amount * elapsed_intervals, anchor_day=monthly_anchor_day)
+    return next_reset
+
+
+def _add_months(value: datetime, months: int, *, anchor_day: int | None = None) -> datetime:
+    zero_based_month = value.month - 1 + months
+    year = value.year + zero_based_month // 12
+    month = zero_based_month % 12 + 1
+    last_day = calendar.monthrange(year, month)[1]
+    if anchor_day is not None:
+        day = min(anchor_day, last_day)
+    else:
+        day = last_day if _is_last_day_of_month(value) else min(value.day, last_day)
+    return value.replace(year=year, month=month, day=day)
+
+
+def _is_last_day_of_month(value: datetime) -> bool:
+    return value.day == calendar.monthrange(value.year, value.month)[1]
+
+
+def _affected_row_count(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _monthly_anchor_day(metadata: Any) -> int | None:
+    if not isinstance(metadata, dict):
+        return None
+    settings = metadata.get(_BUDGET_RESET_METADATA_KEY)
+    if not isinstance(settings, dict):
+        return None
+    try:
+        day = int(settings.get(_MONTHLY_ANCHOR_DAY_KEY))
+    except (TypeError, ValueError):
+        return None
+    if 1 <= day <= 31:
+        return day
     return None
+
+
+def _with_monthly_anchor_day(metadata: Any, day: int) -> dict[str, Any]:
+    next_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    raw_settings = next_metadata.get(_BUDGET_RESET_METADATA_KEY)
+    settings = dict(raw_settings) if isinstance(raw_settings, dict) else {}
+    settings[_MONTHLY_ANCHOR_DAY_KEY] = day
+    next_metadata[_BUDGET_RESET_METADATA_KEY] = settings
+    return next_metadata
+
+
+def _as_utc_naive(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(UTC).replace(tzinfo=None)
 
 
 def _to_float(value: Any) -> float:

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
 
-from src.billing.budget import BudgetEnforcementService, BudgetExceeded
+from src.billing.budget import BudgetEnforcementService, BudgetExceeded, _next_reset_after
 from src.billing.spend import SpendTrackingService
 from src.billing.spend_events import build_spend_event
 
@@ -86,6 +86,50 @@ class OrgBudgetDB:
                 }
             ]
         return []
+
+
+class ResettingOrgBudgetDB:
+    def __init__(self, *, update_count: int = 1, conflict_row: dict | None = None, metadata: dict | None = None) -> None:
+        self.query_calls: list[tuple[str, tuple]] = []
+        self.execute_calls: list[tuple[str, tuple]] = []
+        self.update_count = update_count
+        self.conflict_row = conflict_row
+        self.organization = {
+            "entity_id": "org_1",
+            "max_budget": 10.0,
+            "soft_budget": None,
+            "spend": 12.0,
+            "budget_duration": "1d",
+            "budget_reset_at": datetime(2026, 1, 1, tzinfo=UTC),
+            "metadata": metadata or {},
+        }
+
+    async def query_raw(self, query: str, *args):
+        self.query_calls.append((query, args))
+        normalized = " ".join(query.lower().split())
+        if "from deltallm_organizationtable" in normalized:
+            return [dict(self.organization)]
+        return []
+
+    async def execute_raw(self, query: str, *args):
+        self.execute_calls.append((query, args))
+        normalized = " ".join(query.lower().split())
+        if "update deltallm_organizationtable" not in normalized:
+            return self.update_count
+        if self.update_count <= 0:
+            if self.conflict_row is not None:
+                self.organization.update(self.conflict_row)
+            return 0
+        self.organization["spend"] = 0.0
+        self.organization["budget_reset_at"] = args[0]
+        inferred_anchor_day = args[3] if len(args) > 3 else None
+        if inferred_anchor_day is not None:
+            metadata = dict(self.organization.get("metadata") or {})
+            settings = dict(metadata.get("_budget_reset") or {})
+            settings["monthly_anchor_day"] = inferred_anchor_day
+            metadata["_budget_reset"] = settings
+            self.organization["metadata"] = metadata
+        return self.update_count
 
 
 class RecordingAlertService:
@@ -476,6 +520,225 @@ async def test_budget_enforcement_sends_org_soft_budget_alerts() -> None:
             "hard_budget": 40.0,
         }
     ]
+
+
+def test_next_reset_after_preserves_hour_and_day_durations() -> None:
+    now = datetime(2026, 1, 1, 1, 30, tzinfo=UTC)
+
+    assert _next_reset_after(
+        duration="1h",
+        previous_reset_at=datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+        now=now,
+    ) == datetime(2026, 1, 1, 2, 0, tzinfo=UTC)
+    assert _next_reset_after(
+        duration="30d",
+        previous_reset_at=datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+        now=now,
+    ) == datetime(2026, 1, 31, 0, 0, tzinfo=UTC)
+
+
+def test_next_reset_after_advances_old_fixed_duration_without_iterating_windows() -> None:
+    assert _next_reset_after(
+        duration="1h",
+        previous_reset_at=datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 1, 3, 12, 30, tzinfo=UTC),
+    ) == datetime(2026, 1, 3, 13, 0, tzinfo=UTC)
+
+
+def test_next_reset_after_supports_custom_duration_values() -> None:
+    assert _next_reset_after(
+        duration="2h",
+        previous_reset_at=datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 1, 1, 1, 30, tzinfo=UTC),
+    ) == datetime(2026, 1, 1, 2, 0, tzinfo=UTC)
+    assert _next_reset_after(
+        duration="14d",
+        previous_reset_at=datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 1, 1, 0, 1, tzinfo=UTC),
+    ) == datetime(2026, 1, 15, 0, 0, tzinfo=UTC)
+    assert _next_reset_after(
+        duration="3mo",
+        previous_reset_at=datetime(2026, 1, 31, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 2, 1, 0, 0, tzinfo=UTC),
+        monthly_anchor_day=31,
+    ) == datetime(2026, 4, 30, 0, 0, tzinfo=UTC)
+
+
+def test_next_reset_after_supports_calendar_months() -> None:
+    assert _next_reset_after(
+        duration="1mo",
+        previous_reset_at=datetime(2026, 1, 15, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 1, 15, 0, 1, tzinfo=UTC),
+    ) == datetime(2026, 2, 15, 0, 0, tzinfo=UTC)
+    feb_reset = _next_reset_after(
+        duration="1mo",
+        previous_reset_at=datetime(2026, 1, 31, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 1, 31, 0, 1, tzinfo=UTC),
+    )
+    assert feb_reset == datetime(2026, 2, 28, 0, 0, tzinfo=UTC)
+    assert _next_reset_after(
+        duration="1mo",
+        previous_reset_at=feb_reset,
+        now=datetime(2026, 2, 28, 0, 1, tzinfo=UTC),
+    ) == datetime(2026, 3, 31, 0, 0, tzinfo=UTC)
+    leap_feb_reset = _next_reset_after(
+        duration="1mo",
+        previous_reset_at=datetime(2028, 1, 31, 0, 0, tzinfo=UTC),
+        now=datetime(2028, 1, 31, 0, 1, tzinfo=UTC),
+    )
+    assert leap_feb_reset == datetime(2028, 2, 29, 0, 0, tzinfo=UTC)
+    assert _next_reset_after(
+        duration="1mo",
+        previous_reset_at=leap_feb_reset,
+        now=datetime(2028, 2, 29, 0, 1, tzinfo=UTC),
+    ) == datetime(2028, 3, 31, 0, 0, tzinfo=UTC)
+    assert _next_reset_after(
+        duration="1mo",
+        previous_reset_at=datetime(2026, 12, 31, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 12, 31, 0, 1, tzinfo=UTC),
+    ) == datetime(2027, 1, 31, 0, 0, tzinfo=UTC)
+
+
+def test_next_reset_after_uses_monthly_anchor_day() -> None:
+    feb_reset = _next_reset_after(
+        duration="1mo",
+        previous_reset_at=datetime(2026, 1, 30, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 1, 30, 0, 1, tzinfo=UTC),
+        monthly_anchor_day=30,
+    )
+
+    assert feb_reset == datetime(2026, 2, 28, 0, 0, tzinfo=UTC)
+    assert _next_reset_after(
+        duration="1mo",
+        previous_reset_at=feb_reset,
+        now=datetime(2026, 2, 28, 0, 1, tzinfo=UTC),
+        monthly_anchor_day=30,
+    ) == datetime(2026, 3, 30, 0, 0, tzinfo=UTC)
+
+
+def test_next_reset_after_advances_missed_monthly_windows() -> None:
+    assert _next_reset_after(
+        duration="1mo",
+        previous_reset_at=datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 4, 28, 9, 0, tzinfo=UTC),
+    ) == datetime(2026, 5, 1, 0, 0, tzinfo=UTC)
+
+
+def test_next_reset_after_advances_old_monthly_windows_without_iterating_windows() -> None:
+    assert _next_reset_after(
+        duration="1mo",
+        previous_reset_at=datetime(2020, 1, 31, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 4, 29, 0, 0, tzinfo=UTC),
+        monthly_anchor_day=31,
+    ) == datetime(2026, 4, 30, 0, 0, tzinfo=UTC)
+
+
+def test_next_reset_after_rejects_unsupported_duration() -> None:
+    assert _next_reset_after(
+        duration="monthly",
+        previous_reset_at=datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 1, 2, 0, 0, tzinfo=UTC),
+    ) is None
+    assert _next_reset_after(
+        duration="10001d",
+        previous_reset_at=datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+        now=datetime(2026, 1, 2, 0, 0, tzinfo=UTC),
+    ) is None
+
+
+def test_next_reset_after_returns_none_when_duration_overflows_datetime() -> None:
+    assert _next_reset_after(
+        duration="10000mo",
+        previous_reset_at=datetime(9990, 1, 1, 0, 0, tzinfo=UTC),
+        now=datetime(9990, 1, 2, 0, 0, tzinfo=UTC),
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_budget_enforcement_resets_due_budget_before_hard_budget_check() -> None:
+    db = ResettingOrgBudgetDB()
+    service = BudgetEnforcementService(db_client=db)
+
+    await service.check_budgets(
+        api_key=None,
+        user_id=None,
+        team_id=None,
+        organization_id="org_1",
+    )
+
+    assert db.organization["spend"] == 0.0
+    assert db.organization["budget_reset_at"].tzinfo is None
+    assert db.organization["budget_reset_at"].replace(tzinfo=UTC) > datetime.now(tz=UTC)
+    assert not any("update deltallm_organizationtable" in query.lower() for query, _ in db.query_calls)
+    assert any("update deltallm_organizationtable" in query.lower() for query, _ in db.execute_calls)
+    reset_query, reset_args = db.execute_calls[0]
+    assert "budget_reset_at is not distinct from $3::timestamp" in " ".join(reset_query.lower().split())
+    assert reset_args[2] == datetime(2026, 1, 1)
+    assert reset_args[3] is None
+
+
+@pytest.mark.asyncio
+async def test_budget_enforcement_infers_and_persists_missing_monthly_anchor() -> None:
+    db = ResettingOrgBudgetDB(metadata={})
+    db.organization["budget_duration"] = "1mo"
+    db.organization["budget_reset_at"] = datetime(2026, 1, 30, tzinfo=UTC)
+    service = BudgetEnforcementService(db_client=db)
+
+    await service.check_budgets(
+        api_key=None,
+        user_id=None,
+        team_id=None,
+        organization_id="org_1",
+    )
+
+    assert db.organization["spend"] == 0.0
+    assert db.organization["metadata"]["_budget_reset"]["monthly_anchor_day"] == 30
+    reset_query, reset_args = db.execute_calls[0]
+    assert "jsonb_set" in reset_query
+    assert reset_args[3] == 30
+
+
+@pytest.mark.asyncio
+async def test_budget_enforcement_ignores_out_of_range_legacy_duration() -> None:
+    db = ResettingOrgBudgetDB()
+    db.organization["spend"] = 3.0
+    db.organization["budget_duration"] = "10001d"
+    service = BudgetEnforcementService(db_client=db)
+
+    await service.check_budgets(
+        api_key=None,
+        user_id=None,
+        team_id=None,
+        organization_id="org_1",
+    )
+
+    assert db.organization["spend"] == 3.0
+    assert db.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_budget_enforcement_refetches_when_reset_guard_conflicts() -> None:
+    future_reset = datetime.now(tz=UTC) + timedelta(days=1)
+    db = ResettingOrgBudgetDB(
+        update_count=0,
+        conflict_row={
+            "spend": 3.0,
+            "budget_reset_at": future_reset,
+        },
+    )
+    service = BudgetEnforcementService(db_client=db)
+
+    await service.check_budgets(
+        api_key=None,
+        user_id=None,
+        team_id=None,
+        organization_id="org_1",
+    )
+
+    assert db.organization["spend"] == 3.0
+    assert db.organization["budget_reset_at"] == future_reset
+    assert len(db.execute_calls) == 1
+    assert len(db.query_calls) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_organizations_assets.py
+++ b/tests/test_ui_organizations_assets.py
@@ -23,6 +23,8 @@ class _FakeAdminDB:
                 organization_name,
                 max_budget,
                 soft_budget,
+                budget_duration,
+                budget_reset_at,
                 rpm_limit,
                 tpm_limit,
                 rph_limit,
@@ -32,12 +34,44 @@ class _FakeAdminDB:
                 model_tpm_limit,
                 audit_content_storage_enabled,
                 metadata,
+                reset_fields_provided,
             ) = params
+            row = self.organizations.get(organization_id)
+            if row is not None:
+                next_metadata = _merge_upsert_metadata(
+                    row.get("metadata"),
+                    metadata,
+                    budget_duration=budget_duration,
+                    reset_fields_provided=bool(reset_fields_provided),
+                )
+                row.update(
+                    {
+                        "organization_name": organization_name,
+                        "max_budget": max_budget,
+                        "soft_budget": soft_budget,
+                        "budget_duration": budget_duration if reset_fields_provided else row.get("budget_duration"),
+                        "budget_reset_at": budget_reset_at if reset_fields_provided else row.get("budget_reset_at"),
+                        "rpm_limit": rpm_limit,
+                        "tpm_limit": tpm_limit,
+                        "rph_limit": rph_limit,
+                        "rpd_limit": rpd_limit,
+                        "tpd_limit": tpd_limit,
+                        "model_rpm_limit": model_rpm_limit,
+                        "model_tpm_limit": model_tpm_limit,
+                        "audit_content_storage_enabled": bool(audit_content_storage_enabled),
+                        "metadata": next_metadata or {},
+                        "updated_at": datetime.now(tz=UTC),
+                    }
+                )
+                return 1
+
             self.organizations[organization_id] = {
                 "organization_id": organization_id,
                 "organization_name": organization_name,
                 "max_budget": max_budget,
                 "soft_budget": soft_budget,
+                "budget_duration": budget_duration,
+                "budget_reset_at": budget_reset_at,
                 "spend": 0.0,
                 "rpm_limit": rpm_limit,
                 "tpm_limit": tpm_limit,
@@ -58,6 +92,8 @@ class _FakeAdminDB:
                 organization_name,
                 max_budget,
                 soft_budget,
+                budget_duration,
+                budget_reset_at,
                 rpm_limit,
                 tpm_limit,
                 rph_limit,
@@ -75,6 +111,8 @@ class _FakeAdminDB:
                     "organization_name": organization_name,
                     "max_budget": max_budget,
                     "soft_budget": soft_budget,
+                    "budget_duration": budget_duration,
+                    "budget_reset_at": budget_reset_at,
                     "rpm_limit": rpm_limit,
                     "tpm_limit": tpm_limit,
                     "rph_limit": rph_limit,
@@ -83,7 +121,7 @@ class _FakeAdminDB:
                     "model_rpm_limit": model_rpm_limit,
                     "model_tpm_limit": model_tpm_limit,
                     "audit_content_storage_enabled": bool(audit_content_storage_enabled),
-                    "metadata": metadata or row.get("metadata") or {},
+                    "metadata": metadata or {},
                     "updated_at": datetime.now(tz=UTC),
                 }
             )
@@ -92,11 +130,31 @@ class _FakeAdminDB:
         return 1
 
     async def query_raw(self, query: str, *params):
+        normalized = " ".join(query.lower().split())
+        if "count(*) as total" in normalized and "from deltallm_organizationtable" in normalized:
+            return [{"total": len(self.organizations)}]
+        if "from deltallm_organizationtable o" in normalized:
+            return list(self.organizations.values())
         if "FROM deltallm_organizationtable" in query:
             organization_id = str(params[0])
             row = self.organizations.get(organization_id)
             return [row] if row else []
         return []
+
+
+def _merge_upsert_metadata(
+    existing: Any,
+    incoming: Any,
+    *,
+    budget_duration: str | None,
+    reset_fields_provided: bool,
+) -> dict[str, Any]:
+    if not reset_fields_provided:
+        return {**dict(existing or {}), **dict(incoming or {})}
+    merged = {**dict(existing or {}), **dict(incoming or {})}
+    if budget_duration is None or not budget_duration.endswith("mo"):
+        merged.pop("_budget_reset", None)
+    return merged
 
 
 class _FakeRouteGroupRepository:
@@ -321,6 +379,160 @@ async def test_create_organization_persists_soft_budget(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_create_organization_persists_monthly_budget_reset(client, test_app):
+    fake_db = _FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_catalog = {}
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    response = await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "organization_name": "Org Reset",
+            "max_budget": 100.0,
+            "budget_duration": "1mo",
+            "budget_reset_at": "2099-05-01T00:00:00Z",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["budget_duration"] == "1mo"
+    assert payload["budget_reset_at"] == "2099-05-01T00:00:00Z"
+    assert fake_db.organizations["org-reset"]["budget_reset_at"] == datetime(2099, 5, 1)
+    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 1
+
+    detail = await client.get("/ui/api/organizations/org-reset", headers=headers)
+    assert detail.status_code == 200
+    detail_payload = detail.json()
+    assert detail_payload["budget_duration"] == "1mo"
+    assert detail_payload["budget_reset_at"] == "2099-05-01T00:00:00Z"
+
+    listed = await client.get("/ui/api/organizations", headers=headers)
+    assert listed.status_code == 200
+    listed_payload = listed.json()["data"][0]
+    assert listed_payload["budget_reset_at"] == "2099-05-01T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_create_organization_upsert_preserves_reset_when_fields_are_omitted(client, test_app):
+    fake_db = _FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_catalog = {}
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "organization_name": "Org Reset",
+            "budget_duration": "1mo",
+            "budget_reset_at": "2099-01-30T00:00:00Z",
+        },
+    )
+
+    response = await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "organization_name": "Renamed Org Reset",
+            "metadata": {"source": "upsert"},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["organization_name"] == "Renamed Org Reset"
+    assert payload["budget_duration"] == "1mo"
+    assert payload["budget_reset_at"] == "2099-01-30T00:00:00Z"
+    assert payload["metadata"]["source"] == "upsert"
+    assert payload["metadata"]["_budget_reset"]["monthly_anchor_day"] == 30
+    stored = fake_db.organizations["org-reset"]
+    assert stored["organization_name"] == "Renamed Org Reset"
+    assert stored["budget_duration"] == "1mo"
+    assert stored["budget_reset_at"] == datetime(2099, 1, 30)
+    assert stored["metadata"]["source"] == "upsert"
+    assert stored["metadata"]["_budget_reset"]["monthly_anchor_day"] == 30
+
+
+@pytest.mark.asyncio
+async def test_create_organization_upsert_clears_reset_when_fields_are_null(client, test_app):
+    fake_db = _FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_catalog = {}
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "budget_duration": "1mo",
+            "budget_reset_at": "2099-01-30T00:00:00Z",
+        },
+    )
+
+    response = await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "budget_duration": None,
+            "budget_reset_at": None,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["budget_duration"] is None
+    assert payload["budget_reset_at"] is None
+    assert "_budget_reset" not in payload["metadata"]
+    stored = fake_db.organizations["org-reset"]
+    assert stored["budget_duration"] is None
+    assert stored["budget_reset_at"] is None
+    assert "_budget_reset" not in stored["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_create_organization_normalizes_budget_reset_to_utc(client, test_app):
+    fake_db = _FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_catalog = {}
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    response = await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "budget_duration": "1mo",
+            "budget_reset_at": "2099-05-01T01:30:00+03:00",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["budget_reset_at"] == "2099-04-30T22:30:00Z"
+    assert fake_db.organizations["org-reset"]["budget_reset_at"] == datetime(2099, 4, 30, 22, 30)
+    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 30
+
+
+@pytest.mark.asyncio
 async def test_update_organization_resyncs_route_group_bootstrap_bindings(client, test_app):
     fake_db = _FakeAdminDB()
     route_groups = _FakeRouteGroupRepository()
@@ -419,6 +631,154 @@ async def test_update_organization_persists_soft_budget(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_update_organization_persists_and_clears_monthly_budget_reset(client, test_app):
+    fake_db = _FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_catalog = {}
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "budget_duration": "1mo",
+            "budget_reset_at": "2099-05-01T00:00:00Z",
+        },
+    )
+
+    update = await client.put(
+        "/ui/api/organizations/org-reset",
+        headers=headers,
+        json={
+            "budget_duration": "1mo",
+            "budget_reset_at": "2099-06-01T00:00:00Z",
+        },
+    )
+
+    assert update.status_code == 200
+    update_payload = update.json()
+    assert update_payload["budget_duration"] == "1mo"
+    assert update_payload["budget_reset_at"] == "2099-06-01T00:00:00Z"
+    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 1
+
+    cleared = await client.put(
+        "/ui/api/organizations/org-reset",
+        headers=headers,
+        json={"budget_duration": None, "budget_reset_at": None},
+    )
+
+    assert cleared.status_code == 200
+    cleared_payload = cleared.json()
+    assert cleared_payload["budget_duration"] is None
+    assert cleared_payload["budget_reset_at"] is None
+    assert "_budget_reset" not in fake_db.organizations["org-reset"]["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_update_organization_preserves_monthly_anchor_when_reset_fields_are_omitted(client, test_app):
+    fake_db = _FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_catalog = {}
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "budget_duration": "1mo",
+            "budget_reset_at": "2099-01-30T00:00:00Z",
+        },
+    )
+
+    response = await client.put(
+        "/ui/api/organizations/org-reset",
+        headers=headers,
+        json={"organization_name": "Renamed Org Reset"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["budget_reset_at"] == "2099-01-30T00:00:00Z"
+    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 30
+
+
+@pytest.mark.asyncio
+async def test_update_organization_preserves_budget_reset_when_fields_are_omitted(client, test_app):
+    fake_db = _FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_catalog = {}
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "organization_name": "Org Reset",
+            "budget_duration": "14d",
+            "budget_reset_at": "2099-05-01T00:00:00Z",
+        },
+    )
+
+    response = await client.put(
+        "/ui/api/organizations/org-reset",
+        headers=headers,
+        json={"organization_name": "Renamed Org Reset"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["organization_name"] == "Renamed Org Reset"
+    assert payload["budget_duration"] == "14d"
+    assert payload["budget_reset_at"].startswith("2099-05-01T00:00:00")
+
+
+@pytest.mark.asyncio
+async def test_update_organization_preserves_custom_month_reset_when_fields_are_omitted(client, test_app):
+    fake_db = _FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_catalog = {}
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "organization_name": "Org Reset",
+            "budget_duration": "3mo",
+            "budget_reset_at": "2099-05-31T00:00:00Z",
+        },
+    )
+
+    response = await client.put(
+        "/ui/api/organizations/org-reset",
+        headers=headers,
+        json={"organization_name": "Renamed Org Reset"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["organization_name"] == "Renamed Org Reset"
+    assert payload["budget_duration"] == "3mo"
+    assert payload["budget_reset_at"].startswith("2099-05-31T00:00:00")
+    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 31
+
+
+@pytest.mark.asyncio
 async def test_create_organization_rejects_soft_budget_above_max_budget(client, test_app):
     fake_db = _FakeAdminDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
@@ -440,6 +800,55 @@ async def test_create_organization_rejects_soft_budget_above_max_budget(client, 
 
     assert response.status_code == 400
     assert response.json()["detail"] == "soft_budget must be less than or equal to max_budget"
+
+
+@pytest.mark.asyncio
+async def test_create_organization_rejects_invalid_budget_reset_fields(client, test_app):
+    fake_db = _FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_catalog = {}
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    invalid_duration = await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "budget_duration": "monthly",
+            "budget_reset_at": "2099-05-01T00:00:00Z",
+        },
+    )
+    out_of_range_duration = await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={
+            "organization_id": "org-reset",
+            "budget_duration": "10001d",
+            "budget_reset_at": "2099-05-01T00:00:00Z",
+        },
+    )
+    missing_reset_at = await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={"organization_id": "org-reset", "budget_duration": "1mo"},
+    )
+    missing_duration = await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={"organization_id": "org-reset", "budget_reset_at": "2099-05-01T00:00:00Z"},
+    )
+
+    assert invalid_duration.status_code == 400
+    assert invalid_duration.json()["detail"] == "budget_duration must be a positive integer up to 10000 followed by h, d, or mo"
+    assert out_of_range_duration.status_code == 400
+    assert out_of_range_duration.json()["detail"] == "budget_duration must be a positive integer up to 10000 followed by h, d, or mo"
+    assert missing_reset_at.status_code == 400
+    assert missing_reset_at.json()["detail"] == "budget_reset_at is required when budget_duration is set"
+    assert missing_duration.status_code == 400
+    assert missing_duration.json()["detail"] == "budget_duration is required when budget_reset_at is set"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_rate_limits.py
+++ b/tests/test_ui_rate_limits.py
@@ -18,6 +18,8 @@ class FakeAdminDB:
                 organization_name,
                 max_budget,
                 soft_budget,
+                budget_duration,
+                budget_reset_at,
                 rpm_limit,
                 tpm_limit,
                 rph_limit,
@@ -27,12 +29,14 @@ class FakeAdminDB:
                 model_tpm_limit,
                 audit_content_storage_enabled,
                 metadata,
-            ) = params[:13]
+            ) = params[:15]
             self.organizations[organization_id] = {
                 "organization_id": organization_id,
                 "organization_name": organization_name,
                 "max_budget": max_budget,
                 "soft_budget": soft_budget,
+                "budget_duration": budget_duration,
+                "budget_reset_at": budget_reset_at,
                 "spend": 0.0,
                 "rpm_limit": rpm_limit,
                 "tpm_limit": tpm_limit,
@@ -53,6 +57,8 @@ class FakeAdminDB:
                 organization_name,
                 max_budget,
                 soft_budget,
+                budget_duration,
+                budget_reset_at,
                 rpm_limit,
                 tpm_limit,
                 rph_limit,
@@ -63,13 +69,15 @@ class FakeAdminDB:
                 audit_content_storage_enabled,
                 metadata,
                 organization_id,
-            ) = params[:13]
+            ) = params[:15]
             row = self.organizations[organization_id]
             row.update(
                 {
                     "organization_name": organization_name,
                     "max_budget": max_budget,
                     "soft_budget": soft_budget,
+                    "budget_duration": budget_duration,
+                    "budget_reset_at": budget_reset_at,
                     "rpm_limit": rpm_limit,
                     "tpm_limit": tpm_limit,
                     "rph_limit": rph_limit,
@@ -78,7 +86,7 @@ class FakeAdminDB:
                     "model_rpm_limit": model_rpm_limit,
                     "model_tpm_limit": model_tpm_limit,
                     "audit_content_storage_enabled": bool(audit_content_storage_enabled),
-                    "metadata": metadata or row.get("metadata") or {},
+                    "metadata": metadata or {},
                     "updated_at": datetime.now(tz=UTC),
                 }
             )

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -26,3 +26,61 @@ export function fmtCompact(n: number | null | undefined): string {
   }
   return v.toLocaleString();
 }
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function parseUtcDate(value: string | Date | null | undefined): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const hasTimezone = /(?:z|[+-]\d{2}:?\d{2})$/i.test(trimmed);
+  const date = new Date(hasTimezone ? trimmed : `${trimmed}Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function toUtcDateTimeLocalInputValue(value: string | Date | null | undefined): string {
+  const date = parseUtcDate(value);
+  if (!date) return '';
+  return [
+    date.getUTCFullYear(),
+    '-',
+    pad2(date.getUTCMonth() + 1),
+    '-',
+    pad2(date.getUTCDate()),
+    'T',
+    pad2(date.getUTCHours()),
+    ':',
+    pad2(date.getUTCMinutes()),
+  ].join('');
+}
+
+export function dateTimeLocalUtcInputToIso(value: string): string | null {
+  if (!value.trim()) return null;
+  const date = new Date(`${value.trim()}Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+export function defaultMonthlyResetUtcInputValue(): string {
+  const nextMonth = new Date();
+  nextMonth.setUTCMonth(nextMonth.getUTCMonth() + 1, 1);
+  nextMonth.setUTCHours(0, 0, 0, 0);
+  return toUtcDateTimeLocalInputValue(nextMonth);
+}
+
+export function fmtUtcDateTime(value: string | null | undefined): string {
+  const date = parseUtcDate(value);
+  if (!date) return '';
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'UTC',
+    timeZoneName: 'short',
+  });
+}

--- a/ui/src/pages/OrganizationCreate.tsx
+++ b/ui/src/pages/OrganizationCreate.tsx
@@ -4,6 +4,7 @@ import { useApi } from '../lib/hooks';
 import { useAuth } from '../lib/auth';
 import { callableTargets, organizations } from '../lib/api';
 import { buildCatalogAssetTargets } from '../lib/assetAccess';
+import { dateTimeLocalUtcInputToIso, defaultMonthlyResetUtcInputValue } from '../lib/format';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
 import {
   Building2, X, DollarSign, Gauge, TrendingUp, Info,
@@ -128,10 +129,12 @@ export default function OrganizationCreate() {
   const [name, setName] = useState('');
   const [nameError, setNameError] = useState(false);
   const [budgetEnabled, setBudgetEnabled] = useState(false);
+  const [monthlyResetEnabled, setMonthlyResetEnabled] = useState(false);
   const [rpmEnabled, setRpmEnabled] = useState(false);
   const [tpmEnabled, setTpmEnabled] = useState(false);
   const [budgetValue, setBudgetValue] = useState('');
   const [softBudgetValue, setSoftBudgetValue] = useState('');
+  const [budgetResetAt, setBudgetResetAt] = useState('');
   const [rpmValue, setRpmValue] = useState('');
   const [tpmValue, setTpmValue] = useState('');
   const [rphEnabled, setRphEnabled] = useState(false);
@@ -180,15 +183,31 @@ export default function OrganizationCreate() {
 
   const isReady = name.trim().length > 0;
 
+  const handleMonthlyResetToggle = (checked: boolean) => {
+    setMonthlyResetEnabled(checked);
+    if (checked && !budgetResetAt) {
+      setBudgetResetAt(defaultMonthlyResetUtcInputValue());
+    }
+  };
+
   const handleCreate = async () => {
     if (!name.trim()) { setNameError(true); return; }
     setError(null);
     setSaving(true);
     try {
+      const resetAtIso = budgetEnabled && monthlyResetEnabled
+        ? dateTimeLocalUtcInputToIso(budgetResetAt)
+        : null;
+      if (budgetEnabled && monthlyResetEnabled && !resetAtIso) {
+        setError('Choose a valid next reset date.');
+        return;
+      }
       const payload = {
         organization_name: name.trim(),
         max_budget: budgetEnabled && budgetValue ? Number(budgetValue) : undefined,
         soft_budget: budgetEnabled && softBudgetValue ? Number(softBudgetValue) : undefined,
+        budget_duration: budgetEnabled && monthlyResetEnabled ? '1mo' : undefined,
+        budget_reset_at: budgetEnabled && monthlyResetEnabled ? resetAtIso : undefined,
         rpm_limit: rpmEnabled && rpmValue ? Number(rpmValue) : undefined,
         tpm_limit: tpmEnabled && tpmValue ? Number(tpmValue) : undefined,
         rph_limit: rphEnabled && rphValue ? Number(rphValue) : undefined,
@@ -340,6 +359,30 @@ export default function OrganizationCreate() {
                         />
                       </div>
                       <p className="text-xs text-gray-400 mt-1">Optional notification threshold before the hard budget cap.</p>
+                    </div>
+                    <div className="mt-3 rounded-lg border border-gray-200 bg-white p-3">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-2">
+                          <CalendarDays className="h-4 w-4 text-blue-600" />
+                          <span className="text-sm font-medium text-gray-800">Monthly reset</span>
+                        </div>
+                        <ToggleSwitch
+                          checked={monthlyResetEnabled}
+                          onCheckedChange={handleMonthlyResetToggle}
+                          aria-label="Toggle monthly budget reset"
+                        />
+                      </div>
+                      {monthlyResetEnabled && (
+                        <div className="mt-3">
+                          <FieldLabel label="Next reset (UTC)" />
+                          <input
+                            value={budgetResetAt}
+                            onChange={(e) => setBudgetResetAt(e.target.value)}
+                            type="datetime-local"
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          />
+                        </div>
+                      )}
                     </div>
                   </div>
                 )}

--- a/ui/src/pages/OrganizationDetail.tsx
+++ b/ui/src/pages/OrganizationDetail.tsx
@@ -4,6 +4,12 @@ import { useApi } from '../lib/hooks';
 import { callableTargets, organizations } from '../lib/api';
 import { buildCatalogAssetTargets } from '../lib/assetAccess';
 import { useAuth } from '../lib/auth';
+import {
+  dateTimeLocalUtcInputToIso,
+  defaultMonthlyResetUtcInputValue,
+  fmtUtcDateTime,
+  toUtcDateTimeLocalInputValue,
+} from '../lib/format';
 import Modal from '../components/Modal';
 import UserSearchSelect from '../components/UserSearchSelect';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
@@ -15,7 +21,7 @@ import {
 import {
   ArrowLeft, Building2, Users, DollarSign, Gauge, TrendingUp, Pencil, Plus,
   UserPlus, Trash2, ChevronRight, Shield, CheckCircle2, AlertTriangle,
-  MoreHorizontal, ExternalLink, Info,
+  MoreHorizontal, ExternalLink, Info, CalendarDays,
 } from 'lucide-react';
 
 /* ─────────────── helpers ─────────────── */
@@ -130,6 +136,10 @@ export default function OrganizationDetail() {
     rph_limit: '',
     rpd_limit: '',
     tpd_limit: '',
+    monthly_reset_enabled: false,
+    budget_reset_at: '',
+    existing_budget_duration: '',
+    existing_budget_reset_at: '',
     audit_content_storage_enabled: false,
     select_all_current_assets: false,
     selected_callable_keys: [] as string[],
@@ -183,9 +193,23 @@ export default function OrganizationDetail() {
       rph_limit: org.rph_limit != null ? String(org.rph_limit) : '',
       rpd_limit: org.rpd_limit != null ? String(org.rpd_limit) : '',
       tpd_limit: org.tpd_limit != null ? String(org.tpd_limit) : '',
+      monthly_reset_enabled: org.budget_duration === '1mo' && !!org.budget_reset_at,
+      budget_reset_at: toUtcDateTimeLocalInputValue(org.budget_reset_at),
+      existing_budget_duration: org.budget_duration || '',
+      existing_budget_reset_at: org.budget_reset_at || '',
       audit_content_storage_enabled: !!org.audit_content_storage_enabled,
     }));
     setIsEditingSettings(true);
+  };
+
+  const handleMonthlyResetToggle = (checked: boolean) => {
+    setForm((c) => ({
+      ...c,
+      monthly_reset_enabled: checked,
+      budget_reset_at: checked && (!c.budget_reset_at || c.existing_budget_duration !== '1mo')
+        ? defaultMonthlyResetUtcInputValue()
+        : c.budget_reset_at,
+    }));
   };
 
   const openEditAssets = () => {
@@ -207,7 +231,14 @@ export default function OrganizationDetail() {
     setSaving(true);
     setOrgError(null);
     try {
-      await organizations.update(orgId!, {
+      const resetAtIso = form.monthly_reset_enabled
+        ? dateTimeLocalUtcInputToIso(form.budget_reset_at)
+        : null;
+      if (form.monthly_reset_enabled && !resetAtIso) {
+        setOrgError('Choose a valid next reset date.');
+        return;
+      }
+      const payload: Record<string, unknown> = {
         organization_name: form.organization_name || undefined,
         max_budget: form.max_budget ? Number(form.max_budget) : undefined,
         soft_budget: form.soft_budget ? Number(form.soft_budget) : undefined,
@@ -217,7 +248,15 @@ export default function OrganizationDetail() {
         rpd_limit: form.rpd_limit ? Number(form.rpd_limit) : undefined,
         tpd_limit: form.tpd_limit ? Number(form.tpd_limit) : undefined,
         audit_content_storage_enabled: !!form.audit_content_storage_enabled,
-      });
+      };
+      if (form.monthly_reset_enabled) {
+        payload.budget_duration = '1mo';
+        payload.budget_reset_at = resetAtIso;
+      } else if (form.existing_budget_duration === '1mo') {
+        payload.budget_duration = null;
+        payload.budget_reset_at = null;
+      }
+      await organizations.update(orgId!, payload);
       setIsEditingSettings(false);
       refetchOrg();
     } catch (err: any) {
@@ -672,6 +711,30 @@ export default function OrganizationDetail() {
                         placeholder="Notify before cap"
                       />
                     </div>
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-2.5">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-2">
+                          <CalendarDays className="h-3.5 w-3.5 text-blue-600" />
+                          <span className="text-xs font-medium text-gray-700">Monthly reset</span>
+                        </div>
+                        <input
+                          type="checkbox"
+                          checked={!!form.monthly_reset_enabled}
+                          onChange={(e) => handleMonthlyResetToggle(e.target.checked)}
+                        />
+                      </div>
+                      {form.monthly_reset_enabled && (
+                        <div className="mt-2">
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Next reset (UTC)</label>
+                          <input
+                            type="datetime-local"
+                            value={form.budget_reset_at}
+                            onChange={(e) => setForm({ ...form, budget_reset_at: e.target.value })}
+                            className="w-full px-2.5 py-1.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          />
+                        </div>
+                      )}
+                    </div>
                     <div className="grid grid-cols-2 gap-2">
                       <div>
                         <label className="block text-xs font-medium text-gray-600 mb-1">RPM Limit</label>
@@ -770,6 +833,22 @@ export default function OrganizationDetail() {
                         <span className="text-xs text-gray-500">Soft budget alert</span>
                         <span className="text-xs font-semibold text-gray-800">${Number(org.soft_budget).toLocaleString()}</span>
                       </div>
+                    )}
+                    {org.budget_duration && org.budget_reset_at && (
+                      <>
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs text-gray-500">Budget reset</span>
+                          <span className="text-xs font-semibold text-gray-800">
+                            {org.budget_duration === '1mo' ? 'Monthly' : org.budget_duration}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="text-xs text-gray-500">Next reset (UTC)</span>
+                          <span className="text-right text-xs font-semibold text-gray-800">
+                            {fmtUtcDateTime(org.budget_reset_at)}
+                          </span>
+                        </div>
+                      </>
                     )}
                     {org.rpm_limit != null && (
                       <div className="flex items-center justify-between">

--- a/ui/src/pages/Organizations.tsx
+++ b/ui/src/pages/Organizations.tsx
@@ -5,6 +5,11 @@ import { useAuth } from '../lib/auth';
 import { resolveUiAccess } from '../lib/authorization';
 import { callableTargets, organizations } from '../lib/api';
 import { buildCatalogAssetTargets } from '../lib/assetAccess';
+import {
+  dateTimeLocalUtcInputToIso,
+  defaultMonthlyResetUtcInputValue,
+  toUtcDateTimeLocalInputValue,
+} from '../lib/format';
 import RateLimitSummary from '../components/admin/RateLimitSummary';
 import Modal from '../components/Modal';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
@@ -12,6 +17,7 @@ import { ContentCard, IndexShell } from '../components/admin/shells';
 import {
   Plus, Building2, Users, DollarSign,
   Shield, AlertCircle, Search, MoreHorizontal,
+  CalendarDays,
 } from 'lucide-react';
 
 /* ─────────────── sub-components ─────────────── */
@@ -134,6 +140,10 @@ export default function Organizations() {
     rph_limit: '',
     rpd_limit: '',
     tpd_limit: '',
+    monthly_reset_enabled: false,
+    budget_reset_at: '',
+    existing_budget_duration: '',
+    existing_budget_reset_at: '',
     audit_content_storage_enabled: false,
     select_all_current_assets: false,
     selected_callable_keys: [] as string[],
@@ -170,6 +180,10 @@ export default function Organizations() {
       rph_limit: '',
       rpd_limit: '',
       tpd_limit: '',
+      monthly_reset_enabled: false,
+      budget_reset_at: '',
+      existing_budget_duration: '',
+      existing_budget_reset_at: '',
       audit_content_storage_enabled: false,
       select_all_current_assets: false,
       selected_callable_keys: [],
@@ -190,12 +204,29 @@ export default function Organizations() {
     }));
   }, [editItem, editAssetAccess]);
 
+  const handleMonthlyResetToggle = (checked: boolean) => {
+    setForm((c) => ({
+      ...c,
+      monthly_reset_enabled: checked,
+      budget_reset_at: checked && (!c.budget_reset_at || c.existing_budget_duration !== '1mo')
+        ? defaultMonthlyResetUtcInputValue()
+        : c.budget_reset_at,
+    }));
+  };
+
   const handleSave = async () => {
     if (!editItem) return;
     setError(null);
     setSaving(true);
     try {
-      const payload = {
+      const resetAtIso = form.monthly_reset_enabled
+        ? dateTimeLocalUtcInputToIso(form.budget_reset_at)
+        : null;
+      if (form.monthly_reset_enabled && !resetAtIso) {
+        setError('Choose a valid next reset date.');
+        return;
+      }
+      const payload: Record<string, unknown> = {
         organization_name: form.organization_name || undefined,
         max_budget: form.max_budget ? Number(form.max_budget) : undefined,
         soft_budget: form.soft_budget ? Number(form.soft_budget) : undefined,
@@ -206,6 +237,13 @@ export default function Organizations() {
         tpd_limit: form.tpd_limit ? Number(form.tpd_limit) : undefined,
         audit_content_storage_enabled: !!form.audit_content_storage_enabled,
       };
+      if (form.monthly_reset_enabled) {
+        payload.budget_duration = '1mo';
+        payload.budget_reset_at = resetAtIso;
+      } else if (form.existing_budget_duration === '1mo') {
+        payload.budget_duration = null;
+        payload.budget_reset_at = null;
+      }
       await organizations.update(editItem.organization_id, payload);
       if (isPlatformAdmin) {
         await organizations.updateAssetAccess(editItem.organization_id, {
@@ -235,6 +273,10 @@ export default function Organizations() {
       rph_limit: row.rph_limit != null ? String(row.rph_limit) : '',
       rpd_limit: row.rpd_limit != null ? String(row.rpd_limit) : '',
       tpd_limit: row.tpd_limit != null ? String(row.tpd_limit) : '',
+      monthly_reset_enabled: row.budget_duration === '1mo' && !!row.budget_reset_at,
+      budget_reset_at: toUtcDateTimeLocalInputValue(row.budget_reset_at),
+      existing_budget_duration: row.budget_duration || '',
+      existing_budget_reset_at: row.budget_reset_at || '',
       audit_content_storage_enabled: !!row.audit_content_storage_enabled,
       select_all_current_assets: false,
       selected_callable_keys: [],
@@ -527,6 +569,30 @@ export default function Organizations() {
               className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             <p className="text-xs text-gray-400 mt-1">Notification threshold. Must be less than or equal to max budget.</p>
+          </div>
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <CalendarDays className="h-4 w-4 text-blue-600" />
+                <span className="text-sm font-medium text-gray-800">Monthly reset</span>
+              </div>
+              <input
+                type="checkbox"
+                checked={!!form.monthly_reset_enabled}
+                onChange={(e) => handleMonthlyResetToggle(e.target.checked)}
+              />
+            </div>
+            {form.monthly_reset_enabled && (
+              <div className="mt-3">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Next reset (UTC)</label>
+                <input
+                  type="datetime-local"
+                  value={form.budget_reset_at}
+                  onChange={(e) => setForm({ ...form, budget_reset_at: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            )}
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>


### PR DESCRIPTION
## Summary
- Expose organization budget reset duration and reset timestamp in admin organization APIs.
- Add monthly reset controls to organization create, list edit, and detail settings UI.
- Implement calendar-month reset advancement with durable monthly anchor metadata.
- Preserve reset metadata across org upserts that omit reset fields and return persisted create/upsert state.
- Document monthly reset semantics and include the internal issue 106 implementation plan.

Closes #106

## Validation
- `uv run --extra dev pytest tests/test_billing.py tests/test_ui_organizations_assets.py tests/test_ui_rate_limits.py`
- `uv run --extra dev ruff check src/billing/budget.py src/api/admin/endpoints/organizations.py tests/test_billing.py tests/test_ui_organizations_assets.py tests/test_ui_rate_limits.py`
- `npm run build --prefix ui`
- `git diff --check`