### PR TITLE
Make explicit provider authoritative

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,7 @@ model_list:
   # Keep this if you want to bootstrap one OpenAI-backed chat model on first start.
   - model_name: gpt-4o-mini
     deltallm_params:
+      provider: openai
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY
       api_base: https://api.openai.com/v1

--- a/docs/admin-ui/models.md
+++ b/docs/admin-ui/models.md
@@ -5,6 +5,7 @@ The Models page is where operators create and manage concrete provider-backed de
 Each deployment defines:
 
 - the public model name clients will call
+- the provider identity used for routing visibility, spend reports, callbacks, and dashboards
 - the upstream provider model ID
 - credentials and connection details, either inline or through a shared named credential
 - the workload type, such as chat or embeddings
@@ -35,9 +36,10 @@ Each deployment defines:
 For a simple first deployment:
 
 1. Set `model_name` to the public name you want clients to use
-2. Set `deltallm_params.model` to the provider-prefixed upstream model ID
-3. Add the provider API key inline, or select a shared named credential
-4. Keep the default mode as `chat` unless this is an embeddings, image, audio, or rerank model
+2. Choose the provider
+3. Set `deltallm_params.model` to the upstream model ID
+4. Add the provider API key inline, or select a shared named credential
+5. Keep the default mode as `chat` unless this is an embeddings, image, audio, or rerank model
 
 If you do not set a `deployment_id`, DeltaLLM creates one automatically.
 
@@ -52,7 +54,7 @@ Do not use access groups for routing. Deployment tags remain routing metadata an
 ## What the Table Tells You
 
 - **Model Name**: the public runtime model name
-- **Provider**: resolved provider type such as OpenAI or Groq
+- **Provider**: explicit deployment provider such as OpenAI or Groq
 - **Type**: runtime mode such as `chat` or `embedding`
 - **Deployment ID**: the internal ID used by route groups and policies
 - **Health**: whether the runtime currently sees the deployment as healthy
@@ -114,6 +116,7 @@ For shared gateway credentials, [Named Credentials](named-credentials.md) remain
 ## Operational Notes
 
 - DeltaLLM validates provider and mode compatibility when you create or update a deployment
+- The explicit provider is the source of truth for dashboards, spend reports, callbacks, and metrics
 - Shared provider credentials are best managed through [Named Credentials](named-credentials.md)
 - Creating, updating, and deleting deployments requires admin access
 - Readable deployment IDs make later route-group work easier

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -23,6 +23,7 @@ For most teams, use this model lifecycle:
 model_list:
   - model_name: gpt-4o-mini
     deltallm_params:
+      provider: openai
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY
       api_base: https://api.openai.com/v1
