### PR TITLE
Issue 124 PR4: Document model access groups

### DIFF
--- a/docs/admin-ui/api-keys.md
+++ b/docs/admin-ui/api-keys.md
@@ -19,7 +19,7 @@ The API Keys page is where operators issue credentials for applications, teams, 
    `You` for a human-owned key, or `Service account` for automation.
 3. If you need a new service account, create it directly from the same dialog after selecting a team.
 4. Set optional limits such as budget, RPM, TPM, RPH, RPD, or TPD.
-5. Choose whether the key inherits the team asset set or narrows it to selected assets.
+5. Choose whether the key inherits the team asset set or narrows it to selected targets or access groups.
 6. Create the key and copy the raw secret immediately. It is only shown once.
 
 ## Self-Service Key Creation
@@ -60,11 +60,19 @@ Self-service users cannot see or manage keys owned by other users through the My
 - **RPH**: request throttle per hour
 - **RPD / TPD**: request and token throttles per day
 
+## Key Asset Access
+
+Keys normally inherit the callable-target universe from their team. Use key-level restriction when an integration needs a smaller model set than the team owns.
+
+In restrict mode, a key can select direct callable targets and access groups that are already visible through the team. Selecting an access group grants the key the callable targets currently in that group, and future matching targets after runtime reload, as long as the team and organization also allow them.
+
+Self-service keys follow the team's self-service policy and ownership rules. They still inherit the team asset boundary; admins can use the full key editor when a production integration needs explicit key-level narrowing.
+
 ## Important behavior
 
 - The raw key is shown once at creation time
 - The table keeps the hashed token, owner, status, and budget progress
 - Scoped access still applies: org users only see keys inside their organizations
 - Service accounts are non-login owners for shared services, jobs, or automations
-- Keys no longer carry model allowlists on the key record. The create/edit dialog writes callable-target bindings and scope policies so a key can inherit its team asset set or narrow it further.
+- Keys no longer carry model allowlists on the key record. The create/edit dialog writes callable-target bindings, access-group bindings, and scope policies so a key can inherit its team asset set or narrow it further.
 - When rate limits are updated via the admin API or UI, the key validation cache is automatically invalidated so new limits take effect immediately

--- a/docs/admin-ui/models.md
+++ b/docs/admin-ui/models.md
@@ -26,6 +26,7 @@ Each deployment defines:
 - `deployment_id`: the stable internal identifier for this deployment
 - provider settings in `deltallm_params`
 - workload mode in `model_info.mode`
+- access groups in `model_info.access_groups`
 - pricing metadata for spend tracking
 - default request parameters
 
@@ -39,6 +40,14 @@ For a simple first deployment:
 4. Keep the default mode as `chat` unless this is an embeddings, image, audio, or rerank model
 
 If you do not set a `deployment_id`, DeltaLLM creates one automatically.
+
+## Access Groups
+
+The model form includes an **Access Groups** field for authorization grouping. Enter group keys such as `beta` or `support` when scopes should be able to grant access to a set of callable targets instead of selecting each model separately.
+
+Access groups are attached to the public model name, not a single provider deployment. If several deployments share the same `model_name`, keep their access group lists identical so group expansion remains deterministic.
+
+Do not use access groups for routing. Deployment tags remain routing metadata and can be matched by request `metadata.tags`; tags do not make a model visible to an organization, team, key, or user.
 
 ## What the Table Tells You
 
@@ -108,7 +117,7 @@ For shared gateway credentials, [Named Credentials](named-credentials.md) remain
 - Shared provider credentials are best managed through [Named Credentials](named-credentials.md)
 - Creating, updating, and deleting deployments requires admin access
 - Readable deployment IDs make later route-group work easier
-- Visibility to organizations, teams, keys, and users is governed through callable-target bindings and scope policies
+- Visibility to organizations, teams, keys, and users is governed through callable-target bindings, access-group bindings, and scope policies
 
 ## Related Pages
 

--- a/docs/admin-ui/organizations.md
+++ b/docs/admin-ui/organizations.md
@@ -10,13 +10,13 @@ Organizations are the top-level tenant and budget boundary in the admin UI.
 - Top-level budgets and rate limits (RPM, TPM, RPH, RPD, TPD)
 - Audit content storage behavior
 - Team count and ownership context
