### PR TITLE
Issue 124 PR1: Backend foundation for callable target access groups

### DIFF
--- a/prisma/migrations/20260429110000_callable_target_access_groups/migration.sql
+++ b/prisma/migrations/20260429110000_callable_target_access_groups/migration.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS "deltallm_callabletargetaccessgroupbinding" (
+  "callable_target_access_group_binding_id" TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  "group_key" TEXT NOT NULL,
+  "scope_type" TEXT NOT NULL,
+  "scope_id" TEXT NOT NULL,
+  "enabled" BOOLEAN NOT NULL DEFAULT TRUE,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "updated_at" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "deltallm_callabletargetaccessgroupbinding_scope_group_key"
+  ON "deltallm_callabletargetaccessgroupbinding" ("group_key", "scope_type", "scope_id");
+
+CREATE INDEX IF NOT EXISTS "deltallm_callabletargetaccessgroupbinding_scope_idx"
+  ON "deltallm_callabletargetaccessgroupbinding" ("scope_type", "scope_id", "enabled");
+
+CREATE INDEX IF NOT EXISTS "deltallm_callabletargetaccessgroupbinding_group_idx"
+  ON "deltallm_callabletargetaccessgroupbinding" ("group_key");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -590,6 +590,22 @@ model DeltaLLM_CallableTargetBinding {
   @@map("deltallm_callabletargetbinding")
 }
 
+model DeltaLLM_CallableTargetAccessGroupBinding {
+  callable_target_access_group_binding_id String   @id @default(uuid())
+  group_key                               String
+  scope_type                              String
+  scope_id                                String
+  enabled                                 Boolean  @default(true)
+  metadata                                Json?
+  created_at                              DateTime @default(now())
+  updated_at                              DateTime @updatedAt
+
+  @@unique([group_key, scope_type, scope_id], map: "deltallm_callabletargetaccessgroupbinding_scope_group_key")
+  @@index([scope_type, scope_id, enabled], map: "deltallm_callabletargetaccessgroupbinding_scope_idx")
+  @@index([group_key], map: "deltallm_callabletargetaccessgroupbinding_group_idx")
+  @@map("deltallm_callabletargetaccessgroupbinding")
+}
+
 model DeltaLLM_CallableTargetScopePolicy {
   callable_target_scope_policy_id String   @id @default(uuid())
   scope_type                      String

--- a/src/api/admin/endpoints/models.py
+++ b/src/api/admin/endpoints/models.py
@@ -260,14 +260,13 @@ async def _invalidate_route_group_runtime_cache(app: Any) -> None:
 
 
 async def _sync_auto_follow_org_bindings(app: Any) -> None:
-    changed = await sync_auto_follow_organization_bindings(
+    await sync_auto_follow_organization_bindings(
         db=getattr(getattr(app.state, "prisma_manager", None), "client", None),
         callable_target_binding_repository=getattr(app.state, "callable_target_binding_repository", None),
         route_group_repository=getattr(app.state, "route_group_repository", None),
         callable_target_catalog=getattr(app.state, "callable_target_catalog", None),
     )
-    if changed > 0:
-        await reload_callable_target_grants_for_app(app)
+    await reload_callable_target_grants_for_app(app)
 
 
 def _validate_model_config_or_400(model_config: dict[str, Any]) -> None:

--- a/src/bootstrap/infrastructure.py
+++ b/src/bootstrap/infrastructure.py
@@ -10,6 +10,7 @@ from src.bootstrap.status import BootstrapStatus
 from src.batch import BatchRepository
 from src.config import get_settings, resolve_database_settings, resolve_salt_key
 from src.config_runtime import DynamicConfigManager, SecretResolver, build_app_config, load_yaml_dict
+from src.db.callable_target_access_groups import CallableTargetAccessGroupBindingRepository
 from src.db.callable_targets import CallableTargetBindingRepository
 from src.db.callable_target_policies import CallableTargetScopePolicyRepository
 from src.db.client import prisma_manager
@@ -88,6 +89,9 @@ async def init_infrastructure_runtime(app: Any) -> InfrastructureRuntime:
     app.state.model_deployment_repository = ModelDeploymentRepository(prisma_manager.client)
     app.state.named_credential_repository = NamedCredentialRepository(prisma_manager.client)
     app.state.callable_target_binding_repository = CallableTargetBindingRepository(prisma_manager.client)
+    app.state.callable_target_access_group_repository = CallableTargetAccessGroupBindingRepository(
+        prisma_manager.client
+    )
     app.state.callable_target_scope_policy_repository = CallableTargetScopePolicyRepository(prisma_manager.client)
     app.state.route_group_repository = RouteGroupRepository(prisma_manager.client)
     app.state.prompt_registry_repository = PromptRegistryRepository(prisma_manager.client)

--- a/src/bootstrap/runtime_services.py
+++ b/src/bootstrap/runtime_services.py
@@ -36,6 +36,8 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
     app.state.callable_target_grant_service = CallableTargetGrantService(
         repository=getattr(app.state, "callable_target_binding_repository", None),
         policy_repository=getattr(app.state, "callable_target_scope_policy_repository", None),
+        access_group_repository=getattr(app.state, "callable_target_access_group_repository", None),
+        callable_target_catalog_getter=lambda: getattr(app.state, "callable_target_catalog", None),
     )
     await app.state.callable_target_grant_service.reload()
     app.state.prompt_registry_service = PromptRegistryService(

--- a/src/config.py
+++ b/src/config.py
@@ -11,6 +11,7 @@ import yaml
 from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from src.governance.access_groups import normalize_access_group_list
 from src.batch.create.defaults import (
     DEFAULT_CREATE_SESSION_CLEANUP_INTERVAL_SECONDS,
     DEFAULT_CREATE_SESSION_CLEANUP_SCAN_LIMIT,
@@ -103,6 +104,7 @@ class ModelInfo(BaseModel):
     weight: int = 1
     priority: int = 0
     tags: list[str] = Field(default_factory=list)
+    access_groups: list[str] = Field(default_factory=list)
     input_cost_per_token: float | None = None
     output_cost_per_token: float | None = None
     input_cost_per_token_cache_hit: float | None = None
@@ -131,6 +133,11 @@ class ModelInfo(BaseModel):
     upstream_max_batch_inputs: int | None = Field(default=None, ge=1)
     default_params: dict[str, Any] | None = None
 
+    @field_validator("access_groups", mode="before")
+    @classmethod
+    def validate_access_groups(cls, value: object) -> list[str]:
+        return normalize_access_group_list(value, strict=True)
+
 
 class ModelDeployment(BaseModel):
     model_config = {"populate_by_name": True}
@@ -153,7 +160,13 @@ class RouteGroupConfig(BaseModel):
     key: str
     enabled: bool = True
     strategy: RoutingStrategyName | None = None
+    access_groups: list[str] = Field(default_factory=list)
     members: list[RouteGroupMember] = Field(default_factory=list)
+
+    @field_validator("access_groups", mode="before")
+    @classmethod
+    def validate_access_groups(cls, value: object) -> list[str]:
+        return normalize_access_group_list(value, strict=True)
 
 
 class RouterSettings(BaseModel):

--- a/src/config_runtime/models.py
+++ b/src/config_runtime/models.py
@@ -196,6 +196,7 @@ class ModelHotReloadManager:
             redis_client=getattr(app.state, "redis", None),
             salt_key=salt_key,
         )
+        await reload_callable_target_grants_for_app(app, notify=False)
 
     async def _reload_runtime(self) -> None:
         app_config = self.dynamic_config.get_app_config()

--- a/src/db/callable_target_access_groups.py
+++ b/src/db/callable_target_access_groups.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from src.governance.access_groups import normalize_access_group_key
+
+
+def _parse_json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+        except ValueError:
+            return None
+    return None
+
+
+@dataclass
+class CallableTargetAccessGroupBindingRecord:
+    callable_target_access_group_binding_id: str
+    group_key: str
+    scope_type: str
+    scope_id: str
+    enabled: bool = True
+    metadata: dict[str, Any] | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class CallableTargetAccessGroupBindingRepository:
+    def __init__(self, prisma_client: Any | None = None) -> None:
+        self.prisma = prisma_client
+
+    async def list_bindings(
+        self,
+        *,
+        group_key: str | None = None,
+        scope_type: str | None = None,
+        scope_id: str | None = None,
+        limit: int = 200,
+        offset: int = 0,
+    ) -> tuple[list[CallableTargetAccessGroupBindingRecord], int]:
+        if self.prisma is None:
+            return [], 0
+
+        clauses: list[str] = []
+        params: list[Any] = []
+        if group_key:
+            normalized_group_key = normalize_access_group_key(group_key)
+            if normalized_group_key is None:
+                return [], 0
+            params.append(normalized_group_key)
+            clauses.append(f"group_key = ${len(params)}")
+        if scope_type:
+            params.append(str(scope_type).strip().lower())
+            clauses.append(f"scope_type = ${len(params)}")
+        if scope_id:
+            params.append(str(scope_id).strip())
+            clauses.append(f"scope_id = ${len(params)}")
+
+        where_sql = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        count_rows = await self.prisma.query_raw(
+            f"SELECT COUNT(*)::int AS total FROM deltallm_callabletargetaccessgroupbinding {where_sql}",
+            *params,
+        )
+        total = int((count_rows[0] if count_rows else {}).get("total") or 0)
+
+        page_params = [*params, limit, offset]
+        rows = await self.prisma.query_raw(
+            f"""
+            SELECT
+                callable_target_access_group_binding_id,
+                group_key,
+                scope_type,
+                scope_id,
+                enabled,
+                metadata,
+                created_at,
+                updated_at
+            FROM deltallm_callabletargetaccessgroupbinding
+            {where_sql}
+            ORDER BY created_at DESC, group_key ASC, scope_type ASC, scope_id ASC
+            LIMIT ${len(page_params) - 1} OFFSET ${len(page_params)}
+            """,
+            *page_params,
+        )
+        return [self._to_binding_record(row) for row in rows], total
+
+    async def upsert_binding(
+        self,
+        *,
+        group_key: str,
+        scope_type: str,
+        scope_id: str,
+        enabled: bool,
+        metadata: dict[str, Any] | None,
+    ) -> CallableTargetAccessGroupBindingRecord | None:
+        if self.prisma is None:
+            return None
+
+        normalized_group_key = normalize_access_group_key(group_key, strict=True)
+        if normalized_group_key is None:
+            raise ValueError("group_key is required")
+        normalized_scope_type = str(scope_type or "").strip().lower()
+        normalized_scope_id = str(scope_id or "").strip()
+        if not normalized_scope_type:
+            raise ValueError("scope_type is required")
+        if not normalized_scope_id:
+            raise ValueError("scope_id is required")
+
+        rows = await self.prisma.query_raw(
+            """
+            INSERT INTO deltallm_callabletargetaccessgroupbinding (
+                callable_target_access_group_binding_id,
+                group_key,
+                scope_type,
+                scope_id,
+                enabled,
+                metadata,
+                created_at,
+                updated_at
+            )
+            VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5::jsonb, NOW(), NOW())
+            ON CONFLICT (group_key, scope_type, scope_id)
+            DO UPDATE SET
+                enabled = EXCLUDED.enabled,
+                metadata = EXCLUDED.metadata,
+                updated_at = NOW()
+            RETURNING
+                callable_target_access_group_binding_id,
+                group_key,
+                scope_type,
+                scope_id,
+                enabled,
+                metadata,
+                created_at,
+                updated_at
+            """,
+            normalized_group_key,
+            normalized_scope_type,
+            normalized_scope_id,
+            enabled,
+            json.dumps(metadata) if metadata is not None else None,
+        )
+        return self._to_binding_record(rows[0]) if rows else None
+
+    async def get_binding(
+        self,
+        binding_id: str,
+    ) -> CallableTargetAccessGroupBindingRecord | None:
+        if self.prisma is None:
+            return None
+
+        rows = await self.prisma.query_raw(
+            """
+            SELECT
+                callable_target_access_group_binding_id,
+                group_key,
+                scope_type,
+                scope_id,
+                enabled,
+                metadata,
+                created_at,
+                updated_at
+            FROM deltallm_callabletargetaccessgroupbinding
+            WHERE callable_target_access_group_binding_id = $1
+            LIMIT 1
+            """,
+            binding_id,
+        )
+        return self._to_binding_record(rows[0]) if rows else None
+
+    async def delete_binding(self, binding_id: str) -> bool:
+        if self.prisma is None:
+            return False
+
+        rows = await self.prisma.query_raw(
+            """
+            DELETE FROM deltallm_callabletargetaccessgroupbinding
+            WHERE callable_target_access_group_binding_id = $1
+            RETURNING callable_target_access_group_binding_id
+            """,
+            binding_id,
+        )
+        return bool(rows)
+
+    @staticmethod
+    def _to_binding_record(row: dict[str, Any]) -> CallableTargetAccessGroupBindingRecord:
+        return CallableTargetAccessGroupBindingRecord(
+            callable_target_access_group_binding_id=str(
+                row.get("callable_target_access_group_binding_id") or ""
+            ),
+            group_key=str(row.get("group_key") or ""),
+            scope_type=str(row.get("scope_type") or ""),
+            scope_id=str(row.get("scope_id") or ""),
+            enabled=bool(row.get("enabled", True)),
+            metadata=_parse_json_object(row.get("metadata")) if row.get("metadata") is not None else None,
+            created_at=_parse_datetime(row.get("created_at")),
+            updated_at=_parse_datetime(row.get("updated_at")),
+        )

--- a/src/db/route_groups.py
+++ b/src/db/route_groups.py
@@ -828,6 +828,7 @@ class RouteGroupRepository:
         for row in groups:
             group_id = str(row.get("route_group_id") or "")
             policy_json = _parse_json_object(row.get("policy_json"))
+            metadata = _parse_json_object(row.get("metadata")) if row.get("metadata") is not None else None
             strategy = row.get("routing_strategy")
             if isinstance(policy_json.get("strategy"), str):
                 strategy = policy_json["strategy"]
@@ -848,8 +849,9 @@ class RouteGroupRepository:
                     "timeouts": timeouts if isinstance(timeouts, dict) else None,
                     "retry": retry if isinstance(retry, dict) else None,
                     "default_prompt": _extract_default_prompt(
-                        _parse_json_object(row.get("metadata")) if row.get("metadata") is not None else None
+                        metadata
                     ),
+                    "access_groups": metadata.get("access_groups") if isinstance(metadata, dict) else None,
                     "members": merged_members,
                 }
             )

--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -1,0 +1,1 @@
+"""Governance domain helpers."""

--- a/src/governance/access_groups.py
+++ b/src/governance/access_groups.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+_ACCESS_GROUP_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+MAX_ACCESS_GROUPS_PER_TARGET = 100
+
+
+class InvalidAccessGroupError(ValueError):
+    """Raised when an access group key is malformed."""
+
+
+def normalize_access_group_key(value: object, *, strict: bool = False) -> str | None:
+    if not isinstance(value, str):
+        if strict:
+            raise InvalidAccessGroupError("access group key must be a string")
+        return None
+
+    normalized = value.strip().lower()
+    if not normalized:
+        if strict:
+            raise InvalidAccessGroupError("access group key must be non-empty")
+        return None
+    if not _ACCESS_GROUP_PATTERN.fullmatch(normalized):
+        if strict:
+            raise InvalidAccessGroupError(
+                "access group key must start with a lowercase letter or digit and contain only "
+                "lowercase letters, digits, '.', '_' or '-'"
+            )
+        return None
+    return normalized
+
+
+def normalize_access_groups(value: object, *, strict: bool = False) -> frozenset[str]:
+    if value is None:
+        return frozenset()
+    if not isinstance(value, list):
+        if strict:
+            raise InvalidAccessGroupError("access_groups must be an array")
+        return frozenset()
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        group_key = normalize_access_group_key(item, strict=strict)
+        if group_key is None or group_key in seen:
+            continue
+        if len(normalized) >= MAX_ACCESS_GROUPS_PER_TARGET:
+            if strict:
+                raise InvalidAccessGroupError(
+                    f"access_groups must contain at most {MAX_ACCESS_GROUPS_PER_TARGET} values"
+                )
+            break
+        seen.add(group_key)
+        normalized.append(group_key)
+    return frozenset(normalized)
+
+
+def normalize_access_group_list(value: object, *, strict: bool = False) -> list[str]:
+    return sorted(normalize_access_groups(value, strict=strict))
+
+
+def access_groups_from_metadata(metadata: object) -> frozenset[str]:
+    if not isinstance(metadata, Mapping):
+        return frozenset()
+    return normalize_access_groups(metadata.get("access_groups"))
+
+
+def build_callable_keys_by_access_group(catalog: Mapping[str, Any] | None) -> dict[str, frozenset[str]]:
+    if not isinstance(catalog, Mapping):
+        return {}
+
+    grouped: dict[str, set[str]] = {}
+    for raw_key, target in catalog.items():
+        callable_key = str(raw_key or "").strip()
+        if not callable_key:
+            continue
+        access_groups = getattr(target, "access_groups", frozenset())
+        if not isinstance(access_groups, frozenset):
+            access_groups = normalize_access_groups(list(access_groups) if access_groups else [])
+        for group_key in access_groups:
+            grouped.setdefault(group_key, set()).add(callable_key)
+    return {group_key: frozenset(sorted(keys)) for group_key, keys in grouped.items()}

--- a/src/services/asset_binding_mirror.py
+++ b/src/services/asset_binding_mirror.py
@@ -34,11 +34,11 @@ async def reload_callable_target_grants(request: Request) -> None:
     await reload_callable_target_grants_for_app(request.app)
 
 
-async def reload_callable_target_grants_for_app(app: Any) -> None:
+async def reload_callable_target_grants_for_app(app: Any, *, notify: bool = True) -> None:
     invalidation = getattr(app.state, "governance_invalidation_service", None)
     if invalidation is not None and callable(getattr(invalidation, "invalidate_local", None)):
         await invalidation.invalidate_local("callable_target")
-        if callable(getattr(invalidation, "notify", None)):
+        if notify and callable(getattr(invalidation, "notify", None)):
             await invalidation.notify("callable_target")
         return
     service = getattr(app.state, "callable_target_grant_service", None)

--- a/src/services/callable_target_grants.py
+++ b/src/services/callable_target_grants.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 
 from src.models.responses import UserAPIKeyAuth
+from src.governance.access_groups import build_callable_keys_by_access_group
 from src.services.runtime_scopes import resolve_runtime_scope_context
 
 if TYPE_CHECKING:
+    from src.db.callable_target_access_groups import CallableTargetAccessGroupBindingRepository
     from src.db.callable_targets import CallableTargetBindingRepository
     from src.db.callable_target_policies import CallableTargetScopePolicyRepository
 
@@ -18,6 +20,9 @@ class CallableTargetGrantSnapshot:
     enabled_by_scope: dict[tuple[str, str], frozenset[str]]
     binding_counts_by_scope: dict[tuple[str, str], int]
     scope_modes_by_scope: dict[tuple[str, str], str]
+    enabled_groups_by_scope: dict[tuple[str, str], frozenset[str]]
+    group_binding_counts_by_scope: dict[tuple[str, str], int]
+    callable_keys_by_group: dict[str, frozenset[str]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,29 +38,31 @@ class CallableTargetGrantService:
         repository: CallableTargetBindingRepository | None,
         *,
         policy_repository: CallableTargetScopePolicyRepository | None = None,
+        access_group_repository: CallableTargetAccessGroupBindingRepository | None = None,
+        callable_target_catalog_getter: Callable[[], Mapping[str, Any] | None] | None = None,
     ) -> None:
         self.repository = repository
         self.policy_repository = policy_repository
+        self.access_group_repository = access_group_repository
+        self.callable_target_catalog_getter = callable_target_catalog_getter
         self._reload_lock = asyncio.Lock()
-        self._snapshot = CallableTargetGrantSnapshot(
-            enabled_by_scope={},
-            binding_counts_by_scope={},
-            scope_modes_by_scope={},
-        )
+        self._snapshot = self._empty_snapshot()
 
     async def reload(self) -> None:
-        if self.repository is None and self.policy_repository is None:
-            self._snapshot = CallableTargetGrantSnapshot(
-                enabled_by_scope={},
-                binding_counts_by_scope={},
-                scope_modes_by_scope={},
-            )
+        if (
+            self.repository is None
+            and self.policy_repository is None
+            and self.access_group_repository is None
+        ):
+            self._snapshot = self._empty_snapshot()
             return
 
         async with self._reload_lock:
             enabled_by_scope: dict[tuple[str, str], set[str]] = defaultdict(set)
             binding_counts_by_scope: dict[tuple[str, str], int] = defaultdict(int)
             scope_modes_by_scope: dict[tuple[str, str], str] = {}
+            enabled_groups_by_scope: dict[tuple[str, str], set[str]] = defaultdict(set)
+            group_binding_counts_by_scope: dict[tuple[str, str], int] = defaultdict(int)
             if self.repository is not None:
                 offset = 0
                 limit = 1000
@@ -71,6 +78,23 @@ class CallableTargetGrantService:
                     if not bindings or offset >= total:
                         break
 
+            if self.access_group_repository is not None:
+                offset = 0
+                limit = 1000
+                while True:
+                    group_bindings, total = await self.access_group_repository.list_bindings(
+                        limit=limit,
+                        offset=offset,
+                    )
+                    for binding in group_bindings:
+                        scope = (binding.scope_type, binding.scope_id)
+                        group_binding_counts_by_scope[scope] += 1
+                        if binding.enabled:
+                            enabled_groups_by_scope[scope].add(binding.group_key)
+                    offset += len(group_bindings)
+                    if not group_bindings or offset >= total:
+                        break
+
             if self.policy_repository is not None:
                 offset = 0
                 limit = 1000
@@ -82,10 +106,22 @@ class CallableTargetGrantService:
                     if not policies or offset >= total:
                         break
 
+            callable_keys_by_group = build_callable_keys_by_access_group(
+                self._callable_target_catalog()
+            )
+            for scope, group_keys in enabled_groups_by_scope.items():
+                for group_key in group_keys:
+                    enabled_by_scope[scope].update(callable_keys_by_group.get(group_key, ()))
+
             self._snapshot = CallableTargetGrantSnapshot(
                 enabled_by_scope={scope: frozenset(values) for scope, values in enabled_by_scope.items()},
                 binding_counts_by_scope=dict(binding_counts_by_scope),
                 scope_modes_by_scope=scope_modes_by_scope,
+                enabled_groups_by_scope={
+                    scope: frozenset(values) for scope, values in enabled_groups_by_scope.items()
+                },
+                group_binding_counts_by_scope=dict(group_binding_counts_by_scope),
+                callable_keys_by_group=callable_keys_by_group,
             )
 
     async def invalidate_all(self) -> None:
@@ -100,7 +136,7 @@ class CallableTargetGrantService:
         if not scopes:
             return None
 
-        any_matching_bindings = any(snapshot.binding_counts_by_scope.get(scope, 0) > 0 for scope in scopes)
+        any_matching_bindings = any(self._has_scope_access_configuration(snapshot, scope) for scope in scopes)
         if not any_matching_bindings:
             return None
 
@@ -121,7 +157,10 @@ class CallableTargetGrantService:
         normalized_scope_id = str(scope_id or "").strip() if scope_id is not None else ""
         if not normalized_scope_type or not normalized_scope_id:
             return False
-        return self._snapshot.binding_counts_by_scope.get((normalized_scope_type, normalized_scope_id), 0) > 0
+        return self._has_scope_access_configuration(
+            self._snapshot,
+            (normalized_scope_type, normalized_scope_id),
+        )
 
     def resolve_policy_allowlist(self, auth: UserAPIKeyAuth) -> CallableTargetPolicyResolution:
         scope_context = resolve_runtime_scope_context(auth)
@@ -159,7 +198,7 @@ class CallableTargetGrantService:
         scope_context = resolve_runtime_scope_context(auth)
         if scope_context.organization_id is not None:
             organization_scope = ("organization", scope_context.organization_id)
-            if snapshot.binding_counts_by_scope.get(organization_scope, 0) == 0:
+            if not self._has_scope_access_configuration(snapshot, organization_scope):
                 return set()
             return set(snapshot.enabled_by_scope.get(organization_scope, ()))
 
@@ -167,7 +206,7 @@ class CallableTargetGrantService:
         direct_allowlists = [
             set(snapshot.enabled_by_scope.get(scope, ()))
             for scope in direct_scopes
-            if snapshot.binding_counts_by_scope.get(scope, 0) > 0
+            if self._has_scope_access_configuration(snapshot, scope)
         ]
         if not direct_allowlists:
             return None
@@ -202,4 +241,33 @@ class CallableTargetGrantService:
         mode = snapshot.scope_modes_by_scope.get(user_scope)
         if mode == "restrict":
             return True
-        return mode is None and snapshot.binding_counts_by_scope.get(user_scope, 0) > 0
+        return mode is None and CallableTargetGrantService._has_scope_access_configuration(
+            snapshot,
+            user_scope,
+        )
+
+    @staticmethod
+    def _empty_snapshot() -> CallableTargetGrantSnapshot:
+        return CallableTargetGrantSnapshot(
+            enabled_by_scope={},
+            binding_counts_by_scope={},
+            scope_modes_by_scope={},
+            enabled_groups_by_scope={},
+            group_binding_counts_by_scope={},
+            callable_keys_by_group={},
+        )
+
+    def _callable_target_catalog(self) -> Mapping[str, Any] | None:
+        if self.callable_target_catalog_getter is None:
+            return None
+        return self.callable_target_catalog_getter()
+
+    @staticmethod
+    def _has_scope_access_configuration(
+        snapshot: CallableTargetGrantSnapshot,
+        scope: tuple[str, str],
+    ) -> bool:
+        return (
+            snapshot.binding_counts_by_scope.get(scope, 0)
+            + snapshot.group_binding_counts_by_scope.get(scope, 0)
+        ) > 0

--- a/src/services/callable_targets.py
+++ b/src/services/callable_targets.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
+
+from src.governance.access_groups import access_groups_from_metadata, normalize_access_groups
+
+logger = logging.getLogger(__name__)
 
 
 class DuplicateCallableTargetError(ValueError):
@@ -12,6 +18,7 @@ class DuplicateCallableTargetError(ValueError):
 class CallableTarget:
     key: str
     target_type: Literal["model", "route_group"]
+    access_groups: frozenset[str] = frozenset()
 
 
 def build_callable_target_catalog(
@@ -21,11 +28,15 @@ def build_callable_target_catalog(
     catalog: dict[str, CallableTarget] = {}
     deployment_ids = _collect_deployment_ids(model_registry)
 
-    for model_name in model_registry:
+    for model_name, entries in model_registry.items():
         key = str(model_name).strip()
         if not key:
             continue
-        catalog[key] = CallableTarget(key=key, target_type="model")
+        catalog[key] = CallableTarget(
+            key=key,
+            target_type="model",
+            access_groups=_model_access_groups(key, entries),
+        )
 
     if not route_groups:
         return catalog
@@ -41,7 +52,11 @@ def build_callable_target_catalog(
             raise DuplicateCallableTargetError(
                 f"Callable target key '{group_key}' is declared by both a {existing.target_type} and a route_group"
             )
-        catalog[group_key] = CallableTarget(key=group_key, target_type="route_group")
+        catalog[group_key] = CallableTarget(
+            key=group_key,
+            target_type="route_group",
+            access_groups=_route_group_access_groups(group),
+        )
 
     return catalog
 
@@ -61,6 +76,31 @@ def _collect_deployment_ids(model_registry: dict[str, list[dict[str, object]]]) 
             if deployment_id:
                 deployment_ids.add(deployment_id)
     return deployment_ids
+
+
+def _model_access_groups(model_name: str, entries: list[dict[str, object]]) -> frozenset[str]:
+    resolved: frozenset[str] | None = None
+    for entry in entries:
+        model_info = entry.get("model_info") if isinstance(entry, Mapping) else None
+        groups = access_groups_from_metadata(model_info)
+        if resolved is None:
+            resolved = groups
+            continue
+        if groups != resolved:
+            logger.warning(
+                "callable target access_groups conflict for model_name=%s; "
+                "group expansion disabled for this model",
+                model_name,
+            )
+            return frozenset()
+    return resolved or frozenset()
+
+
+def _route_group_access_groups(group: dict[str, object]) -> frozenset[str]:
+    if isinstance(group, Mapping) and "access_groups" in group:
+        return normalize_access_groups(group.get("access_groups"))
+    metadata = group.get("metadata") if isinstance(group, Mapping) else None
+    return access_groups_from_metadata(metadata)
 
 
 def _route_group_has_live_members(group: dict[str, object], deployment_ids: set[str]) -> bool:

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -5,6 +5,7 @@ import pytest
 from src.config import (
     AppConfig,
     ModelInfo,
+    RouteGroupConfig,
     Settings,
     resolve_app_config_with_secrets,
     resolve_database_settings,
@@ -158,3 +159,49 @@ def test_model_info_accepts_valid_upstream_max_batch_inputs():
 def test_model_info_rejects_non_positive_upstream_max_batch_inputs(value: int):
     with pytest.raises(ValueError, match="greater than or equal to 1"):
         ModelInfo.model_validate({"upstream_max_batch_inputs": value})
+
+
+def test_model_info_normalizes_access_groups():
+    info = ModelInfo.model_validate({"access_groups": ["Beta", "support", "beta"]})
+
+    assert info.access_groups == ["beta", "support"]
+    assert info.model_dump()["access_groups"] == ["beta", "support"]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "beta",
+        [1],
+        ["bad group"],
+    ],
+)
+def test_model_info_rejects_invalid_access_groups(value: object):
+    with pytest.raises(ValueError, match="access"):
+        ModelInfo.model_validate({"access_groups": value})
+
+
+def test_route_group_config_normalizes_access_groups():
+    group = RouteGroupConfig.model_validate(
+        {
+            "key": "support-fast",
+            "access_groups": ["Support", "support", "beta"],
+            "members": [{"deployment_id": "dep-1"}],
+        }
+    )
+
+    assert group.access_groups == ["beta", "support"]
+    assert group.model_dump()["access_groups"] == ["beta", "support"]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "support",
+        [object()],
+        ["bad group"],
+    ],
+)
+def test_route_group_config_rejects_invalid_access_groups(value: object):
+    with pytest.raises(ValueError, match="access"):
+        RouteGroupConfig.model_validate({"key": "support-fast", "access_groups": value})

--- a/tests/db/test_callable_target_access_groups.py
+++ b/tests/db/test_callable_target_access_groups.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from src.db.callable_target_access_groups import CallableTargetAccessGroupBindingRepository
+from src.governance.access_groups import InvalidAccessGroupError
+
+
+class _FakePrisma:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def query_raw(self, sql: str, *params: object) -> list[dict[str, object]]:
+        self.calls.append((sql, params))
+        if "INSERT INTO deltallm_callabletargetaccessgroupbinding" not in sql:
+            return []
+        return [
+            {
+                "callable_target_access_group_binding_id": "ctagb-1",
+                "group_key": params[0],
+                "scope_type": params[1],
+                "scope_id": params[2],
+                "enabled": params[3],
+                "metadata": None,
+                "created_at": None,
+                "updated_at": None,
+            }
+        ]
+
+
+@pytest.mark.asyncio
+async def test_access_group_binding_upsert_normalizes_group_and_scope() -> None:
+    prisma = _FakePrisma()
+    repository = CallableTargetAccessGroupBindingRepository(prisma)
+
+    record = await repository.upsert_binding(
+        group_key="Beta",
+        scope_type="Organization",
+        scope_id=" org-1 ",
+        enabled=True,
+        metadata=None,
+    )
+
+    assert record is not None
+    assert record.group_key == "beta"
+    assert record.scope_type == "organization"
+    assert record.scope_id == "org-1"
+    assert prisma.calls[0][1][:3] == ("beta", "organization", "org-1")
+
+
+@pytest.mark.asyncio
+async def test_access_group_binding_upsert_rejects_invalid_group_key() -> None:
+    repository = CallableTargetAccessGroupBindingRepository(_FakePrisma())
+
+    with pytest.raises(InvalidAccessGroupError, match="access group key"):
+        await repository.upsert_binding(
+            group_key="bad group",
+            scope_type="organization",
+            scope_id="org-1",
+            enabled=True,
+            metadata=None,
+        )

--- a/tests/test_model_visibility.py
+++ b/tests/test_model_visibility.py
@@ -4,17 +4,20 @@ import logging
 
 import pytest
 
-from src.config import GeneralSettings, Settings
+from src.config import AppConfig, GeneralSettings, Settings
+from src.db.callable_target_access_groups import CallableTargetAccessGroupBindingRecord
 from src.db.callable_targets import CallableTargetBindingRecord
 from src.db.callable_target_policies import CallableTargetScopePolicyRecord
 from src.models.responses import UserAPIKeyAuth
 from src.services.callable_target_grants import CallableTargetGrantService
-from src.services.callable_targets import DuplicateCallableTargetError, build_callable_target_catalog
+from src.services.callable_targets import CallableTarget, DuplicateCallableTargetError, build_callable_target_catalog
+from src.services.model_deployments import build_model_registry_from_config
 from src.services.model_visibility import (
     filter_visible_models,
     resolve_effective_model_allowlist,
     resolve_model_allowlist_resolution,
 )
+from src.services.route_groups import route_groups_from_config
 
 
 class _FakeCallableTargetBindingRepository:
@@ -39,6 +42,22 @@ class _FakeCallableTargetScopePolicyRepository:
 
     async def list_policies(self, *, scope_type=None, scope_id=None, limit=200, offset=0):  # noqa: ANN001, ANN201
         items = list(self.policies)
+        if scope_type:
+            items = [item for item in items if item.scope_type == scope_type]
+        if scope_id:
+            items = [item for item in items if item.scope_id == scope_id]
+        sliced = items[offset : offset + limit]
+        return sliced, len(items)
+
+
+class _FakeCallableTargetAccessGroupBindingRepository:
+    def __init__(self, bindings: list[CallableTargetAccessGroupBindingRecord]) -> None:
+        self.bindings = list(bindings)
+
+    async def list_bindings(self, *, group_key=None, scope_type=None, scope_id=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+        items = list(self.bindings)
+        if group_key:
+            items = [item for item in items if item.group_key == group_key]
         if scope_type:
             items = [item for item in items if item.scope_type == scope_type]
         if scope_id:
@@ -343,6 +362,231 @@ async def test_policy_resolution_restricts_team_and_api_key_scopes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_policy_resolution_expands_organization_access_group_grants() -> None:
+    auth = UserAPIKeyAuth(
+        api_key="sk-test",
+        organization_id="org-1",
+    )
+    catalog = {
+        "gpt-4o-mini": CallableTarget(
+            key="gpt-4o-mini",
+            target_type="model",
+            access_groups=frozenset({"beta"}),
+        ),
+        "text-embedding-3-small": CallableTarget(
+            key="text-embedding-3-small",
+            target_type="model",
+            access_groups=frozenset({"embedding"}),
+        ),
+    }
+    service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository([]),
+        access_group_repository=_FakeCallableTargetAccessGroupBindingRepository(
+            [
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-org-1",
+                    group_key="beta",
+                    scope_type="organization",
+                    scope_id="org-1",
+                    enabled=True,
+                )
+            ]
+        ),
+        callable_target_catalog_getter=lambda: catalog,
+    )
+    await service.reload()
+
+    assert resolve_effective_model_allowlist(auth, callable_target_grant_service=service) == {
+        "gpt-4o-mini"
+    }
+
+
+@pytest.mark.asyncio
+async def test_policy_resolution_intersects_restricted_team_group_grants() -> None:
+    auth = UserAPIKeyAuth(
+        api_key="sk-test",
+        team_id="team-1",
+        organization_id="org-1",
+    )
+    catalog = {
+        "gpt-4o-mini": CallableTarget(
+            key="gpt-4o-mini",
+            target_type="model",
+            access_groups=frozenset({"beta", "chat"}),
+        ),
+        "text-embedding-3-small": CallableTarget(
+            key="text-embedding-3-small",
+            target_type="model",
+            access_groups=frozenset({"beta", "embedding"}),
+        ),
+    }
+    service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository([]),
+        access_group_repository=_FakeCallableTargetAccessGroupBindingRepository(
+            [
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-org-1",
+                    group_key="beta",
+                    scope_type="organization",
+                    scope_id="org-1",
+                    enabled=True,
+                ),
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-team-1",
+                    group_key="chat",
+                    scope_type="team",
+                    scope_id="team-1",
+                    enabled=True,
+                ),
+            ]
+        ),
+        policy_repository=_FakeCallableTargetScopePolicyRepository(
+            [
+                CallableTargetScopePolicyRecord(
+                    callable_target_scope_policy_id="ctp-team-1",
+                    scope_type="team",
+                    scope_id="team-1",
+                    mode="restrict",
+                )
+            ]
+        ),
+        callable_target_catalog_getter=lambda: catalog,
+    )
+    await service.reload()
+
+    assert resolve_effective_model_allowlist(auth, callable_target_grant_service=service) == {
+        "gpt-4o-mini"
+    }
+
+
+@pytest.mark.asyncio
+async def test_disabled_group_binding_is_authoritative_without_granting_models() -> None:
+    auth = UserAPIKeyAuth(
+        api_key="sk-test",
+        organization_id="org-1",
+    )
+    catalog = {
+        "gpt-4o-mini": CallableTarget(
+            key="gpt-4o-mini",
+            target_type="model",
+            access_groups=frozenset({"beta"}),
+        )
+    }
+    service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository([]),
+        access_group_repository=_FakeCallableTargetAccessGroupBindingRepository(
+            [
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-org-1",
+                    group_key="beta",
+                    scope_type="organization",
+                    scope_id="org-1",
+                    enabled=False,
+                )
+            ]
+        ),
+        callable_target_catalog_getter=lambda: catalog,
+    )
+    await service.reload()
+
+    assert resolve_effective_model_allowlist(auth, callable_target_grant_service=service) == set()
+
+
+@pytest.mark.asyncio
+async def test_group_grant_picks_up_future_matching_models_after_reload() -> None:
+    auth = UserAPIKeyAuth(
+        api_key="sk-test",
+        organization_id="org-1",
+    )
+    catalog: dict[str, CallableTarget] = {}
+    service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository([]),
+        access_group_repository=_FakeCallableTargetAccessGroupBindingRepository(
+            [
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-org-1",
+                    group_key="future",
+                    scope_type="organization",
+                    scope_id="org-1",
+                    enabled=True,
+                )
+            ]
+        ),
+        callable_target_catalog_getter=lambda: catalog,
+    )
+    await service.reload()
+    assert resolve_effective_model_allowlist(auth, callable_target_grant_service=service) == set()
+
+    catalog["future-model"] = CallableTarget(
+        key="future-model",
+        target_type="model",
+        access_groups=frozenset({"future"}),
+    )
+    await service.reload()
+
+    assert resolve_effective_model_allowlist(auth, callable_target_grant_service=service) == {
+        "future-model"
+    }
+
+
+@pytest.mark.asyncio
+async def test_user_group_grants_restrict_by_default() -> None:
+    auth = UserAPIKeyAuth(
+        api_key="sk-test",
+        user_id="user-1",
+        organization_id="org-1",
+    )
+    catalog = {
+        "gpt-4o-mini": CallableTarget(
+            key="gpt-4o-mini",
+            target_type="model",
+            access_groups=frozenset({"chat"}),
+        ),
+        "text-embedding-3-small": CallableTarget(
+            key="text-embedding-3-small",
+            target_type="model",
+            access_groups=frozenset({"embedding"}),
+        ),
+    }
+    service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository([]),
+        access_group_repository=_FakeCallableTargetAccessGroupBindingRepository(
+            [
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-org-1",
+                    group_key="chat",
+                    scope_type="organization",
+                    scope_id="org-1",
+                    enabled=True,
+                ),
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-org-2",
+                    group_key="embedding",
+                    scope_type="organization",
+                    scope_id="org-1",
+                    enabled=True,
+                ),
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-user-1",
+                    group_key="chat",
+                    scope_type="user",
+                    scope_id="user-1",
+                    enabled=True,
+                ),
+            ]
+        ),
+        callable_target_catalog_getter=lambda: catalog,
+    )
+    await service.reload()
+
+    assert filter_visible_models(
+        ["gpt-4o-mini", "text-embedding-3-small"],
+        auth,
+        callable_target_grant_service=service,
+    ) == ["gpt-4o-mini"]
+
+
+@pytest.mark.asyncio
 async def test_shadow_mode_logs_mismatch_while_preserving_legacy_enforcement(caplog: pytest.LogCaptureFixture) -> None:
     auth = UserAPIKeyAuth(
         api_key="sk-test",
@@ -473,6 +717,46 @@ async def test_v1_models_uses_explicit_callable_target_grants_when_present(clien
 
 
 @pytest.mark.asyncio
+async def test_v1_models_uses_access_group_grants(client, test_app) -> None:
+    record = next(iter(test_app.state._test_repo.records.values()))
+    record.organization_id = "org-1"
+    test_app.state.callable_target_catalog = {
+        "gpt-4o-mini": CallableTarget(
+            key="gpt-4o-mini",
+            target_type="model",
+            access_groups=frozenset({"beta"}),
+        ),
+        "text-embedding-3-small": CallableTarget(
+            key="text-embedding-3-small",
+            target_type="model",
+            access_groups=frozenset({"embedding"}),
+        ),
+    }
+    test_app.state.callable_target_grant_service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository([]),
+        access_group_repository=_FakeCallableTargetAccessGroupBindingRepository(
+            [
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-1",
+                    group_key="beta",
+                    scope_type="organization",
+                    scope_id="org-1",
+                    enabled=True,
+                )
+            ]
+        ),
+        callable_target_catalog_getter=lambda: test_app.state.callable_target_catalog,
+    )
+    await test_app.state.callable_target_grant_service.reload()
+
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    response = await client.get("/v1/models", headers=headers)
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["data"]] == ["gpt-4o-mini"]
+
+
+@pytest.mark.asyncio
 async def test_v1_models_user_scope_explicit_grants_apply_without_legacy_api_key_scope(client, test_app) -> None:
     record = next(iter(test_app.state._test_repo.records.values()))
     record.user_id = "user-1"
