### PR TITLE
Add upstream HTTP pooling controls

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -46,6 +46,18 @@ general_settings:
   db_pool_size: 20
   db_pool_timeout: 30
 
+  # Upstream provider HTTP pool tuning. These are startup-time settings;
+  # restart the process or roll the Kubernetes deployment after changing them.
+  # For Kubernetes, multiply upstream_http_max_connections by workers per pod and pod count
+  # when checking provider, NAT gateway, and file descriptor limits.
+  upstream_http_connect_timeout_seconds: 10
+  upstream_http_read_timeout_seconds: 300
+  upstream_http_write_timeout_seconds: 30
+  upstream_http_pool_timeout_seconds: 10
+  upstream_http_max_connections: 500
+  upstream_http_max_keepalive_connections: 100
+  upstream_http_keepalive_expiry_seconds: 60
+
   # Admin session login
   # Set these only if you want an initial browser-login admin account created on boot.
   platform_bootstrap_admin_email: os.environ/PLATFORM_BOOTSTRAP_ADMIN_EMAIL

--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -39,6 +39,13 @@ general_settings:
   database_url: os.environ/DATABASE_URL
   db_pool_size: 20
   db_pool_timeout: 30
+  upstream_http_connect_timeout_seconds: 10
+  upstream_http_read_timeout_seconds: 300
+  upstream_http_write_timeout_seconds: 30
+  upstream_http_pool_timeout_seconds: 10
+  upstream_http_max_connections: 500
+  upstream_http_max_keepalive_connections: 100
+  upstream_http_keepalive_expiry_seconds: 60
   redis_url: os.environ/REDIS_URL
   redis_host: localhost
   redis_port: 6379
@@ -153,6 +160,24 @@ Environment overrides:
 - `DELTALLM_DB_POOL_TIMEOUT`
 
 If those overrides are unset, DeltaLLM falls back to `general_settings.database_url`, `general_settings.db_pool_size`, and `general_settings.db_pool_timeout`. If no application-level database URL is configured, it will still honor the raw `DATABASE_URL` environment variable used by Prisma.
+
+## Upstream HTTP Settings
+
+These settings control the shared outbound HTTP client used for upstream provider traffic. They are read into a startup snapshot; restart the process or roll the Kubernetes deployment after changing them. Runtime config reloads do not rebuild the HTTP client or change per-request upstream timeout behavior.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `upstream_http_connect_timeout_seconds` | `10` | Time allowed to establish a new upstream TCP/TLS connection |
+| `upstream_http_read_timeout_seconds` | `300` | Time allowed while waiting for upstream response bytes; higher values are useful for streaming |
+| `upstream_http_write_timeout_seconds` | `30` | Time allowed while sending request bytes to the upstream |
+| `upstream_http_pool_timeout_seconds` | `10` | Time a request can wait for an available upstream connection before failing locally |
+| `upstream_http_max_connections` | `500` | Maximum concurrent outbound connections per DeltaLLM process |
+| `upstream_http_max_keepalive_connections` | `100` | Maximum idle keep-alive connections retained per process |
+| `upstream_http_keepalive_expiry_seconds` | `60` | How long an idle keep-alive connection is retained |
+
+Per-deployment `deltallm_params.timeout` overrides the provider read timeout for that deployment. Without an explicit deployment timeout, DeltaLLM uses `upstream_http_read_timeout_seconds` so production operators can tune streaming and long-running provider calls globally. Connect, write, and pool timeouts remain explicit so slow connection establishment and local connection pool pressure fail predictably instead of looking like provider slowness. Background health checks cap their pool wait below the health-check wrapper timeout so local pool pressure is reported as gateway capacity instead of marking a provider deployment unhealthy.
+
+For production sizing, see [Upstream HTTP Tuning](../deployment/upstream-http.md).
 
 ## Redis Settings
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -8,6 +8,7 @@ Use this section when you are moving from local evaluation to a repeatable envir
 |------|----------|------------|
 | Docker Compose | Single instance, demos, small teams, simple self-hosting | [Docker](docker.md) |
 | Kubernetes | Multi-instance production, autoscaling, managed infrastructure | [Kubernetes](kubernetes.md) |
+| Upstream HTTP tuning | Production provider concurrency, streaming, and egress capacity planning | [Upstream HTTP Tuning](upstream-http.md) |
 
 ## Quick Path to Success
 
@@ -23,6 +24,7 @@ All deployment methods rely on the same core services:
 
 - PostgreSQL for persistent runtime data such as keys, accounts, spend logs, and model records
 - Redis for distributed coordination, rate limiting, cache sharing, and runtime state
+- Explicit upstream HTTP connection limits for predictable provider concurrency
 - A master key for admin access
 - A salt key for API key hashing
 
@@ -52,4 +54,5 @@ The application runs Prisma schema setup automatically during container startup.
 
 - [Docker deployment guide](docker.md)
 - [Kubernetes deployment guide](kubernetes.md)
+- [Upstream HTTP tuning](upstream-http.md)
 - [Observability](../features/observability.md)

--- a/docs/deployment/upstream-http.md
+++ b/docs/deployment/upstream-http.md
@@ -1,0 +1,70 @@
+# Upstream HTTP Tuning
+
+DeltaLLM uses a shared async HTTP client for outbound provider calls. Explicit pool limits make gateway behavior predictable under streaming load and prevent local connection pressure from being mistaken for provider slowness.
+
+Authentication, SSO, and email-provider HTTP calls use a separate smaller control-plane client. This keeps login, JWKS refresh, and transactional email delivery from sharing the provider traffic pool.
+
+## Recommended Defaults
+
+```yaml
+general_settings:
+  upstream_http_connect_timeout_seconds: 10
+  upstream_http_read_timeout_seconds: 300
+  upstream_http_write_timeout_seconds: 30
+  upstream_http_pool_timeout_seconds: 10
+  upstream_http_max_connections: 500
+  upstream_http_max_keepalive_connections: 100
+  upstream_http_keepalive_expiry_seconds: 60
+```
+
+These defaults are a conservative production starting point. Streaming requests hold upstream connections for the life of the stream, so streaming-heavy deployments may need a higher `upstream_http_max_connections` value.
+
+`upstream_http_read_timeout_seconds` is the global provider read timeout when a deployment does not set `deltallm_params.timeout`. Deployment-level `timeout` values still override the read phase for that deployment, while connect, write, and pool timeouts remain explicit across upstream requests.
+
+Request duration can also be limited by the router failover wrapper timeout. Audio transcription defaults both the upstream read timeout and the failover wrapper timeout to `600` seconds when the deployment does not set `deltallm_params.timeout`; an explicit route-group timeout still takes priority for operators who need a stricter policy.
+
+The upstream HTTP settings are startup-time settings. DeltaLLM stores one startup snapshot and uses it for provider calls, live model discovery, MCP upstream calls, and health probes. Apply changes with a process restart or Kubernetes rollout; runtime config reloads do not rebuild the HTTP client or partially change timeout behavior.
+
+## Kubernetes Capacity Math
+
+The configured connection limit is per process:
+
+```text
+effective upstream connection ceiling =
+  upstream_http_max_connections * worker_processes_per_pod * pod_count
+```
+
+Before raising limits, check:
+
+- provider account or endpoint connection limits
+- node and container file descriptor limits
+- NAT gateway or egress proxy connection tracking capacity
+- CPU and memory headroom per pod
+- expected streaming concurrency and average stream duration
+
+For Helm deployments, set the values under `config.general_settings` and roll the deployment. Existing processes keep their current HTTP client and upstream HTTP settings snapshot until restart.
+
+## Sizing Profiles
+
+| Profile | Suggested max connections | Suggested keep-alive | Notes |
+|---------|---------------------------|----------------------|-------|
+| Local/dev | `100` | `20` | Keeps resource use low on laptops |
+| Small production | `300`-`500` | `75`-`100` | Good starting point for normal chat and embedding traffic |
+| Streaming-heavy | `500`-`1500` | `100`-`300` | Validate egress and provider limits before rollout |
+
+Keep `upstream_http_pool_timeout_seconds` bounded. A value around `5` to `10` seconds usually gives short bursts room to clear without allowing requests to pile up invisibly inside the gateway.
+
+## Failure Behavior
+
+If the upstream connection pool is exhausted, DeltaLLM returns a controlled `503` gateway capacity error with code `upstream_pool_timeout`. This does not mark the selected model deployment unhealthy because the bottleneck is local gateway capacity, not the provider.
+
+Background health checks cap their upstream pool wait below the health-check wrapper timeout. This keeps an oversized `upstream_http_pool_timeout_seconds` from turning local connection pressure into false provider-unhealthy state.
+
+Provider read, connect, and write timeouts still count as provider-side failures where appropriate and can affect passive health tracking.
+
+## Operating Guidance
+
+- Increase pod replicas and `upstream_http_max_connections` together only after checking the effective cluster-wide connection ceiling.
+- Keep request timeouts realistic for the workload. Long read timeouts are useful for streaming but can hide stalled non-streaming calls.
+- Watch `/metrics`, provider latency, request failure type, pod CPU, pod memory, file descriptors, and egress/NAT saturation during load tests.
+- Prefer a rolling deployment when changing these settings so old streams can drain while new pods pick up the new pool configuration.

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -150,7 +150,19 @@
         "model_list": { "type": "array" },
         "router_settings": { "type": "object" },
         "deltallm_settings": { "type": "object" },
-        "general_settings": { "type": "object" }
+        "general_settings": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "upstream_http_connect_timeout_seconds": { "type": "number", "exclusiveMinimum": 0 },
+            "upstream_http_read_timeout_seconds": { "type": "number", "exclusiveMinimum": 0 },
+            "upstream_http_write_timeout_seconds": { "type": "number", "exclusiveMinimum": 0 },
+            "upstream_http_pool_timeout_seconds": { "type": "number", "exclusiveMinimum": 0 },
+            "upstream_http_max_connections": { "type": "integer", "minimum": 1 },
+            "upstream_http_max_keepalive_connections": { "type": "integer", "minimum": 0 },
+            "upstream_http_keepalive_expiry_seconds": { "type": "number", "minimum": 0 }
+          }
+        }
       }
     },
     "s3": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -149,6 +149,13 @@ config:
     turn_off_message_logging: false
   general_settings:
     deltallm_key_header_name: Authorization
+    upstream_http_connect_timeout_seconds: 10
+    upstream_http_read_timeout_seconds: 300
+    upstream_http_write_timeout_seconds: 30
+    upstream_http_pool_timeout_seconds: 10
+    upstream_http_max_connections: 500
+    upstream_http_max_keepalive_connections: 100
+    upstream_http_keepalive_expiry_seconds: 60
     cache_enabled: false
     cache_backend: memory
     cache_ttl: 3600

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
       - Docker: deployment/docker.md
       - Governance Rollout: deployment/governance.md
       - Kubernetes: deployment/kubernetes.md
+      - Upstream HTTP Tuning: deployment/upstream-http.md
 
 extra:
   social:

--- a/src/api/admin/endpoints/models.py
+++ b/src/api/admin/endpoints/models.py
@@ -510,6 +510,11 @@ async def discover_models_for_provider(request: Request, payload: ProviderModelD
         auth_header_name=merged_params.get("auth_header_name"),
         auth_header_format=merged_params.get("auth_header_format"),
         default_openai_base_url=getattr(request.app.state.settings, "openai_base_url", "https://api.openai.com/v1"),
+        general_settings=getattr(
+            request.app.state,
+            "upstream_http_settings",
+            getattr(getattr(request.app.state, "app_config", None), "general_settings", None),
+        ),
     )
 
 
@@ -539,6 +544,12 @@ async def check_model_health(request: Request, deployment_id: str) -> dict[str, 
             request.app.state.http_client,
             deployment.deltallm_params,
             default_openai_base_url=request.app.state.settings.openai_base_url,
+            general_settings=getattr(
+                request.app.state,
+                "upstream_http_settings",
+                getattr(getattr(request.app.state, "app_config", None), "general_settings", None),
+            ),
+            health_check_timeout_seconds=30,
         )
 
     health = await _serialize_deployment_health(request.app, deployment_id)

--- a/src/bootstrap/auth.py
+++ b/src/bootstrap/auth.py
@@ -86,6 +86,7 @@ async def init_auth_runtime(app: Any, cfg: Any) -> AuthRuntime:
                     ttl_seconds=getattr(cfg.general_settings, "sso_state_ttl_seconds", 600),
                 )
                 statuses.append(BootstrapStatus("sso_state_store", "ready"))