-- The tenant boundary that callable-target access and lower-scope restrictions inherit from
+- The tenant boundary that callable-target and access-group grants inherit from
 
 ## Typical workflow
 
 1. Create the organization
 2. Set the broad budget and rate limits across all time windows
-3. Choose which models and route groups the organization is allowed to use
+3. Choose which models, route groups, and access groups the organization is allowed to use
 4. Add teams inside the organization
 5. Assign platform accounts through People & Access
 
@@ -37,3 +37,15 @@ All limits are optional. Only configured limits are enforced. Organization limit
 Organization scope controls how teams, keys, and access are partitioned. It is the right place for tenant-wide spending and policy boundaries.
 
 Platform admins can bootstrap runtime model and route-group visibility directly in the create/edit dialog through the organization asset access section. Teams, keys, and users can only inherit or narrow from that organization set.
+
+## Asset Access and Access Groups
+
+Organization asset access defines the parent access universe. Grant direct callable targets when the tenant should see specific model names or route groups. Grant access groups when the tenant should see every callable target labelled with a group such as `support`, `finance`, or `beta`.
+
+Access-group grants are valid even before a group has current model members. When a model is later labelled with that group and the runtime reloads, the organization can receive the new callable target without adding another direct binding.
+
+Use organization grants deliberately:
+
+- Grant groups to organizations before using team, key, or user restrictions.
+- Keep route-group keys and public model names unique because both are callable targets.
+- Avoid copying routing tags directly into access groups; tags control deployment routing, while access groups control authorization.

--- a/docs/admin-ui/teams.md
+++ b/docs/admin-ui/teams.md
@@ -9,7 +9,7 @@ Teams are the working unit for developers, applications, keys, and team-level bu
 - Team identity and parent organization
 - Team-level budgets and rate limits (RPM, TPM, RPH, RPD, TPD)
 - Team memberships
-- Team runtime access mode: inherit the organization set or restrict to selected callable targets
+- Team runtime access mode: inherit the organization set or restrict to selected callable targets and access groups
 
 ## Typical workflow
 
@@ -17,7 +17,7 @@ Teams are the working unit for developers, applications, keys, and team-level bu
 2. Confirm the self-service key policy for developers
 3. Set team-specific budgets and rate limits across all time windows
 4. Add team members with the correct role
-5. Choose whether the team inherits the organization asset set or narrows it to selected assets
+5. Choose whether the team inherits the organization asset set or narrows it to selected targets or access groups
 
 ## Rate limit fields
 
@@ -59,3 +59,15 @@ When a developer creates a key through self-service, the backend enforces all of
 Team scope is where most day-to-day ownership lives. API keys, usage, and user access are typically understood in team context.
 
 The team record itself no longer stores model allowlists. The create/edit UI writes callable-target bindings and scope policies so the team can inherit the organization set or narrow it for day-to-day ownership.
+
+## Team Asset Access
+
+Use **Inherit** when the team should receive the same callable-target universe as its parent organization. Use **Restrict** only when the team needs a smaller set.
+
+In restrict mode, the team can select direct callable targets and access groups that are already available through the organization. Selecting an access group grants the team's users and keys every callable target in that group that is also inside the organization boundary.
+
+This keeps lower scopes predictable:
+
+- Teams cannot expand beyond the organization access universe.
+- API keys and runtime users can inherit or narrow from the team.
+- Access groups should represent authorization intent, not routing labels.

--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -52,6 +52,7 @@ These endpoints back browser login, invitation acceptance, password recovery, MF
 
 - Callable-target and MCP runtime checks are enforced from in-memory snapshots, not per-request database reads.
 - In multi-instance deployments, admin writes publish governance invalidation events so other instances reload their local snapshots asynchronously.
+- Callable-target access groups are authorization groups. They grant callable targets such as model names or route-group keys; they do not change deployment routing.
 - MCP binding and tool-policy listing endpoints return **enabled** rows by default. Platform admins can opt in to disabled rows with `include_disabled=true`.
 
 ## Runtime Configuration
@@ -90,6 +91,14 @@ Relevant fields:
 
 List, detail, create, and update responses continue to redact secrets such as `api_key`. When custom upstream auth is configured, `connection_summary` may include the effective `auth_header_name` plus a compact `custom_auth_label` such as `X-API-Key` or `Authorization (Token)`, but not the rendered header value.
 