@@ -519,6 +803,141 @@ def test_callable_target_catalog_includes_live_route_groups() -> None:
 
     assert set(catalog) == {"gpt-4o-mini", "support-fast"}
     assert catalog["support-fast"].target_type == "route_group"
+
+
+def test_callable_target_catalog_includes_model_access_groups() -> None:
+    catalog = build_callable_target_catalog(
+        {
+            "gpt-4o-mini": [
+                {
+                    "deployment_id": "dep-1",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"access_groups": ["Beta", "support", "beta"]},
+                }
+            ]
+        }
+    )
+
+    assert catalog["gpt-4o-mini"].access_groups == frozenset({"beta", "support"})
+
+
+def test_callable_target_catalog_disables_access_groups_for_conflicting_public_model(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        catalog = build_callable_target_catalog(
+            {
+                "shared-model": [
+                    {
+                        "deployment_id": "dep-1",
+                        "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                        "model_info": {"access_groups": ["beta"]},
+                    },
+                    {
+                        "deployment_id": "dep-2",
+                        "deltallm_params": {"model": "azure/gpt-4o-mini"},
+                        "model_info": {"access_groups": ["stable"]},
+                    },
+                ]
+            }
+        )
+
+    assert catalog["shared-model"].access_groups == frozenset()
+    assert "access_groups conflict" in caplog.text
+
+
+def test_callable_target_catalog_includes_route_group_access_groups() -> None:
+    catalog = build_callable_target_catalog(
+        {
+            "gpt-4o-mini": [
+                {"deployment_id": "dep-1", "deltallm_params": {"model": "openai/gpt-4o-mini"}},
+            ]
+        },
+        route_groups=[
+            {
+                "key": "support-fast",
+                "enabled": True,
+                "access_groups": ["support"],
+                "members": [{"deployment_id": "dep-1", "enabled": True}],
+            }
+        ],
+    )
+
+    assert catalog["support-fast"].access_groups == frozenset({"support"})
+
+
+@pytest.mark.asyncio
+async def test_config_loaded_model_access_groups_expand_group_grants() -> None:
+    cfg = AppConfig.model_validate(
+        {
+            "model_list": [
+                {
+                    "deployment_id": "dep-1",
+                    "model_name": "gpt-4o-mini",
+                    "deltallm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "provider-key",
+                        "api_base": "https://api.openai.com/v1",
+                    },
+                    "model_info": {"access_groups": ["Beta"]},
+                }
+            ]
+        }
+    )
+    registry = await build_model_registry_from_config(cfg, Settings.model_validate({}))
+    catalog = build_callable_target_catalog(registry)
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository([]),
+        access_group_repository=_FakeCallableTargetAccessGroupBindingRepository(
+            [
+                CallableTargetAccessGroupBindingRecord(
+                    callable_target_access_group_binding_id="ctagb-org-1",
+                    group_key="beta",
+                    scope_type="organization",
+                    scope_id="org-1",
+                    enabled=True,
+                )
+            ]
+        ),
+        callable_target_catalog_getter=lambda: catalog,
+    )
+    await service.reload()
+
+    assert catalog["gpt-4o-mini"].access_groups == frozenset({"beta"})
+    assert resolve_effective_model_allowlist(auth, callable_target_grant_service=service) == {
+        "gpt-4o-mini"
+    }
+
+
+@pytest.mark.asyncio
+async def test_config_loaded_route_group_access_groups_reach_callable_catalog() -> None:
+    cfg = AppConfig.model_validate(
+        {
+            "model_list": [
+                {
+                    "deployment_id": "dep-1",
+                    "model_name": "gpt-4o-mini",
+                    "deltallm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "provider-key",
+                        "api_base": "https://api.openai.com/v1",
+                    },
+                }
+            ],
+            "router_settings": {
+                "route_groups": [
+                    {
+                        "key": "support-fast",
+                        "access_groups": ["Support"],
+                        "members": [{"deployment_id": "dep-1"}],
+                    }
+                ]
+            },
+        }
+    )
+    registry = await build_model_registry_from_config(cfg, Settings.model_validate({}))
+    catalog = build_callable_target_catalog(registry, route_groups=route_groups_from_config(cfg))
+
+    assert catalog["support-fast"].access_groups == frozenset({"support"})
 
 
 def test_callable_target_catalog_rejects_model_and_route_group_key_collision() -> None:


### PR DESCRIPTION
## Summary

- Adds callable target access group binding storage and repository support.
- Adds governance access-group normalization shared by config, repository writes, catalog build, and grant expansion.
- Extends callable target catalog entries with access groups for models and route groups.
- Expands group grants into the in-memory callable target grant snapshot during reload, keeping request-time authorization DB-free.
- Adds config support for `model_info.access_groups` and route group `access_groups` so Helm/file-config deployments preserve access groups.
- Wires bootstrap/runtime reloads so catalog changes refresh grants and can propagate through existing governance invalidation.

## Validation

- `uv run --extra dev ruff check src/governance/access_groups.py src/config.py src/db/callable_target_access_groups.py src/services/callable_target_grants.py src/services/callable_targets.py tests/config/test_settings.py tests/test_model_visibility.py tests/db/test_callable_target_access_groups.py`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/deltallm' uv run prisma validate --schema=./prisma/schema.prisma`
- `uv run --extra dev pytest tests/config/test_settings.py tests/db/test_callable_target_access_groups.py tests/test_model_visibility.py tests/bootstrap/test_infrastructure_bootstrap.py tests/bootstrap/test_runtime_services_bootstrap.py tests/test_ui_models.py tests/test_ui_route_groups.py`

Notes: pytest emits existing Python 3.14 `pytest_asyncio` deprecation warnings.