+                control_http_client = getattr(app.state, "control_http_client", app.state.http_client)
                 app.state.sso_auth_handler = SSOAuthHandler(
                     config=SSOConfig(
                         provider=SSOProvider(cfg.general_settings.sso_provider),
@@ -100,7 +101,7 @@ async def init_auth_runtime(app: Any, cfg: Any) -> AuthRuntime:
                         default_team_id=cfg.general_settings.sso_default_team_id,
                     ),
                     user_repository=app.state.sso_user_repository,
-                    http_client=app.state.http_client,
+                    http_client=control_http_client,
                     rate_limiter=app.state.limit_counter,
                 )
                 statuses.append(BootstrapStatus("sso_auth", "ready"))
@@ -121,7 +122,7 @@ async def init_auth_runtime(app: Any, cfg: Any) -> AuthRuntime:
             audience=cfg.general_settings.jwt_audience,
             issuer=cfg.general_settings.jwt_issuer,
             claims_mapping=cfg.general_settings.jwt_claims_mapping or None,
-            http_client=app.state.http_client,
+            http_client=getattr(app.state, "control_http_client", app.state.http_client),
         )
         statuses.append(BootstrapStatus("jwt_auth", "ready"))
     else:

--- a/src/bootstrap/email.py
+++ b/src/bootstrap/email.py
@@ -32,7 +32,7 @@ async def init_email_runtime(app: Any, cfg: Any) -> EmailRuntime:
 
     delivery_service = EmailDeliveryService(
         config_getter=lambda: getattr(app.state, "app_config", cfg),
-        http_client=app.state.http_client,
+        http_client=getattr(app.state, "control_http_client", app.state.http_client),
     )
     outbox_service = EmailOutboxService(
         repository=repository,

--- a/src/bootstrap/infrastructure.py
+++ b/src/bootstrap/infrastructure.py
@@ -29,6 +29,7 @@ from src.providers.azure import AzureOpenAIAdapter
 from src.providers.gemini import GeminiAdapter
 from src.providers.openai import OpenAIAdapter
 from src.services.route_groups import RouteGroupRuntimeCache
+from src.upstream_http import build_control_http_client, build_upstream_http_client
 
 
 @dataclass
@@ -36,6 +37,7 @@ class InfrastructureRuntime:
     redis_client: Redis | None
     dynamic_config_manager: DynamicConfigManager
     http_client: httpx.AsyncClient
+    control_http_client: httpx.AsyncClient
     statuses: tuple[BootstrapStatus, ...] = ()
 
 
@@ -78,8 +80,11 @@ async def init_infrastructure_runtime(app: Any) -> InfrastructureRuntime:
     app.state.app_config = cfg
     app.state.salt_key = resolve_salt_key(cfg, settings)
 
-    http_client = httpx.AsyncClient(timeout=60)
+    http_client = build_upstream_http_client(cfg.general_settings)
+    control_http_client = build_control_http_client()
+    app.state.upstream_http_settings = cfg.general_settings
     app.state.http_client = http_client
+    app.state.control_http_client = control_http_client
     app.state.openai_adapter = OpenAIAdapter(http_client)
     app.state.azure_openai_adapter = AzureOpenAIAdapter(http_client)
     app.state.anthropic_adapter = AnthropicAdapter(http_client)
@@ -106,12 +111,14 @@ async def init_infrastructure_runtime(app: Any) -> InfrastructureRuntime:
         redis_client=redis_client,
         dynamic_config_manager=dynamic_config_manager,
         http_client=http_client,
+        control_http_client=control_http_client,
         statuses=(
             BootstrapStatus("config", "ready"),
             BootstrapStatus("redis", "ready"),
             BootstrapStatus("database", "ready"),
             BootstrapStatus("dynamic_config", "ready"),
             BootstrapStatus("http_client", "ready"),
+            BootstrapStatus("control_http_client", "ready"),
             BootstrapStatus("provider_adapters", "ready"),
         ),
     )
@@ -120,6 +127,7 @@ async def init_infrastructure_runtime(app: Any) -> InfrastructureRuntime:
 async def shutdown_infrastructure_runtime(runtime: InfrastructureRuntime) -> None:
     await runtime.dynamic_config_manager.close()
     await runtime.http_client.aclose()
+    await runtime.control_http_client.aclose()
     if runtime.redis_client is not None:
         await runtime.redis_client.close()
     await prisma_manager.disconnect()

--- a/src/bootstrap/routing.py
+++ b/src/bootstrap/routing.py
@@ -164,18 +164,22 @@ async def init_routing_runtime(
         salt_key=salt_key,
     )
 
+    health_check_timeout_seconds = 30
+
     async def _deployment_health_check(deployment):  # noqa: ANN001, ANN202
         return await probe_provider_health(
             app.state.http_client,
             deployment.deltallm_params,
             default_openai_base_url=app.state.settings.openai_base_url,
+            general_settings=getattr(app.state, "upstream_http_settings", cfg.general_settings),
+            health_check_timeout_seconds=health_check_timeout_seconds,
         )
 
     health_checker = BackgroundHealthChecker(
         config=HealthCheckConfig(
             enabled=cfg.general_settings.background_health_checks,
             interval_seconds=cfg.general_settings.health_check_interval,
-            timeout_seconds=30,
+            timeout_seconds=health_check_timeout_seconds,
         ),
         deployment_registry=deployment_registry,
         state_backend=state_backend,

--- a/src/bootstrap/runtime_services.py
+++ b/src/bootstrap/runtime_services.py
@@ -54,7 +54,10 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
         policy_repository=getattr(app.state, "mcp_scope_policy_repository", None),
     )
     await app.state.mcp_governance_service.reload()
-    app.state.mcp_transport_client = StreamableHTTPMCPClient(app.state.http_client)
+    app.state.mcp_transport_client = StreamableHTTPMCPClient(
+        app.state.http_client,
+        general_settings=getattr(app.state, "upstream_http_settings", cfg.general_settings),
+    )
     app.state.mcp_health_probe = MCPHealthProbe(
         registry=app.state.mcp_registry_service,
         client=app.state.mcp_transport_client,

--- a/src/chat/executor.py
+++ b/src/chat/executor.py
@@ -13,6 +13,7 @@ from src.providers.registry import resolve_chat_upstream
 from src.providers.signing import apply_request_signing
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
+from src.upstream_http import build_upstream_request_timeout_for_request
 
 
 @dataclass
@@ -62,19 +63,20 @@ async def execute_chat(
         headers=headers,
         json_body=upstream_payload,
     )
+    request_timeout = build_upstream_request_timeout_for_request(request, timeout)
     if body_override is not None:
         response = await request.app.state.http_client.post(
             request_url,
             headers=signed_headers,
             content=body_override,
-            timeout=timeout,
+            timeout=request_timeout,
         )
     else:
         response = await request.app.state.http_client.post(
             request_url,
             headers=signed_headers,
             json=upstream_payload,
-            timeout=timeout,
+            timeout=request_timeout,
         )
     if response.status_code >= 400:
         status_exc = httpx.HTTPStatusError(
@@ -125,13 +127,14 @@ async def open_stream_with_first_chunk(
         headers=headers,
         json_body=upstream_payload,
     )
+    request_timeout = build_upstream_request_timeout_for_request(request, timeout)
     if body_override is not None:
         context_manager = request.app.state.http_client.stream(
             "POST",
             request_url,
             headers=signed_headers,
             content=body_override,
-            timeout=timeout,
+            timeout=request_timeout,
         )
     else:
         context_manager = request.app.state.http_client.stream(
@@ -139,7 +142,7 @@ async def open_stream_with_first_chunk(
             request_url,
             headers=signed_headers,
             json=upstream_payload,
-            timeout=timeout,
+            timeout=request_timeout,
         )
     response = await context_manager.__aenter__()
     try:

--- a/src/config.py
+++ b/src/config.py
@@ -63,7 +63,7 @@ class DeltaLLMParams(BaseModel):
     api_version: str | None = None
     auth_header_name: str | None = None
     auth_header_format: str | None = None
-    timeout: int | None = 300
+    timeout: int | None = None
     rpm: int | None = None
     tpm: int | None = None
     weight: int = 1
@@ -237,6 +237,13 @@ class GeneralSettings(BaseModel):
     database_url: str | None = None
     db_pool_size: int = Field(default=20, gt=0)
     db_pool_timeout: int = Field(default=30, ge=0)
+    upstream_http_connect_timeout_seconds: float = Field(default=10.0, gt=0)
+    upstream_http_read_timeout_seconds: float = Field(default=300.0, gt=0)
+    upstream_http_write_timeout_seconds: float = Field(default=30.0, gt=0)
+    upstream_http_pool_timeout_seconds: float = Field(default=10.0, gt=0)
+    upstream_http_max_connections: int = Field(default=500, gt=0)
+    upstream_http_max_keepalive_connections: int = Field(default=100, ge=0)
+    upstream_http_keepalive_expiry_seconds: float = Field(default=60.0, ge=0)
     redis_host: str = "localhost"
     redis_port: int = 6379
     redis_password: str | None = None
@@ -404,6 +411,15 @@ class GeneralSettings(BaseModel):
     @classmethod
     def validate_master_key(cls, value: str | None) -> str | None:
         return _validate_master_key_strength(value)
+
+    @model_validator(mode="after")
+    def validate_upstream_http_pool(self) -> "GeneralSettings":
+        if self.upstream_http_max_keepalive_connections > self.upstream_http_max_connections:
+            raise ValueError(
+                "upstream_http_max_keepalive_connections must be less than or equal to "
+                "upstream_http_max_connections"
+            )
+        return self
 
 
 class AppConfig(BaseModel):

--- a/src/email/providers.py
+++ b/src/email/providers.py
@@ -10,6 +10,7 @@ from typing import Any
 import httpx
 
 from src.email.models import EmailDeliveryError, EmailDeliveryResult, PreparedEmail
+from src.upstream_http import build_control_request_timeout
 
 
 def _all_recipients(message: PreparedEmail) -> list[str]:
@@ -136,7 +137,7 @@ class ResendEmailProvider:
                     "text": message.text_body,
                     "html": message.html_body,
                 },
-                timeout=20,
+                timeout=build_control_request_timeout(20),
             )
         except httpx.TransportError as exc:
             raise EmailDeliveryError(str(exc) or "Resend transport error", retriable=True, provider="resend") from exc
@@ -177,7 +178,7 @@ class SendGridEmailProvider:
                         *([{"type": "text/html", "value": message.html_body}] if message.html_body else []),
                     ],
                 },
-                timeout=20,
+                timeout=build_control_request_timeout(20),
             )
         except httpx.TransportError as exc:
             raise EmailDeliveryError(str(exc) or "SendGrid transport error", retriable=True, provider="sendgrid") from exc

--- a/src/mcp/transport_http.py
+++ b/src/mcp/transport_http.py
@@ -9,13 +9,15 @@ from .auth import build_forwarded_headers, build_server_headers
 from .exceptions import MCPAuthError, MCPInvalidResponseError, MCPTransportError
 from .models import MCPRequestEnvelope, MCPServerConfig, MCPToolCallResult, MCPToolSchema
 from .capabilities import extract_tool_schemas
+from src.upstream_http import build_upstream_request_timeout
 
 _request_ids = count(1)
 
 
 class StreamableHTTPMCPClient:
-    def __init__(self, http_client: httpx.AsyncClient) -> None:
+    def __init__(self, http_client: httpx.AsyncClient, *, general_settings: Any | None = None) -> None:
         self.http_client = http_client
+        self.general_settings = general_settings
 
     async def initialize(
         self,
@@ -100,7 +102,10 @@ class StreamableHTTPMCPClient:
                 server.base_url.rstrip("/"),
                 json=body,
                 headers=headers,
-                timeout=max(1.0, float(server.request_timeout_ms) / 1000.0),
+                timeout=build_upstream_request_timeout(
+                    self.general_settings,
+                    max(1.0, float(server.request_timeout_ms) / 1000.0),
+                ),
             )
         except httpx.HTTPError as exc:
             raise MCPTransportError(str(exc)) from exc

--- a/src/models/errors.py
+++ b/src/models/errors.py
@@ -113,3 +113,13 @@ class ServiceUnavailableError(ProxyError):
     status_code = 503
     error_type = "service_unavailable"
     message = "Service unavailable"