@@ -60,18 +61,19 @@ After the initial seed, set `model_deployment_bootstrap_from_config` back to `fa
 
 ## Fields You Usually Need
 
-| Field | Required | What it means |
-|-------|----------|---------------|
-| `model_name` | Yes | Public model name clients send in API requests |
-| `deltallm_params.model` | Yes | Provider-prefixed upstream model ID, such as `openai/gpt-4o-mini` |
-| `deltallm_params.api_key` | Yes | Provider API key |
-| `deltallm_params.api_base` | No | Custom provider base URL |
-| `deltallm_params.auth_header_name` | No | Custom upstream auth header key for supported OpenAI-compatible providers |
-| `deltallm_params.auth_header_format` | No | Custom upstream auth header value template, must include `{api_key}` |
-| `deltallm_params.timeout` | No | Upstream timeout in seconds |
-| `deltallm_params.weight` | No | Relative weight when multiple deployments share one public model |
-| `model_info.mode` | No | Runtime workload type such as `chat`, `embedding`, or `rerank` |
-| `model_info.access_groups` | No | Authorization groups attached to the public callable target |
+| Field | Status | What it means |
+|-------|--------|---------------|
+| `model_name` | Required | Public model name clients send in API requests |
+| `deltallm_params.provider` | Recommended for new config; required by the admin UI/API | Authoritative provider identity for routing visibility, dashboards, spend, callbacks, and metrics |
+| `deltallm_params.model` | Required | Upstream model ID sent to the provider; provider prefixes remain supported as legacy/import fallback |
+| `deltallm_params.api_key` | Required | Provider API key |
+| `deltallm_params.api_base` | Optional | Custom provider base URL |
+| `deltallm_params.auth_header_name` | Optional | Custom upstream auth header key for supported OpenAI-compatible providers |
+| `deltallm_params.auth_header_format` | Optional | Custom upstream auth header value template, must include `{api_key}` |
+| `deltallm_params.timeout` | Optional | Upstream timeout in seconds |
+| `deltallm_params.weight` | Optional | Relative weight when multiple deployments share one public model |
+| `model_info.mode` | Optional | Runtime workload type such as `chat`, `embedding`, or `rerank` |
+| `model_info.access_groups` | Optional | Authorization groups attached to the public callable target |
 | `model_info.tags` | No | Routing tags for deployment selection; not authorization |
 
 ## Custom Upstream Auth Headers
@@ -102,6 +104,7 @@ Example config-file deployment for a vLLM gateway that expects `X-API-Key`:
 model_list:
   - model_name: support-vllm
     deltallm_params:
+      provider: vllm
       model: vllm/meta-llama/Llama-3.1-8B-Instruct
       api_key: os.environ/VLLM_GATEWAY_KEY
       api_base: https://vllm.example/v1
@@ -125,11 +128,13 @@ You can attach more than one deployment to the same public model name by repeati
 model_list:
   - model_name: gpt-4o
     deltallm_params:
+      provider: openai
       model: openai/gpt-4o
       api_key: os.environ/OPENAI_API_KEY
 
   - model_name: gpt-4o
     deltallm_params:
+      provider: azure_openai
       model: azure/gpt-4o-deployment
       api_key: os.environ/AZURE_API_KEY
       api_base: https://your-resource.openai.azure.com
@@ -156,6 +161,7 @@ DeltaLLM supports several runtime modes. Use `model_info.mode` when the deployme
 model_list:
   - model_name: whisper-large
     deltallm_params:
+      provider: groq
       model: groq/whisper-large-v3-turbo
       api_key: os.environ/GROQ_API_KEY
     model_info:
@@ -211,6 +217,7 @@ processed by the async batch worker. It does not change synchronous
 model_list:
   - model_name: text-embedding-3-large
     deltallm_params:
+      provider: openai
       model: openai/text-embedding-3-large
       api_key: os.environ/OPENAI_API_KEY
     model_info:
@@ -239,6 +246,7 @@ Pricing metadata powers spend tracking.
 model_list:
   - model_name: gpt-4o-mini
     deltallm_params:
+      provider: openai
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY
     model_info:
@@ -252,6 +260,7 @@ Default parameters let you inject request defaults for a deployment.
 model_list:
   - model_name: gpt-4o-mini
     deltallm_params:
+      provider: openai
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY
     model_info:
@@ -262,9 +271,9 @@ model_list:
 
 User-supplied request values still take priority over these defaults.
 
-## Provider Prefixes
+## Provider Prefix Fallback
 
-Use a provider prefix in `deltallm_params.model`.
+For new deployments, set `deltallm_params.provider`. Provider prefixes in `deltallm_params.model` remain supported for legacy config/import fallback, but they are not the source of truth when `provider` is present. The admin UI/API requires an explicit provider for created or updated deployments.
 
 | Provider | Prefix | Example |
 |----------|--------|---------|

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -325,6 +325,7 @@ config:
   model_list:
     - model_name: gpt-4o
       deltallm_params:
+        provider: openai
         model: openai/gpt-4o
         api_key: os.environ/OPENAI_API_KEY
         api_base: https://api.openai.com/v1

--- a/docs/features/batching.md
+++ b/docs/features/batching.md
@@ -276,6 +276,7 @@ Micro-batching is configured per model deployment, not globally. Set `upstream_m
 model_list:
   - model_name: text-embedding-3-small
     deltallm_params:
+      provider: openai
       model: openai/text-embedding-3-small
       api_key: os.environ/OPENAI_API_KEY
     model_info:

--- a/docs/features/budgets.md
+++ b/docs/features/budgets.md
@@ -33,6 +33,7 @@ Spend is based on the pricing metadata attached to the served model deployment.
 model_list:
   - model_name: gpt-4o-mini
     deltallm_params:
+      provider: openai
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY
     model_info:

--- a/docs/features/rate-limiting.md
+++ b/docs/features/rate-limiting.md
@@ -165,6 +165,7 @@ Deployment limits are declared in model configuration:
 model_list:
   - model_name: gpt-4
     litellm_params:
+      provider: openai
       model: openai/gpt-4
     model_info:
       rpm_limit: 500

--- a/docs/features/routing.md
+++ b/docs/features/routing.md
@@ -18,6 +18,7 @@ model_list:
   - model_name: gpt-4o-mini
     deployment_id: openai-primary
     deltallm_params:
+      provider: openai
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY
     model_info:
@@ -26,6 +27,7 @@ model_list:
   - model_name: gpt-4o-mini
     deployment_id: openai-secondary
     deltallm_params:
+      provider: openai
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY_2
     model_info:
@@ -121,11 +123,11 @@ Setup:
 model_list:
   - model_name: gpt-4o-mini
     deployment_id: primary
-    deltallm_params: {model: openai/gpt-4o-mini}
+    deltallm_params: {provider: openai, model: openai/gpt-4o-mini}
     model_info: {weight: 9}
   - model_name: gpt-4o-mini
     deployment_id: canary
-    deltallm_params: {model: openai/gpt-4o-mini}
+    deltallm_params: {provider: openai, model: openai/gpt-4o-mini}
     model_info: {weight: 1}
 
 router_settings:
@@ -152,11 +154,11 @@ Setup:
 model_list:
   - model_name: gpt-4o-mini
     deployment_id: primary
-    deltallm_params: {model: openai/gpt-4o-mini}
+    deltallm_params: {provider: openai, model: openai/gpt-4o-mini}
     model_info: {priority: 0}
   - model_name: gpt-4o-mini
     deployment_id: standby
-    deltallm_params: {model: openai/gpt-4o-mini}
+    deltallm_params: {provider: openai, model: openai/gpt-4o-mini}
     model_info: {priority: 1}
 
 router_settings:
@@ -247,11 +249,11 @@ Setup:
 model_list:
   - model_name: gpt-4o-mini
     deployment_id: east
-    deltallm_params: {model: openai/gpt-4o-mini}
+    deltallm_params: {provider: openai, model: openai/gpt-4o-mini}
     model_info: {rpm_limit: 600, tpm_limit: 300000}
   - model_name: gpt-4o-mini
     deployment_id: west
-    deltallm_params: {model: openai/gpt-4o-mini}
+    deltallm_params: {provider: openai, model: openai/gpt-4o-mini}
     model_info: {rpm_limit: 600, tpm_limit: 300000}
 
 router_settings:
@@ -312,11 +314,11 @@ Setup:
 model_list:
   - model_name: gpt-4o-mini
     deployment_id: eu
-    deltallm_params: {model: openai/gpt-4o-mini}
+    deltallm_params: {provider: openai, model: openai/gpt-4o-mini}
     model_info: {tags: ["eu"]}
   - model_name: gpt-4o-mini
     deployment_id: us