+Model create and update payloads also accept these metadata fields:
+
+- `model_info.mode`: runtime workload type, such as `chat`, `embedding`, `image_generation`, `audio_speech`, `audio_transcription`, or `rerank`
+- `model_info.access_groups`: authorization groups attached to the public callable target
+- `model_info.tags`: routing tags for deployment selection; not authorization
+
+`model_info.access_groups` must be an array of valid group keys. Keys are normalized to lowercase, must start with a letter or digit, and may contain lowercase letters, digits, `.`, `_`, or `-`. Access groups expand to the public `model_name`, not to a single deployment. When several deployments share the same `model_name`, keep their access groups identical so group expansion remains deterministic.
+
 Example inline model create payload:
 
 ```json
@@ -104,7 +113,9 @@ Example inline model create payload:
     "auth_header_format": "{api_key}"
   },
   "model_info": {
-    "mode": "chat"
+    "mode": "chat",
+    "access_groups": ["support", "beta"],
+    "tags": ["low-latency"]
   }
 }
 ```
@@ -161,6 +172,10 @@ Callable targets are the public runtime names that callers can use, including bo
 |--------|----------|---------|
 | `GET` | `/ui/api/callable-targets` | List callable targets from the live catalog |
 | `GET` | `/ui/api/callable-targets/{callable_key}` | Get one callable target with current bindings |
+| `GET` | `/ui/api/callable-target-access-groups` | List access groups from the live catalog and existing bindings |
+| `GET` | `/ui/api/callable-target-access-group-bindings` | List access-group bindings |
+| `POST` | `/ui/api/callable-target-access-group-bindings` | Create or update an access-group binding |
+| `DELETE` | `/ui/api/callable-target-access-group-bindings/{binding_id}` | Delete an access-group binding |
 | `GET` | `/ui/api/callable-target-bindings` | List callable-target bindings |
 | `POST` | `/ui/api/callable-target-bindings` | Create or update a binding |
 | `DELETE` | `/ui/api/callable-target-bindings/{binding_id}` | Delete a binding |
@@ -169,6 +184,24 @@ Callable targets are the public runtime names that callers can use, including bo
 | `DELETE` | `/ui/api/callable-target-scope-policies/{policy_id}` | Delete a scope policy |
 | `GET` | `/ui/api/callable-target-migration/report` | Report rollout and migration readiness |
 | `POST` | `/ui/api/callable-target-migration/backfill` | Backfill explicit bindings from legacy data |
+
+`GET /ui/api/callable-target-access-groups` accepts `search`, `include_members`, `limit`, and `offset`. Groups can appear because current callable targets are labelled with `model_info.access_groups` or because a binding already references the group. This supports planned future grants before a group has current members.
+
+Access-group binding upserts use this payload:
+
+```json
+{
+  "group_key": "support",
+  "scope_type": "organization",
+  "scope_id": "org_acme",
+  "enabled": true,
+  "metadata": {
+    "reason": "support tenant baseline"
+  }
+}
+```
+
+`scope_type` supports `organization`, `team`, `api_key`, and `user`. Binding writes trigger governance snapshot reloads and emit `ADMIN_CALLABLE_TARGET_ACCESS_GROUP_BINDING_UPSERT` or `ADMIN_CALLABLE_TARGET_ACCESS_GROUP_BINDING_DELETE` audit events.
 
 ### Route Group Policy
 
@@ -312,6 +345,39 @@ Callable targets are the public runtime names that callers can use, including bo
 | `GET` | `/ui/api/rbac/team-memberships` | List team memberships |
 | `POST` | `/ui/api/rbac/team-memberships` | Create team membership |
 | `DELETE` | `/ui/api/rbac/team-memberships/{membership_id}` | Delete team membership |