+
+
+class GatewayCapacityError(ServiceUnavailableError):
+    error_type = "gateway_capacity_error"
+    message = "Gateway upstream connection pool exhausted"
+
+    def __init__(self, message: str | None = None, **kwargs):
+        kwargs.setdefault("code", "upstream_pool_timeout")
+        kwargs.setdefault("affects_deployment_health", False)
+        super().__init__(message=message, **kwargs)

--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -9,6 +9,7 @@ import httpx
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.healthcheck import is_provider_healthy
 from src.providers.resolution import resolve_upstream_model
 
 
@@ -186,20 +187,9 @@ class AnthropicAdapter(ProviderAdapter):
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
-        api_key = provider_config.get("api_key")
-        if not api_key:
-            return False
-        api_base = provider_config.get("api_base", "https://api.anthropic.com/v1").rstrip("/")
-        version = provider_config.get("api_version") or "2023-06-01"
-        try:
-            response = await self.http_client.get(
-                f"{api_base}/models",
-                headers={
-                    "x-api-key": str(api_key),
-                    "anthropic-version": str(version),
-                },
-                timeout=10.0,
-            )
-            return response.status_code < 500
-        except Exception:
-            return False
+        return await is_provider_healthy(
+            self.http_client,
+            provider_config,
+            default_openai_base_url="https://api.openai.com/v1",
+            default_provider=self.provider_name,
+        )

--- a/src/providers/azure.py
+++ b/src/providers/azure.py
@@ -8,6 +8,7 @@ import httpx
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.healthcheck import is_provider_healthy
 from src.providers.resolution import normalize_openai_chat_payload, resolve_provider, resolve_upstream_model
 
 