-    deltallm_params: {model: openai/gpt-4o-mini}
+    deltallm_params: {provider: openai, model: openai/gpt-4o-mini}
     model_info: {tags: ["us"]}
 ```
 

--- a/src/api/admin/endpoints/spend.py
+++ b/src/api/admin/endpoints/spend.py
@@ -121,10 +121,10 @@ def _canonical_provider_expr(
     model_provider_expr = _provider_from_model_expr(f"{table_alias}.model")
     return f"""
         COALESCE(
-            {api_base_provider_expr},
             NULLIF(LOWER(TRIM(COALESCE({metadata_provider_column}, ''))), ''),
             NULLIF(LOWER(TRIM({provider_column})), ''),
             {legacy_cache_provider_expr},
+            {api_base_provider_expr},
             {deployment_model_provider_expr},
             {model_provider_expr},
             'unknown'

--- a/src/callbacks/payload.py
+++ b/src/callbacks/payload.py
@@ -62,9 +62,13 @@ def _usage_from_response(response_obj: dict[str, Any] | None) -> TokenUsage:
     )
 
 
-def _api_provider(deployment_model: str | None) -> str:
+def _api_provider(deployment_model: str | None, explicit_provider: str | None = None) -> str:
+    provider = str(explicit_provider or "").strip().lower()
+    if provider:
+        return provider
     if deployment_model and "/" in deployment_model:
-        return deployment_model.split("/", 1)[0]
+        provider = deployment_model.split("/", 1)[0].strip().lower()
+        return provider or "unknown"
     return "unknown"
 
 
@@ -84,6 +88,7 @@ def build_standard_logging_payload(
     cache_key: str | None = None,
     response_cost: float = 0.0,
     api_latency_ms: float | None = None,
+    api_provider: str | None = None,
     error_info: dict[str, Any] | None = None,
     turn_off_message_logging: bool = False,
 ) -> StandardLoggingPayload:
@@ -126,7 +131,7 @@ def build_standard_logging_payload(
         end_time=end_time,
         total_latency_ms=max(0.0, (end_time - start_time).total_seconds() * 1000),
         api_latency_ms=api_latency_ms,
-        api_provider=_api_provider(deployment_model),
+        api_provider=_api_provider(deployment_model, api_provider),
         api_base=api_base,
         error_info=error_info,
     )

--- a/src/chat/telemetry.py
+++ b/src/chat/telemetry.py
@@ -81,6 +81,7 @@ async def emit_stream_success(
         api_base=api_base,
         cache_hit=cache_hit,
         cache_key=cache_key,
+        api_provider=resolve_provider(params),
         turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
     )
     callback_manager.dispatch_success_callbacks(callback_payload)
@@ -195,6 +196,7 @@ async def emit_stream_failure(
         api_base=failure_fields["api_base"],
         cache_hit=cache_hit,
         cache_key=cache_key,
+        api_provider=failure_fields["provider"],
         error_info={
             "error_type": getattr(exc, "error_type", None) or exc.__class__.__name__,
             "message": str(exc),
@@ -346,6 +348,7 @@ async def emit_nonstream_success(
         cache_key=cache_key,
         response_cost=request_cost,
         api_latency_ms=api_latency_ms,
+        api_provider=api_provider,
         turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
     )
     callback_manager.dispatch_success_callbacks(callback_payload)
@@ -487,6 +490,7 @@ async def emit_nonstream_failure(
         api_base=failure_fields["api_base"],
         cache_hit=cache_hit,
         cache_key=cache_key,
+        api_provider=str(failure_fields["provider"] or api_provider),
         error_info={"error_type": exc.__class__.__name__, "message": str(exc)},
         turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
     )

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -258,6 +258,7 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
             deployment_model=deployment_model, request_payload=request_data, response_obj={"bytes": len(audio_bytes)},
             user_api_key_dict=auth.model_dump(mode="json"), start_time=callback_start, end_time=datetime.now(tz=UTC),
             api_base=api_base, response_cost=request_cost, api_latency_ms=api_latency_ms,
+            api_provider=api_provider,
             turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
         )
         callback_manager.dispatch_success_callbacks(callback_payload)

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -280,6 +280,7 @@ async def audio_transcriptions(
             deployment_model=deployment_model, request_payload=request_data, response_obj=data,
             user_api_key_dict=auth.model_dump(mode="json"), start_time=callback_start, end_time=datetime.now(tz=UTC),
             api_base=api_base, response_cost=request_cost, api_latency_ms=api_latency_ms,
+            api_provider=api_provider,
             turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
         )
         callback_manager.dispatch_success_callbacks(callback_payload)

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -328,6 +328,7 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
             api_base=api_base,
             response_cost=request_cost,
             api_latency_ms=api_latency_ms,
+            api_provider=api_provider,
             turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
         )
         callback_manager.dispatch_success_callbacks(callback_payload)
@@ -387,6 +388,7 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
             deployment_model=failure_deployment_model, request_payload=request_data, response_obj=None,
             user_api_key_dict=auth.model_dump(mode="json"), start_time=callback_start, end_time=datetime.now(tz=UTC),
             api_base=failure_api_base,
+            api_provider=failure_provider,
             error_info={"error_type": exc.__class__.__name__, "message": str(exc)},
             turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
         )
@@ -453,6 +455,7 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
             deployment_model=failure_deployment_model, request_payload=request_data, response_obj=None,
             user_api_key_dict=auth.model_dump(mode="json"), start_time=callback_start, end_time=datetime.now(tz=UTC),
             api_base=failure_api_base,
+            api_provider=failure_provider,
             error_info={"error_type": exc.__class__.__name__, "message": str(exc)},
             turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
         )

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -212,6 +212,7 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
             deployment_model=deployment_model, request_payload=request_data, response_obj=data,
             user_api_key_dict=auth.model_dump(mode="json"), start_time=callback_start, end_time=datetime.now(tz=UTC),
             api_base=api_base, response_cost=request_cost, api_latency_ms=api_latency_ms,
+            api_provider=api_provider,
             turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
         )
         callback_manager.dispatch_success_callbacks(callback_payload)

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -204,6 +204,7 @@ async def rerank(request: Request, payload: RerankRequest):
             deployment_model=deployment_model, request_payload=request_data, response_obj=data,
             user_api_key_dict=auth.model_dump(mode="json"), start_time=callback_start, end_time=datetime.now(tz=UTC),
             api_base=api_base, response_cost=request_cost, api_latency_ms=api_latency_ms,
+            api_provider=api_provider,
             turn_off_message_logging=bool(getattr(request.app.state, "turn_off_message_logging", False)),
         )
         callback_manager.dispatch_success_callbacks(callback_payload)

--- a/tests/callbacks/test_payload.py
+++ b/tests/callbacks/test_payload.py
@@ -27,3 +27,39 @@ def test_payload_builder_respects_turn_off_message_logging() -> None:
     assert payload.messages is None
     assert payload.tags == ["a", "b"]
     assert payload.usage.total_tokens == 5
+
+
+def test_payload_builder_prefers_explicit_provider_over_deployment_model_prefix() -> None:
+    payload = build_standard_logging_payload(
+        call_type="completion",
+        request_id="req-groq",
+        model="oss-chat",
+        deployment_model="openai/gpt-oss-120b",
+        request_payload={"messages": [{"role": "user", "content": "hello"}]},
+        response_obj={"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}},
+        user_api_key_dict={"api_key": "hashed"},
+        start_time=datetime.now(tz=UTC),
+        end_time=datetime.now(tz=UTC),
+        api_base="https://api.groq.com/openai/v1",
+        api_provider="groq",
+    )
+
+    assert payload.api_provider == "groq"
+    assert payload.deployment_model == "openai/gpt-oss-120b"
+
+
+def test_payload_builder_keeps_deployment_model_prefix_fallback() -> None:
+    payload = build_standard_logging_payload(
+        call_type="completion",
+        request_id="req-legacy",
+        model="legacy-chat",
+        deployment_model="openai/gpt-4o-mini",
+        request_payload={"messages": [{"role": "user", "content": "hello"}]},
+        response_obj=None,
+        user_api_key_dict={"api_key": "hashed"},
+        start_time=datetime.now(tz=UTC),
+        end_time=datetime.now(tz=UTC),
+        api_base="https://api.openai.com/v1",
+    )
+
+    assert payload.api_provider == "openai"

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -385,6 +385,31 @@ def test_build_spend_event_infers_groq_from_openai_compatible_api_base() -> None
     assert event["provider"] == "groq"
 
 
+def test_build_spend_event_prefers_explicit_provider_over_api_base_and_model_prefix() -> None:
+    event = build_spend_event(
+        request_id="req_explicit_groq",
+        api_key="key_hash",
+        user_id=None,
+        team_id=None,
+        organization_id=None,
+        end_user_id=None,
+        model="openai/gpt-oss-120b",
+        call_type="completion",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        cost=0.01,
+        metadata={
+            "provider": "groq",
+            "api_base": "https://api.openai.com/v1",
+            "deployment_model": "openai/gpt-oss-120b",
+        },
+        cache_hit=False,
+        start_time=datetime.now(tz=UTC),
+        end_time=datetime.now(tz=UTC),
+    )
+
+    assert event["provider"] == "groq"
+
+
 @pytest.mark.asyncio
 async def test_spend_tracking_preserves_explicit_provider_for_cache_rows():
     db = RecordingDB()

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -32,14 +32,18 @@ class RecordingCallback(CustomLogger):
     def __init__(self):
         self.success = 0
         self.failure = 0
+        self.success_payloads: list[dict] = []
+        self.failure_payloads: list[dict] = []
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
-        del kwargs, response_obj, start_time, end_time
+        del response_obj, start_time, end_time
         self.success += 1
+        self.success_payloads.append(dict(kwargs))
 
     async def async_log_failure_event(self, kwargs, exception, start_time, end_time):
-        del kwargs, exception, start_time, end_time
+        del exception, start_time, end_time
         self.failure += 1
+        self.failure_payloads.append(dict(kwargs))
 
 
 class BlockingMCPToolGuardrail(CustomGuardrail):
@@ -730,11 +734,50 @@ async def test_chat_completion_runs_success_callback(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_chat_completion_uses_explicit_provider_for_callbacks_and_spend(client, test_app):
+    recorder = RecordingCallback()
+    manager = CallbackManager()
+    manager.register_callback(recorder, callback_type="success")
+    test_app.state.callback_manager = manager
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params.update(
+        {
+            "provider": "groq",
+            "model": "openai/gpt-oss-120b",
+            "api_base": "https://api.groq.com/openai/v1",
+        }
+    )
+
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False}
+
+    response = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert response.status_code == 200
+    await asyncio.sleep(0.05)
+
+    assert recorder.success == 1
+    assert recorder.success_payloads[-1]["api_provider"] == "groq"
+    assert recorder.success_payloads[-1]["deployment_model"] == "openai/gpt-oss-120b"
+    spend_event = test_app.state.spend_tracking_service.events[-1]
+    assert spend_event["metadata"]["provider"] == "groq"
+    assert spend_event["metadata"]["deployment_model"] == "openai/gpt-oss-120b"
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_runs_failure_callback(client, test_app):
     recorder = RecordingCallback()
     manager = CallbackManager()
     manager.register_callback(recorder, callback_type="failure")
     test_app.state.callback_manager = manager
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params.update(
+        {
+            "provider": "groq",
+            "model": "openai/gpt-oss-120b",
+            "api_base": "https://api.groq.com/openai/v1",
+        }
+    )
 
     async def failing_post(url, headers, json, timeout):  # noqa: ANN001, ANN201
         import httpx
@@ -750,6 +793,8 @@ async def test_chat_completion_runs_failure_callback(client, test_app):
     assert response.status_code == 503
     await asyncio.sleep(0.05)
     assert recorder.failure == 1
+    assert recorder.failure_payloads[-1]["api_provider"] == "groq"
+    assert recorder.failure_payloads[-1]["deployment_model"] == "openai/gpt-oss-120b"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_models.py
+++ b/tests/test_ui_models.py
@@ -706,6 +706,38 @@ async def test_provider_health_summary_counts_models_beyond_paginated_limit(clie
 
 
 @pytest.mark.asyncio
+async def test_model_dashboard_uses_explicit_provider_over_model_prefix(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.model_registry = {
+        "oss-chat": [
+            {
+                "deployment_id": "dep-groq-oss",
+                "deltallm_params": {
+                    "provider": "groq",
+                    "model": "openai/gpt-oss-120b",
+                    "api_base": "https://api.groq.com/openai/v1",
+                    "api_key": "provider-key",
+                },
+            }
+        ]
+    }
+
+    models_response = await client.get("/ui/api/models", headers={"Authorization": "Bearer mk-test"})
+    health_response = await client.get("/ui/api/models/provider-health-summary", headers={"Authorization": "Bearer mk-test"})
+
+    assert models_response.status_code == 200
+    assert health_response.status_code == 200
+    model_payload = models_response.json()
+    assert model_payload["data"][0]["provider"] == "groq"
+    assert model_payload["data"][0]["deltallm_params"]["model"] == "openai/gpt-oss-120b"
+
+    health_payload = health_response.json()
+    assert health_payload["summary"]["total_providers"] == 1
+    assert health_payload["providers"][0]["provider"] == "groq"
+    assert health_payload["providers"][0]["models"] == 1
+
+
+@pytest.mark.asyncio
 async def test_create_model_syncs_auto_follow_org_bindings(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
     binding_repository = _MutableCallableTargetBindingRepository(

--- a/tests/test_ui_rbac_scoping.py
+++ b/tests/test_ui_rbac_scoping.py
@@ -288,6 +288,11 @@ async def test_grouped_spend_report_for_provider_uses_canonical_provider_groupin
     assert "THEN 'groq'" in query
     assert "<> 'cache'" in query
     assert "COALESCE(s.api_base, 'unknown')" not in query
+    metadata_pos = query.index("metadata->>'provider'")
+    provider_pos = query.index("NULLIF(LOWER(TRIM(s.provider))")
+    cache_override_pos = query.index("<> 'cache'")
+    api_base_pos = query.index("openai.azure.com")
+    assert metadata_pos < provider_pos < cache_override_pos < api_base_pos
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #140.

This makes explicit provider metadata authoritative across provider reporting and callback payloads while retaining model-prefix parsing only as legacy fallback behavior.

## Changes

- Prefer explicit provider metadata in spend provider grouping before stored provider, cache override, API-base inference, and model-prefix fallbacks.
- Add explicit `api_provider` support to standard callback payload construction.
- Pass resolved deployment provider into chat, embeddings, images, audio speech, audio transcription, and rerank callback payloads.
- Update examples and model configuration docs to show `deltallm_params.provider` as the provider identity source while documenting legacy prefix fallback.
- Add regression coverage for callback payloads, spend event precedence, spend SQL grouping, UI provider display, and chat callback/spend metadata.

## Validation

- `uv run --extra dev pytest tests/callbacks/test_payload.py tests/test_ui_rbac_scoping.py tests/test_billing.py`
- `uv run --extra dev pytest tests/test_ui_models.py tests/test_chat.py tests/test_embeddings.py tests/test_uniformity_hardening.py`
- `uv run --extra dev ruff check src/api/admin/endpoints/spend.py src/callbacks/payload.py src/chat/telemetry.py src/routers/embeddings.py src/routers/images.py src/routers/rerank.py src/routers/audio_speech.py src/routers/audio_transcription.py tests/callbacks/test_payload.py tests/test_billing.py tests/test_chat.py tests/test_ui_models.py tests/test_ui_rbac_scoping.py`
- `git diff --check`

## Note

A full `uv run --extra dev pytest` still reproduces the existing `tests/test_provider_presets_smoke.py` callable-target grant failures on local `main`; those failures are not introduced by this branch.