### PR TITLE
Add admin UI access group controls

### DIFF
--- a/src/api/admin/endpoints/keys.py
+++ b/src/api/admin/endpoints/keys.py
@@ -834,6 +834,10 @@ async def _require_key_access(
 async def get_key_asset_visibility(
     request: Request,
     token_hash: str,
+    include_access_groups: bool = Query(default=False),
+    access_group_search: str | None = Query(default=None),
+    access_group_limit: int = Query(default=50, ge=1, le=200),
+    access_group_offset: int = Query(default=0, ge=0),
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
@@ -852,6 +856,10 @@ async def get_key_asset_visibility(
         team_id=team_id,
         api_key_id=token_hash,
         user_id=user_id,
+        include_access_groups=include_access_groups,
+        access_group_search=access_group_search,
+        access_group_limit=access_group_limit,
+        access_group_offset=access_group_offset,
     )
 
 
@@ -860,6 +868,9 @@ async def get_key_asset_access(
     request: Request,
     token_hash: str,
     include_targets: bool = Query(default=True),
+    access_group_search: str | None = Query(default=None),
+    access_group_limit: int = Query(default=50, ge=1, le=200),
+    access_group_offset: int = Query(default=0, ge=0),
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
@@ -881,6 +892,9 @@ async def get_key_asset_access(
         api_key_id=token_hash,
         user_id=user_id,
         include_targets=include_targets,
+        access_group_search=access_group_search,
+        access_group_limit=access_group_limit,
+        access_group_offset=access_group_offset,
     )
 
 

--- a/src/api/admin/endpoints/organizations.py
+++ b/src/api/admin/endpoints/organizations.py
@@ -687,6 +687,10 @@ async def get_organization_asset_visibility(
     request: Request,
     organization_id: str,
     user_id: str | None = Query(default=None),
+    include_access_groups: bool = Query(default=False),
+    access_group_search: str | None = Query(default=None),
+    access_group_limit: int = Query(default=50, ge=1, le=200),
+    access_group_offset: int = Query(default=0, ge=0),
 ) -> dict[str, Any]:
     db = db_or_503(request)
     rows = await db.query_raw(
@@ -709,6 +713,10 @@ async def get_organization_asset_visibility(
         request,
         organization_id=organization_id,
         user_id=str(user_row.get("user_id") or "").strip() or None if user_row else None,
+        include_access_groups=include_access_groups,
+        access_group_search=access_group_search,
+        access_group_limit=access_group_limit,
+        access_group_offset=access_group_offset,
     )
 
 
@@ -717,6 +725,9 @@ async def get_organization_asset_access(
     request: Request,
     organization_id: str,
     include_targets: bool = Query(default=True),
+    access_group_search: str | None = Query(default=None),
+    access_group_limit: int = Query(default=50, ge=1, le=200),
+    access_group_offset: int = Query(default=0, ge=0),
 ) -> dict[str, Any]:
     db = db_or_503(request)
     rows = await db.query_raw(
@@ -736,6 +747,9 @@ async def get_organization_asset_access(
         scope_id=organization_id,
         organization_id=organization_id,
         include_targets=include_targets,
+        access_group_search=access_group_search,
+        access_group_limit=access_group_limit,
+        access_group_offset=access_group_offset,
     )
     response["auto_follow_catalog"] = await get_organization_auto_follow_catalog(db, organization_id)
     return response

--- a/src/api/admin/endpoints/teams.py
+++ b/src/api/admin/endpoints/teams.py
@@ -241,6 +241,10 @@ async def get_team_asset_visibility(
     request: Request,
     team_id: str,
     user_id: str | None = Query(default=None),
+    include_access_groups: bool = Query(default=False),
+    access_group_search: str | None = Query(default=None),
+    access_group_limit: int = Query(default=50, ge=1, le=200),
+    access_group_offset: int = Query(default=0, ge=0),
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
@@ -260,6 +264,10 @@ async def get_team_asset_visibility(
         organization_id=organization_id,
         team_id=team_id,
         user_id=str(user_row.get("user_id") or "").strip() or None if user_row else None,
+        include_access_groups=include_access_groups,
+        access_group_search=access_group_search,
+        access_group_limit=access_group_limit,
+        access_group_offset=access_group_offset,
     )
 
 
@@ -268,6 +276,9 @@ async def get_team_asset_access(
     request: Request,
     team_id: str,
     include_targets: bool = Query(default=True),
+    access_group_search: str | None = Query(default=None),
+    access_group_limit: int = Query(default=50, ge=1, le=200),
+    access_group_offset: int = Query(default=0, ge=0),
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
@@ -284,6 +295,9 @@ async def get_team_asset_access(
         organization_id=organization_id,
         team_id=team_id,
         include_targets=include_targets,
+        access_group_search=access_group_search,
+        access_group_limit=access_group_limit,
+        access_group_offset=access_group_offset,
     )
 
 

--- a/src/api/admin/endpoints/users.py
+++ b/src/api/admin/endpoints/users.py
@@ -185,6 +185,10 @@ async def update_user(
 async def get_user_asset_visibility(
     request: Request,
     user_id: str,
+    include_access_groups: bool = Query(default=False),
+    access_group_search: str | None = Query(default=None),
+    access_group_limit: int = Query(default=50, ge=1, le=200),
+    access_group_offset: int = Query(default=0, ge=0),
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
@@ -200,6 +204,10 @@ async def get_user_asset_visibility(
         organization_id=organization_id,
         team_id=team_id,
         user_id=user_id,
+        include_access_groups=include_access_groups,
+        access_group_search=access_group_search,
+        access_group_limit=access_group_limit,
+        access_group_offset=access_group_offset,
     )
 
 
@@ -208,6 +216,9 @@ async def get_user_asset_access(
     request: Request,
     user_id: str,
     include_targets: bool = Query(default=True),
+    access_group_search: str | None = Query(default=None),
+    access_group_limit: int = Query(default=50, ge=1, le=200),
+    access_group_offset: int = Query(default=0, ge=0),
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
@@ -226,6 +237,9 @@ async def get_user_asset_access(
         team_id=team_id,
         user_id=user_id,
         include_targets=include_targets,
+        access_group_search=access_group_search,
+        access_group_limit=access_group_limit,
+        access_group_offset=access_group_offset,
     )
 
 

--- a/src/services/asset_visibility_preview.py
+++ b/src/services/asset_visibility_preview.py
@@ -18,6 +18,9 @@ from src.services.asset_binding_mirror import (
 from src.services.callable_targets import CallableTarget
 from src.governance.access_groups import build_callable_keys_by_access_group
 
+_DEFAULT_ACCESS_GROUP_PAGE_LIMIT = 50
+_MAX_ACCESS_GROUP_PAGE_LIMIT = 200
+
 
 def _callable_target_scope_policy_repository(request: Request) -> CallableTargetScopePolicyRepository | None:
     repository = getattr(request.app.state, "callable_target_scope_policy_repository", None)
@@ -287,6 +290,54 @@ def _has_source(item: dict[str, Any], *, scope_type: str, kind: str | None = Non
     return False
 
 
+def _normalize_page_limit(value: int | None, *, default: int = _DEFAULT_ACCESS_GROUP_PAGE_LIMIT) -> int:
+    try:
+        limit = int(value if value is not None else default)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(limit, _MAX_ACCESS_GROUP_PAGE_LIMIT))
+
+
+def _normalize_page_offset(value: int | None) -> int:
+    try:
+        offset = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, offset)
+
+
+def _page_access_group_keys(
+    keys: set[str],
+    *,
+    search: str | None,
+    limit: int,
+    offset: int,
+) -> tuple[list[str], dict[str, int | bool]]:
+    query = str(search or "").strip().lower()
+    ordered = sorted(key for key in keys if not query or query in key.lower())
+    return ordered[offset : offset + limit], {
+        "total": len(ordered),
+        "limit": limit,
+        "offset": offset,
+        "has_more": offset + limit < len(ordered),
+    }
+
+
+def _access_group_visibility_payload(
+    *,
+    group_key: str,
+    member_keys: frozenset[str],
+    effective_keys: set[str],
+) -> dict[str, Any]:
+    return {
+        "group_key": group_key,
+        "member_count": len(member_keys),
+        "selectable": bool(member_keys & effective_keys),
+        "selected": False,
+        "effective_visible": bool(member_keys & effective_keys),
+    }
+
+
 def _apply_effective_visibility(
     item: dict[str, Any],
     *,
@@ -320,6 +371,10 @@ async def build_asset_visibility_preview(
     team_id: str | None = None,
     api_key_id: str | None = None,
     user_id: str | None = None,
+    include_access_groups: bool = False,
+    access_group_search: str | None = None,
+    access_group_limit: int | None = None,
+    access_group_offset: int | None = None,
 ) -> dict[str, Any]:
     route_group_items: dict[str, dict[str, Any]] = {}
     callable_items: dict[str, dict[str, Any]] = {}
@@ -509,7 +564,7 @@ async def build_asset_visibility_preview(
             key=lambda source: (str(source.get("scope_type") or ""), str(source.get("scope_id") or "")),
         )
 
-    return {
+    response: dict[str, Any] = {
         "organization_id": organization_id,
         "team_id": team_id,
         "api_key_id": api_key_id,
@@ -532,3 +587,35 @@ async def build_asset_visibility_preview(
             "items": sorted(callable_items.values(), key=lambda item: item["callable_key"]),
         },
     }
+    if include_access_groups:
+        page_limit = _normalize_page_limit(access_group_limit)
+        page_offset = _normalize_page_offset(access_group_offset)
+        effective_callable_keys = {
+            callable_key
+            for callable_key, item in callable_items.items()
+            if bool(item.get("effective_visible", False))
+        }
+        selectable_group_keys = {
+            group_key
+            for group_key, member_keys in callable_keys_by_access_group.items()
+            if bool(member_keys & effective_callable_keys)
+        }
+        page, pagination = _page_access_group_keys(
+            selectable_group_keys,
+            search=access_group_search,
+            limit=page_limit,
+            offset=page_offset,
+        )
+        response["access_groups"] = {
+            "total": pagination["total"],
+            "items": [
+                _access_group_visibility_payload(
+                    group_key=group_key,
+                    member_keys=callable_keys_by_access_group.get(group_key, frozenset()),
+                    effective_keys=effective_callable_keys,
+                )
+                for group_key in page
+            ],
+            "pagination": pagination,
+        }
+    return response

--- a/src/services/scoped_asset_access.py
+++ b/src/services/scoped_asset_access.py
@@ -32,6 +32,8 @@ from src.services.callable_targets import CallableTarget
 _SCOPES_WITH_POLICY = {"team", "api_key", "user"}
 _ALLOWED_SCOPE_TYPES = {"organization", "team", "api_key", "user"}
 _MISSING = object()
+_DEFAULT_ACCESS_GROUP_PAGE_LIMIT = 50
+_MAX_ACCESS_GROUP_PAGE_LIMIT = 200
 
 
 def _policy_repository(request: Request) -> CallableTargetScopePolicyRepository | None:
@@ -155,6 +157,39 @@ def _normalize_selected_access_group_keys(value: Any) -> list[str]:
     return normalized
 
 
+def _normalize_page_limit(value: int | None, *, default: int = _DEFAULT_ACCESS_GROUP_PAGE_LIMIT) -> int:
+    try:
+        limit = int(value if value is not None else default)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(limit, _MAX_ACCESS_GROUP_PAGE_LIMIT))
+
+
+def _normalize_page_offset(value: int | None) -> int:
+    try:
+        offset = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, offset)
+
+
+def _filter_page_keys(
+    keys: set[str],
+    *,
+    search: str | None,
+    limit: int,
+    offset: int,
+) -> tuple[list[str], dict[str, int | bool]]:
+    query = str(search or "").strip().lower()
+    ordered = sorted(key for key in keys if not query or query in key.lower())
+    return ordered[offset : offset + limit], {
+        "total": len(ordered),
+        "limit": limit,
+        "offset": offset,
+        "has_more": offset + limit < len(ordered),
+    }
+
+
 async def build_scope_asset_access(
     request: Request,
     *,
@@ -165,6 +200,9 @@ async def build_scope_asset_access(
     api_key_id: str | None = None,
     user_id: str | None = None,
     include_targets: bool = True,
+    access_group_search: str | None = None,
+    access_group_limit: int | None = None,
+    access_group_offset: int | None = None,
 ) -> dict[str, Any]:
     normalized_scope_type = _normalize_scope_type(scope_type)
     mode = await _resolved_mode(
@@ -231,6 +269,14 @@ async def build_scope_asset_access(
     selectable_targets: list[dict[str, Any]] = []
     effective_targets: list[dict[str, Any]] = []
     selectable_access_groups: list[dict[str, Any]] = []
+    access_group_page_limit = _normalize_page_limit(access_group_limit)
+    access_group_page_offset = _normalize_page_offset(access_group_offset)
+    access_group_pagination: dict[str, int | bool] = {
+        "total": 0,
+        "limit": access_group_page_limit,
+        "offset": access_group_page_offset,
+        "has_more": False,
+    }
     if include_targets:
         visible_keys = sorted(selectable_keys | direct_selected)
         selectable_targets = [
@@ -260,7 +306,13 @@ async def build_scope_asset_access(
             )
             for callable_key in sorted(effective_keys)
         ]
-        visible_group_keys = sorted(selectable_group_keys | direct_selected_groups)
+        visible_group_keys = selectable_group_keys | direct_selected_groups
+        access_group_page, access_group_pagination = _filter_page_keys(
+            visible_group_keys,
+            search=access_group_search,
+            limit=access_group_page_limit,
+            offset=access_group_page_offset,
+        )
         selectable_access_groups = [
             _access_group_payload(
                 group_key=group_key,
@@ -269,7 +321,7 @@ async def build_scope_asset_access(
                 selected=group_key in direct_selected_groups,
                 effective_visible=bool(callable_keys_by_group.get(group_key, frozenset()) & effective_keys),
             )
-            for group_key in visible_group_keys
+            for group_key in access_group_page
         ]
 
     return {
@@ -284,6 +336,7 @@ async def build_scope_asset_access(
         "selected_access_group_keys": sorted(direct_selected_groups),
         "selectable_targets": selectable_targets,
         "selectable_access_groups": selectable_access_groups,
+        "access_group_pagination": access_group_pagination,
         "effective_targets": effective_targets,
         "summary": {
             "selected_total": len(direct_selected),

--- a/tests/test_ui_asset_access.py
+++ b/tests/test_ui_asset_access.py
@@ -377,6 +377,38 @@ async def test_get_organization_asset_access_returns_selected_access_groups(clie
 
 
 @pytest.mark.asyncio
+async def test_get_organization_asset_access_pages_access_groups(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.prisma_manager = type("Prisma", (), {"client": _FakeScopeDB()})()
+    access_group_repository = _FakeCallableTargetAccessGroupBindingRepository()
+    test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
+    test_app.state.callable_target_access_group_repository = access_group_repository
+    test_app.state.callable_target_scope_policy_repository = _FakeCallableTargetScopePolicyRepository()
+    test_app.state.callable_target_grant_service = _FakeGrantService()
+    test_app.state.callable_target_catalog = {
+        "alpha-model": CallableTarget(key="alpha-model", target_type="model", access_groups=frozenset({"alpha"})),
+        "beta-model": CallableTarget(key="beta-model", target_type="model", access_groups=frozenset({"beta"})),
+        "gamma-model": CallableTarget(key="gamma-model", target_type="model", access_groups=frozenset({"gamma"})),
+    }
+
+    response = await client.get(
+        "/ui/api/organizations/org-1/asset-access?access_group_search=a&access_group_limit=1&access_group_offset=1",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["group_key"] for item in payload["selectable_access_groups"]] == ["beta"]
+    assert payload["access_group_pagination"] == {
+        "total": 3,
+        "limit": 1,
+        "offset": 1,
+        "has_more": True,
+    }
+    assert payload["summary"]["selectable_access_group_total"] == 3
+
+
+@pytest.mark.asyncio
 async def test_update_organization_asset_access_select_all_enables_auto_follow(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
     scope_db = _FakeScopeDB()

--- a/tests/test_ui_scope_asset_visibility.py
+++ b/tests/test_ui_scope_asset_visibility.py
@@ -354,6 +354,54 @@ async def test_team_asset_visibility_includes_org_inherited_and_team_direct_sour
 
 
 @pytest.mark.asyncio
+async def test_parent_asset_visibility_returns_paged_selectable_access_groups(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.prisma_manager = type("Prisma", (), {"client": _FakeScopeDB()})()
+    route_groups = _FakeRouteGroupRepository()
+    callable_targets = _FakeCallableTargetBindingRepository()
+    access_groups = _FakeCallableTargetAccessGroupBindingRepository()
+    policies = _FakeCallableTargetScopePolicyRepository()
+    test_app.state.route_group_repository = route_groups
+    test_app.state.callable_target_binding_repository = callable_targets
+    test_app.state.callable_target_access_group_repository = access_groups
+    test_app.state.callable_target_scope_policy_repository = policies
+    test_app.state.callable_target_catalog = {
+        "gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model", access_groups=frozenset({"beta"})),
+        "support-chat": CallableTarget(key="support-chat", target_type="route_group", access_groups=frozenset({"support"})),
+    }
+    await access_groups.upsert_binding(
+        group_key="beta",
+        scope_type="organization",
+        scope_id="org-1",
+        enabled=True,
+        metadata=None,
+    )
+
+    response = await client.get(
+        "/ui/api/organizations/org-1/asset-visibility?include_access_groups=true&access_group_limit=1",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["access_groups"]["pagination"] == {
+        "total": 1,
+        "limit": 1,
+        "offset": 0,
+        "has_more": False,
+    }
+    assert payload["access_groups"]["items"] == [
+        {
+            "group_key": "beta",
+            "member_count": 1,
+            "selectable": True,
+            "selected": False,
+            "effective_visible": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_key_asset_visibility_includes_org_team_and_key_sources(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
     test_app.state.prisma_manager = type("Prisma", (), {"client": _FakeScopeDB()})()

--- a/ui/src/components/ModelForm.tsx
+++ b/ui/src/components/ModelForm.tsx
@@ -724,6 +724,16 @@ export default function ModelForm({
             <input value={form.tags} onChange={(e) => setForm({ ...form, tags: e.target.value })} placeholder="production, fast, us-east" className={inputClass} />
             <p className="text-xs text-gray-400 mt-1">Comma-separated, for tag-based routing</p>
           </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Access Groups</label>
+            <input
+              value={form.access_groups}
+              onChange={(e) => setForm({ ...form, access_groups: e.target.value })}
+              placeholder="premium, beta, internal"
+              className={inputClass}
+            />
+            <p className="text-xs text-gray-400 mt-1">Comma-separated authorization labels for model grants</p>
+          </div>
         </div>
       </CollapsibleCard>
 

--- a/ui/src/components/access/AssetAccessEditor.tsx
+++ b/ui/src/components/access/AssetAccessEditor.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import type { AssetAccessTarget } from '../../lib/api';
+import type { AssetAccessGroup, AssetAccessTarget } from '../../lib/api';
 
 type AssetAccessMode = 'grant' | 'inherit' | 'restrict';
 type TargetFilter = 'all' | 'model' | 'route_group';
@@ -13,8 +13,14 @@ type Props = {
   targets: AssetAccessTarget[];
   selectedKeys: string[];
   onSelectedKeysChange: (keys: string[]) => void;
+  accessGroups?: AssetAccessGroup[];
+  selectedAccessGroupKeys?: string[];
+  onSelectedAccessGroupKeysChange?: (keys: string[]) => void;
   loading?: boolean;
+  targetsLoading?: boolean;
+  accessGroupsLoading?: boolean;
   disabled?: boolean;
+  modeControlsDisabled?: boolean;
   searchValue?: string;
   onSearchValueChange?: (value: string) => void;
   targetTypeFilter?: TargetFilter;
@@ -26,6 +32,13 @@ type Props = {
     has_more: boolean;
   };
   onPageChange?: (offset: number) => void;
+  accessGroupPagination?: {
+    total: number;
+    limit: number;
+    offset: number;
+    has_more: boolean;
+  };
+  onAccessGroupPageChange?: (offset: number) => void;
   primaryActionLabel?: string;
   onPrimaryAction?: () => void;
   secondaryActionLabel?: string;
@@ -37,6 +50,28 @@ function badgeClasses(kind: 'model' | 'route_group') {
   return 'bg-blue-50 text-blue-700 border-blue-200';
 }
 
+function targetAccessDescription(target: AssetAccessTarget, checked: boolean): string {
+  if (checked) {
+    if (target.effective_visible) return 'Saved policy currently allows this target.';
+    if (target.selectable) return 'Selected for save; it will be allowed after saving.';
+    return 'Selected, but not currently selectable from the parent scope.';
+  }
+  if (target.effective_visible) return 'Allowed by saved policy.';
+  if (target.selectable) return 'Available to assign.';
+  return 'Not currently selectable from the parent scope.';
+}
+
+function accessGroupDescription(group: AssetAccessGroup, checked: boolean): string {
+  if (checked) {
+    if (group.effective_visible) return 'Saved policy currently grants visible targets.';
+    if (group.selectable) return 'Selected for save; visible members will be granted after saving.';
+    return 'Selected, but no current parent-visible members.';
+  }
+  if (group.effective_visible) return 'Granted by saved policy.';
+  if (group.selectable) return 'Available to assign.';
+  return 'Not currently selectable from the parent scope.';
+}
+
 export default function AssetAccessEditor({
   title = 'Asset Access',
   description,
@@ -46,14 +81,22 @@ export default function AssetAccessEditor({
   targets,
   selectedKeys,
   onSelectedKeysChange,
+  accessGroups = [],
+  selectedAccessGroupKeys = [],
+  onSelectedAccessGroupKeysChange,
   loading = false,
+  targetsLoading,
+  accessGroupsLoading,
   disabled = false,
+  modeControlsDisabled,
   searchValue,
   onSearchValueChange,
   targetTypeFilter,
   onTargetTypeFilterChange,
   pagination,
   onPageChange,
+  accessGroupPagination,
+  onAccessGroupPageChange,
   primaryActionLabel,
   onPrimaryAction,
   secondaryActionLabel,
@@ -63,19 +106,47 @@ export default function AssetAccessEditor({
   const [localTargetType, setLocalTargetType] = useState<TargetFilter>('all');
   const search = searchValue ?? localSearch;
   const targetType = targetTypeFilter ?? localTargetType;
-  const usesRemoteFiltering = !!onSearchValueChange || !!onTargetTypeFilterChange || !!pagination;
+  const targetLoading = targetsLoading ?? loading;
+  const groupLoading = accessGroupsLoading ?? loading;
+  const modeDisabled = modeControlsDisabled ?? disabled;
+  const usesRemoteTargetFiltering = !!pagination;
+  const usesRemoteAccessGroupFiltering = !!accessGroupPagination;
 
   const filteredTargets = useMemo(() => {
-    if (usesRemoteFiltering) return targets;
+    if (usesRemoteTargetFiltering) return targets;
     const query = search.trim().toLowerCase();
     return targets.filter((target) => {
       if (targetType !== 'all' && target.target_type !== targetType) return false;
       if (!query) return true;
       return target.callable_key.toLowerCase().includes(query);
     });
-  }, [search, targetType, targets]);
+  }, [search, targetType, targets, usesRemoteTargetFiltering]);
+
+  const filteredAccessGroups = useMemo(() => {
+    if (usesRemoteAccessGroupFiltering) return accessGroups;
+    const query = search.trim().toLowerCase();
+    if (!query) return accessGroups;
+    return accessGroups.filter((group) => group.group_key.toLowerCase().includes(query));
+  }, [accessGroups, search, usesRemoteAccessGroupFiltering]);
 
   const selectedSet = useMemo(() => new Set(selectedKeys), [selectedKeys]);
+  const selectedAccessGroupSet = useMemo(() => new Set(selectedAccessGroupKeys), [selectedAccessGroupKeys]);
+  const visibleTargetSet = useMemo(
+    () => new Set(filteredTargets.map((target) => target.callable_key)),
+    [filteredTargets],
+  );
+  const hiddenSelectedTargetKeys = useMemo(
+    () => selectedKeys.filter((callableKey) => !visibleTargetSet.has(callableKey)).sort(),
+    [selectedKeys, visibleTargetSet],
+  );
+  const visibleAccessGroupSet = useMemo(
+    () => new Set(filteredAccessGroups.map((group) => group.group_key)),
+    [filteredAccessGroups],
+  );
+  const hiddenSelectedAccessGroupKeys = useMemo(
+    () => selectedAccessGroupKeys.filter((groupKey) => !visibleAccessGroupSet.has(groupKey)).sort(),
+    [selectedAccessGroupKeys, visibleAccessGroupSet],
+  );
 
   const toggleKey = (callableKey: string) => {
     if (disabled || mode === 'inherit') return;
@@ -86,6 +157,17 @@ export default function AssetAccessEditor({
       next.add(callableKey);
     }
     onSelectedKeysChange(Array.from(next).sort());
+  };
+
+  const toggleAccessGroup = (groupKey: string) => {
+    if (disabled || mode === 'inherit' || !onSelectedAccessGroupKeysChange) return;
+    const next = new Set(selectedAccessGroupSet);
+    if (next.has(groupKey)) {
+      next.delete(groupKey);
+    } else {
+      next.add(groupKey);
+    }
+    onSelectedAccessGroupKeysChange(Array.from(next).sort());
   };
 
   return (
@@ -104,7 +186,7 @@ export default function AssetAccessEditor({
                 name={`${title}-mode`}
                 checked={mode === 'inherit'}
                 onChange={() => onModeChange?.('inherit')}
-                disabled={disabled}
+                disabled={modeDisabled}
                 className="mt-0.5"
               />
               <span>
@@ -120,7 +202,7 @@ export default function AssetAccessEditor({
                 name={`${title}-mode`}
                 checked={mode === 'restrict'}
                 onChange={() => onModeChange?.('restrict')}
-                disabled={disabled}
+                disabled={modeDisabled}
                 className="mt-0.5"
               />
               <span>
@@ -198,14 +280,151 @@ export default function AssetAccessEditor({
       </div>
 
       <div className="flex items-center justify-between text-xs text-gray-500">
-        <span>{selectedKeys.length} selected</span>
+        <span>
+          {selectedKeys.length} target{selectedKeys.length === 1 ? '' : 's'} selected
+          {accessGroups.length > 0 || selectedAccessGroupKeys.length > 0
+            ? ` · ${selectedAccessGroupKeys.length} group${selectedAccessGroupKeys.length === 1 ? '' : 's'} selected`
+            : ''}
+        </span>
         <span>
           {pagination ? `${pagination.total} total` : `${targets.filter((target) => target.selectable).length} selectable`}
         </span>
       </div>
 
+      {(accessGroups.length > 0 || selectedAccessGroupKeys.length > 0 || groupLoading || (accessGroupPagination && accessGroupPagination.total > 0)) && (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <div className="border-b border-gray-100 bg-gray-50 px-4 py-2">
+            <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">Access Groups</div>
+          </div>
+          {hiddenSelectedAccessGroupKeys.length > 0 && (
+            <div className="border-b border-gray-100 bg-amber-50/50 px-4 py-3">
+              <div className="mb-2 text-xs font-medium text-amber-800">Selected outside current filter/page</div>
+              <div className="space-y-1.5">
+                {hiddenSelectedAccessGroupKeys.map((groupKey) => {
+                  const checkboxDisabled = disabled || mode === 'inherit' || !onSelectedAccessGroupKeysChange;
+                  return (
+                    <label
+                      key={groupKey}
+                      className={`flex items-center gap-3 rounded-lg border border-amber-100 bg-white px-3 py-2 text-sm ${checkboxDisabled ? 'cursor-not-allowed opacity-70' : 'cursor-pointer hover:bg-amber-50'}`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked
+                        onChange={() => toggleAccessGroup(groupKey)}
+                        disabled={checkboxDisabled}
+                      />
+                      <span className="min-w-0 flex-1 break-all font-medium text-gray-900">{groupKey}</span>
+                      <span className="shrink-0 text-xs text-amber-700">Selected</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+          {groupLoading ? (
+            <div className="px-4 py-4 text-sm text-gray-500">Loading access groups...</div>
+          ) : filteredAccessGroups.length === 0 ? (
+            <div className="px-4 py-4 text-sm text-gray-500">No access groups match the current filter.</div>
+          ) : (
+            <div className="max-h-48 divide-y divide-gray-100 overflow-y-auto">
+              {filteredAccessGroups.map((group) => {
+                const checked = selectedAccessGroupSet.has(group.group_key);
+                const checkboxDisabled = disabled || mode === 'inherit' || !onSelectedAccessGroupKeysChange || (!group.selectable && !checked);
+                return (
+                  <label
+                    key={group.group_key}
+                    className={`flex items-start gap-3 px-4 py-3 text-sm ${checkboxDisabled ? 'cursor-not-allowed bg-gray-50/60' : 'cursor-pointer hover:bg-gray-50'}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleAccessGroup(group.group_key)}
+                      disabled={checkboxDisabled}
+                      className="mt-0.5"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium text-gray-900 break-all">{group.group_key}</span>
+                        <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+                          {group.member_count} member{group.member_count === 1 ? '' : 's'}
+                        </span>
+                        {checked && group.selectable && (
+                          <span className="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700">
+                            Selected
+                          </span>
+                        )}
+                        {!group.selectable && (
+                          <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                            Outside parent scope
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-1 text-xs text-gray-500">
+                        {accessGroupDescription(group, checked)}
+                      </p>
+                    </div>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+          {accessGroupPagination && onAccessGroupPageChange && (
+            <div className="flex items-center justify-between border-t border-gray-100 px-4 py-2 text-xs text-gray-500">
+              <span>
+                {accessGroupPagination.total === 0
+                  ? 'No access groups'
+                  : `${accessGroupPagination.offset + 1}-${Math.min(accessGroupPagination.offset + accessGroupPagination.limit, accessGroupPagination.total)} of ${accessGroupPagination.total}`}
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => onAccessGroupPageChange(Math.max(0, accessGroupPagination.offset - accessGroupPagination.limit))}
+                  disabled={disabled || accessGroupPagination.offset <= 0 || groupLoading}
+                  className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Previous
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onAccessGroupPageChange(accessGroupPagination.offset + accessGroupPagination.limit)}
+                  disabled={disabled || !accessGroupPagination.has_more || groupLoading}
+                  className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="max-h-72 overflow-y-auto rounded-lg border border-gray-200 bg-white">
-        {loading ? (
+        {hiddenSelectedTargetKeys.length > 0 && (
+          <div className="border-b border-gray-100 bg-amber-50/50 px-4 py-3">
+            <div className="mb-2 text-xs font-medium text-amber-800">Selected outside current filter/page</div>
+            <div className="space-y-1.5">
+              {hiddenSelectedTargetKeys.map((callableKey) => {
+                const checkboxDisabled = disabled || mode === 'inherit';
+                return (
+                  <label
+                    key={callableKey}
+                    className={`flex items-center gap-3 rounded-lg border border-amber-100 bg-white px-3 py-2 text-sm ${checkboxDisabled ? 'cursor-not-allowed opacity-70' : 'cursor-pointer hover:bg-amber-50'}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked
+                      onChange={() => toggleKey(callableKey)}
+                      disabled={checkboxDisabled}
+                    />
+                    <span className="min-w-0 flex-1 break-all font-medium text-gray-900">{callableKey}</span>
+                    <span className="shrink-0 text-xs text-amber-700">Selected</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        )}
+        {targetLoading ? (
           <div className="px-4 py-6 text-sm text-gray-500">Loading assets...</div>
         ) : filteredTargets.length === 0 ? (
           <div className="px-4 py-6 text-sm text-gray-500">No assets match the current filter.</div>
@@ -237,6 +456,11 @@ export default function AssetAccessEditor({
                           Inherited
                         </span>
                       )}
+                      {target.via_access_groups && target.via_access_groups.length > 0 && (
+                        <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+                          Via {target.via_access_groups.join(', ')}
+                        </span>
+                      )}
                       {checked && target.selectable && (
                         <span className="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700">
                           Selected
@@ -249,11 +473,7 @@ export default function AssetAccessEditor({
                       )}
                     </div>
                     <p className="mt-1 text-xs text-gray-500">
-                      {target.effective_visible
-                        ? 'Currently visible at runtime.'
-                        : target.selectable
-                          ? 'Available to assign.'
-                          : 'Not currently selectable from the parent scope.'}
+                      {targetAccessDescription(target, checked)}
                     </p>
                   </div>
                 </label>

--- a/ui/src/components/modelFormShared.ts
+++ b/ui/src/components/modelFormShared.ts
@@ -68,6 +68,7 @@ export interface ModelFormValues {
   weight: string;
   priority: string;
   tags: string;
+  access_groups: string;
   input_cost_per_token: string;
   output_cost_per_token: string;
   input_cost_per_token_cache_hit: string;
@@ -121,6 +122,7 @@ export const EMPTY_FORM: ModelFormValues = {
   weight: '',
   priority: '',
   tags: '',
+  access_groups: '',
   input_cost_per_token: '',
   output_cost_per_token: '',
   input_cost_per_token_cache_hit: '',
@@ -150,6 +152,11 @@ function positiveIntOrUndef(val: string): number | undefined {
   if (!val) return undefined;
   const parsed = Number(val);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function commaSeparatedListOrUndef(val: string): string[] | undefined {
+  const items = val.split(',').map((item) => item.trim()).filter(Boolean);
+  return items.length > 0 ? items : undefined;
 }
 
 export function strOrEmpty(val: unknown): string {
@@ -198,7 +205,8 @@ export function buildModelPayload(
   const model_info: Record<string, unknown> = {
     mode: form.mode,
     priority: numOrUndef(form.priority),
-    tags: form.tags ? form.tags.split(',').map((tag) => tag.trim()).filter(Boolean) : undefined,
+    tags: form.tags ? commaSeparatedListOrUndef(form.tags) : undefined,
+    access_groups: form.access_groups ? commaSeparatedListOrUndef(form.access_groups) : undefined,
     weight: numOrUndef(form.weight),
   };
 
@@ -299,6 +307,7 @@ export function formFromModel(
     weight: strOrEmpty(mi.weight ?? lp.weight),
     priority: strOrEmpty(mi.priority),
     tags: Array.isArray(mi.tags) ? mi.tags.join(', ') : '',
+    access_groups: Array.isArray(mi.access_groups) ? mi.access_groups.join(', ') : '',
     input_cost_per_token: strOrEmpty(mi.input_cost_per_token),
     output_cost_per_token: strOrEmpty(mi.output_cost_per_token),
     input_cost_per_token_cache_hit: strOrEmpty(mi.input_cost_per_token_cache_hit),

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -437,6 +437,16 @@ export interface CallableTargetListItem {
   binding_count: number;
 }
 
+export interface CallableTargetAccessGroupListItem {
+  group_key: string;
+  member_count: number;
+  binding_count: number;
+  members?: Array<{
+    callable_key: string;
+    target_type: 'model' | 'route_group';
+  }>;
+}
+
 export interface AssetAccessTarget {
   callable_key: string;
   target_type: 'model' | 'route_group';
@@ -444,6 +454,16 @@ export interface AssetAccessTarget {
   selected: boolean;
   effective_visible: boolean;
   inherited_only: boolean;
+  via_access_groups?: string[];
+}
+
+export interface AssetAccessGroup {
+  group_key: string;
+  selectable: boolean;
+  selected: boolean;
+  member_count: number;
+  effective_visible: boolean;
+  callable_keys?: string[];
 }
 
 export interface AssetVisibilityTarget {
@@ -468,6 +488,11 @@ export interface AssetVisibilityResponse {
     total: number;
     items: AssetVisibilityTarget[];
   };
+  access_groups?: {
+    total: number;
+    items: AssetAccessGroup[];
+    pagination: Pagination;
+  };
 }
 
 export interface ScopedAssetAccess {
@@ -480,14 +505,34 @@ export interface ScopedAssetAccess {
   mode: 'grant' | 'inherit' | 'restrict';
   auto_follow_catalog?: boolean;
   selected_callable_keys: string[];
+  selected_access_group_keys: string[];
   selectable_targets: AssetAccessTarget[];
+  selectable_access_groups: AssetAccessGroup[];
+  access_group_pagination?: Pagination;
   effective_targets: AssetAccessTarget[];
   summary: {
     selected_total: number;
     selectable_total: number;
     effective_total: number;
+    selected_access_group_total?: number;
+    selectable_access_group_total?: number;
   };
 }
+
+type AssetAccessGroupPageParams = {
+  access_group_search?: string;
+  access_group_limit?: number;
+  access_group_offset?: number;
+};
+
+type AssetVisibilityParams = AssetAccessGroupPageParams & {
+  user_id?: string;
+  include_access_groups?: boolean;
+};
+
+type ScopedAssetAccessParams = AssetAccessGroupPageParams & {
+  include_targets?: boolean;
+};
 
 export interface ProviderPreset {
   provider: string;
@@ -578,6 +623,8 @@ export interface ModelDeploymentDetail {
 export const callableTargets = {
   list: (params?: { search?: string; target_type?: string; limit?: number; offset?: number }) =>
     apiFetch<Paginated<CallableTargetListItem>>(withQuery('/ui/api/callable-targets', params as any)),
+  listAccessGroups: (params?: { search?: string; include_members?: boolean; limit?: number; offset?: number }) =>
+    apiFetch<Paginated<CallableTargetAccessGroupListItem>>(withQuery('/ui/api/callable-target-access-groups', params as any)),
   listAll: async (params?: { search?: string; target_type?: string }) => {
     const limit = 500;
     let offset = 0;
@@ -962,11 +1009,11 @@ export const organizations = {
   removeMember: (orgId: string, membershipId: string) =>
     apiFetch<any>(`/ui/api/organizations/${encodeURIComponent(orgId)}/members/${encodeURIComponent(membershipId)}`, { method: 'DELETE' }),
   teams: (orgId: string) => apiFetch<any[]>(`/ui/api/organizations/${encodeURIComponent(orgId)}/teams`),
-  assetVisibility: (orgId: string, params?: { user_id?: string }) =>
+  assetVisibility: (orgId: string, params?: AssetVisibilityParams) =>
     apiFetch<AssetVisibilityResponse>(withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/asset-visibility`, params as any)),
-  assetAccess: (orgId: string, params?: { include_targets?: boolean }) =>
+  assetAccess: (orgId: string, params?: ScopedAssetAccessParams) =>
     apiFetch<ScopedAssetAccess>(withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/asset-access`, params as any)),
-  updateAssetAccess: (orgId: string, payload: { mode?: string; selected_callable_keys: string[]; select_all_selectable?: boolean }) =>
+  updateAssetAccess: (orgId: string, payload: { mode?: string; selected_callable_keys: string[]; selected_access_group_keys?: string[]; select_all_selectable?: boolean }) =>
     apiFetch<ScopedAssetAccess>(`/ui/api/organizations/${encodeURIComponent(orgId)}/asset-access`, { method: 'PUT', json: payload }),
 };
 
@@ -1001,11 +1048,11 @@ export const teams = {
   addMember: (teamId: string, payload: any) => apiFetch<any>(`/ui/api/teams/${encodeURIComponent(teamId)}/members`, { method: 'POST', json: payload }),
   removeMember: (teamId: string, userId: string) =>
     apiFetch<any>(`/ui/api/teams/${encodeURIComponent(teamId)}/members/${encodeURIComponent(userId)}`, { method: 'DELETE' }),
-  assetVisibility: (teamId: string, params?: { user_id?: string }) =>
+  assetVisibility: (teamId: string, params?: AssetVisibilityParams) =>
     apiFetch<AssetVisibilityResponse>(withQuery(`/ui/api/teams/${encodeURIComponent(teamId)}/asset-visibility`, params as any)),
-  assetAccess: (teamId: string, params?: { include_targets?: boolean }) =>
+  assetAccess: (teamId: string, params?: ScopedAssetAccessParams) =>
     apiFetch<ScopedAssetAccess>(withQuery(`/ui/api/teams/${encodeURIComponent(teamId)}/asset-access`, params as any)),
-  updateAssetAccess: (teamId: string, payload: { mode: 'inherit' | 'restrict'; selected_callable_keys: string[]; select_all_selectable?: boolean }) =>
+  updateAssetAccess: (teamId: string, payload: { mode: 'inherit' | 'restrict'; selected_callable_keys: string[]; selected_access_group_keys?: string[]; select_all_selectable?: boolean }) =>
     apiFetch<ScopedAssetAccess>(`/ui/api/teams/${encodeURIComponent(teamId)}/asset-access`, { method: 'PUT', json: payload }),
 };
 
@@ -1063,20 +1110,20 @@ export const keys = {
   regenerate: (tokenHash: string) => apiFetch<{ token: string; raw_key: string }>(`/ui/api/keys/${encodeURIComponent(tokenHash)}/regenerate`, { method: 'POST' }),
   revoke: (tokenHash: string) => apiFetch<{ revoked: boolean }>(`/ui/api/keys/${encodeURIComponent(tokenHash)}/revoke`, { method: 'POST' }),
   delete: (tokenHash: string) => apiFetch<{ deleted: boolean }>(`/ui/api/keys/${encodeURIComponent(tokenHash)}`, { method: 'DELETE' }),
-  assetVisibility: (tokenHash: string, params?: { user_id?: string }) =>
+  assetVisibility: (tokenHash: string, params?: AssetVisibilityParams) =>
     apiFetch<AssetVisibilityResponse>(withQuery(`/ui/api/keys/${encodeURIComponent(tokenHash)}/asset-visibility`, params as any)),
-  assetAccess: (tokenHash: string, params?: { include_targets?: boolean }) =>
+  assetAccess: (tokenHash: string, params?: ScopedAssetAccessParams) =>
     apiFetch<ScopedAssetAccess>(withQuery(`/ui/api/keys/${encodeURIComponent(tokenHash)}/asset-access`, params as any)),
-  updateAssetAccess: (tokenHash: string, payload: { mode: 'inherit' | 'restrict'; selected_callable_keys: string[]; select_all_selectable?: boolean }) =>
+  updateAssetAccess: (tokenHash: string, payload: { mode: 'inherit' | 'restrict'; selected_callable_keys: string[]; selected_access_group_keys?: string[]; select_all_selectable?: boolean }) =>
     apiFetch<ScopedAssetAccess>(`/ui/api/keys/${encodeURIComponent(tokenHash)}/asset-access`, { method: 'PUT', json: payload }),
 };
 
 export const users = {
-  assetVisibility: (userId: string) =>
-    apiFetch<AssetVisibilityResponse>(`/ui/api/users/${encodeURIComponent(userId)}/asset-visibility`),
-  assetAccess: (userId: string, params?: { include_targets?: boolean }) =>
+  assetVisibility: (userId: string, params?: Omit<AssetVisibilityParams, 'user_id'>) =>
+    apiFetch<AssetVisibilityResponse>(withQuery(`/ui/api/users/${encodeURIComponent(userId)}/asset-visibility`, params as any)),
+  assetAccess: (userId: string, params?: ScopedAssetAccessParams) =>
     apiFetch<ScopedAssetAccess>(withQuery(`/ui/api/users/${encodeURIComponent(userId)}/asset-access`, params as any)),
-  updateAssetAccess: (userId: string, payload: { mode: 'inherit' | 'restrict'; selected_callable_keys: string[]; select_all_selectable?: boolean }) =>
+  updateAssetAccess: (userId: string, payload: { mode: 'inherit' | 'restrict'; selected_callable_keys: string[]; selected_access_group_keys?: string[]; select_all_selectable?: boolean }) =>
     apiFetch<ScopedAssetAccess>(`/ui/api/users/${encodeURIComponent(userId)}/asset-access`, { method: 'PUT', json: payload }),
 };
 

--- a/ui/src/lib/assetAccess.ts
+++ b/ui/src/lib/assetAccess.ts
@@ -1,21 +1,93 @@
 import type {
+  AssetAccessGroup,
   AssetAccessTarget,
+  AssetVisibilityResponse,
   AssetVisibilityTarget,
+  CallableTargetAccessGroupListItem,
   CallableTargetListItem,
   ScopedAssetAccess,
 } from './api';
 
 type AssetAccessMode = ScopedAssetAccess['mode'];
+type AssetAccessIdentity = {
+  scopeType?: ScopedAssetAccess['scope_type'];
+  scopeId?: string | null;
+  organizationId?: string | null;
+  teamId?: string | null;
+  apiKeyId?: string | null;
+  userId?: string | null;
+};
+
+export function assetAccessLoadErrorMessage(error: unknown): string | null {
+  if (!error) return null;
+  return error instanceof Error && error.message.trim()
+    ? error.message
+    : 'Asset access options failed to load. Refresh and try again.';
+}
 
 function compareTargets(a: { callable_key: string }, b: { callable_key: string }) {
   return a.callable_key.localeCompare(b.callable_key);
 }
 
+function compareGroups(a: { group_key: string }, b: { group_key: string }) {
+  return a.group_key.localeCompare(b.group_key);
+}
+
+function groupCallableKeys(item: CallableTargetAccessGroupListItem | AssetAccessGroup): string[] {
+  if ('callable_keys' in item && Array.isArray(item.callable_keys)) {
+    return item.callable_keys;
+  }
+  if ('members' in item && Array.isArray(item.members)) {
+    return item.members.map((member) => member.callable_key);
+  }
+  return [];
+}
+
+function normalizedId(value: string | null | undefined): string | null {
+  const normalized = String(value ?? '').trim();
+  return normalized || null;
+}
+
+function idMatches(actual: string | null | undefined, expected: string | null | undefined): boolean {
+  if (expected === undefined) return true;
+  return normalizedId(actual) === normalizedId(expected);
+}
+
+export function isAssetVisibilityFor(
+  response: AssetVisibilityResponse | null | undefined,
+  expected: AssetAccessIdentity,
+): response is AssetVisibilityResponse {
+  if (!response) return false;
+  return (
+    idMatches(response.organization_id, expected.organizationId) &&
+    idMatches(response.team_id, expected.teamId) &&
+    idMatches(response.api_key_id, expected.apiKeyId) &&
+    idMatches(response.user_id, expected.userId)
+  );
+}
+
+export function isScopedAssetAccessFor(
+  response: ScopedAssetAccess | null | undefined,
+  expected: AssetAccessIdentity,
+): response is ScopedAssetAccess {
+  if (!response) return false;
+  return (
+    (expected.scopeType === undefined || response.scope_type === expected.scopeType) &&
+    idMatches(response.scope_id, expected.scopeId) &&
+    idMatches(response.organization_id, expected.organizationId) &&
+    idMatches(response.team_id, expected.teamId) &&
+    idMatches(response.api_key_id, expected.apiKeyId) &&
+    idMatches(response.user_id, expected.userId)
+  );
+}
+
 export function buildCatalogAssetTargets(
   items: Array<Pick<CallableTargetListItem, 'callable_key' | 'target_type'>>,
   selectedKeys: string[],
+  persistedSelectedKeys: string[] = [],
 ): AssetAccessTarget[] {
   const selected = new Set(selectedKeys);
+  const persisted = new Set(persistedSelectedKeys);
   return [...items]
     .sort(compareTargets)
     .map((item) => ({
@@ -23,8 +95,27 @@ export function buildCatalogAssetTargets(
       target_type: item.target_type,
       selectable: true,
       selected: selected.has(item.callable_key),
-      effective_visible: selected.has(item.callable_key),
+      effective_visible: persisted.has(item.callable_key),
       inherited_only: false,
+    }));
+}
+
+export function buildCatalogAccessGroups(
+  items: CallableTargetAccessGroupListItem[],
+  selectedKeys: string[],
+  persistedSelectedKeys: string[] = [],
+): AssetAccessGroup[] {
+  const selected = new Set(selectedKeys);
+  const persisted = new Set(persistedSelectedKeys);
+  return [...items]
+    .sort(compareGroups)
+    .map((item) => ({
+      group_key: item.group_key,
+      member_count: item.member_count,
+      selectable: true,
+      selected: selected.has(item.group_key),
+      effective_visible: persisted.has(item.group_key),
+      callable_keys: groupCallableKeys(item),
     }));
 }
 
@@ -42,13 +133,13 @@ export function buildParentScopedAssetTargets(
       target_type: item.target_type,
       selectable: true,
       selected: selected.has(item.callable_key),
-      effective_visible: mode === 'inherit' ? true : selected.has(item.callable_key),
+      effective_visible: mode === 'inherit',
       inherited_only: mode === 'inherit',
     }));
 }
 
 export function buildScopedSelectableTargets(
-  items: Array<Pick<AssetAccessTarget, 'callable_key' | 'target_type' | 'selectable'>>,
+  items: Array<Pick<AssetAccessTarget, 'callable_key' | 'target_type' | 'selectable'> & Partial<AssetAccessTarget>>,
   selectedKeys: string[],
   mode: AssetAccessMode,
 ): AssetAccessTarget[] {
@@ -60,7 +151,28 @@ export function buildScopedSelectableTargets(
       target_type: item.target_type,
       selectable: item.selectable,
       selected: selected.has(item.callable_key),
-      effective_visible: mode === 'inherit' ? item.selectable : selected.has(item.callable_key),
+      effective_visible: Boolean(item.effective_visible),
       inherited_only: mode === 'inherit' && item.selectable,
+      via_access_groups: item.via_access_groups,
     }));
+}
+
+export function buildScopedSelectableAccessGroups(
+  items: Array<Pick<AssetAccessGroup, 'group_key' | 'member_count' | 'selectable' | 'effective_visible'> & Partial<AssetAccessGroup>>,
+  selectedKeys: string[],
+): AssetAccessGroup[] {
+  const selected = new Set(selectedKeys);
+  return [...items]
+    .sort(compareGroups)
+    .map((item) => {
+      const isSelected = selected.has(item.group_key);
+      return {
+        group_key: item.group_key,
+        member_count: item.member_count,
+        selectable: item.selectable,
+        selected: isSelected,
+        effective_visible: Boolean(item.effective_visible),
+        callable_keys: item.callable_keys,
+      };
+    });
 }

--- a/ui/src/pages/ApiKeys.tsx
+++ b/ui/src/pages/ApiKeys.tsx
@@ -1,7 +1,14 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useApi } from '../lib/hooks';
 import { keys, serviceAccounts, teams } from '../lib/api';
-import { buildParentScopedAssetTargets, buildScopedSelectableTargets } from '../lib/assetAccess';
+import {
+  assetAccessLoadErrorMessage,
+  buildParentScopedAssetTargets,
+  buildScopedSelectableAccessGroups,
+  buildScopedSelectableTargets,
+  isAssetVisibilityFor,
+  isScopedAssetAccessFor,
+} from '../lib/assetAccess';
 import type { ApiKey, ServiceAccount } from '../lib/api';
 import { useAuth } from '../lib/auth';
 import DataTable from '../components/DataTable';
@@ -34,6 +41,7 @@ type KeyFormState = {
   expires: string;
   asset_access_mode: 'inherit' | 'restrict';
   selected_callable_keys: string[];
+  selected_access_group_keys: string[];
 };
 
 const EMPTY_PAGINATION = { total: 0, limit: 200, offset: 0, has_more: false };
@@ -53,6 +61,7 @@ function emptyForm(): KeyFormState {
     expires: '',
     asset_access_mode: 'inherit',
     selected_callable_keys: [],
+    selected_access_group_keys: [],
   };
 }
 
@@ -142,27 +151,48 @@ export default function ApiKeys() {
   const [saving, setSaving] = useState(false);
   const [newServiceAccountName, setNewServiceAccountName] = useState('');
   const [creatingServiceAccount, setCreatingServiceAccount] = useState(false);
+  const [assetSearchInput, setAssetSearchInput] = useState('');
+  const [assetSearch, setAssetSearch] = useState('');
+  const [accessGroupPageOffset, setAccessGroupPageOffset] = useState(0);
+  const accessGroupPageSize = 50;
   const selectedTeamId = form.team_id;
   const usesParentPreview = !editItem || selectedTeamId !== (editItem.team_id || '');
-  const { data: editAssetAccess, loading: editAssetAccessLoading } = useApi(
+  const { data: editAssetAccess, error: editAssetAccessError, loading: editAssetAccessLoading } = useApi(
     () => (editItem ? keys.assetAccess(editItem.token, { include_targets: false }) : Promise.resolve(null)),
     [editItem?.token],
   );
-  const { data: editAssetAccessTargets, loading: editAssetAccessTargetsLoading } = useApi(
+  const currentEditAssetAccess = editItem && isScopedAssetAccessFor(editAssetAccess, {
+    scopeType: 'api_key',
+    scopeId: editItem.token,
+  })
+    ? editAssetAccess
+    : null;
+  const editAssetAccessPending = !!editItem && (editAssetAccessLoading || !currentEditAssetAccess);
+  const { data: editAssetAccessTargets, error: editAssetAccessTargetsError, loading: editAssetAccessTargetsLoading } = useApi(
     () => (
       editItem && !usesParentPreview && form.asset_access_mode === 'restrict'
-        ? keys.assetAccess(editItem.token, { include_targets: true })
+        ? keys.assetAccess(editItem.token, {
+            include_targets: true,
+            access_group_search: assetSearch || undefined,
+            access_group_limit: accessGroupPageSize,
+            access_group_offset: accessGroupPageOffset,
+          })
         : Promise.resolve(null)
     ),
-    [editItem?.token, usesParentPreview, form.asset_access_mode],
+    [editItem?.token, usesParentPreview, form.asset_access_mode, assetSearch, accessGroupPageOffset],
   );
-  const { data: parentTeamAssetVisibility, loading: parentTeamAssetVisibilityLoading } = useApi(
+  const { data: parentTeamAssetVisibility, error: parentTeamAssetVisibilityError, loading: parentTeamAssetVisibilityLoading } = useApi(
     () => (
       (showCreate || !!editItem) && usesParentPreview && form.asset_access_mode === 'restrict' && selectedTeamId
-        ? teams.assetVisibility(selectedTeamId)
+        ? teams.assetVisibility(selectedTeamId, {
+            include_access_groups: true,
+            access_group_search: assetSearch || undefined,
+            access_group_limit: accessGroupPageSize,
+            access_group_offset: accessGroupPageOffset,
+          })
         : Promise.resolve(null)
     ),
-    [showCreate, editItem?.token, selectedTeamId, usesParentPreview, form.asset_access_mode],
+    [showCreate, editItem?.token, selectedTeamId, usesParentPreview, form.asset_access_mode, assetSearch, accessGroupPageOffset],
   );
   const { data: serviceAccountsResult, loading: serviceAccountsLoading, refetch: refetchServiceAccounts } = useApi(
     () => (
@@ -193,6 +223,14 @@ export default function ApiKeys() {
   }, [searchInput]);
 
   useEffect(() => {
+    const t = setTimeout(() => {
+      setAssetSearch(assetSearchInput);
+      setAccessGroupPageOffset(0);
+    }, 250);
+    return () => clearTimeout(t);
+  }, [assetSearchInput]);
+
+  useEffect(() => {
     if (form.owner_mode !== 'service_account' && form.owner_service_account_id) {
       setForm((current) => ({ ...current, owner_service_account_id: '' }));
     }
@@ -207,13 +245,14 @@ export default function ApiKeys() {
   }, [availableServiceAccounts, form.owner_service_account_id]);
 
   useEffect(() => {
-    if (!editItem || !editAssetAccess) return;
+    if (!editItem || !currentEditAssetAccess) return;
     setForm((current) => ({
       ...current,
-      asset_access_mode: editAssetAccess.mode === 'restrict' ? 'restrict' : 'inherit',
-      selected_callable_keys: editAssetAccess.selected_callable_keys || [],
+      asset_access_mode: currentEditAssetAccess.mode === 'restrict' ? 'restrict' : 'inherit',
+      selected_callable_keys: currentEditAssetAccess.selected_callable_keys || [],
+      selected_access_group_keys: currentEditAssetAccess.selected_access_group_keys || [],
     }));
-  }, [editItem, editAssetAccess]);
+  }, [editItem, currentEditAssetAccess]);
 
   const closeEditor = () => {
     setShowCreate(false);
@@ -223,6 +262,9 @@ export default function ApiKeys() {
     setCreatingServiceAccount(false);
     setNewServiceAccountName('');
     setForm(emptyForm());
+    setAssetSearchInput('');
+    setAssetSearch('');
+    setAccessGroupPageOffset(0);
   };
 
   const openCreate = () => {
@@ -235,6 +277,9 @@ export default function ApiKeys() {
       initial.team_id = selfServiceTeams[0].team_id;
     }
     setForm(initial);
+    setAssetSearchInput('');
+    setAssetSearch('');
+    setAccessGroupPageOffset(0);
     setShowCreate(true);
   };
 
@@ -279,6 +324,14 @@ export default function ApiKeys() {
       }
       if (!form.team_id) {
         setError('Select a team before creating a key.');
+        return;
+      }
+      if (assetAccessLoadError) {
+        setError(assetAccessLoadError);
+        return;
+      }
+      if (assetAccessLoading) {
+        setError('Wait for asset access options to finish loading before creating the key.');
         return;
       }
       if (!isSelfServiceCreate && form.owner_mode === 'service_account' && !form.owner_service_account_id) {
@@ -330,6 +383,7 @@ export default function ApiKeys() {
           await keys.updateAssetAccess(result.token, {
             mode: 'restrict',
             selected_callable_keys: form.selected_callable_keys,
+            selected_access_group_keys: form.selected_access_group_keys,
           });
         } catch (err: unknown) {
           assetAccessError = getErrorMessage(
@@ -362,6 +416,14 @@ export default function ApiKeys() {
         setError('Select a team before saving changes.');
         return;
       }
+      if (assetAccessLoadError) {
+        setError(assetAccessLoadError);
+        return;
+      }
+      if (editAssetAccessPending || assetAccessLoading) {
+        setError('Wait for asset access options to finish loading before saving the key.');
+        return;
+      }
       if (form.owner_mode === 'service_account' && !form.owner_service_account_id) {
         setError('Select a service account or switch ownership to You.');
         return;
@@ -385,6 +447,7 @@ export default function ApiKeys() {
       await keys.updateAssetAccess(editItem.token, {
         mode: form.asset_access_mode,
         selected_callable_keys: form.asset_access_mode === 'restrict' ? form.selected_callable_keys : [],
+        selected_access_group_keys: form.asset_access_mode === 'restrict' ? form.selected_access_group_keys : [],
       });
       closeEditor();
       refetch();
@@ -411,9 +474,13 @@ export default function ApiKeys() {
       expires: row.expires ? row.expires.slice(0, 16) : '',
       asset_access_mode: 'inherit',
       selected_callable_keys: [],
+      selected_access_group_keys: [],
     });
     setEditItem(row);
     setError(null);
+    setAssetSearchInput('');
+    setAssetSearch('');
+    setAccessGroupPageOffset(0);
   };
 
   const handleTeamChange = (teamId: string) => {
@@ -424,8 +491,12 @@ export default function ApiKeys() {
         team_id: teamId,
         asset_access_mode: changed ? 'inherit' : current.asset_access_mode,
         selected_callable_keys: changed ? [] : current.selected_callable_keys,
+        selected_access_group_keys: changed ? [] : current.selected_access_group_keys,
       };
     });
+    setAssetSearchInput('');
+    setAssetSearch('');
+    setAccessGroupPageOffset(0);
   };
 
   const handleRevoke = async (hash: string) => {
@@ -487,22 +558,57 @@ export default function ApiKeys() {
       ),
     },
   ];
+  const currentEditAssetAccessTargets = editItem && isScopedAssetAccessFor(editAssetAccessTargets, {
+    scopeType: 'api_key',
+    scopeId: editItem.token,
+  })
+    ? editAssetAccessTargets
+    : null;
+  const currentParentTeamAssetVisibility = selectedTeamId && isAssetVisibilityFor(parentTeamAssetVisibility, {
+    teamId: selectedTeamId,
+  })
+    ? parentTeamAssetVisibility
+    : null;
   const assetTargets = usesParentPreview
     ? buildParentScopedAssetTargets(
-        parentTeamAssetVisibility?.callable_targets?.items || [],
+        currentParentTeamAssetVisibility?.callable_targets?.items || [],
         form.selected_callable_keys,
         form.asset_access_mode,
       )
     : buildScopedSelectableTargets(
-        editAssetAccessTargets?.selectable_targets || [],
+        currentEditAssetAccessTargets?.selectable_targets || [],
         form.selected_callable_keys,
         form.asset_access_mode,
       );
-  const assetAccessLoading = form.asset_access_mode !== 'restrict'
+  const assetAccessGroups = usesParentPreview
+    ? buildScopedSelectableAccessGroups(
+        currentParentTeamAssetVisibility?.access_groups?.items || [],
+        form.selected_access_group_keys,
+      )
+    : buildScopedSelectableAccessGroups(
+        currentEditAssetAccessTargets?.selectable_access_groups || [],
+        form.selected_access_group_keys,
+      );
+  const accessGroupPagination = usesParentPreview
+    ? currentParentTeamAssetVisibility?.access_groups?.pagination
+    : currentEditAssetAccessTargets?.access_group_pagination;
+  const assetTargetsLoading = form.asset_access_mode !== 'restrict'
+    ? false
+    : usesParentPreview
+      ? !currentParentTeamAssetVisibility && parentTeamAssetVisibilityLoading
+      : !currentEditAssetAccessTargets && (editAssetAccessTargetsLoading || editAssetAccessLoading);
+  const accessGroupsLoading = form.asset_access_mode !== 'restrict'
     ? false
     : usesParentPreview
       ? parentTeamAssetVisibilityLoading
       : editAssetAccessTargetsLoading || editAssetAccessLoading;
+  const assetAccessLoading = assetTargetsLoading || accessGroupsLoading;
+  const activeAssetAccessError = !isSelfServiceCreate && form.asset_access_mode === 'restrict'
+    ? usesParentPreview ? parentTeamAssetVisibilityError : editAssetAccessTargetsError
+    : null;
+  const assetAccessLoadError = !isSelfServiceCreate && (showCreate || !!editItem)
+    ? assetAccessLoadErrorMessage((editItem ? editAssetAccessError : null) || activeAssetAccessError)
+    : null;
 
   const createTeamOptions = isSelfServiceCreate ? selfServiceTeams : teamsList;
   const createFormTitle = isSelfServiceCreate
@@ -776,20 +882,30 @@ export default function ApiKeys() {
                   ...current,
                   asset_access_mode: asset_access_mode === 'restrict' ? 'restrict' : 'inherit',
                   selected_callable_keys: asset_access_mode === 'restrict' ? current.selected_callable_keys : [],
+                  selected_access_group_keys: asset_access_mode === 'restrict' ? current.selected_access_group_keys : [],
                 }))}
                 targets={assetTargets}
                 selectedKeys={form.selected_callable_keys}
                 onSelectedKeysChange={(selected_callable_keys) => setForm({ ...form, selected_callable_keys })}
-                loading={assetAccessLoading}
-                disabled={saving || !form.team_id}
+                accessGroups={assetAccessGroups}
+                selectedAccessGroupKeys={form.selected_access_group_keys}
+                onSelectedAccessGroupKeysChange={(selected_access_group_keys) => setForm({ ...form, selected_access_group_keys })}
+                targetsLoading={assetTargetsLoading}
+                accessGroupsLoading={accessGroupsLoading}
+                disabled={saving || !form.team_id || editAssetAccessPending || Boolean(assetAccessLoadError)}
+                modeControlsDisabled={saving || !form.team_id || editAssetAccessPending}
+                searchValue={assetSearchInput}
+                onSearchValueChange={setAssetSearchInput}
+                accessGroupPagination={accessGroupPagination}
+                onAccessGroupPageChange={setAccessGroupPageOffset}
               />
             </>
           )}
 
-          {error && <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{error}</div>}
+          {(error || assetAccessLoadError) && <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{error || assetAccessLoadError}</div>}
           <div className="flex justify-end gap-3 pt-2">
             <button onClick={closeEditor} className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg transition-colors">Cancel</button>
-            <button onClick={editItem ? handleUpdate : handleCreate} disabled={saving || !form.team_id || assetAccessLoading} className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50">{saving ? 'Saving...' : editItem ? 'Save Changes' : 'Create Key'}</button>
+            <button onClick={editItem ? handleUpdate : handleCreate} disabled={saving || !form.team_id || editAssetAccessPending || assetAccessLoading || Boolean(assetAccessLoadError)} className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50">{saving ? 'Saving...' : editItem ? 'Save Changes' : 'Create Key'}</button>
           </div>
         </div>
       </Modal>

--- a/ui/src/pages/ModelDetail.tsx
+++ b/ui/src/pages/ModelDetail.tsx
@@ -11,6 +11,7 @@ import {
   Pencil,
   RefreshCw,
   Route,
+  Shield,
   Tag,
   Terminal,
   Trash2,
@@ -288,6 +289,7 @@ function RoutingTab({ model }: { model: any }) {
   const tpmLimit = lp.tpm ?? mi.tpm_limit;
   const weight = mi.weight ?? lp.weight;
   const tags: string[] = Array.isArray(mi.tags) ? mi.tags : [];
+  const accessGroups: string[] = Array.isArray(mi.access_groups) ? mi.access_groups : [];
   const totalWeight = 10;
   const weightNum = Number(weight) || 0;
 
@@ -335,7 +337,24 @@ function RoutingTab({ model }: { model: any }) {
         </div>
       )}
 
-      {weight == null && rpmLimit == null && tpmLimit == null && (
+      {accessGroups.length > 0 && (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">Access Groups</h3>
+          <div className="flex flex-wrap gap-2">
+            {accessGroups.map((groupKey: string) => (
+              <span
+                key={groupKey}
+                className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700"
+              >
+                <Shield className="h-3 w-3 text-emerald-500" />
+                {groupKey}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {weight == null && rpmLimit == null && tpmLimit == null && tags.length === 0 && accessGroups.length === 0 && (
         <p className="text-sm text-gray-500">No routing configuration set.</p>
       )}
     </div>

--- a/ui/src/pages/OrganizationCreate.tsx
+++ b/ui/src/pages/OrganizationCreate.tsx
@@ -3,7 +3,7 @@ import { Navigate, useNavigate } from 'react-router-dom';
 import { useApi } from '../lib/hooks';
 import { useAuth } from '../lib/auth';
 import { callableTargets, organizations } from '../lib/api';
-import { buildCatalogAssetTargets } from '../lib/assetAccess';
+import { assetAccessLoadErrorMessage, buildCatalogAccessGroups, buildCatalogAssetTargets } from '../lib/assetAccess';
 import { dateTimeLocalUtcInputToIso, defaultMonthlyResetUtcInputValue } from '../lib/format';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
 import {
@@ -114,14 +114,12 @@ export default function OrganizationCreate() {
   const userRole = session?.role || (authMode === 'master_key' ? 'platform_admin' : '');
   const isPlatformAdmin = userRole === 'platform_admin';
 
-  if (!isPlatformAdmin) {
-    return <Navigate to="/organizations" replace />;
-  }
-
   /* live list for background */
   const { data: listResult } = useApi(
-    () => organizations.list({ limit: 8, offset: 0 }),
-    [],
+    () => isPlatformAdmin
+      ? organizations.list({ limit: 8, offset: 0 })
+      : Promise.resolve({ data: [], pagination: { total: 0, limit: 8, offset: 0, has_more: false } }),
+    [isPlatformAdmin],
   );
   const bgItems: any[] = listResult?.data || [];
 
@@ -146,18 +144,25 @@ export default function OrganizationCreate() {
   const [auditStorage, setAuditStorage] = useState(false);
   const [selectAll, setSelectAll] = useState(false);
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [selectedAccessGroupKeys, setSelectedAccessGroupKeys] = useState<string[]>([]);
   const [assetSearchInput, setAssetSearchInput] = useState('');
   const [assetSearch, setAssetSearch] = useState('');
   const [assetPageOffset, setAssetPageOffset] = useState(0);
+  const [accessGroupPageOffset, setAccessGroupPageOffset] = useState(0);
   const [assetTargetType, setAssetTargetType] = useState<'all' | 'model' | 'route_group'>('all');
   const assetPageSize = 50;
+  const accessGroupPageSize = 50;
 
   useEffect(() => {
-    const t = setTimeout(() => { setAssetSearch(assetSearchInput); setAssetPageOffset(0); }, 250);
+    const t = setTimeout(() => {
+      setAssetSearch(assetSearchInput);
+      setAssetPageOffset(0);
+      setAccessGroupPageOffset(0);
+    }, 250);
     return () => clearTimeout(t);
   }, [assetSearchInput]);
 
-  const { data: callableTargetPage, loading: callableTargetPageLoading } = useApi(
+  const { data: callableTargetPage, error: callableTargetPageError, loading: callableTargetPageLoading } = useApi(
     () => (
       isPlatformAdmin && !selectAll
         ? callableTargets.list({
@@ -170,12 +175,34 @@ export default function OrganizationCreate() {
     ),
     [isPlatformAdmin, selectAll, assetSearch, assetTargetType, assetPageOffset],
   );
+  const { data: callableTargetAccessGroups, error: accessGroupError, loading: accessGroupLoading } = useApi(
+    () => (
+      isPlatformAdmin && !selectAll
+        ? callableTargets.listAccessGroups({
+            search: assetSearch || undefined,
+            include_members: false,
+            limit: accessGroupPageSize,
+            offset: accessGroupPageOffset,
+          })
+        : Promise.resolve({ data: [], pagination: { total: 0, limit: accessGroupPageSize, offset: 0, has_more: false } })
+    ),
+    [isPlatformAdmin, selectAll, assetSearch, accessGroupPageOffset],
+  );
 
   const assetTargets = buildCatalogAssetTargets(
     (callableTargetPage?.data || []) as any[],
     selectedKeys,
   );
+  const assetAccessGroups = buildCatalogAccessGroups(
+    callableTargetAccessGroups?.data || [],
+    selectedAccessGroupKeys,
+  );
   const assetPagePagination = callableTargetPage?.pagination;
+  const accessGroupPagination = callableTargetAccessGroups?.pagination;
+  const assetAccessLoading = !selectAll && (callableTargetPageLoading || accessGroupLoading);
+  const assetAccessLoadError = !selectAll && isPlatformAdmin
+    ? assetAccessLoadErrorMessage(callableTargetPageError || accessGroupError)
+    : null;
 
   /* submit */
   const [saving, setSaving] = useState(false);
@@ -192,6 +219,14 @@ export default function OrganizationCreate() {
 
   const handleCreate = async () => {
     if (!name.trim()) { setNameError(true); return; }
+    if (assetAccessLoading) {
+      setError('Wait for asset access options to finish loading before creating the organization.');
+      return;
+    }
+    if (assetAccessLoadError) {
+      setError(assetAccessLoadError);
+      return;
+    }
     setError(null);
     setSaving(true);
     try {
@@ -221,14 +256,15 @@ export default function OrganizationCreate() {
       const created = await organizations.create(payload);
 
       let pageWarning: string | null = null;
-      if (isPlatformAdmin && selectAll) {
+      if (isPlatformAdmin && (selectAll || selectedAccessGroupKeys.length > 0)) {
         try {
           await organizations.updateAssetAccess(created.organization_id, {
-            selected_callable_keys: [],
-            select_all_selectable: true,
+            selected_callable_keys: selectAll ? [] : selectedKeys,
+            selected_access_group_keys: selectAll ? [] : selectedAccessGroupKeys,
+            select_all_selectable: selectAll,
           });
         } catch (err: any) {
-          pageWarning = err?.message || 'Organization created, but all-asset access could not be applied.';
+          pageWarning = err?.message || 'Organization created, but asset access could not be applied.';
         }
       }
 
@@ -245,6 +281,10 @@ export default function OrganizationCreate() {
   const handleCancel = () => navigate('/organizations');
 
   /* ─────────────── render ─────────────── */
+  if (!isPlatformAdmin) {
+    return <Navigate to="/organizations" replace />;
+  }
+
   return (
     <div className="flex h-screen overflow-hidden relative">
       {/* Faded background list */}
@@ -281,9 +321,9 @@ export default function OrganizationCreate() {
         {/* Scrollable body */}
         <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
 
-          {error && (
+          {(error || assetAccessLoadError) && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 flex items-center gap-2">
-              <AlertCircle className="w-4 h-4 shrink-0" /> {error}
+              <AlertCircle className="w-4 h-4 shrink-0" /> {error || assetAccessLoadError}
             </div>
           )}
 
@@ -568,7 +608,7 @@ export default function OrganizationCreate() {
                           type="radio"
                           name="org-create-asset-strategy"
                           checked={selectAll}
-                          onChange={() => { setSelectAll(true); setSelectedKeys([]); }}
+                          onChange={() => { setSelectAll(true); setSelectedKeys([]); setSelectedAccessGroupKeys([]); }}
                           disabled={saving}
                           className="mt-0.5"
                         />
@@ -610,18 +650,28 @@ export default function OrganizationCreate() {
                       targets={assetTargets}
                       selectedKeys={selectedKeys}
                       onSelectedKeysChange={setSelectedKeys}
-                      loading={callableTargetPageLoading}
-                      disabled={saving}
+                      accessGroups={assetAccessGroups}
+                      selectedAccessGroupKeys={selectedAccessGroupKeys}
+                      onSelectedAccessGroupKeysChange={setSelectedAccessGroupKeys}
+                      targetsLoading={callableTargetPageLoading}
+                      accessGroupsLoading={accessGroupLoading}
+                      disabled={saving || Boolean(assetAccessLoadError)}
                       searchValue={assetSearchInput}
                       onSearchValueChange={setAssetSearchInput}
                       targetTypeFilter={assetTargetType}
                       onTargetTypeFilterChange={(next) => { setAssetTargetType(next); setAssetPageOffset(0); }}
                       pagination={assetPagePagination}
                       onPageChange={setAssetPageOffset}
+                      accessGroupPagination={accessGroupPagination}
+                      onAccessGroupPageChange={setAccessGroupPageOffset}
                       primaryActionLabel="Allow all assets"
-                      onPrimaryAction={() => { setSelectAll(true); setSelectedKeys([]); }}
-                      secondaryActionLabel={selectedKeys.length > 0 ? 'Clear selection' : undefined}
-                      onSecondaryAction={selectedKeys.length > 0 ? () => setSelectedKeys([]) : undefined}
+                      onPrimaryAction={() => { setSelectAll(true); setSelectedKeys([]); setSelectedAccessGroupKeys([]); }}
+                      secondaryActionLabel={selectedKeys.length > 0 || selectedAccessGroupKeys.length > 0 ? 'Clear selection' : undefined}
+                      onSecondaryAction={
+                        selectedKeys.length > 0 || selectedAccessGroupKeys.length > 0
+                          ? () => { setSelectedKeys([]); setSelectedAccessGroupKeys([]); }
+                          : undefined
+                      }
                     />
                   )}
                 </div>
@@ -637,6 +687,14 @@ export default function OrganizationCreate() {
               {!isReady ? (
                 <span className="flex items-center gap-1 text-amber-600">
                   <AlertCircle className="w-3 h-3" /> Fill in required fields to continue
+                </span>
+              ) : assetAccessLoading ? (
+                <span className="flex items-center gap-1 text-amber-600">
+                  <AlertCircle className="w-3 h-3" /> Loading asset access options
+                </span>
+              ) : assetAccessLoadError ? (
+                <span className="flex items-center gap-1 text-red-600">
+                  <AlertCircle className="w-3 h-3" /> Asset access options failed to load
                 </span>
               ) : (
                 <span className="flex items-center gap-1 text-green-600">
@@ -654,7 +712,7 @@ export default function OrganizationCreate() {
               </button>
               <button
                 onClick={handleCreate}
-                disabled={saving || !isReady}
+                disabled={saving || !isReady || assetAccessLoading || Boolean(assetAccessLoadError)}
                 className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {saving ? 'Creating…' : 'Create Organization'}

--- a/ui/src/pages/OrganizationDetail.tsx
+++ b/ui/src/pages/OrganizationDetail.tsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
 import { useApi } from '../lib/hooks';
 import { callableTargets, organizations } from '../lib/api';
-import { buildCatalogAssetTargets } from '../lib/assetAccess';
+import {
+  assetAccessLoadErrorMessage,
+  buildCatalogAccessGroups,
+  buildCatalogAssetTargets,
+  isScopedAssetAccessFor,
+} from '../lib/assetAccess';
 import { useAuth } from '../lib/auth';
 import {
   dateTimeLocalUtcInputToIso,
@@ -107,7 +112,7 @@ export default function OrganizationDetail() {
   const { data: orgMembers, loading: membersLoading, refetch: refetchMembers } = useApi(
     () => organizations.members(orgId!), [orgId],
   );
-  const { data: orgAssetAccess, loading: orgAssetAccessLoading, refetch: refetchOrgAssetAccess } = useApi(
+  const { data: orgAssetAccess, error: orgAssetAccessError, loading: orgAssetAccessLoading, refetch: refetchOrgAssetAccess } = useApi(
     () => (isPlatformAdmin ? organizations.assetAccess(orgId!, { include_targets: false }) : Promise.resolve(null)),
     [orgId, isPlatformAdmin],
   );
@@ -118,6 +123,20 @@ export default function OrganizationDetail() {
       : Promise.resolve(null)),
     [orgId, isPlatformAdmin, tab],
   );
+  const currentOrgAssetAccess = orgId && isScopedAssetAccessFor(orgAssetAccess, {
+    scopeType: 'organization',
+    scopeId: orgId,
+    organizationId: orgId,
+  })
+    ? orgAssetAccess
+    : null;
+  const currentOrgAssetTargetsFull = orgId && isScopedAssetAccessFor(orgAssetTargetsFull, {
+    scopeType: 'organization',
+    scopeId: orgId,
+    organizationId: orgId,
+  })
+    ? orgAssetTargetsFull
+    : null;
 
   /* ── edit org modal ── */
   const [isEditingSettings, setIsEditingSettings] = useState(false);
@@ -125,8 +144,10 @@ export default function OrganizationDetail() {
   const [assetSearchInput, setAssetSearchInput] = useState('');
   const [assetSearch, setAssetSearch] = useState('');
   const [assetPageOffset, setAssetPageOffset] = useState(0);
+  const [accessGroupPageOffset, setAccessGroupPageOffset] = useState(0);
   const [assetTargetType, setAssetTargetType] = useState<'all' | 'model' | 'route_group'>('all');
   const assetPageSize = 50;
+  const accessGroupPageSize = 50;
   const [form, setForm] = useState({
     organization_name: '',
     max_budget: '',
@@ -143,6 +164,7 @@ export default function OrganizationDetail() {
     audit_content_storage_enabled: false,
     select_all_current_assets: false,
     selected_callable_keys: [] as string[],
+    selected_access_group_keys: [] as string[],
   });
   const [saving, setSaving] = useState(false);
   const [pageError, setPageError] = useState<string | null>(
@@ -153,20 +175,25 @@ export default function OrganizationDetail() {
   const [orgError, setOrgError] = useState<string | null>(null);
 
   useEffect(() => {
-    const t = setTimeout(() => { setAssetSearch(assetSearchInput); setAssetPageOffset(0); }, 250);
+    const t = setTimeout(() => {
+      setAssetSearch(assetSearchInput);
+      setAssetPageOffset(0);
+      setAccessGroupPageOffset(0);
+    }, 250);
     return () => clearTimeout(t);
   }, [assetSearchInput]);
 
   useEffect(() => {
-    if (!isEditingAssets || !orgAssetAccess) return;
+    if (!isEditingAssets || !currentOrgAssetAccess) return;
     setForm((c) => ({
       ...c,
-      select_all_current_assets: !!orgAssetAccess.auto_follow_catalog,
-      selected_callable_keys: orgAssetAccess.selected_callable_keys || [],
+      select_all_current_assets: !!currentOrgAssetAccess.auto_follow_catalog,
+      selected_callable_keys: currentOrgAssetAccess.selected_callable_keys || [],
+      selected_access_group_keys: currentOrgAssetAccess.selected_access_group_keys || [],
     }));
-  }, [isEditingAssets, orgAssetAccess]);
+  }, [isEditingAssets, currentOrgAssetAccess]);
 
-  const { data: callableTargetPage, loading: callableTargetPageLoading } = useApi(
+  const { data: callableTargetPage, error: callableTargetPageError, loading: callableTargetPageLoading } = useApi(
     () => (
       isPlatformAdmin && isEditingAssets && !form.select_all_current_assets
         ? callableTargets.list({
@@ -178,6 +205,19 @@ export default function OrganizationDetail() {
         : Promise.resolve({ data: [], pagination: { total: 0, limit: assetPageSize, offset: 0, has_more: false } })
     ),
     [isPlatformAdmin, isEditingAssets, form.select_all_current_assets, assetSearch, assetTargetType, assetPageOffset],
+  );
+  const { data: callableTargetAccessGroups, error: accessGroupError, loading: accessGroupLoading } = useApi(
+    () => (
+      isPlatformAdmin && isEditingAssets && !form.select_all_current_assets
+        ? callableTargets.listAccessGroups({
+            search: assetSearch || undefined,
+            include_members: false,
+            limit: accessGroupPageSize,
+            offset: accessGroupPageOffset,
+          })
+        : Promise.resolve({ data: [], pagination: { total: 0, limit: accessGroupPageSize, offset: 0, has_more: false } })
+    ),
+    [isPlatformAdmin, isEditingAssets, form.select_all_current_assets, assetSearch, accessGroupPageOffset],
   );
 
   const openEditSettings = () => {
@@ -218,11 +258,13 @@ export default function OrganizationDetail() {
     setForm((c) => ({
       ...c,
       select_all_current_assets: false,
-      selected_callable_keys: orgAssetAccess?.selected_callable_keys || [],
+      selected_callable_keys: currentOrgAssetAccess?.selected_callable_keys || [],
+      selected_access_group_keys: currentOrgAssetAccess?.selected_access_group_keys || [],
     }));
     setAssetSearchInput('');
     setAssetSearch('');
     setAssetPageOffset(0);
+    setAccessGroupPageOffset(0);
     setAssetTargetType('all');
     setIsEditingAssets(true);
   };
@@ -267,11 +309,20 @@ export default function OrganizationDetail() {
   };
 
   const handleSaveAssets = async () => {
+    if (assetAccessLoadError) {
+      setOrgError(assetAccessLoadError);
+      return;
+    }
+    if (orgAssetAccessPending || assetAccessLoading) {
+      setOrgError('Wait for asset access options to finish loading before saving.');
+      return;
+    }
     setSaving(true);
     setOrgError(null);
     try {
       await organizations.updateAssetAccess(orgId!, {
         selected_callable_keys: form.select_all_current_assets ? [] : form.selected_callable_keys,
+        selected_access_group_keys: form.select_all_current_assets ? [] : form.selected_access_group_keys,
         select_all_selectable: form.select_all_current_assets,
       });
       refetchOrgAssetAccess();
@@ -351,16 +402,31 @@ export default function OrganizationDetail() {
   const spend = org?.spend || 0;
   const budget = org?.max_budget ?? null;
   const spendPct = budget ? Math.min(100, Math.round((spend / budget) * 100)) : null;
-  const orgAssetSummary = orgAssetAccess?.summary;
+  const orgAssetSummary = currentOrgAssetAccess?.summary;
+  const orgAccessibleTargets = currentOrgAssetTargetsFull?.effective_targets ?? [];
   const assetPct = orgAssetSummary && orgAssetSummary.selectable_total > 0
-    ? Math.round((orgAssetSummary.selected_total / orgAssetSummary.selectable_total) * 100)
+    ? Math.round((orgAssetSummary.effective_total / orgAssetSummary.selectable_total) * 100)
     : null;
 
   const orgAssetTargets = buildCatalogAssetTargets(
     (callableTargetPage?.data || []) as any[],
     form.selected_callable_keys,
+    currentOrgAssetAccess?.selected_callable_keys || [],
+  );
+  const orgAssetAccessGroups = buildCatalogAccessGroups(
+    callableTargetAccessGroups?.data || [],
+    form.selected_access_group_keys,
+    currentOrgAssetAccess?.selected_access_group_keys || [],
   );
   const orgAssetPagination = callableTargetPage?.pagination;
+  const accessGroupPagination = callableTargetAccessGroups?.pagination;
+  const orgAssetAccessPending = isEditingAssets && isPlatformAdmin && (orgAssetAccessLoading || !currentOrgAssetAccess);
+  const assetAccessLoading = !form.select_all_current_assets && (callableTargetPageLoading || accessGroupLoading);
+  const assetAccessLoadError = isEditingAssets && isPlatformAdmin
+    ? assetAccessLoadErrorMessage(
+        orgAssetAccessError || (!form.select_all_current_assets ? callableTargetPageError || accessGroupError : null),
+      )
+    : null;
 
   /* teams over 80% of budget = "warning" for alert card */
   const warningTeam = teamList.find((t: any) => {
@@ -453,7 +519,7 @@ export default function OrganizationDetail() {
             label="Assets granted"
             value={
               orgAssetSummary
-                ? `${orgAssetSummary.selected_total}/${orgAssetSummary.selectable_total}`
+                ? `${orgAssetSummary.effective_total}/${orgAssetSummary.selectable_total}`
                 : isPlatformAdmin ? '—' : 'N/A'
             }
             sub={assetPct != null ? `${assetPct}% of catalog` : 'of catalog'}
@@ -894,7 +960,7 @@ export default function OrganizationDetail() {
                     <>
                       <div className="mb-3">
                         <div className="flex justify-between text-xs mb-1.5">
-                          <span className="text-gray-600">{orgAssetSummary.selected_total} models &amp; routes</span>
+                          <span className="text-gray-600">{orgAssetSummary.effective_total} models &amp; routes</span>
                           <span className="text-gray-400">of {orgAssetSummary.selectable_total}</span>
                         </div>
                         <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
@@ -904,6 +970,9 @@ export default function OrganizationDetail() {
                           />
                         </div>
                       </div>
+                      <p className="text-[10px] text-gray-400 leading-relaxed mb-1">
+                        Direct targets: {orgAssetSummary.selected_total} · Access groups: {orgAssetSummary.selected_access_group_total ?? 0}
+                      </p>
                       <p className="text-[10px] text-gray-400 leading-relaxed">
                         Teams and API keys within this org can only use assets from this allowed set.
                       </p>
@@ -1154,8 +1223,8 @@ export default function OrganizationDetail() {
               </div>
               {isEditingAssets ? (
                 <div className="space-y-4">
-                  {orgError && (
-                    <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{orgError}</div>
+                  {(orgError || assetAccessLoadError) && (
+                    <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{orgError || assetAccessLoadError}</div>
                   )}
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                     <label className={`rounded-lg border px-3 py-2 text-sm cursor-pointer ${form.select_all_current_assets ? 'border-blue-500 bg-blue-50' : 'border-gray-200 bg-white'}`}>
@@ -1164,7 +1233,12 @@ export default function OrganizationDetail() {
                           type="radio"
                           name="org-detail-asset-strategy"
                           checked={form.select_all_current_assets}
-                          onChange={() => setForm((c) => ({ ...c, select_all_current_assets: true, selected_callable_keys: [] }))}
+                          onChange={() => setForm((c) => ({
+                            ...c,
+                            select_all_current_assets: true,
+                            selected_callable_keys: [],
+                            selected_access_group_keys: [],
+                          }))}
                           disabled={saving}
                           className="mt-0.5"
                         />
@@ -1193,8 +1267,8 @@ export default function OrganizationDetail() {
                   </div>
                   {form.select_all_current_assets ? (
                     <div className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-3 text-xs text-blue-800">
-                      {orgAssetAccess
-                        ? `This organization currently has ${orgAssetAccess.summary.selected_total} of ${orgAssetAccess.summary.selectable_total} assets granted. Saving will align it to all current assets and automatically include future additions.`
+                      {currentOrgAssetAccess
+                        ? `This organization currently has ${currentOrgAssetAccess.summary.effective_total} of ${currentOrgAssetAccess.summary.selectable_total} assets granted. Saving will align it to all current assets and automatically include future additions.`
                         : 'Saving will grant every currently available model and route group to this organization and automatically include future additions.'}
                     </div>
                   ) : (
@@ -1205,18 +1279,33 @@ export default function OrganizationDetail() {
                       targets={orgAssetTargets}
                       selectedKeys={form.selected_callable_keys}
                       onSelectedKeysChange={(selected_callable_keys) => setForm({ ...form, selected_callable_keys })}
-                      loading={orgAssetAccessLoading || callableTargetPageLoading}
-                      disabled={saving}
+                      accessGroups={orgAssetAccessGroups}
+                      selectedAccessGroupKeys={form.selected_access_group_keys}
+                      onSelectedAccessGroupKeysChange={(selected_access_group_keys) => setForm({ ...form, selected_access_group_keys })}
+                      targetsLoading={orgAssetAccessPending || callableTargetPageLoading}
+                      accessGroupsLoading={orgAssetAccessPending || accessGroupLoading}
+                      disabled={saving || orgAssetAccessPending || Boolean(assetAccessLoadError)}
                       searchValue={assetSearchInput}
                       onSearchValueChange={setAssetSearchInput}
                       targetTypeFilter={assetTargetType}
                       onTargetTypeFilterChange={(next) => { setAssetTargetType(next); setAssetPageOffset(0); }}
                       pagination={orgAssetPagination}
                       onPageChange={setAssetPageOffset}
+                      accessGroupPagination={accessGroupPagination}
+                      onAccessGroupPageChange={setAccessGroupPageOffset}
                       primaryActionLabel="Allow all assets"
-                      onPrimaryAction={() => setForm((c) => ({ ...c, select_all_current_assets: true, selected_callable_keys: [] }))}
-                      secondaryActionLabel={form.selected_callable_keys.length > 0 ? 'Clear selection' : undefined}
-                      onSecondaryAction={form.selected_callable_keys.length > 0 ? () => setForm((c) => ({ ...c, selected_callable_keys: [] })) : undefined}
+                      onPrimaryAction={() => setForm((c) => ({
+                        ...c,
+                        select_all_current_assets: true,
+                        selected_callable_keys: [],
+                        selected_access_group_keys: [],
+                      }))}
+                      secondaryActionLabel={form.selected_callable_keys.length > 0 || form.selected_access_group_keys.length > 0 ? 'Clear selection' : undefined}
+                      onSecondaryAction={
+                        form.selected_callable_keys.length > 0 || form.selected_access_group_keys.length > 0
+                          ? () => setForm((c) => ({ ...c, selected_callable_keys: [], selected_access_group_keys: [] }))
+                          : undefined
+                      }
                     />
                   )}
                   <div className="flex justify-end gap-3 pt-2 border-t border-gray-100">
@@ -1228,42 +1317,45 @@ export default function OrganizationDetail() {
                     </button>
                     <button
                       onClick={handleSaveAssets}
-                      disabled={saving || (isPlatformAdmin && orgAssetAccessLoading)}
+                      disabled={saving || orgAssetAccessPending || assetAccessLoading || Boolean(assetAccessLoadError)}
                       className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"
                     >
                       {saving ? 'Saving…' : 'Save Changes'}
                     </button>
                   </div>
                 </div>
-              ) : orgAssetTargetsFullLoading ? (
+              ) : !currentOrgAssetTargetsFull && orgAssetTargetsFullLoading ? (
                 <div className="py-12 flex items-center justify-center">
                   <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600" />
                 </div>
-              ) : (orgAssetTargetsFull?.selectable_targets || []).length === 0 ? (
-                <p className="text-sm text-gray-400 text-center py-8">No assets configured for this organization.</p>
+              ) : orgAccessibleTargets.length === 0 ? (
+                <p className="text-sm text-gray-400 text-center py-8">No assets granted for this organization.</p>
               ) : (
                 <div className="space-y-2">
-                  {(orgAssetTargetsFull?.selectable_targets || [])
-                    .filter((t: any) => t.selected)
-                    .map((t: any) => (
-                      <div key={t.callable_key} className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-gray-50 border border-gray-200 hover:bg-blue-50/50 transition-colors">
-                        <div className="flex items-center gap-2.5">
-                          <Shield className="w-3.5 h-3.5 text-green-500 shrink-0" />
-                          <span className="text-sm font-medium text-gray-800">{t.callable_key}</span>
-                          <span className={`text-xs px-1.5 py-0.5 rounded ${
-                            t.target_type === 'model' ? 'bg-blue-50 text-blue-600' : 'bg-purple-50 text-purple-600'
-                          }`}>
-                            {t.target_type === 'route_group' ? 'route group' : t.target_type}
+                  {orgAccessibleTargets.map((t: any) => (
+                    <div key={t.callable_key} className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-gray-50 border border-gray-200 hover:bg-blue-50/50 transition-colors">
+                      <div className="flex items-center gap-2.5">
+                        <Shield className="w-3.5 h-3.5 text-green-500 shrink-0" />
+                        <span className="text-sm font-medium text-gray-800">{t.callable_key}</span>
+                        <span className={`text-xs px-1.5 py-0.5 rounded ${
+                          t.target_type === 'model' ? 'bg-blue-50 text-blue-600' : 'bg-purple-50 text-purple-600'
+                        }`}>
+                          {t.target_type === 'route_group' ? 'route group' : t.target_type}
+                        </span>
+                        {Array.isArray(t.via_access_groups) && t.via_access_groups.length > 0 && (
+                          <span className="text-xs px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700">
+                            via {t.via_access_groups.join(', ')}
                           </span>
-                        </div>
-                        <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+                        )}
                       </div>
-                    ))}
+                      <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+                    </div>
+                  ))}
                 </div>
               )}
               {orgAssetSummary && (
                 <p className="text-xs text-gray-400 mt-3 text-center">
-                  Showing {orgAssetSummary.selected_total} of {orgAssetSummary.selectable_total} granted assets
+                  Showing {orgAssetSummary.effective_total} of {orgAssetSummary.selectable_total} granted assets
                 </p>
               )}
             </div>
@@ -1274,8 +1366,16 @@ export default function OrganizationDetail() {
                 <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide mb-3">Access Summary</h4>
                 <div className="space-y-2.5 text-sm">
                   <div className="flex justify-between">
-                    <span className="text-gray-500">Selected</span>
+                    <span className="text-gray-500">Accessible</span>
+                    <span className="font-medium text-gray-800">{orgAssetSummary?.effective_total ?? '—'}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Direct targets</span>
                     <span className="font-medium text-gray-800">{orgAssetSummary?.selected_total ?? '—'}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Access groups</span>
+                    <span className="font-medium text-gray-800">{orgAssetSummary?.selected_access_group_total ?? '—'}</span>
                   </div>
                   <div className="flex justify-between">
                     <span className="text-gray-500">Available</span>

--- a/ui/src/pages/Organizations.tsx
+++ b/ui/src/pages/Organizations.tsx
@@ -4,7 +4,12 @@ import { useApi } from '../lib/hooks';
 import { useAuth } from '../lib/auth';
 import { resolveUiAccess } from '../lib/authorization';
 import { callableTargets, organizations } from '../lib/api';
-import { buildCatalogAssetTargets } from '../lib/assetAccess';
+import {
+  assetAccessLoadErrorMessage,
+  buildCatalogAccessGroups,
+  buildCatalogAssetTargets,
+  isScopedAssetAccessFor,
+} from '../lib/assetAccess';
 import {
   dateTimeLocalUtcInputToIso,
   defaultMonthlyResetUtcInputValue,
@@ -121,11 +126,17 @@ export default function Organizations() {
   const [assetSearchInput, setAssetSearchInput] = useState('');
   const [assetSearch, setAssetSearch] = useState('');
   const [assetPageOffset, setAssetPageOffset] = useState(0);
+  const [accessGroupPageOffset, setAccessGroupPageOffset] = useState(0);
   const [assetTargetType, setAssetTargetType] = useState<'all' | 'model' | 'route_group'>('all');
   const assetPageSize = 50;
+  const accessGroupPageSize = 50;
 
   useEffect(() => {
-    const t = setTimeout(() => { setAssetSearch(assetSearchInput); setAssetPageOffset(0); }, 250);
+    const t = setTimeout(() => {
+      setAssetSearch(assetSearchInput);
+      setAssetPageOffset(0);
+      setAccessGroupPageOffset(0);
+    }, 250);
     return () => clearTimeout(t);
   }, [assetSearchInput]);
 
@@ -147,16 +158,25 @@ export default function Organizations() {
     audit_content_storage_enabled: false,
     select_all_current_assets: false,
     selected_callable_keys: [] as string[],
+    selected_access_group_keys: [] as string[],
   });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pageError, setPageError] = useState<string | null>(null);
 
-  const { data: editAssetAccess, loading: editAssetAccessLoading } = useApi(
+  const { data: editAssetAccess, error: editAssetAccessError, loading: editAssetAccessLoading } = useApi(
     () => (editItem ? organizations.assetAccess(editItem.organization_id, { include_targets: false }) : Promise.resolve(null)),
     [editItem?.organization_id],
   );
-  const { data: callableTargetPage, loading: callableTargetPageLoading } = useApi(
+  const currentEditAssetAccess = editItem && isScopedAssetAccessFor(editAssetAccess, {
+    scopeType: 'organization',
+    scopeId: editItem.organization_id,
+    organizationId: editItem.organization_id,
+  })
+    ? editAssetAccess
+    : null;
+  const editAssetAccessPending = isPlatformAdmin && !!editItem && (editAssetAccessLoading || !currentEditAssetAccess);
+  const { data: callableTargetPage, error: callableTargetPageError, loading: callableTargetPageLoading } = useApi(
     () => (
       isPlatformAdmin && !!editItem && !form.select_all_current_assets
         ? callableTargets.list({
@@ -168,6 +188,19 @@ export default function Organizations() {
         : Promise.resolve({ data: [], pagination: { total: 0, limit: assetPageSize, offset: 0, has_more: false } })
     ),
     [isPlatformAdmin, editItem?.organization_id, form.select_all_current_assets, assetSearch, assetTargetType, assetPageOffset],
+  );
+  const { data: callableTargetAccessGroups, error: accessGroupError, loading: accessGroupLoading } = useApi(
+    () => (
+      isPlatformAdmin && !!editItem && !form.select_all_current_assets
+        ? callableTargets.listAccessGroups({
+            search: assetSearch || undefined,
+            include_members: false,
+            limit: accessGroupPageSize,
+            offset: accessGroupPageOffset,
+          })
+        : Promise.resolve({ data: [], pagination: { total: 0, limit: accessGroupPageSize, offset: 0, has_more: false } })
+    ),
+    [isPlatformAdmin, editItem?.organization_id, form.select_all_current_assets, assetSearch, accessGroupPageOffset],
   );
 
   const resetForm = () => {
@@ -187,22 +220,25 @@ export default function Organizations() {
       audit_content_storage_enabled: false,
       select_all_current_assets: false,
       selected_callable_keys: [],
+      selected_access_group_keys: [],
     });
     setError(null);
     setAssetSearchInput('');
     setAssetSearch('');
     setAssetPageOffset(0);
+    setAccessGroupPageOffset(0);
     setAssetTargetType('all');
   };
 
   useEffect(() => {
-    if (!editItem || !editAssetAccess) return;
+    if (!editItem || !currentEditAssetAccess) return;
     setForm((c) => ({
       ...c,
-      select_all_current_assets: !!editAssetAccess.auto_follow_catalog,
-      selected_callable_keys: editAssetAccess.selected_callable_keys || [],
+      select_all_current_assets: !!currentEditAssetAccess.auto_follow_catalog,
+      selected_callable_keys: currentEditAssetAccess.selected_callable_keys || [],
+      selected_access_group_keys: currentEditAssetAccess.selected_access_group_keys || [],
     }));
-  }, [editItem, editAssetAccess]);
+  }, [editItem, currentEditAssetAccess]);
 
   const handleMonthlyResetToggle = (checked: boolean) => {
     setForm((c) => ({
@@ -216,6 +252,14 @@ export default function Organizations() {
 
   const handleSave = async () => {
     if (!editItem) return;
+    if (assetAccessLoadError) {
+      setError(assetAccessLoadError);
+      return;
+    }
+    if (editAssetAccessPending || assetAccessLoading) {
+      setError('Wait for asset access options to finish loading before saving the organization.');
+      return;
+    }
     setError(null);
     setSaving(true);
     try {
@@ -248,6 +292,7 @@ export default function Organizations() {
       if (isPlatformAdmin) {
         await organizations.updateAssetAccess(editItem.organization_id, {
           selected_callable_keys: form.select_all_current_assets ? [] : form.selected_callable_keys,
+          selected_access_group_keys: form.select_all_current_assets ? [] : form.selected_access_group_keys,
           select_all_selectable: form.select_all_current_assets,
         });
       }
@@ -280,16 +325,34 @@ export default function Organizations() {
       audit_content_storage_enabled: !!row.audit_content_storage_enabled,
       select_all_current_assets: false,
       selected_callable_keys: [],
+      selected_access_group_keys: [],
     });
     setAssetSearchInput('');
     setAssetSearch('');
     setAssetPageOffset(0);
+    setAccessGroupPageOffset(0);
     setAssetTargetType('all');
     setEditItem(row);
   };
 
-  const assetTargets = buildCatalogAssetTargets((callableTargetPage?.data || []) as any[], form.selected_callable_keys);
+  const assetTargets = buildCatalogAssetTargets(
+    (callableTargetPage?.data || []) as any[],
+    form.selected_callable_keys,
+    currentEditAssetAccess?.selected_callable_keys || [],
+  );
+  const assetAccessGroups = buildCatalogAccessGroups(
+    callableTargetAccessGroups?.data || [],
+    form.selected_access_group_keys,
+    currentEditAssetAccess?.selected_access_group_keys || [],
+  );
   const assetPagePagination = callableTargetPage?.pagination;
+  const accessGroupPagination = callableTargetAccessGroups?.pagination;
+  const assetAccessLoading = !form.select_all_current_assets && (callableTargetPageLoading || accessGroupLoading);
+  const assetAccessLoadError = isPlatformAdmin && !!editItem
+    ? assetAccessLoadErrorMessage(
+        editAssetAccessError || (!form.select_all_current_assets ? callableTargetPageError || accessGroupError : null),
+      )
+    : null;
 
   /* ── pagination helpers ── */
   const total = pagination?.total ?? 0;
@@ -537,8 +600,8 @@ export default function Organizations() {
         title="Edit Organization"
       >
         <div className="space-y-4">
-          {error && (
-            <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{error}</div>
+          {(error || assetAccessLoadError) && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{error || assetAccessLoadError}</div>
           )}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Organization Name</label>
@@ -671,7 +734,12 @@ export default function Organizations() {
                       type="radio"
                       name="organization-asset-strategy"
                       checked={form.select_all_current_assets}
-                      onChange={() => setForm((c) => ({ ...c, select_all_current_assets: true, selected_callable_keys: [] }))}
+                      onChange={() => setForm((c) => ({
+                        ...c,
+                        select_all_current_assets: true,
+                        selected_callable_keys: [],
+                        selected_access_group_keys: [],
+                      }))}
                       disabled={saving}
                       className="mt-0.5"
                     />
@@ -700,8 +768,8 @@ export default function Organizations() {
               </div>
               {form.select_all_current_assets ? (
                 <div className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-3 text-xs text-blue-800">
-                  {editItem && editAssetAccess
-                    ? `This organization currently has ${editAssetAccess.summary.selected_total} of ${editAssetAccess.summary.selectable_total} assets granted. Saving will align it to all current assets and automatically include future additions.`
+                  {editItem && currentEditAssetAccess
+                    ? `This organization currently has ${currentEditAssetAccess.summary.effective_total} of ${currentEditAssetAccess.summary.selectable_total} assets granted. Saving will align it to all current assets and automatically include future additions.`
                     : 'Saving will grant every currently available model and route group to this organization and automatically include future additions.'}
                 </div>
               ) : (
@@ -712,18 +780,33 @@ export default function Organizations() {
                   targets={assetTargets}
                   selectedKeys={form.selected_callable_keys}
                   onSelectedKeysChange={(selected_callable_keys) => setForm({ ...form, selected_callable_keys })}
-                  loading={callableTargetPageLoading || (!!editItem && editAssetAccessLoading)}
-                  disabled={saving}
+                  accessGroups={assetAccessGroups}
+                  selectedAccessGroupKeys={form.selected_access_group_keys}
+                  onSelectedAccessGroupKeysChange={(selected_access_group_keys) => setForm({ ...form, selected_access_group_keys })}
+                  targetsLoading={callableTargetPageLoading || editAssetAccessPending}
+                  accessGroupsLoading={accessGroupLoading || editAssetAccessPending}
+                  disabled={saving || editAssetAccessPending || Boolean(assetAccessLoadError)}
                   searchValue={assetSearchInput}
                   onSearchValueChange={setAssetSearchInput}
                   targetTypeFilter={assetTargetType}
                   onTargetTypeFilterChange={(next) => { setAssetTargetType(next); setAssetPageOffset(0); }}
                   pagination={assetPagePagination}
                   onPageChange={setAssetPageOffset}
+                  accessGroupPagination={accessGroupPagination}
+                  onAccessGroupPageChange={setAccessGroupPageOffset}
                   primaryActionLabel="Allow all assets"
-                  onPrimaryAction={() => setForm((c) => ({ ...c, select_all_current_assets: true, selected_callable_keys: [] }))}
-                  secondaryActionLabel={form.selected_callable_keys.length > 0 ? 'Clear selection' : undefined}
-                  onSecondaryAction={form.selected_callable_keys.length > 0 ? () => setForm((c) => ({ ...c, selected_callable_keys: [] })) : undefined}
+                  onPrimaryAction={() => setForm((c) => ({
+                    ...c,
+                    select_all_current_assets: true,
+                    selected_callable_keys: [],
+                    selected_access_group_keys: [],
+                  }))}
+                  secondaryActionLabel={form.selected_callable_keys.length > 0 || form.selected_access_group_keys.length > 0 ? 'Clear selection' : undefined}
+                  onSecondaryAction={
+                    form.selected_callable_keys.length > 0 || form.selected_access_group_keys.length > 0
+                      ? () => setForm((c) => ({ ...c, selected_callable_keys: [], selected_access_group_keys: [] }))
+                      : undefined
+                  }
                 />
               )}
             </div>
@@ -737,7 +820,7 @@ export default function Organizations() {
             </button>
             <button
               onClick={handleSave}
-              disabled={saving || (!!editItem && editAssetAccessLoading)}
+              disabled={saving || editAssetAccessPending || assetAccessLoading || Boolean(assetAccessLoadError)}
               className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"
             >
               {saving ? 'Saving…' : editItem ? 'Save Changes' : 'Create'}

--- a/ui/src/pages/RBACAccounts.tsx
+++ b/ui/src/pages/RBACAccounts.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { invitations, organizations, rbac, teams, users, type Invitation, type Principal, type PrincipalSummary, type ScopedAssetAccess } from '../lib/api';
 import { Plus, UserCog, ShieldCheck, Search, Building2, UsersRound, Trash2, Mail } from 'lucide-react';
@@ -66,6 +66,7 @@ function MembershipCountBadge({ count, label }: { count: number; label: string }
 type PeopleAccessTab = 'users' | 'invitations';
 type InvitationStatusFilter = Invitation['status'] | 'active';
 const EMPTY_PAGINATION = { total: 0, limit: 20, offset: 0, has_more: false };
+const USER_ACCESS_GROUP_PAGE_SIZE = 50;
 const EMPTY_SUMMARY: PrincipalSummary = {
   total_accounts: 0,
   active_accounts: 0,
@@ -126,11 +127,20 @@ export default function RBACAccounts() {
   const [userAssetAccess, setUserAssetAccess] = useState<ScopedAssetAccess | null>(null);
   const [userAssetMode, setUserAssetMode] = useState<'inherit' | 'restrict'>('inherit');
   const [userAssetSelectedKeys, setUserAssetSelectedKeys] = useState<string[]>([]);
+  const [userAssetSelectedAccessGroupKeys, setUserAssetSelectedAccessGroupKeys] = useState<string[]>([]);
+  const [userAssetSearchInput, setUserAssetSearchInput] = useState('');
+  const [userAssetSearch, setUserAssetSearch] = useState('');
+  const [userAccessGroupPageOffset, setUserAccessGroupPageOffset] = useState(0);
   const [userAssetLoading, setUserAssetLoading] = useState(false);
   const [userAssetError, setUserAssetError] = useState('');
+  const userAssetSelectionInitializedRef = useRef(false);
+  const userAssetRequestIdRef = useRef(0);
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const userAssetAccessInitialized = userAssetSelectionInitializedRef.current;
+  const canSaveUserAssetAccess = Boolean(userAssetAccess) || (userAssetMode === 'inherit' && userAssetAccessInitialized);
+  const userAssetModeControlsDisabled = saving || userAssetLoading || (!userAssetAccess && !userAssetAccessInitialized);
 
   const loadReferenceData = useCallback(async () => {
     setReferenceLoading(true);
@@ -217,6 +227,61 @@ export default function RBACAccounts() {
     if (referenceLoading) return;
     setShowProvisionModal(true);
   }, [inviteOrganizationId, inviteTeamId, referenceLoading]);
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setUserAssetSearch(userAssetSearchInput.trim());
+      setUserAccessGroupPageOffset(0);
+    }, 250);
+    return () => clearTimeout(t);
+  }, [userAssetSearchInput]);
+
+  const loadUserAssetAccess = useCallback(async (
+    runtimeUserId: string,
+    options: { search?: string; offset?: number; preserveSelections?: boolean } = {},
+  ) => {
+    const requestId = userAssetRequestIdRef.current + 1;
+    userAssetRequestIdRef.current = requestId;
+    setUserAssetLoading(true);
+    setUserAssetError('');
+    try {
+      const access = await users.assetAccess(runtimeUserId, {
+        include_targets: true,
+        access_group_search: options.search || undefined,
+        access_group_limit: USER_ACCESS_GROUP_PAGE_SIZE,
+        access_group_offset: options.offset ?? 0,
+      });
+      if (requestId !== userAssetRequestIdRef.current) return;
+      setUserAssetAccess(access);
+      if (!options.preserveSelections) {
+        setUserAssetMode(access.mode === 'restrict' ? 'restrict' : 'inherit');
+        setUserAssetSelectedKeys(access.selected_callable_keys || []);
+        setUserAssetSelectedAccessGroupKeys(access.selected_access_group_keys || []);
+        userAssetSelectionInitializedRef.current = true;
+      }
+    } catch (err: unknown) {
+      if (requestId !== userAssetRequestIdRef.current) return;
+      setUserAssetAccess(null);
+      setUserAssetError(err instanceof Error ? err.message : 'Failed to load runtime user asset access');
+    } finally {
+      if (requestId === userAssetRequestIdRef.current) {
+        setUserAssetLoading(false);
+      }
+    }
+  }, []);
+  useEffect(() => {
+    if (!showUserAccessModal || !selectedRuntimeUser?.runtime_user_id) return;
+    void loadUserAssetAccess(selectedRuntimeUser.runtime_user_id, {
+      search: userAssetSearch,
+      offset: userAccessGroupPageOffset,
+      preserveSelections: userAssetSelectionInitializedRef.current,
+    });
+  }, [
+    loadUserAssetAccess,
+    selectedRuntimeUser?.runtime_user_id,
+    showUserAccessModal,
+    userAccessGroupPageOffset,
+    userAssetSearch,
+  ]);
 
   const clearInvitePrefill = useCallback(() => {
     if (!inviteOrganizationId && !inviteTeamId) return;
@@ -357,7 +422,15 @@ export default function RBACAccounts() {
     }
   };
 
-  const openUserAssetAccess = async (acct: Principal) => {
+  const openUserAssetAccess = (acct: Principal) => {
+    userAssetRequestIdRef.current += 1;
+    userAssetSelectionInitializedRef.current = false;
+    setUserAssetMode('inherit');
+    setUserAssetSelectedKeys([]);
+    setUserAssetSelectedAccessGroupKeys([]);
+    setUserAssetSearchInput('');
+    setUserAssetSearch('');
+    setUserAccessGroupPageOffset(0);
     if (!acct.runtime_user_id) {
       setSelectedRuntimeUser(acct);
       setShowUserAccessModal(true);
@@ -371,30 +444,28 @@ export default function RBACAccounts() {
     setUserAssetLoading(true);
     setUserAssetError('');
     setUserAssetAccess(null);
-    try {
-      const access = await users.assetAccess(acct.runtime_user_id, { include_targets: true });
-      setUserAssetAccess(access);
-      setUserAssetMode(access.mode === 'restrict' ? 'restrict' : 'inherit');
-      setUserAssetSelectedKeys(access.selected_callable_keys || []);
-    } catch (err: any) {
-      setUserAssetError(err?.message || 'Failed to load runtime user asset access');
-    } finally {
-      setUserAssetLoading(false);
-    }
   };
 
   const saveUserAssetAccess = async () => {
     if (!selectedRuntimeUser?.runtime_user_id) return;
+    if (userAssetLoading || !canSaveUserAssetAccess) {
+      setUserAssetError('Wait for runtime user asset access to finish loading before saving.');
+      return;
+    }
+    userAssetRequestIdRef.current += 1;
     setSaving(true);
     setUserAssetError('');
     try {
       const response = await users.updateAssetAccess(selectedRuntimeUser.runtime_user_id, {
         mode: userAssetMode,
         selected_callable_keys: userAssetMode === 'inherit' ? [] : userAssetSelectedKeys,
+        selected_access_group_keys: userAssetMode === 'inherit' ? [] : userAssetSelectedAccessGroupKeys,
       });
       setUserAssetAccess(response);
       setUserAssetMode(response.mode === 'restrict' ? 'restrict' : 'inherit');
       setUserAssetSelectedKeys(response.selected_callable_keys || []);
+      setUserAssetSelectedAccessGroupKeys(response.selected_access_group_keys || []);
+      userAssetSelectionInitializedRef.current = true;
       setShowUserAccessModal(false);
     } catch (err: any) {
       setUserAssetError(err?.message || 'Failed to update runtime user asset access');
@@ -448,6 +519,7 @@ export default function RBACAccounts() {
   const hasPrev = principalPageOffset > 0;
   const hasNext = principalPagination.has_more;
   const visibleCount = viewTab === 'users' ? principalPagination.total : invitationPagination.total;
+  const hasUserAssetSelections = userAssetSelectedKeys.length > 0 || userAssetSelectedAccessGroupKeys.length > 0;
   const showPageNotice =
     viewTab === 'users' &&
     !!principalError &&
@@ -959,12 +1031,28 @@ export default function RBACAccounts() {
             description="Restrict this runtime user below the inherited team and organization asset set when needed."
             mode={userAssetMode}
             allowModeSelection
-            onModeChange={(mode) => setUserAssetMode(mode === 'restrict' ? 'restrict' : 'inherit')}
+            onModeChange={(mode) => {
+              const nextMode = mode === 'restrict' ? 'restrict' : 'inherit';
+              setUserAssetMode(nextMode);
+              if (nextMode === 'inherit') {
+                setUserAssetSelectedKeys([]);
+                setUserAssetSelectedAccessGroupKeys([]);
+              }
+            }}
             targets={userAssetAccess?.selectable_targets || []}
             selectedKeys={userAssetSelectedKeys}
             onSelectedKeysChange={setUserAssetSelectedKeys}
-            loading={userAssetLoading}
-            disabled={saving || !userAssetAccess}
+            accessGroups={userAssetAccess?.selectable_access_groups || []}
+            selectedAccessGroupKeys={userAssetSelectedAccessGroupKeys}
+            onSelectedAccessGroupKeysChange={setUserAssetSelectedAccessGroupKeys}
+            targetsLoading={userAssetLoading}
+            accessGroupsLoading={userAssetLoading}
+            disabled={saving || userAssetLoading || !userAssetAccess}
+            modeControlsDisabled={userAssetModeControlsDisabled}
+            searchValue={userAssetSearchInput}
+            onSearchValueChange={setUserAssetSearchInput}
+            accessGroupPagination={userAssetAccess?.access_group_pagination}
+            onAccessGroupPageChange={setUserAccessGroupPageOffset}
             primaryActionLabel={userAssetMode === 'restrict' ? 'Select All Visible' : undefined}
             onPrimaryAction={userAssetMode === 'restrict' ? (() => {
               const next = (userAssetAccess?.selectable_targets || [])
@@ -973,12 +1061,15 @@ export default function RBACAccounts() {
                 .sort();
               setUserAssetSelectedKeys(next);
             }) : undefined}
-            secondaryActionLabel={userAssetMode === 'restrict' && userAssetSelectedKeys.length > 0 ? 'Clear Selection' : undefined}
-            onSecondaryAction={userAssetMode === 'restrict' && userAssetSelectedKeys.length > 0 ? (() => setUserAssetSelectedKeys([])) : undefined}
+            secondaryActionLabel={userAssetMode === 'restrict' && hasUserAssetSelections ? 'Clear Selection' : undefined}
+            onSecondaryAction={userAssetMode === 'restrict' && hasUserAssetSelections ? (() => {
+              setUserAssetSelectedKeys([]);
+              setUserAssetSelectedAccessGroupKeys([]);
+            }) : undefined}
           />
           {userAssetAccess && (
             <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
-              Effective visible assets: {userAssetAccess.summary.effective_total} · Direct selections: {userAssetSelectedKeys.length}
+              Effective visible assets: {userAssetAccess.summary.effective_total} · Direct selections: {userAssetSelectedKeys.length} · Access groups: {userAssetSelectedAccessGroupKeys.length}
             </div>
           )}
           <div className="flex gap-3 pt-2">
@@ -991,7 +1082,7 @@ export default function RBACAccounts() {
             </button>
             <button
               onClick={saveUserAssetAccess}
-              disabled={saving || !userAssetAccess}
+              disabled={saving || userAssetLoading || !canSaveUserAssetAccess}
               className="flex-1 bg-indigo-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors disabled:opacity-50"
             >
               {saving ? 'Saving...' : 'Save Access'}

--- a/ui/src/pages/TeamCreate.tsx
+++ b/ui/src/pages/TeamCreate.tsx
@@ -1,8 +1,13 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { useApi } from '../lib/hooks';
 import { teams, organizations } from '../lib/api';
-import { buildParentScopedAssetTargets } from '../lib/assetAccess';
+import {
+  assetAccessLoadErrorMessage,
+  buildParentScopedAssetTargets,
+  buildScopedSelectableAccessGroups,
+  isAssetVisibilityFor,
+} from '../lib/assetAccess';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
 import TeamSelfServicePolicySection from '../components/admin/TeamSelfServicePolicySection';
 import ToggleSwitch from '../components/ToggleSwitch';
@@ -120,16 +125,22 @@ export default function TeamCreate() {
   const { session, authMode } = useAuth();
   const uiAccess = resolveUiAccess(authMode, session);
 
-  if (!uiAccess.team_create) {
-    return <Navigate to="/teams" replace />;
-  }
-
   /* background teams list */
-  const { data: teamsResult } = useApi(() => teams.list({ limit: 8, offset: 0 }), []);
+  const { data: teamsResult } = useApi(
+    () => uiAccess.team_create
+      ? teams.list({ limit: 8, offset: 0 })
+      : Promise.resolve({ data: [], pagination: { total: 0, limit: 8, offset: 0, has_more: false } }),
+    [uiAccess.team_create],
+  );
   const bgItems: any[] = teamsResult?.data || [];
 
   /* org list for selector */
-  const { data: orgResult } = useApi(() => organizations.list({ limit: 500 }), []);
+  const { data: orgResult } = useApi(
+    () => uiAccess.team_create
+      ? organizations.list({ limit: 500 })
+      : Promise.resolve({ data: [], pagination: { total: 0, limit: 500, offset: 0, has_more: false } }),
+    [uiAccess.team_create],
+  );
   const orgList: any[] = orgResult?.data || [];
 
   /* form state */
@@ -150,6 +161,11 @@ export default function TeamCreate() {
   const [tpdValue, setTpdValue] = useState('');
   const [assetMode, setAssetMode] = useState<'inherit' | 'restrict'>('inherit');
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [selectedAccessGroupKeys, setSelectedAccessGroupKeys] = useState<string[]>([]);
+  const [assetSearchInput, setAssetSearchInput] = useState('');
+  const [assetSearch, setAssetSearch] = useState('');
+  const [accessGroupPageOffset, setAccessGroupPageOffset] = useState(0);
+  const accessGroupPageSize = 50;
   const [selfServiceEnabled, setSelfServiceEnabled] = useState(true);
   const [selfServiceMaxKeysPerUser, setSelfServiceMaxKeysPerUser] = useState('');
   const [selfServiceBudgetCeiling, setSelfServiceBudgetCeiling] = useState('');
@@ -168,21 +184,53 @@ export default function TeamCreate() {
     setSelectedOrgId(orgId);
     setAssetMode('inherit');
     setSelectedKeys([]);
+    setSelectedAccessGroupKeys([]);
+    setAssetSearchInput('');
+    setAssetSearch('');
+    setAccessGroupPageOffset(0);
   };
 
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setAssetSearch(assetSearchInput);
+      setAccessGroupPageOffset(0);
+    }, 250);
+    return () => clearTimeout(t);
+  }, [assetSearchInput]);
+
   /* org asset visibility for restrict mode */
-  const { data: orgAssetVisibility, loading: orgAssetVisibilityLoading } = useApi(
+  const { data: orgAssetVisibility, error: orgAssetVisibilityError, loading: orgAssetVisibilityLoading } = useApi(
     () => (assetMode === 'restrict' && selectedOrgId
-      ? organizations.assetVisibility(selectedOrgId)
+      ? organizations.assetVisibility(selectedOrgId, {
+          include_access_groups: true,
+          access_group_search: assetSearch || undefined,
+          access_group_limit: accessGroupPageSize,
+          access_group_offset: accessGroupPageOffset,
+        })
       : Promise.resolve(null)),
-    [assetMode, selectedOrgId],
+    [assetMode, selectedOrgId, assetSearch, accessGroupPageOffset],
   );
 
+  const currentOrgAssetVisibility = selectedOrgId && isAssetVisibilityFor(orgAssetVisibility, {
+    organizationId: selectedOrgId,
+  })
+    ? orgAssetVisibility
+    : null;
   const assetTargets = buildParentScopedAssetTargets(
-    orgAssetVisibility?.callable_targets?.items || [],
+    currentOrgAssetVisibility?.callable_targets?.items || [],
     selectedKeys,
     assetMode,
   );
+  const assetAccessGroups = buildScopedSelectableAccessGroups(
+    currentOrgAssetVisibility?.access_groups?.items || [],
+    selectedAccessGroupKeys,
+  );
+  const accessGroupPagination = currentOrgAssetVisibility?.access_groups?.pagination;
+  const assetTargetsLoading = !currentOrgAssetVisibility && orgAssetVisibilityLoading;
+  const assetAccessLoading = assetMode === 'restrict' && Boolean(selectedOrgId) && (assetTargetsLoading || orgAssetVisibilityLoading);
+  const assetAccessLoadError = assetMode === 'restrict' && Boolean(selectedOrgId)
+    ? assetAccessLoadErrorMessage(orgAssetVisibilityError)
+    : null;
 
   /* submit */
   const [saving, setSaving] = useState(false);
@@ -200,6 +248,14 @@ export default function TeamCreate() {
   const handleCreate = async () => {
     if (!teamName.trim()) { setNameError(true); return; }
     if (!selectedOrgId) { setError('Please select an organization.'); return; }
+    if (assetAccessLoading) {
+      setError('Wait for asset access options to finish loading before creating the team.');
+      return;
+    }
+    if (assetAccessLoadError) {
+      setError(assetAccessLoadError);
+      return;
+    }
     setError(null);
     setSaving(true);
     try {
@@ -238,6 +294,7 @@ export default function TeamCreate() {
           await teams.updateAssetAccess(created.team_id, {
             mode: 'restrict',
             selected_callable_keys: selectedKeys,
+            selected_access_group_keys: selectedAccessGroupKeys,
           });
         } catch (err: any) {
           pageWarning = err?.message || 'Team created, but restricted asset access could not be applied.';
@@ -257,6 +314,10 @@ export default function TeamCreate() {
   const handleCancel = () => navigate(returnTo || '/teams');
 
   /* ─────────────── render ─────────────── */
+  if (!uiAccess.team_create) {
+    return <Navigate to="/teams" replace />;
+  }
+
   return (
     <div className="flex h-screen overflow-hidden relative">
       {/* Faded background */}
@@ -294,9 +355,9 @@ export default function TeamCreate() {
         {/* Scrollable body */}
         <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
 
-          {error && (
+          {(error || assetAccessLoadError) && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 flex items-center gap-2">
-              <AlertCircle className="w-4 h-4 shrink-0" /> {error}
+              <AlertCircle className="w-4 h-4 shrink-0" /> {error || assetAccessLoadError}
             </div>
           )}
 
@@ -647,7 +708,13 @@ export default function TeamCreate() {
                 <button
                   key={mode}
                   type="button"
-                  onClick={() => { setAssetMode(mode); if (mode === 'inherit') setSelectedKeys([]); }}
+                  onClick={() => {
+                    setAssetMode(mode);
+                    if (mode === 'inherit') {
+                      setSelectedKeys([]);
+                      setSelectedAccessGroupKeys([]);
+                    }
+                  }}
                   disabled={saving}
                   className={`flex flex-col items-start gap-1.5 p-3.5 rounded-xl border-2 text-left transition-all disabled:opacity-50 ${
                     assetMode === mode
@@ -707,10 +774,22 @@ export default function TeamCreate() {
                 targets={assetTargets}
                 selectedKeys={selectedKeys}
                 onSelectedKeysChange={setSelectedKeys}
-                loading={orgAssetVisibilityLoading}
-                disabled={saving}
-                secondaryActionLabel={selectedKeys.length > 0 ? 'Clear selection' : undefined}
-                onSecondaryAction={selectedKeys.length > 0 ? () => setSelectedKeys([]) : undefined}
+                accessGroups={assetAccessGroups}
+                selectedAccessGroupKeys={selectedAccessGroupKeys}
+                onSelectedAccessGroupKeysChange={setSelectedAccessGroupKeys}
+                targetsLoading={assetTargetsLoading}
+                accessGroupsLoading={orgAssetVisibilityLoading}
+                disabled={saving || Boolean(assetAccessLoadError)}
+                searchValue={assetSearchInput}
+                onSearchValueChange={setAssetSearchInput}
+                accessGroupPagination={accessGroupPagination}
+                onAccessGroupPageChange={setAccessGroupPageOffset}
+                secondaryActionLabel={selectedKeys.length > 0 || selectedAccessGroupKeys.length > 0 ? 'Clear selection' : undefined}
+                onSecondaryAction={
+                  selectedKeys.length > 0 || selectedAccessGroupKeys.length > 0
+                    ? () => { setSelectedKeys([]); setSelectedAccessGroupKeys([]); }
+                    : undefined
+                }
               />
             )}
           </div>
@@ -758,6 +837,14 @@ export default function TeamCreate() {
                   <AlertCircle className="w-3 h-3" />
                   {!selectedOrgId ? 'Select an organization to continue' : 'Fill in required fields to continue'}
                 </span>
+              ) : assetAccessLoading ? (
+                <span className="flex items-center gap-1 text-amber-600">
+                  <AlertCircle className="w-3 h-3" /> Loading asset access options
+                </span>
+              ) : assetAccessLoadError ? (
+                <span className="flex items-center gap-1 text-red-600">
+                  <AlertCircle className="w-3 h-3" /> Asset access options failed to load
+                </span>
               ) : (
                 <span className="flex items-center gap-1 text-green-600">
                   <Check className="w-3 h-3" /> Ready to create
@@ -774,7 +861,7 @@ export default function TeamCreate() {
               </button>
               <button
                 onClick={handleCreate}
-                disabled={saving || !isReady}
+                disabled={saving || !isReady || assetAccessLoading || Boolean(assetAccessLoadError)}
                 className="px-3 py-1.5 text-xs font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {saving ? 'Creating…' : 'Create Team'}

--- a/ui/src/pages/TeamDetail.tsx
+++ b/ui/src/pages/TeamDetail.tsx
@@ -4,7 +4,14 @@ import { useApi } from '../lib/hooks';
 import { useAuth } from '../lib/auth';
 import { resolveUiAccess } from '../lib/authorization';
 import { organizations, teams } from '../lib/api';
-import { buildParentScopedAssetTargets, buildScopedSelectableTargets } from '../lib/assetAccess';
+import {
+  assetAccessLoadErrorMessage,
+  buildParentScopedAssetTargets,
+  buildScopedSelectableAccessGroups,
+  buildScopedSelectableTargets,
+  isAssetVisibilityFor,
+  isScopedAssetAccessFor,
+} from '../lib/assetAccess';
 import Modal from '../components/Modal';
 import UserSearchSelect from '../components/UserSearchSelect';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
@@ -73,7 +80,7 @@ export default function TeamDetail() {
     () => teams.members(teamId!),
     [teamId],
   );
-  const { data: teamAssetAccess, refetch: refetchTeamAssetAccess } = useApi(
+  const { data: teamAssetAccess, error: teamAssetAccessError, loading: teamAssetAccessLoading, refetch: refetchTeamAssetAccess } = useApi(
     () => teams.assetAccess(teamId!, { include_targets: false }),
     [teamId],
   );
@@ -102,6 +109,7 @@ export default function TeamDetail() {
     tpd_limit: '',
     asset_access_mode: 'inherit' as 'inherit' | 'restrict',
     selected_callable_keys: [] as string[],
+    selected_access_group_keys: [] as string[],
   });
   const [saving, setSaving] = useState(false);
   const [teamError, setTeamError] = useState<string | null>(
@@ -109,31 +117,61 @@ export default function TeamDetail() {
       ? String((location.state as { pageWarning?: string }).pageWarning || '') || null
       : null,
   );
+  const [assetSearchInput, setAssetSearchInput] = useState('');
+  const [assetSearch, setAssetSearch] = useState('');
+  const [accessGroupPageOffset, setAccessGroupPageOffset] = useState(0);
+  const accessGroupPageSize = 50;
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setAssetSearch(assetSearchInput);
+      setAccessGroupPageOffset(0);
+    }, 250);
+    return () => clearTimeout(t);
+  }, [assetSearchInput]);
 
   const selectedOrganizationId = form.organization_id.trim();
   const usesParentPreview = selectedOrganizationId !== (team?.organization_id || '');
 
-  const { data: teamAssetAccessTargets, loading: teamAssetAccessTargetsLoading } = useApi(
+  const { data: teamAssetAccessTargets, error: teamAssetAccessTargetsError, loading: teamAssetAccessTargetsLoading } = useApi(
     () => (isEditingAssets && !usesParentPreview && form.asset_access_mode === 'restrict'
-      ? teams.assetAccess(teamId!, { include_targets: true })
+      ? teams.assetAccess(teamId!, {
+          include_targets: true,
+          access_group_search: assetSearch || undefined,
+          access_group_limit: accessGroupPageSize,
+          access_group_offset: accessGroupPageOffset,
+        })
       : Promise.resolve(null)),
-    [isEditingAssets, teamId, usesParentPreview, form.asset_access_mode],
+    [isEditingAssets, teamId, usesParentPreview, form.asset_access_mode, assetSearch, accessGroupPageOffset],
   );
-  const { data: parentOrgAssetVisibility, loading: parentOrgAssetVisibilityLoading } = useApi(
+  const { data: parentOrgAssetVisibility, error: parentOrgAssetVisibilityError, loading: parentOrgAssetVisibilityLoading } = useApi(
     () => (isEditingAssets && usesParentPreview && form.asset_access_mode === 'restrict' && selectedOrganizationId
-      ? organizations.assetVisibility(selectedOrganizationId)
+      ? organizations.assetVisibility(selectedOrganizationId, {
+          include_access_groups: true,
+          access_group_search: assetSearch || undefined,
+          access_group_limit: accessGroupPageSize,
+          access_group_offset: accessGroupPageOffset,
+        })
       : Promise.resolve(null)),
-    [isEditingAssets, selectedOrganizationId, usesParentPreview, form.asset_access_mode],
+    [isEditingAssets, selectedOrganizationId, usesParentPreview, form.asset_access_mode, assetSearch, accessGroupPageOffset],
   );
+  const currentTeamAssetAccess = isScopedAssetAccessFor(teamAssetAccess, {
+    scopeType: 'team',
+    scopeId: teamId,
+  })
+    ? teamAssetAccess
+    : null;
+  const teamAssetAccessPending = isEditingAssets && (teamAssetAccessLoading || !currentTeamAssetAccess);
 
   useEffect(() => {
-    if (!isEditingAssets || !teamAssetAccess) return;
+    if (!isEditingAssets || !currentTeamAssetAccess) return;
     setForm((c) => ({
       ...c,
-      asset_access_mode: teamAssetAccess.mode === 'restrict' ? 'restrict' : 'inherit',
-      selected_callable_keys: teamAssetAccess.selected_callable_keys || [],
+      asset_access_mode: currentTeamAssetAccess.mode === 'restrict' ? 'restrict' : 'inherit',
+      selected_callable_keys: currentTeamAssetAccess.selected_callable_keys || [],
+      selected_access_group_keys: currentTeamAssetAccess.selected_access_group_keys || [],
     }));
-  }, [isEditingAssets, teamAssetAccess]);
+  }, [isEditingAssets, currentTeamAssetAccess]);
 
   const openEditSettings = () => {
     if (!team) return;
@@ -158,18 +196,61 @@ export default function TeamDetail() {
     setForm((c) => ({
       ...c,
       organization_id: team.organization_id || '',
-      asset_access_mode: teamAssetAccess?.mode === 'restrict' ? 'restrict' : 'inherit',
-      selected_callable_keys: teamAssetAccess?.selected_callable_keys || [],
+      asset_access_mode: currentTeamAssetAccess?.mode === 'restrict' ? 'restrict' : 'inherit',
+      selected_callable_keys: currentTeamAssetAccess?.selected_callable_keys || [],
+      selected_access_group_keys: currentTeamAssetAccess?.selected_access_group_keys || [],
     }));
+    setAssetSearchInput('');
+    setAssetSearch('');
+    setAccessGroupPageOffset(0);
     setIsEditingAssets(true);
   };
 
+  const currentTeamAssetAccessTargets = isScopedAssetAccessFor(teamAssetAccessTargets, {
+    scopeType: 'team',
+    scopeId: teamId,
+  })
+    ? teamAssetAccessTargets
+    : null;
+  const currentTeamAssetTargetsFull = isScopedAssetAccessFor(teamAssetTargets, {
+    scopeType: 'team',
+    scopeId: teamId,
+  })
+    ? teamAssetTargets
+    : null;
+  const currentParentOrgAssetVisibility = selectedOrganizationId && isAssetVisibilityFor(parentOrgAssetVisibility, {
+    organizationId: selectedOrganizationId,
+  })
+    ? parentOrgAssetVisibility
+    : null;
   const assetTargets = usesParentPreview
-    ? buildParentScopedAssetTargets(parentOrgAssetVisibility?.callable_targets?.items || [], form.selected_callable_keys, form.asset_access_mode)
-    : buildScopedSelectableTargets(teamAssetAccessTargets?.selectable_targets || [], form.selected_callable_keys, form.asset_access_mode);
-  const assetAccessLoading = form.asset_access_mode !== 'restrict' ? false
+    ? buildParentScopedAssetTargets(currentParentOrgAssetVisibility?.callable_targets?.items || [], form.selected_callable_keys, form.asset_access_mode)
+    : buildScopedSelectableTargets(currentTeamAssetAccessTargets?.selectable_targets || [], form.selected_callable_keys, form.asset_access_mode);
+  const assetAccessGroups = usesParentPreview
+    ? buildScopedSelectableAccessGroups(
+        currentParentOrgAssetVisibility?.access_groups?.items || [],
+        form.selected_access_group_keys,
+      )
+    : buildScopedSelectableAccessGroups(
+        currentTeamAssetAccessTargets?.selectable_access_groups || [],
+        form.selected_access_group_keys,
+      );
+  const accessGroupPagination = usesParentPreview
+    ? currentParentOrgAssetVisibility?.access_groups?.pagination
+    : currentTeamAssetAccessTargets?.access_group_pagination;
+  const assetTargetsLoading = form.asset_access_mode !== 'restrict' ? false
+    : usesParentPreview ? !currentParentOrgAssetVisibility && parentOrgAssetVisibilityLoading
+    : !currentTeamAssetAccessTargets && teamAssetAccessTargetsLoading;
+  const accessGroupsLoading = form.asset_access_mode !== 'restrict' ? false
     : usesParentPreview ? parentOrgAssetVisibilityLoading
     : teamAssetAccessTargetsLoading;
+  const assetAccessLoading = assetTargetsLoading || accessGroupsLoading;
+  const activeAssetAccessError = form.asset_access_mode === 'restrict'
+    ? usesParentPreview ? parentOrgAssetVisibilityError : teamAssetAccessTargetsError
+    : null;
+  const assetAccessLoadError = isEditingAssets
+    ? assetAccessLoadErrorMessage(teamAssetAccessError || activeAssetAccessError)
+    : null;
 
   const handleSaveSettings = async () => {
     setSaving(true);
@@ -194,12 +275,21 @@ export default function TeamDetail() {
   };
 
   const handleSaveAssets = async () => {
+    if (assetAccessLoadError) {
+      setTeamError(assetAccessLoadError);
+      return;
+    }
+    if (teamAssetAccessPending || assetAccessLoading) {
+      setTeamError('Wait for asset access options to finish loading before saving.');
+      return;
+    }
     setSaving(true);
     setTeamError(null);
     try {
       await teams.updateAssetAccess(teamId!, {
         mode: form.asset_access_mode,
         selected_callable_keys: form.asset_access_mode === 'restrict' ? form.selected_callable_keys : [],
+        selected_access_group_keys: form.asset_access_mode === 'restrict' ? form.selected_access_group_keys : [],
       });
       setIsEditingAssets(false);
       refetchTeam();
@@ -293,11 +383,11 @@ export default function TeamDetail() {
   const spend = team?.spend || 0;
   const budget = team?.max_budget ?? null;
   const spendPct = budget ? Math.min(100, Math.round((spend / budget) * 100)) : null;
-  const assetMode = teamAssetAccess?.mode ?? 'inherit';
-  const assetSummary = teamAssetAccess?.summary;
+  const assetMode = currentTeamAssetAccess?.mode ?? 'inherit';
+  const assetSummary = currentTeamAssetAccess?.summary;
 
-  const grantedTargets = teamAssetTargets?.selectable_targets?.filter((t: any) => t.selected) ?? [];
-  const blockedTargets = teamAssetTargets?.selectable_targets?.filter((t: any) => !t.selected) ?? [];
+  const accessibleTargets = currentTeamAssetTargetsFull?.effective_targets ?? [];
+  const blockedTargets = currentTeamAssetTargetsFull?.selectable_targets?.filter((t: any) => t.selectable && !t.effective_visible) ?? [];
   const teamCapabilities = team?.capabilities || {};
   const canEditTeam = Boolean(teamCapabilities.edit);
   const canManageMembers = Boolean(teamCapabilities.manage_members);
@@ -411,10 +501,10 @@ export default function TeamDetail() {
             label="Asset access"
             value={
               assetMode === 'restrict' && assetSummary
-                ? `${assetSummary.selected_total}/${assetSummary.selectable_total}`
+                ? `${assetSummary.effective_total}/${assetSummary.selectable_total}`
                 : assetMode === 'restrict' ? 'Restricted' : 'Inherited'
             }
-            sub={assetMode === 'restrict' ? 'from org ceiling' : 'full org access'}
+            sub={assetMode === 'restrict' ? 'effective access' : 'full org access'}
             tone="indigo"
           />
         </>
@@ -757,15 +847,18 @@ export default function TeamDetail() {
                 {assetMode === 'restrict' && assetSummary && (
                   <>
                     <div className="flex justify-between text-xs mb-1.5 text-gray-600">
-                      <span>{assetSummary.selected_total} assets selected</span>
+                      <span>{assetSummary.effective_total} assets accessible</span>
                       <span className="text-gray-400">of {assetSummary.selectable_total}</span>
                     </div>
                     <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden mb-2">
                       <div
                         className="h-full bg-indigo-500 rounded-full"
-                        style={{ width: `${Math.min(100, (assetSummary.selected_total / Math.max(1, assetSummary.selectable_total)) * 100)}%` }}
+                        style={{ width: `${Math.min(100, (assetSummary.effective_total / Math.max(1, assetSummary.selectable_total)) * 100)}%` }}
                       />
                     </div>
+                    <p className="text-[10px] text-gray-400">
+                      Direct targets: {assetSummary.selected_total} · Access groups: {assetSummary.selected_access_group_total ?? 0}
+                    </p>
                   </>
                 )}
                 <button
@@ -1047,8 +1140,8 @@ export default function TeamDetail() {
                       ✕ Cancel
                     </button>
                   </div>
-                  {teamError && (
-                    <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{teamError}</div>
+                  {(teamError || assetAccessLoadError) && (
+                    <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{teamError || assetAccessLoadError}</div>
                   )}
                   <AssetAccessEditor
                     title="Team Asset Access"
@@ -1059,12 +1152,22 @@ export default function TeamDetail() {
                       ...c,
                       asset_access_mode: mode === 'restrict' ? 'restrict' : 'inherit',
                       selected_callable_keys: mode === 'restrict' ? c.selected_callable_keys : [],
+                      selected_access_group_keys: mode === 'restrict' ? c.selected_access_group_keys : [],
                     }))}
                     targets={assetTargets}
                     selectedKeys={form.selected_callable_keys}
                     onSelectedKeysChange={(selected_callable_keys) => setForm({ ...form, selected_callable_keys })}
-                    loading={assetAccessLoading}
-                    disabled={saving || !form.organization_id}
+                    accessGroups={assetAccessGroups}
+                    selectedAccessGroupKeys={form.selected_access_group_keys}
+                    onSelectedAccessGroupKeysChange={(selected_access_group_keys) => setForm({ ...form, selected_access_group_keys })}
+                    targetsLoading={assetTargetsLoading}
+                    accessGroupsLoading={accessGroupsLoading}
+                    disabled={saving || !form.organization_id || teamAssetAccessPending || Boolean(assetAccessLoadError)}
+                    modeControlsDisabled={saving || !form.organization_id || teamAssetAccessPending}
+                    searchValue={assetSearchInput}
+                    onSearchValueChange={setAssetSearchInput}
+                    accessGroupPagination={accessGroupPagination}
+                    onAccessGroupPageChange={setAccessGroupPageOffset}
                   />
                   <div className="flex justify-end gap-3 pt-2 border-t border-gray-100">
                     <button
@@ -1075,14 +1178,14 @@ export default function TeamDetail() {
                     </button>
                     <button
                       onClick={handleSaveAssets}
-                      disabled={saving || !form.organization_id || assetAccessLoading}
+                      disabled={saving || !form.organization_id || teamAssetAccessPending || assetAccessLoading || Boolean(assetAccessLoadError)}
                       className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors disabled:opacity-50"
                     >
                       {saving ? 'Saving…' : 'Save Changes'}
                     </button>
                   </div>
                 </div>
-              ) : teamAssetTargetsLoading ? (
+              ) : !currentTeamAssetTargetsFull && teamAssetTargetsLoading ? (
                 <div className="bg-white rounded-xl border border-gray-200 p-8 flex items-center justify-center">
                   <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-indigo-600" />
                 </div>
@@ -1095,9 +1198,9 @@ export default function TeamDetail() {
                   <p className="text-sm text-gray-500 mb-4">
                     This team inherits the full asset set available to its organization. All models and routes accessible to the org are also accessible here.
                   </p>
-                  {teamAssetTargets?.effective_targets && teamAssetTargets.effective_targets.length > 0 && (
+                  {accessibleTargets.length > 0 && (
                     <div className="space-y-1.5">
-                      {teamAssetTargets.effective_targets.map((t: any) => (
+                      {accessibleTargets.map((t: any) => (
                         <div key={t.callable_key} className="flex items-center gap-2.5 px-3 py-2.5 rounded-lg bg-gray-50 border border-gray-200">
                           <CheckCircle2 className="w-4 h-4 text-gray-400 shrink-0" />
                           <span className="text-sm font-medium text-gray-700">{t.callable_key}</span>
@@ -1113,19 +1216,24 @@ export default function TeamDetail() {
                   <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
                     <div className="px-5 py-4 border-b border-gray-200 flex items-center gap-2">
                       <Lock className="w-4 h-4 text-indigo-600" />
-                      <h3 className="text-sm font-semibold text-gray-900">Granted to this team</h3>
+                      <h3 className="text-sm font-semibold text-gray-900">Accessible to this team</h3>
                       <span className="ml-auto inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded-full bg-gray-100 text-xs font-semibold text-gray-600">
-                        {grantedTargets.length}
+                        {accessibleTargets.length}
                       </span>
                     </div>
                     <div className="p-3 space-y-1.5">
-                      {grantedTargets.length === 0
-                        ? <p className="text-sm text-gray-400 text-center py-4">No assets granted yet.</p>
-                        : grantedTargets.map((t: any) => (
+                      {accessibleTargets.length === 0
+                        ? <p className="text-sm text-gray-400 text-center py-4">No assets accessible yet.</p>
+                        : accessibleTargets.map((t: any) => (
                           <div key={t.callable_key} className="flex items-center gap-2.5 px-3 py-2.5 rounded-lg bg-indigo-50 border border-indigo-100">
                             <CheckCircle2 className="w-4 h-4 text-indigo-600 shrink-0" />
                             <span className="text-sm font-medium text-gray-800">{t.callable_key}</span>
                             <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-600">{t.target_type}</span>
+                            {Array.isArray(t.via_access_groups) && t.via_access_groups.length > 0 && (
+                              <span className="text-xs px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700">
+                                via {t.via_access_groups.join(', ')}
+                              </span>
+                            )}
                           </div>
                         ))}
                     </div>
@@ -1174,7 +1282,7 @@ export default function TeamDetail() {
                       </p>
                       <p className={`text-[10px] mt-0.5 ${assetMode === 'restrict' ? 'text-indigo-700' : 'text-gray-500'}`}>
                         {assetMode === 'restrict'
-                          ? `Only ${assetSummary?.selected_total ?? '?'} selected assets are accessible. Org ceiling: ${assetSummary?.selectable_total ?? '?'} assets.`
+                          ? `${assetSummary?.effective_total ?? '?'} assets are accessible. Org ceiling: ${assetSummary?.selectable_total ?? '?'} assets.`
                           : 'All org assets are available to this team.'}
                       </p>
                     </div>

--- a/ui/src/pages/Teams.tsx
+++ b/ui/src/pages/Teams.tsx
@@ -4,7 +4,14 @@ import { useApi } from '../lib/hooks';
 import { teams, organizations } from '../lib/api';
 import { useAuth } from '../lib/auth';
 import { resolveUiAccess } from '../lib/authorization';
-import { buildParentScopedAssetTargets, buildScopedSelectableTargets } from '../lib/assetAccess';
+import {
+  assetAccessLoadErrorMessage,
+  buildParentScopedAssetTargets,
+  buildScopedSelectableAccessGroups,
+  buildScopedSelectableTargets,
+  isAssetVisibilityFor,
+  isScopedAssetAccessFor,
+} from '../lib/assetAccess';
 import RateLimitSummary from '../components/admin/RateLimitSummary';
 import Modal from '../components/Modal';
 import UserSearchSelect from '../components/UserSearchSelect';
@@ -77,11 +84,11 @@ export default function Teams() {
     () => teams.list({ search, limit: pageSize, offset: pageOffset, organization_id: orgFilter || undefined }),
     [search, pageOffset, orgFilter],
   );
-  const items: any[] = result?.data || [];
+  const items = useMemo<any[]>(() => result?.data || [], [result?.data]);
   const pagination = result?.pagination;
 
   const { data: orgResult } = useApi(() => organizations.list({ limit: 500 }), []);
-  const orgList: any[] = orgResult?.data || [];
+  const orgList = useMemo<any[]>(() => orgResult?.data || [], [orgResult?.data]);
 
   /* org name lookup */
   const orgNameMap = useMemo(() => {
@@ -125,62 +132,148 @@ export default function Teams() {
     tpd_limit: '',
     asset_access_mode: 'inherit' as 'inherit' | 'restrict',
     selected_callable_keys: [] as string[],
+    selected_access_group_keys: [] as string[],
   });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pageError, setPageError] = useState<string | null>(null);
+  const [assetSearchInput, setAssetSearchInput] = useState('');
+  const [assetSearch, setAssetSearch] = useState('');
+  const [accessGroupPageOffset, setAccessGroupPageOffset] = useState(0);
+  const accessGroupPageSize = 50;
 
-  const resetForm = () => setForm({
-    team_alias: '', organization_id: '', max_budget: '', rpm_limit: '', tpm_limit: '', rph_limit: '', rpd_limit: '', tpd_limit: '',
-    asset_access_mode: 'inherit', selected_callable_keys: [],
-  });
+  const resetForm = () => {
+    setForm({
+      team_alias: '', organization_id: '', max_budget: '', rpm_limit: '', tpm_limit: '', rph_limit: '', rpd_limit: '', tpd_limit: '',
+      asset_access_mode: 'inherit', selected_callable_keys: [], selected_access_group_keys: [],
+    });
+    setAssetSearchInput('');
+    setAssetSearch('');
+    setAccessGroupPageOffset(0);
+  };
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setAssetSearch(assetSearchInput);
+      setAccessGroupPageOffset(0);
+    }, 250);
+    return () => clearTimeout(t);
+  }, [assetSearchInput]);
 
   /* asset access helpers */
   const selectedOrganizationId = form.organization_id.trim();
   const usesParentPreview = !editItem || selectedOrganizationId !== (editItem.organization_id || '');
 
-  const { data: editAssetAccess } = useApi(
+  const { data: editAssetAccess, error: editAssetAccessError, loading: editAssetAccessLoading } = useApi(
     () => (editItem ? teams.assetAccess(editItem.team_id, { include_targets: false }) : Promise.resolve(null)),
     [editItem?.team_id],
   );
-  const { data: editAssetAccessTargets, loading: editAssetAccessTargetsLoading } = useApi(
+  const currentEditAssetAccess = editItem && isScopedAssetAccessFor(editAssetAccess, {
+    scopeType: 'team',
+    scopeId: editItem.team_id,
+  })
+    ? editAssetAccess
+    : null;
+  const editAssetAccessPending = !!editItem && (editAssetAccessLoading || !currentEditAssetAccess);
+  const { data: editAssetAccessTargets, error: editAssetAccessTargetsError, loading: editAssetAccessTargetsLoading } = useApi(
     () => (editItem && !usesParentPreview && form.asset_access_mode === 'restrict'
-      ? teams.assetAccess(editItem.team_id, { include_targets: true })
+      ? teams.assetAccess(editItem.team_id, {
+          include_targets: true,
+          access_group_search: assetSearch || undefined,
+          access_group_limit: accessGroupPageSize,
+          access_group_offset: accessGroupPageOffset,
+        })
       : Promise.resolve(null)),
-    [editItem?.team_id, usesParentPreview, form.asset_access_mode],
+    [editItem?.team_id, usesParentPreview, form.asset_access_mode, assetSearch, accessGroupPageOffset],
   );
-  const { data: parentOrgAssetVisibility, loading: parentOrgAssetVisibilityLoading } = useApi(
+  const { data: parentOrgAssetVisibility, error: parentOrgAssetVisibilityError, loading: parentOrgAssetVisibilityLoading } = useApi(
     () => (!!editItem && usesParentPreview && form.asset_access_mode === 'restrict' && selectedOrganizationId
-      ? organizations.assetVisibility(selectedOrganizationId)
+      ? organizations.assetVisibility(selectedOrganizationId, {
+          include_access_groups: true,
+          access_group_search: assetSearch || undefined,
+          access_group_limit: accessGroupPageSize,
+          access_group_offset: accessGroupPageOffset,
+        })
       : Promise.resolve(null)),
-    [editItem?.team_id, selectedOrganizationId, usesParentPreview, form.asset_access_mode],
+    [editItem?.team_id, selectedOrganizationId, usesParentPreview, form.asset_access_mode, assetSearch, accessGroupPageOffset],
   );
 
   useEffect(() => {
-    if (!editItem || !editAssetAccess) return;
+    if (!editItem || !currentEditAssetAccess) return;
     setForm((c) => ({
       ...c,
-      asset_access_mode: editAssetAccess.mode === 'restrict' ? 'restrict' : 'inherit',
-      selected_callable_keys: editAssetAccess.selected_callable_keys || [],
+      asset_access_mode: currentEditAssetAccess.mode === 'restrict' ? 'restrict' : 'inherit',
+      selected_callable_keys: currentEditAssetAccess.selected_callable_keys || [],
+      selected_access_group_keys: currentEditAssetAccess.selected_access_group_keys || [],
     }));
-  }, [editItem, editAssetAccess]);
+  }, [editItem, currentEditAssetAccess]);
 
   const handleOrganizationChange = (organizationId: string) => {
     setForm((c) => {
       const changed = c.organization_id !== organizationId;
-      return { ...c, organization_id: organizationId, asset_access_mode: changed ? 'inherit' : c.asset_access_mode, selected_callable_keys: changed ? [] : c.selected_callable_keys };
+      return {
+        ...c,
+        organization_id: organizationId,
+        asset_access_mode: changed ? 'inherit' : c.asset_access_mode,
+        selected_callable_keys: changed ? [] : c.selected_callable_keys,
+        selected_access_group_keys: changed ? [] : c.selected_access_group_keys,
+      };
     });
+    setAssetSearchInput('');
+    setAssetSearch('');
+    setAccessGroupPageOffset(0);
   };
 
+  const currentEditAssetAccessTargets = editItem && isScopedAssetAccessFor(editAssetAccessTargets, {
+    scopeType: 'team',
+    scopeId: editItem.team_id,
+  })
+    ? editAssetAccessTargets
+    : null;
+  const currentParentOrgAssetVisibility = selectedOrganizationId && isAssetVisibilityFor(parentOrgAssetVisibility, {
+    organizationId: selectedOrganizationId,
+  })
+    ? parentOrgAssetVisibility
+    : null;
   const assetTargets = usesParentPreview
-    ? buildParentScopedAssetTargets(parentOrgAssetVisibility?.callable_targets?.items || [], form.selected_callable_keys, form.asset_access_mode)
-    : buildScopedSelectableTargets(editAssetAccessTargets?.selectable_targets || [], form.selected_callable_keys, form.asset_access_mode);
-  const assetAccessLoading = form.asset_access_mode !== 'restrict' ? false
+    ? buildParentScopedAssetTargets(currentParentOrgAssetVisibility?.callable_targets?.items || [], form.selected_callable_keys, form.asset_access_mode)
+    : buildScopedSelectableTargets(currentEditAssetAccessTargets?.selectable_targets || [], form.selected_callable_keys, form.asset_access_mode);
+  const assetAccessGroups = usesParentPreview
+    ? buildScopedSelectableAccessGroups(
+        currentParentOrgAssetVisibility?.access_groups?.items || [],
+        form.selected_access_group_keys,
+      )
+    : buildScopedSelectableAccessGroups(
+        currentEditAssetAccessTargets?.selectable_access_groups || [],
+        form.selected_access_group_keys,
+      );
+  const accessGroupPagination = usesParentPreview
+    ? currentParentOrgAssetVisibility?.access_groups?.pagination
+    : currentEditAssetAccessTargets?.access_group_pagination;
+  const assetTargetsLoading = form.asset_access_mode !== 'restrict' ? false
+    : usesParentPreview ? !currentParentOrgAssetVisibility && parentOrgAssetVisibilityLoading
+    : !currentEditAssetAccessTargets && editAssetAccessTargetsLoading;
+  const accessGroupsLoading = form.asset_access_mode !== 'restrict' ? false
     : usesParentPreview ? parentOrgAssetVisibilityLoading
     : editAssetAccessTargetsLoading;
+  const assetAccessLoading = assetTargetsLoading || accessGroupsLoading;
+  const activeAssetAccessError = form.asset_access_mode === 'restrict'
+    ? usesParentPreview ? parentOrgAssetVisibilityError : editAssetAccessTargetsError
+    : null;
+  const assetAccessLoadError = editItem
+    ? assetAccessLoadErrorMessage(editAssetAccessError || activeAssetAccessError)
+    : null;
 
   const handleSave = async () => {
     if (!editItem) return;
+    if (assetAccessLoadError) {
+      setError(assetAccessLoadError);
+      return;
+    }
+    if (editAssetAccessPending || assetAccessLoading) {
+      setError('Wait for asset access options to finish loading before saving the team.');
+      return;
+    }
     setError(null);
     setSaving(true);
     try {
@@ -198,6 +291,7 @@ export default function Teams() {
       await teams.updateAssetAccess(editItem.team_id, {
         mode: form.asset_access_mode,
         selected_callable_keys: form.asset_access_mode === 'restrict' ? form.selected_callable_keys : [],
+        selected_access_group_keys: form.asset_access_mode === 'restrict' ? form.selected_access_group_keys : [],
       });
       setPageError(null);
       setEditItem(null);
@@ -223,7 +317,11 @@ export default function Teams() {
       tpd_limit: row.tpd_limit != null ? String(row.tpd_limit) : '',
       asset_access_mode: 'inherit',
       selected_callable_keys: [],
+      selected_access_group_keys: [],
     });
+    setAssetSearchInput('');
+    setAssetSearch('');
+    setAccessGroupPageOffset(0);
     setEditItem(row);
   };
 
@@ -535,7 +633,7 @@ export default function Teams() {
         title="Edit Team"
       >
         <div className="space-y-4">
-          {error && <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{error}</div>}
+          {(error || assetAccessLoadError) && <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{error || assetAccessLoadError}</div>}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Team Name</label>
             <input
@@ -642,12 +740,22 @@ export default function Teams() {
               ...c,
               asset_access_mode: mode === 'restrict' ? 'restrict' : 'inherit',
               selected_callable_keys: mode === 'restrict' ? c.selected_callable_keys : [],
+              selected_access_group_keys: mode === 'restrict' ? c.selected_access_group_keys : [],
             }))}
             targets={assetTargets}
             selectedKeys={form.selected_callable_keys}
             onSelectedKeysChange={(selected_callable_keys) => setForm({ ...form, selected_callable_keys })}
-            loading={assetAccessLoading}
-            disabled={saving || !form.organization_id}
+            accessGroups={assetAccessGroups}
+            selectedAccessGroupKeys={form.selected_access_group_keys}
+            onSelectedAccessGroupKeysChange={(selected_access_group_keys) => setForm({ ...form, selected_access_group_keys })}
+            targetsLoading={assetTargetsLoading}
+            accessGroupsLoading={accessGroupsLoading}
+            disabled={saving || !form.organization_id || editAssetAccessPending || Boolean(assetAccessLoadError)}
+            modeControlsDisabled={saving || !form.organization_id || editAssetAccessPending}
+            searchValue={assetSearchInput}
+            onSearchValueChange={setAssetSearchInput}
+            accessGroupPagination={accessGroupPagination}
+            onAccessGroupPageChange={setAccessGroupPageOffset}
           />
           <div className="flex justify-end gap-3 pt-2">
             <button
@@ -658,7 +766,7 @@ export default function Teams() {
             </button>
             <button
               onClick={handleSave}
-              disabled={!form.organization_id || saving || assetAccessLoading}
+              disabled={!form.organization_id || saving || editAssetAccessPending || assetAccessLoading || Boolean(assetAccessLoadError)}
               className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {saving ? 'Saving…' : editItem ? 'Save Changes' : 'Create Team'}


### PR DESCRIPTION
## Summary
- add access-group selection and pagination to org/team/key/user asset access UI flows
- expose model deployment access group metadata in create/edit/detail surfaces
- extend asset access and visibility admin APIs to return paged selectable access groups
- preserve selected keys across pages and block saves on selector load failures while allowing safe inherit recovery

## Validation
- `git diff --check`
- focused ESLint on changed UI files
- `npm run build` (existing chunk-size warning only)
- `uv run --extra dev pytest tests/test_ui_callable_targets.py tests/test_ui_models.py tests/test_model_visibility.py tests/test_ui_asset_access.py tests/test_ui_scope_asset_visibility.py tests/test_ui_organizations_assets.py`

Part of #124