@@ -47,16 +48,9 @@ class AzureOpenAIAdapter(ProviderAdapter):
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
-        api_base = str(provider_config.get("api_base") or "").rstrip("/")
-        api_key = provider_config.get("api_key")
-        if not api_base or not api_key:
-            return False
-        try:
-            response = await self.http_client.get(
-                f"{api_base}/models",
-                headers={"api-key": str(api_key)},
-                timeout=10.0,
-            )
-            return response.status_code < 500
-        except Exception:
-            return False
+        return await is_provider_healthy(
+            self.http_client,
+            provider_config,
+            default_openai_base_url="https://api.openai.com/v1",
+            default_provider=self.provider_name,
+        )

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncIterator
 import httpx
 
 from src.models.errors import (
+    GatewayCapacityError,
     InvalidRequestError,
     RateLimitError,
     ServiceUnavailableError,
@@ -23,6 +24,9 @@ def map_standard_provider_error(
     unavailable_message: str | None = None,
     rate_limit_message: str | None = None,
 ) -> Exception:
+    if isinstance(provider_error, httpx.PoolTimeout):
+        return GatewayCapacityError()
+
     if isinstance(provider_error, httpx.TimeoutException):
         return TimeoutError(affects_deployment_health=True)
 

--- a/src/providers/bedrock.py
+++ b/src/providers/bedrock.py
@@ -10,6 +10,7 @@ from src.models.errors import InvalidRequestError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.healthcheck import is_provider_healthy
 
 
 class BedrockAdapter(ProviderAdapter):
@@ -111,7 +112,9 @@ class BedrockAdapter(ProviderAdapter):
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
-        access_key = provider_config.get("aws_access_key_id")
-        secret_key = provider_config.get("aws_secret_access_key")
-        region = provider_config.get("region")
-        return bool(access_key and secret_key and region)
+        return await is_provider_healthy(
+            self.http_client,
+            provider_config,
+            default_openai_base_url="https://api.openai.com/v1",
+            default_provider=self.provider_name,
+        )

--- a/src/providers/gemini.py
+++ b/src/providers/gemini.py
@@ -10,6 +10,7 @@ from src.models.errors import InvalidRequestError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.healthcheck import is_provider_healthy
 
 
 class GeminiAdapter(ProviderAdapter):
@@ -112,15 +113,9 @@ class GeminiAdapter(ProviderAdapter):
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
-        api_base = str(provider_config.get("api_base") or "https://generativelanguage.googleapis.com/v1beta").rstrip("/")
-        api_key = provider_config.get("api_key")
-        if not api_key:
-            return False
-        try:
-            response = await self.http_client.get(
-                f"{api_base}/models?key={api_key}",
-                timeout=10.0,
-            )
-            return response.status_code < 500
-        except Exception:
-            return False
+        return await is_provider_healthy(
+            self.http_client,
+            provider_config,
+            default_openai_base_url="https://api.openai.com/v1",
+            default_provider=self.provider_name,
+        )

--- a/src/providers/healthcheck.py
+++ b/src/providers/healthcheck.py
@@ -6,8 +6,10 @@ from typing import Any
 
 import httpx
 
+from src.models.errors import GatewayCapacityError, InvalidRequestError
 from src.providers.resolution import is_openai_compatible_provider, resolve_provider
 from src.upstream_auth import build_openai_compatible_auth_headers
+from src.upstream_http import build_health_check_request_timeout
 
 
 @dataclass
@@ -16,6 +18,7 @@ class HealthProbeResult:
     error: str | None = None
     status_code: int | None = None
     checked_at: int = field(default_factory=lambda: int(time.time()))
+    affects_deployment_health: bool = True
 
 
 def _status_error(prefix: str, status_code: int) -> str:
@@ -27,8 +30,17 @@ async def probe_provider_health(
     params: dict[str, Any],
     *,
     default_openai_base_url: str,
+    general_settings: Any | None = None,
+    health_check_timeout_seconds: float | int | None = None,
 ) -> HealthProbeResult:
     provider = resolve_provider(params)
+    if provider in {"unknown", ""}:
+        provider = "openai"
+    request_timeout = build_health_check_request_timeout(
+        general_settings,
+        read_timeout_seconds=10.0,
+        health_check_timeout_seconds=health_check_timeout_seconds,
+    )
 
     if provider == "anthropic":
         api_key = str(params.get("api_key") or "").strip()
@@ -40,7 +52,7 @@ async def probe_provider_health(
             response = await http_client.get(
                 f"{api_base}/models",
                 headers={"x-api-key": api_key, "anthropic-version": version},
-                timeout=10.0,
+                timeout=request_timeout,
             )
             if response.status_code >= 400:
                 return HealthProbeResult(
@@ -49,6 +61,9 @@ async def probe_provider_health(
                     status_code=response.status_code,
                 )
             return HealthProbeResult(healthy=True, status_code=response.status_code)
+        except httpx.PoolTimeout:
+            error = GatewayCapacityError()
+            return HealthProbeResult(healthy=False, error=error.message, affects_deployment_health=False)
         except httpx.TimeoutException:
             return HealthProbeResult(healthy=False, error="Anthropic health check timed out")
         except httpx.HTTPError as exc:
@@ -65,7 +80,7 @@ async def probe_provider_health(
             response = await http_client.get(
                 f"{api_base}/models",
                 headers={"api-key": api_key},
-                timeout=10.0,
+                timeout=request_timeout,
             )
             if response.status_code >= 400:
                 return HealthProbeResult(
@@ -74,6 +89,9 @@ async def probe_provider_health(
                     status_code=response.status_code,
                 )
             return HealthProbeResult(healthy=True, status_code=response.status_code)
+        except httpx.PoolTimeout:
+            error = GatewayCapacityError()
+            return HealthProbeResult(healthy=False, error=error.message, affects_deployment_health=False)
         except httpx.TimeoutException:
             return HealthProbeResult(healthy=False, error="Azure OpenAI health check timed out")
         except httpx.HTTPError as exc:
@@ -85,7 +103,7 @@ async def probe_provider_health(
             return HealthProbeResult(healthy=False, error="Provider API key is missing")
         api_base = str(params.get("api_base") or "https://generativelanguage.googleapis.com/v1beta").rstrip("/")
         try:
-            response = await http_client.get(f"{api_base}/models?key={api_key}", timeout=10.0)
+            response = await http_client.get(f"{api_base}/models?key={api_key}", timeout=request_timeout)
             if response.status_code >= 400:
                 return HealthProbeResult(
                     healthy=False,
@@ -93,6 +111,9 @@ async def probe_provider_health(
                     status_code=response.status_code,
                 )
             return HealthProbeResult(healthy=True, status_code=response.status_code)
+        except httpx.PoolTimeout:
+            error = GatewayCapacityError()
+            return HealthProbeResult(healthy=False, error=error.message, affects_deployment_health=False)
         except httpx.TimeoutException:
             return HealthProbeResult(healthy=False, error="Gemini health check timed out")
         except httpx.HTTPError as exc:
@@ -107,9 +128,6 @@ async def probe_provider_health(
             return HealthProbeResult(healthy=False, error="AWS region is missing")
         return HealthProbeResult(healthy=True)
 
-    if provider in {"unknown", ""}:
-        return HealthProbeResult(healthy=False, error="Provider could not be resolved for this deployment")
-
     if not is_openai_compatible_provider(provider):
         return HealthProbeResult(healthy=False, error=f"Health checks are not implemented for provider '{provider}'")
 
@@ -122,15 +140,20 @@ async def probe_provider_health(
         return HealthProbeResult(healthy=False, error="API base URL is missing")
 
     try:
+        headers = build_openai_compatible_auth_headers(
+            provider=provider,
+            api_key=api_key,
+            auth_header_name=str(params.get("auth_header_name") or "").strip() or None,
+            auth_header_format=str(params.get("auth_header_format") or "").strip() or None,
+        )
+    except (InvalidRequestError, ValueError) as exc:
+        return HealthProbeResult(healthy=False, error=str(exc) or "Provider auth configuration is invalid")
+
+    try:
         response = await http_client.get(
             f"{api_base}/models",
-            headers=build_openai_compatible_auth_headers(
-                provider=provider,
-                api_key=api_key,
-                auth_header_name=str(params.get("auth_header_name") or "").strip() or None,
-                auth_header_format=str(params.get("auth_header_format") or "").strip() or None,
-            ),
-            timeout=10.0,
+            headers=headers,
+            timeout=request_timeout,
         )
         if response.status_code >= 400:
             return HealthProbeResult(
@@ -139,7 +162,35 @@ async def probe_provider_health(
                 status_code=response.status_code,
             )
         return HealthProbeResult(healthy=True, status_code=response.status_code)
+    except httpx.PoolTimeout:
+        error = GatewayCapacityError()
+        return HealthProbeResult(healthy=False, error=error.message, affects_deployment_health=False)
     except httpx.TimeoutException:
         return HealthProbeResult(healthy=False, error=f"{provider} health check timed out")
     except httpx.HTTPError as exc:
         return HealthProbeResult(healthy=False, error=f"{provider} health check failed: {exc}")
+
+
+async def is_provider_healthy(
+    http_client: httpx.AsyncClient,
+    params: dict[str, Any],
+    *,
+    default_openai_base_url: str,
+    default_provider: str | None = None,
+    general_settings: Any | None = None,
+) -> bool:
+    probe_params = dict(params)
+    has_provider = bool(str(probe_params.get("provider") or "").strip())
+    has_model = bool(str(probe_params.get("model") or "").strip())
+    if default_provider and not has_provider and not has_model:
+        probe_params["provider"] = default_provider
+    try:
+        result = await probe_provider_health(
+            http_client,
+            probe_params,
+            default_openai_base_url=default_openai_base_url,
+            general_settings=general_settings,
+        )
+    except Exception:
+        return False
+    return result.healthy

--- a/src/providers/model_discovery.py
+++ b/src/providers/model_discovery.py
@@ -8,6 +8,7 @@ from src.config import ModelMode
 from src.providers.model_catalog import canonical_catalog_provider, catalog_model_metadata, catalog_models_for_provider
 from src.providers.resolution import PROVIDER_PRESETS, is_openai_compatible_provider
 from src.upstream_auth import build_openai_compatible_auth_headers
+from src.upstream_http import build_upstream_request_timeout
 
 
 def _normalized_provider(provider: str | None) -> str:
@@ -114,8 +115,13 @@ async def _load_json(
     url: str,
     headers: dict[str, str] | None = None,
     timeout: float = 10.0,
+    general_settings: Any | None = None,
 ) -> Any:
-    response = await http_client.get(url, headers=headers or None, timeout=timeout)
+    response = await http_client.get(
+        url,
+        headers=headers or None,
+        timeout=build_upstream_request_timeout(general_settings, timeout),
+    )
     if response.status_code >= 400:
         raise httpx.HTTPStatusError(
             f"Provider model discovery returned {response.status_code}",
@@ -139,6 +145,7 @@ async def _discover_live_models(
     api_version: str | None,
     auth_header_name: str | None,
     auth_header_format: str | None,
+    general_settings: Any | None,
 ) -> list[dict[str, Any]]:
     if provider == "bedrock":
         raise NotImplementedError("Live discovery is not yet implemented for AWS Bedrock.")
@@ -153,6 +160,7 @@ async def _discover_live_models(
                 "x-api-key": api_key,
                 "anthropic-version": str(api_version or "2023-06-01").strip() or "2023-06-01",
             },
+            general_settings=general_settings,
         )
         return _extract_anthropic_models(payload, provider=response_provider)
 
@@ -163,6 +171,7 @@ async def _discover_live_models(
             http_client,
             url=f"{str(api_base).rstrip('/')}/models",
             headers={"api-key": api_key},
+            general_settings=general_settings,
         )
         return _extract_openai_style_models(payload, provider=response_provider)
 
@@ -172,6 +181,7 @@ async def _discover_live_models(
         payload = await _load_json(
             http_client,
             url=f"{str(api_base or '').rstrip('/')}/models?key={api_key}",
+            general_settings=general_settings,
         )
         return _extract_gemini_models(payload, provider=response_provider)
 
@@ -189,6 +199,7 @@ async def _discover_live_models(
             auth_header_name=auth_header_name,
             auth_header_format=auth_header_format,
         ),
+        general_settings=general_settings,
     )
     return _extract_openai_style_models(payload, provider=response_provider)
 
@@ -257,6 +268,7 @@ async def discover_provider_models(
     auth_header_name: str | None = None,
     auth_header_format: str | None = None,
     default_openai_base_url: str,
+    general_settings: Any | None = None,
 ) -> dict[str, Any]:
     normalized_provider = _normalized_provider(provider)
     response_provider = _response_provider(provider)
@@ -275,6 +287,7 @@ async def discover_provider_models(
             api_version=str(api_version or "").strip() or None,
             auth_header_name=str(auth_header_name or "").strip() or None,
             auth_header_format=str(auth_header_format or "").strip() or None,
+            general_settings=general_settings,
         )
     except NotImplementedError as exc:
         live_options = []

--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -8,8 +8,8 @@ import httpx
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.healthcheck import is_provider_healthy
 from src.providers.resolution import normalize_openai_chat_payload, resolve_provider, resolve_upstream_model
-from src.upstream_auth import build_openai_compatible_auth_headers
 
 
 class OpenAIAdapter(ProviderAdapter):
@@ -86,21 +86,9 @@ class OpenAIAdapter(ProviderAdapter):
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:
-        api_base = provider_config.get("api_base", "https://api.openai.com/v1")
-        api_key = provider_config.get("api_key")
-        if not api_key:
-            return False
-        try:
-            response = await self.http_client.get(
-                f"{api_base}/models",
-                headers=build_openai_compatible_auth_headers(
-                    provider=resolve_provider(provider_config),
-                    api_key=str(api_key),
-                    auth_header_name=provider_config.get("auth_header_name"),
-                    auth_header_format=provider_config.get("auth_header_format"),
-                ),
-                timeout=10.0,
-            )
-            return response.status_code < 500
-        except Exception:
-            return False
+        return await is_provider_healthy(
+            self.http_client,
+            provider_config,
+            default_openai_base_url="https://api.openai.com/v1",
+            default_provider=self.provider_name,
+        )

--- a/src/providers/registry.py
+++ b/src/providers/registry.py
@@ -9,6 +9,7 @@ from src.models.errors import InvalidRequestError
 from src.providers.base import ProviderAdapter
 from src.providers.resolution import is_openai_compatible_provider, resolve_provider, resolve_upstream_model
 from src.upstream_auth import build_openai_compatible_auth_headers
+from src.upstream_http import configured_timeout_seconds
 
 
 @dataclass
@@ -17,7 +18,7 @@ class ChatUpstream:
     api_base: str
     endpoint: str
     headers: dict[str, str]
-    timeout: int
+    timeout: float | None
 
 
 def resolve_chat_upstream(
@@ -27,7 +28,7 @@ def resolve_chat_upstream(
     is_stream: bool = False,
 ) -> ChatUpstream:
     provider = resolve_provider(params)
-    timeout = int(params.get("timeout") or 300)
+    timeout = configured_timeout_seconds(params.get("timeout"))
     if provider == "anthropic":
         api_key = params.get("api_key")
         if not api_key:

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -11,6 +11,7 @@ from typing import Any, Awaitable, Callable
 import httpx
 
 from src.models.errors import (
+    GatewayCapacityError,
     InvalidRequestError,
     NO_HEALTHY_DEPLOYMENTS_CODE,
     ProxyError,
@@ -25,6 +26,8 @@ from src.router.router import Deployment
 from src.router.state import DeploymentStateBackend
 
 logger = logging.getLogger(__name__)
+
+TimeoutForDeployment = Callable[[Deployment], float | int | None]
 
 
 @dataclass
@@ -275,6 +278,8 @@ class FailoverManager:
         return str(error)
 
     def _normalize_http_error(self, error: httpx.HTTPError) -> ProxyError:
+        if isinstance(error, httpx.PoolTimeout):
+            return GatewayCapacityError()
         if isinstance(error, httpx.TimeoutException):
             return TimeoutError(
                 message=str(error) or None,
@@ -327,11 +332,11 @@ class FailoverManager:
         return_deployment: bool = False,
         on_attempt: Callable[[Deployment], None] | None = None,
         timeout_seconds: float | None = None,
+        timeout_for_deployment: TimeoutForDeployment | None = None,
         retry_max_attempts: int | None = None,
         retryable_error_classes: list[str] | set[str] | None = None,
     ) -> Any:
         chain = self._build_fallback_chain(primary_deployment, model_group, request_tokens)
-        effective_timeout = self._effective_timeout(timeout_seconds)
         effective_retries = self._effective_retry_count(retry_max_attempts)
         effective_retry_classes = self._normalize_retryable_error_classes(retryable_error_classes)
         last_error: Exception | None = None
@@ -349,9 +354,14 @@ class FailoverManager:
                 try:
                     self._notify_attempt(on_attempt, deployment)
                     await self.state.increment_active(deployment.deployment_id)
+                    attempt_timeout = self._effective_attempt_timeout(
+                        deployment,
+                        timeout_seconds,
+                        timeout_for_deployment,
+                    )
                     result = await asyncio.wait_for(
                         execute(deployment),
-                        timeout=effective_timeout,
+                        timeout=attempt_timeout,
                     )
                     latency_ms = (time.monotonic() - started) * 1000
                     await self.state.record_latency(deployment.deployment_id, latency_ms)
@@ -406,7 +416,8 @@ class FailoverManager:
                                 deployment.deployment_id,
                                 classification,
                                 on_attempt=on_attempt,
-                                timeout_seconds=effective_timeout,
+                                timeout_seconds=timeout_seconds,
+                                timeout_for_deployment=timeout_for_deployment,
                             )
                             if extra_result is not None:
                                 if return_deployment:
@@ -471,7 +482,8 @@ class FailoverManager:
         classification: str,
         *,
         on_attempt: Callable[[Deployment], None] | None = None,
-        timeout_seconds: float,
+        timeout_seconds: float | None,
+        timeout_for_deployment: TimeoutForDeployment | None = None,
     ) -> tuple[Any, Deployment] | None:
         for deployment in chain:
             if await self.state.is_cooled_down(deployment.deployment_id):
@@ -484,9 +496,14 @@ class FailoverManager:
                 self._notify_attempt(on_attempt, deployment)
                 await self.state.increment_active(deployment.deployment_id)
                 started = time.monotonic()
+                attempt_timeout = self._effective_attempt_timeout(
+                    deployment,
+                    timeout_seconds,
+                    timeout_for_deployment,
+                )
                 result = await asyncio.wait_for(
                     execute(deployment),
-                    timeout=timeout_seconds,
+                    timeout=attempt_timeout,
                 )
                 latency_ms = (time.monotonic() - started) * 1000
                 await self.state.record_latency(deployment.deployment_id, latency_ms)
@@ -539,14 +556,39 @@ class FailoverManager:
 
         return None
 
-    def _effective_timeout(self, timeout_seconds: float | None) -> float:
+    @staticmethod
+    def _coerce_positive_timeout(timeout_seconds: Any) -> float | None:
         if timeout_seconds is None:
-            return self.config.timeout
+            return None
         try:
             parsed = float(timeout_seconds)
         except (TypeError, ValueError):
-            return self.config.timeout
-        return parsed if parsed > 0 else self.config.timeout
+            return None
+        return parsed if parsed > 0 else None
+
+    def _effective_timeout(self, timeout_seconds: float | None) -> float:
+        return self._coerce_positive_timeout(timeout_seconds) or self.config.timeout
+
+    def _effective_attempt_timeout(
+        self,
+        deployment: Deployment,
+        timeout_seconds: float | None,
+        timeout_for_deployment: TimeoutForDeployment | None,
+    ) -> float:
+        if timeout_for_deployment is None:
+            return self._effective_timeout(timeout_seconds)
+        try:
+            deployment_timeout = timeout_for_deployment(deployment)
+        except Exception:
+            logger.debug(
+                "Failed to resolve timeout for deployment %s",
+                deployment.deployment_id,
+                exc_info=True,
+            )
+            return self._effective_timeout(timeout_seconds)
+        if deployment_timeout is None:
+            return self._effective_timeout(timeout_seconds)
+        return self._coerce_positive_timeout(deployment_timeout) or self._effective_timeout(timeout_seconds)
 
     def _effective_retry_count(self, retry_max_attempts: int | None) -> int:
         if retry_max_attempts is None:

--- a/src/router/health.py
+++ b/src/router/health.py
@@ -90,6 +90,9 @@ class BackgroundHealthChecker:
                 await self.state.clear_cooldown(deployment.deployment_id)
             return
 
+        if result.affects_deployment_health is False:
+            return
+
         await self.state.set_health(deployment.deployment_id, False)
         await self.state.record_failure(
             deployment.deployment_id,

--- a/src/router/health_policy.py
+++ b/src/router/health_policy.py
@@ -33,6 +33,9 @@ def affects_deployment_health(exc: Exception) -> bool:
     if explicit is not None:
         return bool(explicit)
 
+    if isinstance(exc, httpx.PoolTimeout):
+        return False
+
     if isinstance(exc, (httpx.TimeoutException, TimeoutError)):
         return True
 

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -28,6 +28,7 @@ from src.models.errors import InvalidRequestError
 from src.models.requests import AudioSpeechRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.upstream_auth import build_openai_compatible_auth_headers
+from src.upstream_http import build_upstream_request_timeout_for_request, configured_timeout_seconds
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
@@ -105,7 +106,7 @@ async def _execute_tts(
         f"{api_base}/audio/speech",
         headers=headers,
         json=upstream_payload,
-        timeout=params.get("timeout") or 300,
+        timeout=build_upstream_request_timeout_for_request(request, configured_timeout_seconds(params.get("timeout"))),
     )
     if response.status_code >= 400:
         try:
@@ -440,7 +441,10 @@ async def _execute_gemini_tts(
         endpoint,
         headers={"Content-Type": "application/json"},
         json=upstream_payload,
-        timeout=deployment.deltallm_params.get("timeout") or 300,
+        timeout=build_upstream_request_timeout_for_request(
+            request,
+            configured_timeout_seconds(deployment.deltallm_params.get("timeout")),
+        ),
     )
     if response.status_code >= 400:
         raise httpx.HTTPStatusError(

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -27,6 +27,7 @@ from src.providers.resolution import (
     resolve_upstream_model,
 )
 from src.upstream_auth import build_openai_compatible_auth_headers
+from src.upstream_http import build_upstream_request_timeout_for_request, configured_timeout_seconds
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
@@ -44,7 +45,13 @@ from src.routers.routing_decision import (
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
 from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
 
+DEFAULT_AUDIO_TRANSCRIPTION_TIMEOUT_SECONDS = 600.0
+
 router = APIRouter(prefix="/v1", tags=["audio"])
+
+
+def _transcription_timeout_seconds(params: dict[str, Any]) -> float:
+    return configured_timeout_seconds(params.get("timeout")) or DEFAULT_AUDIO_TRANSCRIPTION_TIMEOUT_SECONDS
 
 
 async def _execute_stt(
@@ -97,12 +104,13 @@ async def _execute_stt(
         form_data[_fk] = str(_fv) if _fv is not None else ""
 
     upstream_start = perf_counter()
+    timeout_seconds = _transcription_timeout_seconds(params)
     response = await request.app.state.http_client.post(
         f"{api_base}/audio/transcriptions",
         headers=headers,
         files={"file": (filename, file_content, content_type)},
         data=form_data,
-        timeout=params.get("timeout") or 600,
+        timeout=build_upstream_request_timeout_for_request(request, timeout_seconds),
     )
     if response.status_code >= 400:
         try:
@@ -178,6 +186,11 @@ async def audio_transcriptions(
         deployment=await app_router.select_deployment(model_group, request_context),
     )
     failover_kwargs = route_failover_kwargs(request_context)
+    if "timeout_seconds" not in failover_kwargs:
+        def timeout_for_deployment(deployment: Deployment) -> float:
+            return _transcription_timeout_seconds(deployment.deltallm_params)
+
+        failover_kwargs["timeout_for_deployment"] = timeout_for_deployment
     capture_initial_route_decision(request, request_context)
     api_provider = resolve_provider(primary.deltallm_params)
     request_id = request.headers.get("x-request-id")

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -28,6 +28,7 @@ from src.upstream_auth import build_openai_compatible_auth_headers
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.telemetry.request_failures import enqueue_request_log_write, seed_request_failure_context
+from src.upstream_http import build_upstream_request_timeout_for_request, configured_timeout_seconds
 from src.routers.routing_decision import (
     capture_attempted_deployment,
     capture_initial_route_decision,
@@ -141,7 +142,7 @@ async def _execute_embedding(
         f"{api_base}/embeddings",
         headers=headers,
         json=upstream_payload,
-        timeout=params.get("timeout") or 300,
+        timeout=build_upstream_request_timeout_for_request(request, configured_timeout_seconds(params.get("timeout"))),
     )
     if response.status_code >= 400:
         raise httpx.HTTPStatusError(

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -30,6 +30,7 @@ from src.upstream_auth import build_openai_compatible_auth_headers
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.telemetry.request_failures import enqueue_request_log_write, seed_request_failure_context
+from src.upstream_http import build_upstream_request_timeout_for_request, configured_timeout_seconds
 from src.audit.actions import AuditAction
 from src.routers.audit_helpers import emit_audit_event
 from src.routers.routing_decision import (
@@ -84,7 +85,7 @@ async def _execute_image_generation(
         f"{api_base}/images/generations",
         headers=headers,
         json=upstream_payload,
-        timeout=params.get("timeout") or 300,
+        timeout=build_upstream_request_timeout_for_request(request, configured_timeout_seconds(params.get("timeout"))),
     )
     if response.status_code >= 400:
         raise httpx.HTTPStatusError(

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -23,6 +23,7 @@ from src.models.errors import InvalidRequestError
 from src.models.requests import RerankRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.upstream_auth import build_openai_compatible_auth_headers
+from src.upstream_http import build_upstream_request_timeout_for_request, configured_timeout_seconds
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
 from src.audit.actions import AuditAction
@@ -75,7 +76,7 @@ async def _execute_rerank(
         f"{api_base}/rerank",
         headers=headers,
         json=upstream_payload,
-        timeout=params.get("timeout") or 300,
+        timeout=build_upstream_request_timeout_for_request(request, configured_timeout_seconds(params.get("timeout"))),
     )
     if response.status_code >= 400:
         raise httpx.HTTPStatusError(

--- a/src/upstream_http.py
+++ b/src/upstream_http.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+DEFAULT_UPSTREAM_HTTP_CONNECT_TIMEOUT_SECONDS = 10.0
+DEFAULT_UPSTREAM_HTTP_READ_TIMEOUT_SECONDS = 300.0
+DEFAULT_UPSTREAM_HTTP_WRITE_TIMEOUT_SECONDS = 30.0
+DEFAULT_UPSTREAM_HTTP_POOL_TIMEOUT_SECONDS = 10.0
+DEFAULT_UPSTREAM_HTTP_MAX_CONNECTIONS = 500
+DEFAULT_UPSTREAM_HTTP_MAX_KEEPALIVE_CONNECTIONS = 100
+DEFAULT_UPSTREAM_HTTP_KEEPALIVE_EXPIRY_SECONDS = 60.0
+HEALTH_CHECK_POOL_TIMEOUT_RATIO = 0.8
+MIN_HEALTH_CHECK_POOL_TIMEOUT_SECONDS = 0.1
+
+CONTROL_HTTP_TIMEOUT_SECONDS = 20.0
+CONTROL_HTTP_CONNECT_TIMEOUT_SECONDS = 5.0
+CONTROL_HTTP_READ_TIMEOUT_SECONDS = 20.0
+CONTROL_HTTP_WRITE_TIMEOUT_SECONDS = 10.0
+CONTROL_HTTP_POOL_TIMEOUT_SECONDS = 5.0
+CONTROL_HTTP_MAX_CONNECTIONS = 100
+CONTROL_HTTP_MAX_KEEPALIVE_CONNECTIONS = 20
+CONTROL_HTTP_KEEPALIVE_EXPIRY_SECONDS = 30.0
+
+
+def _setting(settings: Any, name: str, default: float | int) -> float | int:
+    value = getattr(settings, name, None)
+    return default if value is None else value
+
+
+def build_upstream_http_timeout(general_settings: Any) -> httpx.Timeout:
+    return httpx.Timeout(
+        connect=float(
+            _setting(
+                general_settings,
+                "upstream_http_connect_timeout_seconds",
+                DEFAULT_UPSTREAM_HTTP_CONNECT_TIMEOUT_SECONDS,
+            )
+        ),
+        read=float(
+            _setting(
+                general_settings,
+                "upstream_http_read_timeout_seconds",
+                DEFAULT_UPSTREAM_HTTP_READ_TIMEOUT_SECONDS,
+            )
+        ),
+        write=float(
+            _setting(
+                general_settings,
+                "upstream_http_write_timeout_seconds",
+                DEFAULT_UPSTREAM_HTTP_WRITE_TIMEOUT_SECONDS,
+            )
+        ),
+        pool=float(
+            _setting(
+                general_settings,
+                "upstream_http_pool_timeout_seconds",
+                DEFAULT_UPSTREAM_HTTP_POOL_TIMEOUT_SECONDS,
+            )
+        ),
+    )
+
+
+def build_upstream_http_limits(general_settings: Any) -> httpx.Limits:
+    return httpx.Limits(
+        max_connections=int(
+            _setting(
+                general_settings,
+                "upstream_http_max_connections",
+                DEFAULT_UPSTREAM_HTTP_MAX_CONNECTIONS,
+            )
+        ),
+        max_keepalive_connections=int(
+            _setting(
+                general_settings,
+                "upstream_http_max_keepalive_connections",
+                DEFAULT_UPSTREAM_HTTP_MAX_KEEPALIVE_CONNECTIONS,
+            )
+        ),
+        keepalive_expiry=float(
+            _setting(
+                general_settings,
+                "upstream_http_keepalive_expiry_seconds",
+                DEFAULT_UPSTREAM_HTTP_KEEPALIVE_EXPIRY_SECONDS,
+            )
+        ),
+    )
+
+
+def build_upstream_http_client(general_settings: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        timeout=build_upstream_http_timeout(general_settings),
+        limits=build_upstream_http_limits(general_settings),
+    )
+
+
+def build_control_http_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        timeout=httpx.Timeout(
+            timeout=CONTROL_HTTP_TIMEOUT_SECONDS,
+            connect=CONTROL_HTTP_CONNECT_TIMEOUT_SECONDS,
+            read=CONTROL_HTTP_READ_TIMEOUT_SECONDS,
+            write=CONTROL_HTTP_WRITE_TIMEOUT_SECONDS,
+            pool=CONTROL_HTTP_POOL_TIMEOUT_SECONDS,
+        ),
+        limits=httpx.Limits(
+            max_connections=CONTROL_HTTP_MAX_CONNECTIONS,
+            max_keepalive_connections=CONTROL_HTTP_MAX_KEEPALIVE_CONNECTIONS,
+            keepalive_expiry=CONTROL_HTTP_KEEPALIVE_EXPIRY_SECONDS,
+        ),
+    )
+
+
+def build_control_request_timeout(timeout_seconds: float | int | None = None) -> httpx.Timeout:
+    return httpx.Timeout(
+        connect=CONTROL_HTTP_CONNECT_TIMEOUT_SECONDS,
+        read=float(timeout_seconds or CONTROL_HTTP_READ_TIMEOUT_SECONDS),
+        write=CONTROL_HTTP_WRITE_TIMEOUT_SECONDS,
+        pool=CONTROL_HTTP_POOL_TIMEOUT_SECONDS,
+    )
+
+
+def configured_timeout_seconds(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    parsed = float(value)
+    return parsed if parsed > 0 else None
+
+
+def build_upstream_request_timeout(
+    general_settings: Any,
+    timeout_seconds: float | int | None,
+    *,
+    pool_timeout_seconds: float | int | None = None,
+) -> httpx.Timeout:
+    read_timeout = float(
+        timeout_seconds
+        if timeout_seconds is not None
+        else _setting(
+            general_settings,
+            "upstream_http_read_timeout_seconds",
+            DEFAULT_UPSTREAM_HTTP_READ_TIMEOUT_SECONDS,
+        )
+    )
+    return httpx.Timeout(
+        connect=float(
+            _setting(
+                general_settings,
+                "upstream_http_connect_timeout_seconds",
+                DEFAULT_UPSTREAM_HTTP_CONNECT_TIMEOUT_SECONDS,
+            )
+        ),
+        read=read_timeout,
+        write=float(
+            _setting(
+                general_settings,
+                "upstream_http_write_timeout_seconds",
+                DEFAULT_UPSTREAM_HTTP_WRITE_TIMEOUT_SECONDS,
+            )
+        ),
+        pool=float(
+            pool_timeout_seconds
+            if pool_timeout_seconds is not None
+            else _setting(
+                general_settings,
+                "upstream_http_pool_timeout_seconds",
+                DEFAULT_UPSTREAM_HTTP_POOL_TIMEOUT_SECONDS,
+            )
+        ),
+    )
+
+
+def build_health_check_request_timeout(
+    general_settings: Any,
+    *,
+    read_timeout_seconds: float | int,
+    health_check_timeout_seconds: float | int | None,
+) -> httpx.Timeout:
+    configured_pool_timeout = float(
+        _setting(
+            general_settings,
+            "upstream_http_pool_timeout_seconds",
+            DEFAULT_UPSTREAM_HTTP_POOL_TIMEOUT_SECONDS,
+        )
+    )
+    wrapper_timeout = configured_timeout_seconds(health_check_timeout_seconds)
+    pool_timeout = configured_pool_timeout
+    if wrapper_timeout is not None:
+        pool_timeout = min(
+            configured_pool_timeout,
+            max(MIN_HEALTH_CHECK_POOL_TIMEOUT_SECONDS, wrapper_timeout * HEALTH_CHECK_POOL_TIMEOUT_RATIO),
+        )
+    return build_upstream_request_timeout(
+        general_settings,
+        read_timeout_seconds,
+        pool_timeout_seconds=pool_timeout,
+    )
+
+
+def get_upstream_http_settings_from_request(request: Any) -> Any:
+    app_state = getattr(getattr(request, "app", None), "state", None)
+    startup_settings = getattr(app_state, "upstream_http_settings", None)
+    if startup_settings is not None:
+        return startup_settings
+    app_config = getattr(app_state, "app_config", None)
+    return getattr(app_config, "general_settings", None)
+
+
+def build_upstream_request_timeout_for_request(
+    request: Any,
+    timeout_seconds: float | int | None,
+) -> httpx.Timeout:
+    return build_upstream_request_timeout(get_upstream_http_settings_from_request(request), timeout_seconds)

--- a/tests/bootstrap/test_auth_bootstrap.py
+++ b/tests/bootstrap/test_auth_bootstrap.py
@@ -77,6 +77,7 @@ async def test_init_auth_runtime_wires_enabled_handlers(monkeypatch: pytest.Monk
             salt_key="salt",
             settings=SimpleNamespace(redis_degraded_mode="fail_open"),
             http_client="http-client",
+            control_http_client="control-http-client",
         )
     )
 
@@ -88,7 +89,9 @@ async def test_init_auth_runtime_wires_enabled_handlers(monkeypatch: pytest.Monk
     assert app.state.sso_user_repository == "user-repo"
     assert app.state.sso_state_store[0] == "sso-state-store"
     assert app.state.sso_auth_handler[0] == "sso-handler"
+    assert app.state.sso_auth_handler[1]["http_client"] == "control-http-client"
     assert app.state.jwt_auth_handler[0] == "jwt-handler"
+    assert app.state.jwt_auth_handler[1]["http_client"] == "control-http-client"
     assert app.state.custom_auth_manager.registered == ["module.handler"]
     assert runtime.statuses == (
         BootstrapStatus("key_service", "ready"),

--- a/tests/bootstrap/test_email_bootstrap.py
+++ b/tests/bootstrap/test_email_bootstrap.py
@@ -67,6 +67,22 @@ async def test_init_email_runtime_marks_invalid_config_degraded() -> None:
 
 
 @pytest.mark.asyncio
+async def test_init_email_runtime_uses_control_http_client_when_available() -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            email_outbox_repository=None,
+            prisma_manager=SimpleNamespace(client="db-client"),
+            http_client="provider-http-client",
+            control_http_client="control-http-client",
+        )
+    )
+
+    await init_email_runtime(app, _config(email_enabled=False))
+
+    assert app.state.email_delivery_service._http_client == "control-http-client"
+
+
+@pytest.mark.asyncio
 async def test_init_email_runtime_requires_absolute_email_base_url() -> None:
     app = SimpleNamespace(state=_app_state())
 

--- a/tests/bootstrap/test_infrastructure_bootstrap.py
+++ b/tests/bootstrap/test_infrastructure_bootstrap.py
@@ -22,15 +22,28 @@ async def test_init_and_shutdown_infrastructure_runtime(monkeypatch: pytest.Monk
             created["dynamic_initialized"] = True
 
         def get_app_config(self):  # noqa: ANN201
-            return SimpleNamespace(general_settings=SimpleNamespace(), deltallm_settings=SimpleNamespace())
+            return SimpleNamespace(
+                general_settings=SimpleNamespace(
+                    upstream_http_connect_timeout_seconds=7,
+                    upstream_http_read_timeout_seconds=301,
+                    upstream_http_write_timeout_seconds=33,
+                    upstream_http_pool_timeout_seconds=4,
+                    upstream_http_max_connections=123,
+                    upstream_http_max_keepalive_connections=45,
+                    upstream_http_keepalive_expiry_seconds=12,
+                ),
+                deltallm_settings=SimpleNamespace(),
+            )
 
         async def close(self) -> None:
             self.closed = True
 
     class FakeHTTPClient:
-        def __init__(self, timeout) -> None:  # noqa: ANN001
+        def __init__(self, *, timeout, limits) -> None:  # noqa: ANN001
             self.timeout = timeout
+            self.limits = limits
             self.closed = False
+            created.setdefault("http_clients", []).append(self)
 
         async def aclose(self) -> None:
             self.closed = True
@@ -96,7 +109,7 @@ async def test_init_and_shutdown_infrastructure_runtime(monkeypatch: pytest.Monk
     monkeypatch.setattr("src.bootstrap.infrastructure.Redis", FakeRedis)
     monkeypatch.setattr("src.bootstrap.infrastructure.prisma_manager", FakePrismaManager())
     monkeypatch.setattr("src.bootstrap.infrastructure.resolve_salt_key", lambda cfg, settings: "salt")  # noqa: ARG005
-    monkeypatch.setattr("src.bootstrap.infrastructure.httpx.AsyncClient", FakeHTTPClient)
+    monkeypatch.setattr("src.upstream_http.httpx.AsyncClient", FakeHTTPClient)
     monkeypatch.setattr("src.bootstrap.infrastructure.OpenAIAdapter", lambda client: ("openai", client))
     monkeypatch.setattr("src.bootstrap.infrastructure.AzureOpenAIAdapter", lambda client: ("azure", client))
     monkeypatch.setattr("src.bootstrap.infrastructure.AnthropicAdapter", lambda client: ("anthropic", client))
@@ -126,6 +139,22 @@ async def test_init_and_shutdown_infrastructure_runtime(monkeypatch: pytest.Monk
     )
     assert app.state.dynamic_config_manager is runtime.dynamic_config_manager
     assert app.state.salt_key == "salt"
+    assert runtime.http_client.timeout.connect == 7
+    assert runtime.http_client.timeout.read == 301
+    assert runtime.http_client.timeout.write == 33
+    assert runtime.http_client.timeout.pool == 4
+    assert runtime.http_client.limits.max_connections == 123
+    assert runtime.http_client.limits.max_keepalive_connections == 45
+    assert runtime.http_client.limits.keepalive_expiry == 12
+    assert app.state.control_http_client is runtime.control_http_client
+    assert runtime.control_http_client is not runtime.http_client
+    assert runtime.control_http_client.timeout.connect == 5
+    assert runtime.control_http_client.timeout.read == 20
+    assert runtime.control_http_client.timeout.write == 10
+    assert runtime.control_http_client.timeout.pool == 5
+    assert runtime.control_http_client.limits.max_connections == 100
+    assert runtime.control_http_client.limits.max_keepalive_connections == 20
+    assert runtime.control_http_client.limits.keepalive_expiry == 30
     assert app.state.openai_adapter[0] == "openai"
     assert app.state.batch_repository == ("batch-repo", "db-client")
 
@@ -133,5 +162,6 @@ async def test_init_and_shutdown_infrastructure_runtime(monkeypatch: pytest.Monk
 
     assert runtime.dynamic_config_manager.closed is True
     assert runtime.http_client.closed is True
+    assert runtime.control_http_client.closed is True
     assert runtime.redis_client.closed is True
     assert app.state.prisma_manager.disconnected is True

--- a/tests/bootstrap/test_runtime_services_bootstrap.py
+++ b/tests/bootstrap/test_runtime_services_bootstrap.py
@@ -70,7 +70,10 @@ async def test_init_and_shutdown_runtime_services(monkeypatch: pytest.MonkeyPatc
             self.reloaded = True
 
     monkeypatch.setattr("src.bootstrap.runtime_services.MCPGovernanceService", FakeMCPGovernanceService)
-    monkeypatch.setattr("src.bootstrap.runtime_services.StreamableHTTPMCPClient", lambda client: ("mcp-client", client))
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.StreamableHTTPMCPClient",
+        lambda client, **kwargs: ("mcp-client", client, kwargs),
+    )
     monkeypatch.setattr("src.bootstrap.runtime_services.MCPHealthProbe", lambda **kwargs: ("mcp-health", kwargs))
     monkeypatch.setattr("src.bootstrap.runtime_services.MCPToolPolicyEnforcer", lambda limit_counter: ("policy", limit_counter))
     monkeypatch.setattr("src.bootstrap.runtime_services.MCPToolResultCache", lambda cache_backend: ("result-cache", cache_backend))
@@ -93,15 +96,22 @@ async def test_init_and_shutdown_runtime_services(monkeypatch: pytest.MonkeyPatc
             mcp_scope_policy_repository="mcp-scope-policy-repo",
             redis="redis-client",
             http_client="http-client",
+            upstream_http_settings="startup-upstream-settings",
             limit_counter="limit-counter",
             cache_backend="cache-backend",
             prisma_manager=SimpleNamespace(client="db-client"),
         )
     )
 
-    runtime = await init_runtime_services(app, _runtime_config())
+    cfg = _runtime_config()
+    runtime = await init_runtime_services(app, cfg)
 
     assert app.state.prompt_registry_service[0] == "prompt-registry"
+    assert app.state.mcp_transport_client == (
+        "mcp-client",
+        "http-client",
+        {"general_settings": "startup-upstream-settings"},
+    )
     assert app.state.mcp_gateway_service[0] == "mcp-gateway"
     assert app.state.mcp_governance_service.reloaded is True
     assert app.state.governance_invalidation_service.started is True

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -4,12 +4,22 @@ import pytest
 
 from src.config import (
     AppConfig,
+    GeneralSettings,
+    ModelDeployment,
     ModelInfo,
     RouteGroupConfig,
     Settings,
     resolve_app_config_with_secrets,
     resolve_database_settings,
     resolve_salt_key,
+)
+from src.upstream_http import (
+    build_control_request_timeout,
+    build_health_check_request_timeout,
+    build_upstream_http_limits,
+    build_upstream_http_timeout,
+    build_upstream_request_timeout,
+    configured_timeout_seconds,
 )
 
 
@@ -147,6 +157,155 @@ def test_settings_load_database_pool_overrides_from_environment(monkeypatch):
 
     assert settings.db_pool_size == 13
     assert settings.db_pool_timeout == 21
+
+
+def test_general_settings_upstream_http_defaults_build_httpx_config():
+    settings = GeneralSettings()
+
+    timeout = build_upstream_http_timeout(settings)
+    limits = build_upstream_http_limits(settings)
+
+    assert timeout.connect == 10.0
+    assert timeout.read == 300.0
+    assert timeout.write == 30.0
+    assert timeout.pool == 10.0
+    assert limits.max_connections == 500
+    assert limits.max_keepalive_connections == 100
+    assert limits.keepalive_expiry == 60.0
+
+
+def test_general_settings_accepts_custom_upstream_http_values():
+    settings = GeneralSettings.model_validate(
+        {
+            "upstream_http_connect_timeout_seconds": 6,
+            "upstream_http_read_timeout_seconds": 120,
+            "upstream_http_write_timeout_seconds": 25,
+            "upstream_http_pool_timeout_seconds": 3,
+            "upstream_http_max_connections": 80,
+            "upstream_http_max_keepalive_connections": 20,
+            "upstream_http_keepalive_expiry_seconds": 15,
+        }
+    )
+
+    timeout = build_upstream_http_timeout(settings)
+    limits = build_upstream_http_limits(settings)
+
+    assert timeout.connect == 6.0
+    assert timeout.read == 120.0
+    assert timeout.write == 25.0
+    assert timeout.pool == 3.0
+    assert limits.max_connections == 80
+    assert limits.max_keepalive_connections == 20
+    assert limits.keepalive_expiry == 15.0
+
+
+def test_general_settings_rejects_invalid_upstream_http_pool_limits():
+    with pytest.raises(ValueError, match="upstream_http_max_keepalive_connections"):
+        GeneralSettings.model_validate(
+            {
+                "upstream_http_max_connections": 10,
+                "upstream_http_max_keepalive_connections": 11,
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "upstream_http_connect_timeout_seconds",
+        "upstream_http_read_timeout_seconds",
+        "upstream_http_write_timeout_seconds",
+        "upstream_http_pool_timeout_seconds",
+        "upstream_http_max_connections",
+    ],
+)
+def test_general_settings_rejects_non_positive_upstream_http_values(field: str):
+    with pytest.raises(ValueError):
+        GeneralSettings.model_validate({field: 0})
+
+
+def test_upstream_request_timeout_preserves_pool_timeout_with_deployment_override():
+    settings = GeneralSettings.model_validate(
+        {
+            "upstream_http_connect_timeout_seconds": 4,
+            "upstream_http_write_timeout_seconds": 9,
+            "upstream_http_pool_timeout_seconds": 2,
+        }
+    )
+
+    timeout = build_upstream_request_timeout(settings, 180)
+
+    assert timeout.connect == 4.0
+    assert timeout.read == 180.0
+    assert timeout.write == 9.0
+    assert timeout.pool == 2.0
+
+
+def test_upstream_request_timeout_uses_general_fallback_without_override():
+    settings = GeneralSettings.model_validate(
+        {
+            "upstream_http_connect_timeout_seconds": 7,
+            "upstream_http_read_timeout_seconds": 84,
+            "upstream_http_write_timeout_seconds": 11,
+            "upstream_http_pool_timeout_seconds": 2,
+        }
+    )
+
+    timeout = build_upstream_request_timeout(settings, None)
+
+    assert timeout.connect == 7.0
+    assert timeout.read == 84.0
+    assert timeout.write == 11.0
+    assert timeout.pool == 2.0
+
+
+def test_config_model_without_timeout_does_not_create_deployment_override():
+    deployment = ModelDeployment.model_validate(
+        {
+            "model_name": "gpt-4o-mini",
+            "deltallm_params": {
+                "model": "openai/gpt-4o-mini",
+                "api_key": "provider-key",
+            },
+        }
+    )
+
+    params = deployment.deltallm_params.model_dump(exclude_none=True)
+
+    assert "timeout" not in params
+
+
+def test_health_check_request_timeout_caps_pool_below_wrapper_timeout():
+    settings = GeneralSettings.model_validate(
+        {
+            "upstream_http_pool_timeout_seconds": 30,
+        }
+    )
+
+    timeout = build_health_check_request_timeout(
+        settings,
+        read_timeout_seconds=10,
+        health_check_timeout_seconds=5,
+    )
+
+    assert timeout.read == 10.0
+    assert timeout.pool == 4.0
+
+
+def test_control_request_timeout_preserves_control_pool_timeout():
+    timeout = build_control_request_timeout(20)
+
+    assert timeout.connect == 5.0
+    assert timeout.read == 20.0
+    assert timeout.write == 10.0
+    assert timeout.pool == 5.0
+
+
+def test_configured_timeout_seconds_only_uses_explicit_positive_values():
+    assert configured_timeout_seconds(None) is None
+    assert configured_timeout_seconds("") is None
+    assert configured_timeout_seconds(0) is None
+    assert configured_timeout_seconds("12.5") == 12.5
 
 
 def test_model_info_accepts_valid_upstream_max_batch_inputs():

--- a/tests/mcp/test_transport_http.py
+++ b/tests/mcp/test_transport_http.py
@@ -14,7 +14,7 @@ class _FakeHTTPClient:
         self.exc = exc
         self.calls: list[dict[str, object]] = []
 
-    async def post(self, url: str, *, json: dict[str, object], headers: dict[str, str], timeout: float) -> httpx.Response:
+    async def post(self, url: str, *, json: dict[str, object], headers: dict[str, str], timeout: object) -> httpx.Response:
         self.calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
         if self.exc is not None:
             raise self.exc
@@ -50,7 +50,8 @@ async def test_initialize_sends_jsonrpc_request_and_returns_result() -> None:
     client = _FakeHTTPClient(
         _response(200, {"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "github"}}})
     )
-    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+    general_settings = type("GeneralSettings", (), {"upstream_http_pool_timeout_seconds": 2})()
+    transport = StreamableHTTPMCPClient(client, general_settings=general_settings)  # type: ignore[arg-type]
 
     payload = await transport.initialize(
         _server(),
@@ -61,7 +62,9 @@ async def test_initialize_sends_jsonrpc_request_and_returns_result() -> None:
     assert len(client.calls) == 1
     call = client.calls[0]
     assert call["url"] == "https://mcp.example.com"
-    assert call["timeout"] == 5.0
+    timeout = call["timeout"]
+    assert getattr(timeout, "read") == 5.0
+    assert getattr(timeout, "pool") == 2.0
     headers = call["headers"]
     assert isinstance(headers, dict)
     assert headers["Authorization"] == "Bearer secret-token"

--- a/tests/services/test_email_delivery_service.py
+++ b/tests/services/test_email_delivery_service.py
@@ -148,6 +148,34 @@ async def test_resend_provider_returns_provider_message_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resend_provider_preserves_control_pool_timeout() -> None:
+    captured: dict[str, object] = {}
+
+    class FakeHTTPClient:
+        async def post(self, url, *, headers, json, timeout):  # noqa: ANN001, ANN201
+            del url, headers, json
+            captured["timeout"] = timeout
+            return httpx.Response(200, json={"id": "re_msg_123"})
+
+    provider = ResendEmailProvider(FakeHTTPClient(), {"api_key": "re_test"})  # type: ignore[arg-type]
+
+    await provider.send(
+        PreparedEmail(
+            kind="test",
+            provider="resend",
+            to_addresses=("user@example.com",),
+            from_address="DeltaLLM <noreply@example.com>",
+            subject="subject",
+            text_body="body",
+        )
+    )
+
+    timeout = captured["timeout"]
+    assert getattr(timeout, "read") == 20.0
+    assert getattr(timeout, "pool") == 5.0
+
+
+@pytest.mark.asyncio
 async def test_sendgrid_provider_splits_display_name_from_address() -> None:
     captured: dict[str, object] = {}
 
@@ -175,6 +203,34 @@ async def test_sendgrid_provider_splits_display_name_from_address() -> None:
     assert captured["headers"]["authorization"] == "Bearer sg_test"
     assert '"email":"noreply@example.com"' in str(captured["body"])
     assert '"name":"DeltaLLM"' in str(captured["body"])
+
+
+@pytest.mark.asyncio
+async def test_sendgrid_provider_preserves_control_pool_timeout() -> None:
+    captured: dict[str, object] = {}
+
+    class FakeHTTPClient:
+        async def post(self, url, *, headers, json, timeout):  # noqa: ANN001, ANN201
+            del url, headers, json
+            captured["timeout"] = timeout
+            return httpx.Response(202, headers={"X-Message-Id": "sg_msg_123"})
+
+    provider = SendGridEmailProvider(FakeHTTPClient(), {"api_key": "sg_test"})  # type: ignore[arg-type]
+
+    await provider.send(
+        PreparedEmail(
+            kind="test",
+            provider="sendgrid",
+            to_addresses=("user@example.com",),
+            from_address="DeltaLLM <noreply@example.com>",
+            subject="subject",
+            text_body="body",
+        )
+    )
+
+    timeout = captured["timeout"]
+    assert getattr(timeout, "read") == 20.0
+    assert getattr(timeout, "pool") == 5.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -176,6 +176,100 @@ async def test_chat_completion_success(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_chat_completion_uses_global_read_timeout_without_deployment_override(client, test_app):
+    test_app.state.app_config.general_settings.upstream_http_read_timeout_seconds = 123
+    test_app.state.app_config.general_settings.upstream_http_pool_timeout_seconds = 4
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params.pop("timeout", None)
+    captured: dict[str, object] = {}
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del headers
+        captured["timeout"] = timeout
+        assert url.endswith("/chat/completions")
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "model": json["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    assert response.status_code == 200
+    timeout = captured["timeout"]
+    assert getattr(timeout, "read") == 123.0
+    assert getattr(timeout, "pool") == 4.0
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_uses_startup_upstream_http_settings_snapshot(client, test_app):
+    test_app.state.app_config.general_settings.upstream_http_read_timeout_seconds = 123
+    test_app.state.upstream_http_settings = type(
+        "StartupUpstreamHTTPSettings",
+        (),
+        {
+            "upstream_http_read_timeout_seconds": 222,
+            "upstream_http_pool_timeout_seconds": 3,
+        },
+    )()
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params.pop("timeout", None)
+    captured: dict[str, object] = {}
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del url, headers
+        captured["timeout"] = timeout
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "model": json["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    assert response.status_code == 200
+    timeout = captured["timeout"]
+    assert getattr(timeout, "read") == 222.0
+    assert getattr(timeout, "pool") == 3.0
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_success_ignores_router_usage_write_failure(client, test_app):
     async def fail_usage(*args, **kwargs):  # noqa: ANN001, ANN201
         del args, kwargs

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from src.models.errors import (
+    GatewayCapacityError,
     InvalidRequestError,
     NO_HEALTHY_DEPLOYMENTS_CODE,
     RateLimitError,
@@ -15,7 +16,16 @@ from src.models.errors import (
     TimeoutError,
     parse_retry_after_header,
 )
-from src.router import CooldownManager, FallbackConfig, FailoverManager, PassiveHealthTracker, RedisStateBackend
+from src.providers.healthcheck import HealthProbeResult, probe_provider_health
+from src.router import (
+    BackgroundHealthChecker,
+    CooldownManager,
+    FallbackConfig,
+    FailoverManager,
+    HealthCheckConfig,
+    PassiveHealthTracker,
+    RedisStateBackend,
+)
 from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
 
@@ -86,6 +96,42 @@ async def test_failover_applies_timeout_override():
 
 
 @pytest.mark.asyncio
+async def test_failover_applies_timeout_resolver_per_deployment():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback = _deployment("dep-b")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary, fallback]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment.deployment_id == "dep-a":
+            await asyncio.sleep(0.05)
+            return "late-primary"
+        return "fallback-ok"
+
+    def timeout_for_deployment(deployment: Deployment) -> float:
+        return 0.01 if deployment.deployment_id == "dep-a" else 1.0
+
+    data, served = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=run,
+        return_deployment=True,
+        timeout_for_deployment=timeout_for_deployment,
+    )
+
+    assert data == "fallback-ok"
+    assert served.deployment_id == "dep-b"
+    assert attempts == ["dep-a", "dep-b"]
+
+
+@pytest.mark.asyncio
 async def test_cooldown_manager_default_marks_unhealthy_on_third_failure():
     state = RedisStateBackend(redis=None)
     cooldown = CooldownManager(state)
@@ -142,6 +188,7 @@ async def test_cooldown_manager_default_marks_unhealthy_on_third_failure():
             True,
         ),
         (httpx.ReadError("connection reset"), True),
+        (httpx.PoolTimeout("connection pool exhausted"), False),
     ],
 )
 def test_affects_deployment_health_matrix(exc: Exception, expected: bool):
@@ -478,6 +525,49 @@ async def test_failover_classified_fallback_continues_after_upstream_service_una
 
 
 @pytest.mark.asyncio
+async def test_failover_applies_timeout_resolver_to_classified_fallbacks():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback_a = _deployment("dep-b")
+    fallback_b = _deployment("dep-c")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=0,
+            timeout=1.0,
+            context_window_fallbacks={"group-a": ["ctx-fallbacks"]},
+        ),
+        deployment_registry={"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment.deployment_id == "dep-a":
+            raise InvalidRequestError(message="maximum context length reached")
+        if deployment.deployment_id == "dep-b":
+            await asyncio.sleep(0.05)
+            return "late-fallback"
+        return "fallback-ok"
+
+    def timeout_for_deployment(deployment: Deployment) -> float:
+        return 0.01 if deployment.deployment_id == "dep-b" else 1.0
+
+    data, served = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=run,
+        return_deployment=True,
+        timeout_for_deployment=timeout_for_deployment,
+    )
+
+    assert data == "fallback-ok"
+    assert served.deployment_id == "dep-c"
+    assert attempts == ["dep-a", "dep-b", "dep-c"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("status_code", "headers"),
     [
@@ -570,6 +660,134 @@ async def test_passive_health_tracker_ignores_invalid_request_errors():
     )
 
     health = await state.get_health("dep-a")
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+    assert health.get("last_error") is None
+
+
+@pytest.mark.asyncio
+async def test_failover_treats_pool_timeout_as_gateway_capacity_error():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        deployment_registry={"group-a": [primary]},
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+
+    async def run(deployment: Deployment):  # noqa: ARG001, ANN202
+        raise httpx.PoolTimeout("connection pool exhausted")
+
+    with pytest.raises(GatewayCapacityError) as exc_info:
+        await manager.execute_with_failover(primary, "group-a", run)
+
+    assert exc_info.value.code == "upstream_pool_timeout"
+    assert exc_info.value.affects_deployment_health is False
+    health = await state.get_health(primary.deployment_id)
+    assert health.get("healthy", "true") != "false"
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_provider_health_check_preserves_pool_timeout_and_marks_pool_timeout_local():
+    captured: dict[str, object] = {}
+
+    class FakeHTTPClient:
+        async def get(self, url, headers=None, timeout=None):  # noqa: ANN001, ANN201
+            del url, headers
+            captured["timeout"] = timeout
+            raise httpx.PoolTimeout("connection pool exhausted")
+
+    general_settings = type("GeneralSettings", (), {"upstream_http_pool_timeout_seconds": 2})()
+
+    result = await probe_provider_health(
+        FakeHTTPClient(),  # type: ignore[arg-type]
+        {"provider": "openai", "model": "openai/gpt-4o-mini", "api_key": "provider-key"},
+        default_openai_base_url="https://api.openai.com/v1",
+        general_settings=general_settings,
+    )
+
+    timeout = captured["timeout"]
+    assert getattr(timeout, "read") == 10.0
+    assert getattr(timeout, "pool") == 2.0
+    assert result.healthy is False
+    assert result.affects_deployment_health is False
+    assert result.error == "Gateway upstream connection pool exhausted"
+
+
+@pytest.mark.asyncio
+async def test_provider_health_check_caps_pool_timeout_below_health_wrapper_timeout():
+    captured: dict[str, object] = {}
+
+    class FakeHTTPClient:
+        async def get(self, url, headers=None, timeout=None):  # noqa: ANN001, ANN201
+            del url, headers
+            captured["timeout"] = timeout
+            raise httpx.PoolTimeout("connection pool exhausted")
+
+    general_settings = type("GeneralSettings", (), {"upstream_http_pool_timeout_seconds": 30})()
+
+    result = await probe_provider_health(
+        FakeHTTPClient(),  # type: ignore[arg-type]
+        {"provider": "openai", "model": "openai/gpt-4o-mini", "api_key": "provider-key"},
+        default_openai_base_url="https://api.openai.com/v1",
+        general_settings=general_settings,
+        health_check_timeout_seconds=5,
+    )
+
+    timeout = captured["timeout"]
+    assert getattr(timeout, "pool") == 4.0
+    assert result.healthy is False
+    assert result.affects_deployment_health is False
+
+
+@pytest.mark.asyncio
+async def test_provider_health_check_defaults_unresolved_provider_to_openai():
+    captured: dict[str, object] = {}
+
+    class FakeHTTPClient:
+        async def get(self, url, headers=None, timeout=None):  # noqa: ANN001, ANN201
+            captured["url"] = url
+            captured["headers"] = dict(headers or {})
+            captured["timeout"] = timeout
+            return httpx.Response(200, json={"data": []}, request=httpx.Request("GET", url))
+
+    result = await probe_provider_health(
+        FakeHTTPClient(),  # type: ignore[arg-type]
+        {"model": "gpt-4o-mini", "api_key": "provider-key"},
+        default_openai_base_url="https://api.openai.com/v1",
+    )
+
+    assert result.healthy is True
+    assert captured["url"] == "https://api.openai.com/v1/models"
+    assert captured["headers"] == {"Authorization": "Bearer provider-key"}
+    timeout = captured["timeout"]
+    assert getattr(timeout, "read") == 10.0
+
+
+@pytest.mark.asyncio
+async def test_background_health_checker_ignores_non_health_affecting_result():
+    state = RedisStateBackend(redis=None)
+    deployment = _deployment("dep-a")
+    checker = BackgroundHealthChecker(
+        config=HealthCheckConfig(enabled=False),
+        deployment_registry={"group-a": [deployment]},
+        state_backend=state,
+        checker=lambda _: asyncio.sleep(
+            0,
+            result=HealthProbeResult(
+                healthy=False,
+                error="Gateway upstream connection pool exhausted",
+                affects_deployment_health=False,
+            ),
+        ),
+    )
+
+    result = await checker.check_deployment_once(deployment)
+
+    assert result.affects_deployment_health is False
+    health = await state.get_health(deployment.deployment_id)
     assert health.get("healthy", "true") != "false"
     assert int(health.get("consecutive_failures", 0) or 0) == 0
     assert health.get("last_error") is None

--- a/tests/test_provider_compat.py
+++ b/tests/test_provider_compat.py
@@ -185,7 +185,50 @@ async def test_openai_adapter_health_check_uses_custom_auth_headers() -> None:
         assert healthy is True
         assert captured["url"] == "https://vllm.example/v1/models"
         assert captured["headers"] == {"X-API-Key": "provider-key"}
-        assert captured["timeout"] == 10.0
+        timeout = captured["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.read == 10.0
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_openai_adapter_health_check_defaults_provider_when_missing() -> None:
+    adapter = OpenAIAdapter(httpx.AsyncClient())
+    try:
+        captured: dict[str, object] = {}
+
+        async def fake_get(url, headers, timeout):  # noqa: ANN001, ANN201
+            captured["url"] = url
+            captured["headers"] = dict(headers)
+            captured["timeout"] = timeout
+            return httpx.Response(200, json={"data": []}, request=httpx.Request("GET", url))
+
+        adapter.http_client.get = fake_get  # type: ignore[method-assign]
+
+        healthy = await adapter.health_check({"api_key": "provider-key"})
+
+        assert healthy is True
+        assert captured["url"] == "https://api.openai.com/v1/models"
+        assert captured["headers"] == {"Authorization": "Bearer provider-key"}
+        timeout = captured["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.read == 10.0
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_openai_adapter_health_check_returns_false_on_unexpected_error() -> None:
+    adapter = OpenAIAdapter(httpx.AsyncClient())
+    try:
+        async def fake_get(url, headers, timeout):  # noqa: ANN001, ANN201
+            del url, headers, timeout
+            raise RuntimeError("unexpected client failure")
+
+        adapter.http_client.get = fake_get  # type: ignore[method-assign]
+
+        assert await adapter.health_check({"api_key": "provider-key"}) is False
     finally:
         await adapter.http_client.aclose()
 

--- a/tests/test_provider_model_discovery.py
+++ b/tests/test_provider_model_discovery.py
@@ -89,9 +89,12 @@ async def test_provider_model_discovery_catalog_matches_current_provider_models(
 @pytest.mark.asyncio
 async def test_provider_model_discovery_merges_catalog_and_live_results(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.app_config.general_settings.upstream_http_pool_timeout_seconds = 2
+    captured: dict[str, object] = {}
 
-    async def get(url: str, headers: dict[str, str] | None = None, timeout: float = 10.0):  # noqa: ANN201
-        del headers, timeout
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        del headers
+        captured["timeout"] = timeout
         assert url == "https://api.openai.com/v1/models"
         return httpx.Response(
             200,
@@ -119,6 +122,9 @@ async def test_provider_model_discovery_merges_catalog_and_live_results(client, 
     assert models["gpt-4o"]["known_metadata"]["max_tokens"] == 128000
     assert models["gpt-5-custom"]["source"] == "provider_api"
     assert models["gpt-5-custom"]["known_metadata"] is None
+    timeout = captured["timeout"]
+    assert getattr(timeout, "read") == 10.0
+    assert getattr(timeout, "pool") == 2.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_uniformity_hardening.py
+++ b/tests/test_uniformity_hardening.py
@@ -9,6 +9,7 @@ import pytest
 from src.billing.budget import BudgetExceeded
 from src.services.limit_counter import LimitCounter, RateLimitCheck
 from src.models.errors import RateLimitError, ServiceUnavailableError
+from src.router.router import Deployment, RouteGroupPolicy
 
 
 class _AlwaysBudgetExceeded:
@@ -30,6 +31,26 @@ class _SpendRecorder:
             exc = kwargs.get("exc")
             error_type = getattr(exc, "error_type", None) or (exc.__class__.__name__ if exc is not None else None)
         self.events.append({"status": "error", "cost": 0.0, "error_type": error_type, **kwargs})
+
+
+class _CapturingFailoverManager:
+    def __init__(self, captured: dict[str, object]) -> None:
+        self.captured = captured
+
+    async def execute_with_failover(
+        self,
+        *,
+        primary_deployment,
+        model_group,
+        execute,
+        return_deployment=False,
+        **kwargs,
+    ):  # noqa: ANN001, ANN003, ANN201
+        del model_group
+        self.captured["failover_timeout_seconds"] = kwargs.get("timeout_seconds")
+        self.captured["timeout_for_deployment"] = kwargs.get("timeout_for_deployment")
+        data = await execute(primary_deployment)
+        return (data, primary_deployment) if return_deployment else data
 
 
 class _RecordingAuditService:
@@ -373,6 +394,115 @@ async def test_audio_transcription_spend_log_includes_billing_metadata(client, t
     assert billing["billing_unit"] == "second"
     assert billing["cost"] == 0.5
     assert billing["usage_snapshot"]["duration_seconds"] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_audio_transcription_preserves_600_second_default_timeout(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params.pop("timeout", None)
+    test_app.state.app_config.general_settings.upstream_http_read_timeout_seconds = 123
+    captured: dict[str, object] = {}
+
+    async def post(url, headers=None, json=None, timeout=None, files=None, data=None):  # noqa: ANN001, ANN201
+        del headers, json, files, data
+        captured["timeout"] = timeout
+        return httpx.Response(200, json={"text": "hello"}, request=httpx.Request("POST", url))
+
+    test_app.state.failover_manager = _CapturingFailoverManager(captured)
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/transcriptions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        data={"model": "gpt-4o-mini", "response_format": "json"},
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    timeout = captured["timeout"]
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read == 600.0
+    assert captured["failover_timeout_seconds"] is None
+    timeout_for_deployment = captured["timeout_for_deployment"]
+    assert callable(timeout_for_deployment)
+    assert timeout_for_deployment(deployment) == 600.0
+
+
+@pytest.mark.asyncio
+async def test_audio_transcription_short_primary_timeout_uses_per_deployment_failover_timeout(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["timeout"] = 60
+    fallback = Deployment(
+        deployment_id="gpt-4o-mini-fallback",
+        model_name="gpt-4o-mini",
+        deltallm_params={
+            "model": "openai/gpt-4o-mini",
+            "api_key": "fallback-key",
+            "api_base": "https://fallback.example/v1",
+        },
+    )
+    test_app.state.router.deployment_registry["gpt-4o-mini"].append(fallback)
+    captured: dict[str, object] = {}
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return deployment
+
+    async def post(url, headers=None, json=None, timeout=None, files=None, data=None):  # noqa: ANN001, ANN201
+        del headers, json, files, data
+        captured["timeout"] = timeout
+        return httpx.Response(200, json={"text": "hello"}, request=httpx.Request("POST", url))
+
+    test_app.state.router.select_deployment = choose_primary
+    test_app.state.failover_manager = _CapturingFailoverManager(captured)
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/transcriptions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        data={"model": "gpt-4o-mini", "response_format": "json"},
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    timeout = captured["timeout"]
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read == 60.0
+    assert captured["failover_timeout_seconds"] is None
+    timeout_for_deployment = captured["timeout_for_deployment"]
+    assert callable(timeout_for_deployment)
+    assert timeout_for_deployment(deployment) == 60.0
+    assert timeout_for_deployment(fallback) == 600.0
+
+
+@pytest.mark.asyncio
+async def test_audio_transcription_route_policy_timeout_overrides_default_failover_timeout(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params.pop("timeout", None)
+    test_app.state.router.config.route_group_policies["gpt-4o-mini"] = RouteGroupPolicy(timeout_seconds=45)
+    captured: dict[str, object] = {}
+
+    async def post(url, headers=None, json=None, timeout=None, files=None, data=None):  # noqa: ANN001, ANN201
+        del headers, json, files, data
+        captured["timeout"] = timeout
+        return httpx.Response(200, json={"text": "hello"}, request=httpx.Request("POST", url))
+
+    test_app.state.failover_manager = _CapturingFailoverManager(captured)
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/transcriptions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        data={"model": "gpt-4o-mini", "response_format": "json"},
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert captured["failover_timeout_seconds"] == 45.0
+    assert captured["timeout_for_deployment"] is None
+    timeout = captured["timeout"]
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read == 600.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add shared upstream and control-plane HTTP clients with explicit timeout and connection-pool settings.
- Route provider calls, health checks, model discovery, MCP upstream calls, auth/JWT/SSO, and email through the appropriate shared client.
- Map local upstream pool exhaustion to a gateway capacity error that does not mark provider deployments unhealthy.
- Preserve audio transcription's 600s default while using per-deployment failover timeouts so short primaries do not cap long-running fallbacks.
- Document production tuning, Helm values, and config options for Kubernetes deployments.

## Why
Closes #131.

Issue #131 calls for upstream HTTP pool controls so gateway replicas behave predictably under load. The previous request model relied on implicit client behavior and could mix local gateway capacity problems with provider health.

## Impact
- Improves gateway reliability under concurrent upstream traffic by bounding connection behavior explicitly.
- Keeps latency behavior predictable through shared client reuse instead of repeated ad hoc clients.
- Gives Kubernetes/Helm deployments documented tuning knobs for replica-level and upstream capacity planning.

## Validation
- `uv run --extra dev ruff check src tests`
- `uv run --extra dev pytest tests/test_uniformity_hardening.py tests/bootstrap/test_runtime_services_bootstrap.py tests/config/test_settings.py tests/test_failover.py`
- `git diff --check`

Targeted pytest result: `105 passed`; only existing `pytest-asyncio` deprecation warnings were observed.