+
+### Scoped Asset Access Payloads
+
+Asset-access endpoints for organizations, teams, API keys, and runtime users use the same response shape:
+
+- `mode`: `grant` for organizations, or `inherit` / `restrict` for teams, keys, and users
+- `selected_callable_keys`: direct model names or route-group keys selected for the scope
+- `selected_access_group_keys`: access groups selected for the scope
+- `selectable_targets`: callable targets that can be selected from the parent access universe
+- `selectable_access_groups`: access groups that can be selected from the parent access universe
+- `effective_targets`: callable targets visible after inheritance, direct bindings, and access-group expansion
+- `summary`: selected, selectable, effective, and access-group counts
+
+Update payloads accept direct targets and access groups:
+
+```json
+{
+  "mode": "restrict",
+  "selected_callable_keys": ["gpt-4o-mini"],
+  "selected_access_group_keys": ["support"]
+}
+```
+
+For organization updates, omit `mode` or set it to `grant`. For teams, keys, and users, `inherit` requires empty `selected_callable_keys` and `selected_access_group_keys`; use `restrict` only when narrowing access below the parent scope.
+
+Query parameters:
+
+| Endpoint kind | Parameters |
+|---------------|------------|
+| `GET .../asset-visibility` | `include_access_groups`, `access_group_search`, `access_group_limit`, `access_group_offset` |
+| `GET .../asset-access` | `include_targets`, `access_group_search`, `access_group_limit`, `access_group_offset` |
+
+Asset-access writes emit the matching scope audit action, such as `ADMIN_ORGANIZATION_ASSET_ACCESS_UPDATE`, `ADMIN_TEAM_ASSET_ACCESS_UPDATE`, or `ADMIN_KEY_ASSET_ACCESS_UPDATE`.
 
 ### Invitations
 

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -70,6 +70,9 @@ After the initial seed, set `model_deployment_bootstrap_from_config` back to `fa
 | `deltallm_params.auth_header_format` | No | Custom upstream auth header value template, must include `{api_key}` |
 | `deltallm_params.timeout` | No | Upstream timeout in seconds |
 | `deltallm_params.weight` | No | Relative weight when multiple deployments share one public model |
+| `model_info.mode` | No | Runtime workload type such as `chat`, `embedding`, or `rerank` |
+| `model_info.access_groups` | No | Authorization groups attached to the public callable target |
+| `model_info.tags` | No | Routing tags for deployment selection; not authorization |
 
 ## Custom Upstream Auth Headers
 
@@ -158,6 +161,45 @@ model_list:
     model_info:
       mode: audio_transcription
 ```
+
+## Access Groups and Routing Tags
+
+Use `model_info.access_groups` when you want to grant model access by group instead of binding every model name separately.
+
+```yaml
+model_list:
+  - model_name: gpt-4o-mini
+    deltallm_params:
+      provider: openai
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      mode: chat
+      access_groups:
+        - beta
+        - support
+      tags:
+        - low-latency
+```
+
+In this example, granting the `beta` or `support` access group to an organization, team, key, or runtime user can make the `gpt-4o-mini` callable target visible to that scope. The `low-latency` tag is separate routing metadata: requests can use `metadata.tags` to prefer matching deployments, but tags do not grant access.
+
+Important behavior:
+
+- Access groups grant callable targets such as `gpt-4o-mini`, not individual deployments.
+- Access group keys are normalized to lowercase and may contain letters, digits, `.`, `_`, and `-`.
+- If multiple deployments share one `model_name`, give every deployment the same `model_info.access_groups`; conflicting values disable group expansion for that public model.
+- Route groups are callable targets too. Keep route-group keys and public model names unique so grants are unambiguous.
+- Newly added models become available to scopes already granted a matching access group after the runtime reloads its model and governance snapshots.
+- In Kubernetes, admin writes publish governance invalidation events so other replicas refresh their in-memory snapshots asynchronously.
+- Organization-level grants can reference an access group before any model currently belongs to it. This is useful when you want a tenant to receive future models as they are added to that group.
+
+Recommended rollout:
+
+1. Label models with access groups that describe authorization intent, such as `support`, `finance`, or `beta`.
+2. Grant access groups to organizations first; organizations define the parent access universe.
+3. Use team, key, or user `restrict` mode only when you need to narrow access below the organization.
+4. Do not migrate routing tags blindly into access groups. Tags describe routing preferences; access groups describe who can call a target.
 
 ## Embedding Batch Worker Micro-batching
 


### PR DESCRIPTION
## Summary
- Document `model_info.access_groups` semantics and how they differ from routing tags
- Add Admin UI guidance for model, organization, team, and key access-group workflows
- Update Admin API docs with callable-target access-group endpoints, scoped asset-access payloads, query params, and audit actions

## Validation
- `git diff --check` passed
- `mkdocs build` was not run locally because `mkdocs` is not installed and is not present in `pyproject.toml` / `uv.lock`