### PR TITLE
Add chat completions batch MVP

### DIFF
--- a/docs/admin-ui/batch-jobs.md
+++ b/docs/admin-ui/batch-jobs.md
@@ -2,7 +2,7 @@
 
 Batch Jobs is the operations view for long-running asynchronous work.
 
-Today, the public batch API is focused on embeddings batches, and this page helps operators inspect job progress, failures, and cost after submission.
+The public batch API supports embeddings and non-streaming chat completion batches. This page helps operators inspect job progress, failures, and cost after submission.
 
 ![Batch Jobs](images/batch-jobs.png)
 

--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -43,7 +43,7 @@ curl http://localhost:8000/v1/chat/completions \
 | `POST /v1/files` | Upload batch input files |
 | `GET /v1/files/{file_id}` | Inspect batch files |
 | `GET /v1/files/{file_id}/content` | Download batch file content |
-| `POST /v1/batches` | Create embeddings batches |
+| `POST /v1/batches` | Create embedding or non-streaming chat completion batches |
 | `GET /v1/batches` | List batches |
 | `GET /v1/batches/{batch_id}` | Inspect one batch |
 | `POST /v1/batches/{batch_id}/cancel` | Cancel a batch |
@@ -241,7 +241,9 @@ curl http://localhost:8000/v1/batches/batch_123 \
 Current behavior:
 
 - batch endpoints are available only when `general_settings.embeddings_batch_enabled: true`
-- the current implementation supports `endpoint: "/v1/embeddings"` only
+- supported endpoints are `"/v1/embeddings"` and `"/v1/chat/completions"`
+- chat batch requests must be non-streaming; `stream: true` is rejected
+- MCP tools are not supported in chat batch requests yet
 
 ## Model Discovery
 

--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -291,7 +291,9 @@ Governance notifications are opt-in and disabled by default.
 | `prometheus_endpoint` | `/metrics` | Path for Prometheus metrics endpoint |
 | `metrics_retention_days` | `30` | Days to retain spend log data |
 
-## Embeddings Batch Settings
+## Batch Settings
+
+These settings retain the historical `embeddings_batch_*` names for compatibility. They now control the internal Batch API for supported endpoints, including `/v1/embeddings` and non-streaming `/v1/chat/completions`.
 
 | Setting | Default | Description |
 |---------|---------|-------------|

--- a/docs/features/batching.md
+++ b/docs/features/batching.md
@@ -1,6 +1,6 @@
-# Embeddings Batch API
+# Batch API
 
-Process large volumes of embedding requests asynchronously. Upload a JSONL file, create a batch, and download results when the job completes. This is ideal when you have thousands of texts to embed and don't need results in real time.
+Process large volumes of embedding or non-streaming chat completion requests asynchronously. Upload a JSONL file, create a batch, and download results when the job completes. This is ideal when you have thousands of requests to run and don't need results in real time.
 
 ## Quick Start
 
@@ -15,12 +15,21 @@ Restart DeltaLLM after changing this setting.
 
 ### 2. Upload an input file
 
-Create a JSONL file where each line is a batch request:
+Create a JSONL file where each line is a batch request.
+
+Embedding example:
 
 ```jsonl
 {"custom_id": "doc-1", "url": "/v1/embeddings", "body": {"model": "text-embedding-3-small", "input": "DeltaLLM is an LLM gateway"}}
 {"custom_id": "doc-2", "url": "/v1/embeddings", "body": {"model": "text-embedding-3-small", "input": "It supports async batch processing"}}
 {"custom_id": "doc-3", "url": "/v1/embeddings", "body": {"model": "text-embedding-3-small", "input": "Batching reduces cost for high-volume workloads"}}
+```
+
+Chat completion example:
+
+```jsonl
+{"custom_id": "chat-1", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Summarize DeltaLLM in one sentence."}]}}
+{"custom_id": "chat-2", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Write a short support reply."}]}}
 ```
 
 Upload it:
@@ -93,7 +102,7 @@ curl http://localhost:8000/v1/files/file_out456/content \
   -o output.jsonl
 ```
 
-Each output line contains the `custom_id` you provided and the embedding response.
+Each output line contains the `custom_id` you provided and the endpoint response.
 
 ## Input Format
 
@@ -102,10 +111,16 @@ Each line of the input JSONL file must be a JSON object with these fields:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `custom_id` | Yes | Your unique identifier for this request. Used to match input to output. Must be unique within the file. |
-| `url` | No | Must be `/v1/embeddings` if provided. Defaults to the batch endpoint. |
-| `body` | Yes | The embedding request payload, same schema as a synchronous `POST /v1/embeddings` call. |
+| `method` | No | Defaults to `POST`. If provided, it must be `POST`. |
+| `url` | No | Must match the batch endpoint if provided. Defaults to the batch endpoint. |
+| `body` | Yes | The endpoint request payload. |
 
-The `body` object follows the standard embeddings request format:
+Supported batch endpoints:
+
+- `/v1/embeddings`
+- `/v1/chat/completions`
+
+For `/v1/embeddings`, the `body` object follows the standard embeddings request format:
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -113,6 +128,16 @@ The `body` object follows the standard embeddings request format:
 | `input` | Yes | Text to embed. A string or an array of integers (token IDs). |
 | `encoding_format` | No | `float` or `base64` |
 | `dimensions` | No | Output dimensionality (if the model supports it) |
+
+For `/v1/chat/completions`, the `body` object follows the non-streaming chat completions request format:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `model` | Yes | The model name, e.g. `gpt-4o-mini` |
+| `messages` | Yes | Chat messages using the same shape as synchronous `POST /v1/chat/completions` |
+| `stream` | No | Must be omitted or `false`; streaming is not supported in batch |
+| `tools` | No | Function tools are accepted; MCP tools are rejected in batch chat for now |
+| `response_format` | No | Preserved and forwarded like the synchronous chat endpoint |
 
 > **Note:** All items in a batch should target the same model. The model is inferred from the first item and tracked on the batch record.
 
@@ -254,11 +279,13 @@ Completed batches and their artifacts are automatically cleaned up by a backgrou
 | `embeddings_batch_gc_interval_seconds` | `86400` | How often the cleanup loop runs (default: daily) |
 | `embeddings_batch_gc_scan_limit` | `200` | Maximum expired items processed per cleanup pass |
 
-For the full settings reference, see [Configuration > General](../configuration/general.md#embeddings-batch-settings).
+For the full settings reference, see [Configuration > General](../configuration/general.md#batch-settings).
 
 ## Upstream Micro-batching
 
-When the batch worker processes embedding items, it normally sends one upstream HTTP request per item. Micro-batching groups compatible items into a single upstream call, reducing HTTP round trips and improving throughput.
+When the batch worker processes embedding items, it normally sends one upstream HTTP request per item. Embedding micro-batching groups compatible items into a single upstream call, reducing HTTP round trips and improving throughput.
+
+Chat completion batch jobs use bounded per-item concurrency in this release. For vLLM, this is the preferred default because vLLM performs continuous batching inside the serving engine while DeltaLLM keeps one canonical response, usage record, and spend record per batch item.
 
 ### How it works
 
@@ -286,7 +313,7 @@ model_list:
 
 This tells the batch worker to group up to 8 compatible items per upstream request.
 
-> **Note:** Micro-batching only applies to the async batch worker. It does not change synchronous `/v1/embeddings` behavior.
+> **Note:** Micro-batching only applies to embedding items in the async batch worker. It does not change synchronous `/v1/embeddings` behavior and does not combine chat requests in this release.
 
 ### Eligible inputs
 
@@ -401,7 +428,10 @@ Provider `Retry-After` hints are honored for retryable rate-limit failures, but 
 
 ## Known Limitations
 
-- Only `/v1/embeddings` is supported as a batch endpoint
+- Chat batch supports non-streaming `/v1/chat/completions` requests only
+- MCP tools are not supported in chat batch requests yet
+- Provider-native async chat batch APIs are not used in this release
+- Chat requests are executed with bounded concurrency; synchronous upstream chat micro-batching is planned separately
 - `list[str]` and `list[list[int]]` inputs are not eligible for micro-batching (they are processed individually)
 - Local storage is not safe for multi-instance deployments; use S3
 - Batch creation is not fully transactional when the database does not support interactive transactions
@@ -411,5 +441,5 @@ Provider `Retry-After` hints are honored for retryable rate-limit failures, but 
 - [Proxy Endpoints](../api/proxy.md#batch-endpoints)
 - [Admin Endpoints](../api/admin.md#batches)
 - [Admin UI: Batch Jobs](../admin-ui/batch-jobs.md)
-- [Configuration Reference](../configuration/general.md#embeddings-batch-settings)
+- [Configuration Reference](../configuration/general.md#batch-settings)
 - [Model Deployments](../configuration/models.md#embedding-batch-worker-micro-batching)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -13,7 +13,7 @@ Use this section when DeltaLLM is already running and you want to turn on a capa
 | Block or sanitize unsafe content | [Guardrails](guardrails.md) |
 | Control request volume at each scope | [Rate Limiting](rate-limiting.md) |
 | Track or cap spend | [Budgets & Spend](budgets.md) |
-| Process large embedding workloads asynchronously | [Embeddings Batch API](batching.md) |
+| Process large embedding or chat workloads asynchronously | [Batch API](batching.md) |
 | Export evidence for compliance or investigations | [Audit Log](audit-log.md) |
 | Monitor health, latency, and request volume | [Observability](observability.md) |
 

--- a/scripts/measure_embedding_batch_load.py
+++ b/scripts/measure_embedding_batch_load.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 
 from prisma import Prisma
 
-import src.batch.service as batch_service_module
+import src.batch.request_validation as batch_request_validation_module
 from src.batch.models import BatchJobRecord
 from src.batch.repository import BatchRepository
 from src.batch.service import BatchService
@@ -244,12 +244,12 @@ async def run_measurement(args: argparse.Namespace) -> BatchLoadMeasurement:
     await db.connect()
     run_api_key = f"load-script-{uuid4().hex}"
     schema_ready = False
-    original_batch_model_allowed = batch_service_module.ensure_batch_model_allowed
+    original_batch_model_allowed = batch_request_validation_module.ensure_batch_model_allowed
     import src.batch.worker as batch_worker_module
 
     original_execute_embedding = batch_worker_module._execute_embedding
     try:
-        batch_service_module.ensure_batch_model_allowed = lambda *args, **kwargs: None
+        batch_request_validation_module.ensure_batch_model_allowed = lambda *args, **kwargs: None
         await ensure_batch_schema(db)
         schema_ready = True
 
@@ -336,7 +336,7 @@ async def run_measurement(args: argparse.Namespace) -> BatchLoadMeasurement:
             )
     finally:
         active_error = sys.exc_info()[1]
-        batch_service_module.ensure_batch_model_allowed = original_batch_model_allowed
+        batch_request_validation_module.ensure_batch_model_allowed = original_batch_model_allowed
         batch_worker_module._execute_embedding = original_execute_embedding
         cleanup_error: Exception | None = None
         if schema_ready:

--- a/src/api/v1/endpoints/batches.py
+++ b/src/api/v1/endpoints/batches.py
@@ -31,7 +31,8 @@ async def create_batch(request: Request, payload: dict[str, Any]):
     try:
         service = _batch_service_or_404(request)
         audit_metadata = {"route": request.url.path, "idempotency_key_present": bool(idempotency_key)}
-        result = await service.create_embeddings_batch_result(
+        create_batch_result = getattr(service, "create_batch_result", None) or service.create_embeddings_batch_result
+        result = await create_batch_result(
             auth=auth,
             input_file_id=input_file_id,
             endpoint=endpoint,

--- a/src/batch/create/service.py
+++ b/src/batch/create/service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from typing import Any, AsyncIterator
@@ -9,6 +8,7 @@ from uuid import uuid4
 from fastapi import HTTPException, status
 
 from src.batch.access import can_access_owned_resource
+from src.batch.endpoints import SUPPORTED_BATCH_ENDPOINT_SET, supported_batch_endpoints_display
 from src.batch.create.models import (
     BatchCreateSessionCreate,
     BatchCreateSessionRecord,
@@ -20,16 +20,16 @@ from src.batch.create.session_repository import BatchCreateSessionRepository
 from src.batch.create.session_stager import BatchCreateSessionStager
 from src.batch.models import BatchJobRecord
 from src.batch.repository import BatchRepository
+from src.batch.request_validation import parse_batch_input_line
 from src.batch.scopes import (
     batch_idempotency_scope_key,
     batch_pending_scope_key_for_auth,
     batch_pending_scope_target_for_auth,
 )
 from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorage
-from src.models.requests import EmbeddingRequest
 from src.models.responses import UserAPIKeyAuth
 from src.services.callable_target_grants import CallableTargetGrantService
-from src.services.model_visibility import CallableTargetPolicyMode, ensure_batch_model_allowed
+from src.services.model_visibility import CallableTargetPolicyMode
 from src.metrics import increment_batch_artifact_failure
 
 logger = logging.getLogger(__name__)
@@ -86,9 +86,32 @@ class BatchCreateSessionService:
         completion_window: str | None,
         idempotency_key: str | None = None,
     ) -> BatchCreateSessionServiceResult:
+        return await self.create_batch(
+            auth=auth,
+            input_file_id=input_file_id,
+            endpoint=endpoint,
+            metadata=metadata,
+            completion_window=completion_window,
+            idempotency_key=idempotency_key,
+        )
+
+    async def create_batch(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        input_file_id: str,
+        endpoint: str,
+        metadata: dict[str, Any] | None,
+        completion_window: str | None,
+        idempotency_key: str | None = None,
+    ) -> BatchCreateSessionServiceResult:
         del completion_window
-        if endpoint != "/v1/embeddings":
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only /v1/embeddings is supported")
+        endpoint = str(endpoint or "").strip()
+        if endpoint not in SUPPORTED_BATCH_ENDPOINT_SET:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unsupported batch endpoint '{endpoint}'. Supported endpoints: {supported_batch_endpoints_display()}",
+            )
 
         normalized_metadata = self._normalize_metadata(metadata)
         idem_scope_key, idem_key = self._idempotency_pair(auth=auth, idempotency_key=idempotency_key)
@@ -390,43 +413,23 @@ class BatchCreateSessionService:
         auth: UserAPIKeyAuth,
         seen_custom_ids: set[str],
     ):
-        line = raw_line.strip()
-        if not line:
-            return None, None
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid JSONL at line {line_number}: {exc.msg}",
-            ) from exc
-        if not isinstance(obj, dict):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must be an object")
-        custom_id = str(obj.get("custom_id") or "").strip()
-        if not custom_id:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing custom_id")
-        if custom_id in seen_custom_ids:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Duplicate custom_id at line {line_number}")
-        seen_custom_ids.add(custom_id)
-        url = str(obj.get("url") or endpoint)
-        if url != endpoint:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must target {endpoint}")
-        body = obj.get("body")
-        if not isinstance(body, dict):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing body")
-        validated = EmbeddingRequest.model_validate(body)
-        ensure_batch_model_allowed(
-            auth,
-            validated.model,
-            callable_target_grant_service=self.callable_target_grant_service,
-            policy_mode=self.callable_target_scope_policy_mode,
-        )
-        item = BatchCreateStagedRequest(
+        parsed = parse_batch_input_line(
+            raw_line,
             line_number=line_number,
-            custom_id=custom_id,
-            request_body=validated.model_dump(exclude_none=True),
+            endpoint=endpoint,
+            auth=auth,
+            seen_custom_ids=seen_custom_ids,
+            callable_target_grant_service=self.callable_target_grant_service,
+            callable_target_scope_policy_mode=self.callable_target_scope_policy_mode,
         )
-        return item, validated.model
+        if parsed is None:
+            return None, None
+        item = BatchCreateStagedRequest(
+            line_number=parsed.line_number,
+            custom_id=parsed.custom_id,
+            request_body=parsed.request_body,
+        )
+        return item, parsed.model
 
     def _idempotency_pair(
         self,

--- a/src/batch/endpoints.py
+++ b/src/batch/endpoints.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+BATCH_ENDPOINT_EMBEDDINGS = "/v1/embeddings"
+BATCH_ENDPOINT_CHAT_COMPLETIONS = "/v1/chat/completions"
+
+SUPPORTED_BATCH_ENDPOINTS: tuple[str, ...] = (
+    BATCH_ENDPOINT_EMBEDDINGS,
+    BATCH_ENDPOINT_CHAT_COMPLETIONS,
+)
+SUPPORTED_BATCH_ENDPOINT_SET = frozenset(SUPPORTED_BATCH_ENDPOINTS)
+
+BATCH_CALL_TYPE_BY_ENDPOINT = {
+    BATCH_ENDPOINT_EMBEDDINGS: "embedding_batch",
+    BATCH_ENDPOINT_CHAT_COMPLETIONS: "chat_batch",
+}
+
+BATCH_ROUTER_USAGE_MODE_BY_ENDPOINT = {
+    BATCH_ENDPOINT_EMBEDDINGS: "embedding",
+    BATCH_ENDPOINT_CHAT_COMPLETIONS: "chat",
+}
+
+
+def supported_batch_endpoints_display() -> str:
+    return ", ".join(SUPPORTED_BATCH_ENDPOINTS)
+
+
+def batch_call_type_for_endpoint(endpoint: str) -> str:
+    return BATCH_CALL_TYPE_BY_ENDPOINT.get(endpoint, "batch")
+
+
+def router_usage_mode_for_batch_endpoint(endpoint: str) -> str:
+    return BATCH_ROUTER_USAGE_MODE_BY_ENDPOINT.get(endpoint, "batch")

--- a/src/batch/request_validation.py
+++ b/src/batch/request_validation.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import HTTPException, status
+from pydantic import ValidationError
+
+from src.batch.endpoints import (
+    BATCH_ENDPOINT_CHAT_COMPLETIONS,
+    BATCH_ENDPOINT_EMBEDDINGS,
+    SUPPORTED_BATCH_ENDPOINT_SET,
+    supported_batch_endpoints_display,
+)
+from src.models.requests import ChatCompletionRequest, EmbeddingRequest, MCPToolDefinition
+from src.models.responses import UserAPIKeyAuth
+from src.services.callable_target_grants import CallableTargetGrantService
+from src.services.model_visibility import CallableTargetPolicyMode, ensure_batch_model_allowed
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedBatchInputLine:
+    line_number: int
+    custom_id: str
+    request_body: dict[str, Any]
+    model: str
+
+
+def parse_batch_input_line(
+    raw_line: str,
+    *,
+    line_number: int,
+    endpoint: str,
+    auth: UserAPIKeyAuth,
+    seen_custom_ids: set[str],
+    callable_target_grant_service: CallableTargetGrantService | None,
+    callable_target_scope_policy_mode: CallableTargetPolicyMode | str,
+) -> ParsedBatchInputLine | None:
+    endpoint = str(endpoint or "").strip()
+    if endpoint not in SUPPORTED_BATCH_ENDPOINT_SET:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported batch endpoint '{endpoint}'. Supported endpoints: {supported_batch_endpoints_display()}",
+        )
+
+    line = raw_line.strip()
+    if not line:
+        return None
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid JSONL at line {line_number}: {exc.msg}",
+        ) from exc
+    if not isinstance(obj, dict):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must be an object")
+
+    method = str(obj.get("method") or "POST").strip().upper()
+    if method != "POST":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} method must be POST")
+
+    custom_id = str(obj.get("custom_id") or "").strip()
+    if not custom_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing custom_id")
+    if custom_id in seen_custom_ids:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Duplicate custom_id at line {line_number}")
+    seen_custom_ids.add(custom_id)
+
+    url = str(obj.get("url") or endpoint)
+    if url != endpoint:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must target {endpoint}")
+
+    body = obj.get("body")
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing body")
+
+    request_body, model = _validate_batch_request_body(body, endpoint=endpoint, line_number=line_number)
+    ensure_batch_model_allowed(
+        auth,
+        model,
+        callable_target_grant_service=callable_target_grant_service,
+        policy_mode=callable_target_scope_policy_mode,
+    )
+    return ParsedBatchInputLine(
+        line_number=line_number,
+        custom_id=custom_id,
+        request_body=request_body,
+        model=model,
+    )
+
+
+def _validate_batch_request_body(
+    body: dict[str, Any],
+    *,
+    endpoint: str,
+    line_number: int,
+) -> tuple[dict[str, Any], str]:
+    try:
+        if endpoint == BATCH_ENDPOINT_EMBEDDINGS:
+            validated = EmbeddingRequest.model_validate(body)
+            return validated.model_dump(exclude_none=True), validated.model
+        if endpoint == BATCH_ENDPOINT_CHAT_COMPLETIONS:
+            validated = ChatCompletionRequest.model_validate(body)
+            _validate_batch_chat_request(validated, line_number=line_number)
+            return validated.model_dump(exclude_none=True), validated.model
+    except ValidationError as exc:
+        message = exc.errors()[0].get("msg") if exc.errors() else str(exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid request body at line {line_number}: {message}",
+        ) from exc
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"Unsupported batch endpoint '{endpoint}'. Supported endpoints: {supported_batch_endpoints_display()}",
+    )
+
+
+def _validate_batch_chat_request(payload: ChatCompletionRequest, *, line_number: int) -> None:
+    if payload.stream is True:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Line {line_number} chat batch requests support non-streaming requests only; stream must be false",
+        )
+    if any(isinstance(tool, MCPToolDefinition) for tool in payload.tools or []):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Line {line_number} MCP tools are not supported in batch chat yet",
+        )

--- a/src/batch/service.py
+++ b/src/batch/service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -10,16 +9,16 @@ from fastapi import HTTPException, UploadFile, status
 
 from src.batch.access import can_access_owned_resource
 from src.batch.models import BatchItemCreate
+from src.batch.request_validation import parse_batch_input_line
 from src.batch.repository import BatchRepository
 from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorage
 from src.metrics import (
     increment_batch_artifact_failure,
     publish_batch_runtime_summary,
 )
-from src.models.requests import EmbeddingRequest
 from src.models.responses import UserAPIKeyAuth
-from src.services.model_visibility import CallableTargetPolicyMode, ensure_batch_model_allowed
 from src.services.callable_target_grants import CallableTargetGrantService
+from src.services.model_visibility import CallableTargetPolicyMode
 
 if TYPE_CHECKING:
     from src.batch.create import BatchCreateSessionService
@@ -141,44 +140,24 @@ class BatchService:
         auth: UserAPIKeyAuth,
         seen_custom_ids: set[str],
     ) -> tuple[BatchItemCreate | None, str | None]:
-        line = raw_line.strip()
-        if not line:
-            return None, None
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid JSONL at line {line_number}: {exc.msg}",
-            ) from exc
-        if not isinstance(obj, dict):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must be an object")
-        custom_id = str(obj.get("custom_id") or "").strip()
-        if not custom_id:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing custom_id")
-        if custom_id in seen_custom_ids:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Duplicate custom_id at line {line_number}")
-        seen_custom_ids.add(custom_id)
-        url = str(obj.get("url") or endpoint)
-        if url != endpoint:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} must target {endpoint}")
-        body = obj.get("body")
-        if not isinstance(body, dict):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Line {line_number} missing body")
-        validated = EmbeddingRequest.model_validate(body)
-        ensure_batch_model_allowed(
-            auth,
-            validated.model,
+        parsed = parse_batch_input_line(
+            raw_line,
+            line_number=line_number,
+            endpoint=endpoint,
+            auth=auth,
+            seen_custom_ids=seen_custom_ids,
             callable_target_grant_service=self.callable_target_grant_service,
-            policy_mode=self.callable_target_scope_policy_mode,
+            callable_target_scope_policy_mode=self.callable_target_scope_policy_mode,
         )
+        if parsed is None:
+            return None, None
         return (
             BatchItemCreate(
-                line_number=line_number,
-                custom_id=custom_id,
-                request_body=validated.model_dump(exclude_none=True),
+                line_number=parsed.line_number,
+                custom_id=parsed.custom_id,
+                request_body=parsed.request_body,
             ),
-            validated.model,
+            parsed.model,
         )
 
     async def create_file(self, *, auth: UserAPIKeyAuth, upload: UploadFile, purpose: str) -> dict[str, Any]:
@@ -242,7 +221,26 @@ class BatchService:
         completion_window: str | None,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
-        result = await self.create_embeddings_batch_result(
+        return await self.create_batch(
+            auth=auth,
+            input_file_id=input_file_id,
+            endpoint=endpoint,
+            metadata=metadata,
+            completion_window=completion_window,
+            idempotency_key=idempotency_key,
+        )
+
+    async def create_batch(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        input_file_id: str,
+        endpoint: str,
+        metadata: dict[str, Any] | None,
+        completion_window: str | None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        result = await self.create_batch_result(
             auth=auth,
             input_file_id=input_file_id,
             endpoint=endpoint,
@@ -262,12 +260,7 @@ class BatchService:
         completion_window: str | None,
         idempotency_key: str | None = None,
     ) -> BatchCreateResponseResult:
-        if self.create_session_service is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Batch create-session service unavailable",
-            )
-        result = await self.create_session_service.create_embeddings_batch(
+        return await self.create_batch_result(
             auth=auth,
             input_file_id=input_file_id,
             endpoint=endpoint,
@@ -275,6 +268,40 @@ class BatchService:
             completion_window=completion_window,
             idempotency_key=idempotency_key,
         )
+
+    async def create_batch_result(
+        self,
+        *,
+        auth: UserAPIKeyAuth,
+        input_file_id: str,
+        endpoint: str,
+        metadata: dict[str, Any] | None,
+        completion_window: str | None,
+        idempotency_key: str | None = None,
+    ) -> BatchCreateResponseResult:
+        if self.create_session_service is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Batch create-session service unavailable",
+            )
+        if hasattr(self.create_session_service, "create_batch"):
+            result = await self.create_session_service.create_batch(
+                auth=auth,
+                input_file_id=input_file_id,
+                endpoint=endpoint,
+                metadata=metadata,
+                completion_window=completion_window,
+                idempotency_key=idempotency_key,
+            )
+        else:
+            result = await self.create_session_service.create_embeddings_batch(
+                auth=auth,
+                input_file_id=input_file_id,
+                endpoint=endpoint,
+                metadata=metadata,
+                completion_window=completion_window,
+                idempotency_key=idempotency_key,
+            )
         return BatchCreateResponseResult(
             response=self.job_to_response(result.job),
             audit_metadata=result.audit_metadata,

--- a/src/batch/worker.py
+++ b/src/batch/worker.py
@@ -14,9 +14,11 @@ from src.batch.worker_execution import BatchExecutionEngine
 from src.batch.worker_types import (
     BatchArtifactValidationError,
     BatchWorkerConfig,
+    _PreparedChatItem,
     _PreparedEmbeddingItem,
     _RequestShim,
 )
+from src.chat.executor import execute_chat
 from src.metrics import (
     observe_batch_item_execution_latency,
     publish_batch_runtime_summary,
@@ -32,6 +34,7 @@ __all__ = [
     "BatchExecutorWorker",
     "BatchWorkerConfig",
     "_PreparedEmbeddingItem",
+    "_PreparedChatItem",
     "_RequestShim",
 ]
 
@@ -61,6 +64,7 @@ class BatchExecutorWorker:
             config=config,
             normalize_persisted_embedding_response_body=self._artifact_finalizer.normalize_persisted_embedding_response_body,
             execute_embedding=self._call_execute_embedding,
+            execute_chat=self._call_execute_chat,
             record_router_usage=self._call_record_router_usage,
             observe_item_execution_latency=self._call_observe_item_execution_latency,
             start_heartbeat=self._call_start_heartbeat,
@@ -77,6 +81,9 @@ class BatchExecutorWorker:
 
     async def _call_execute_embedding(self, request, payload, deployment):  # noqa: ANN001, ANN201
         return await _execute_embedding(request, payload, deployment)
+
+    async def _call_execute_chat(self, request, payload, deployment, *, record_usage: bool = True):  # noqa: ANN001, ANN201
+        return await execute_chat(request, payload, deployment, record_usage=record_usage)
 
     async def _call_record_router_usage(self, router_state_backend, deployment_id: str, *, mode: str, usage: dict) -> None:
         await record_router_usage(
@@ -176,7 +183,7 @@ class BatchExecutorWorker:
             await self._stop_heartbeat(job_heartbeat)
             await self.repository.release_job_lease(batch_id=job.batch_id, worker_id=self.config.worker_id)
 
-    async def _prepare_item_for_execution(self, job, item) -> _PreparedEmbeddingItem:  # noqa: ANN001
+    async def _prepare_item_for_execution(self, job, item) -> _PreparedEmbeddingItem | _PreparedChatItem:  # noqa: ANN001
         self._sync_dependencies()
         return await self._execution_engine.prepare_item_for_execution(job, item)
 
@@ -201,9 +208,9 @@ class BatchExecutorWorker:
         self._sync_dependencies()
         await self._artifact_finalizer.finalize_with_retry(job, finalize_artifacts=self._finalize_artifacts)
 
-    async def _iter_output_lines(self, batch_id: str):  # noqa: ANN201
+    async def _iter_output_lines(self, batch_id: str, *, endpoint: str = "/v1/embeddings"):  # noqa: ANN201
         self._sync_dependencies()
-        async for line in self._artifact_finalizer.iter_output_lines(batch_id):
+        async for line in self._artifact_finalizer.iter_output_lines(batch_id, endpoint=endpoint):
             yield line
 
     async def _iter_error_lines(self, batch_id: str):  # noqa: ANN201

--- a/src/batch/worker_artifacts.py
+++ b/src/batch/worker_artifacts.py
@@ -7,6 +7,7 @@ import logging
 from time import perf_counter
 from typing import Any, AsyncIterator, Awaitable, Callable
 
+from src.batch.endpoints import BATCH_ENDPOINT_CHAT_COMPLETIONS, BATCH_ENDPOINT_EMBEDDINGS
 from src.batch.models import BatchJobStatus, is_operator_failed_reason
 from src.batch.repository import BatchRepository
 from src.batch.storage import BatchArtifactStorage
@@ -113,6 +114,9 @@ class BatchArtifactFinalizer:
         normalized_model = request_model.strip()
         return normalized_model or None
 
+    def _public_chat_model_fallback(self, item) -> str | None:  # noqa: ANN001
+        return self._public_embedding_model_fallback(item)
+
     def _sanitize_public_embedding_body(self, item) -> dict[str, Any]:  # noqa: ANN001
         response_body = item.response_body
         if not isinstance(response_body, dict):
@@ -184,14 +188,98 @@ class BatchArtifactFinalizer:
 
         return sanitized
 
-    def _serialize_completed_artifact_row(self, item) -> dict[str, Any]:  # noqa: ANN001
+    def _normalized_chat_usage_or_none(self, value: Any) -> dict[str, Any] | None:
+        if not isinstance(value, dict):
+            return None
+        normalized_usage = dict(value)
+        for token_field in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            token_value = normalized_usage.get(token_field)
+            if token_value is None:
+                continue
+            if type(token_value) is not int or token_value < 0:
+                return None
+        return normalized_usage
+
+    def _validate_public_chat_usage(self, value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise BatchArtifactValidationError("completed batch item chat response usage is not an object")
+
+        normalized_usage = dict(value)
+        for token_field in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            token_value = normalized_usage.get(token_field)
+            if token_value is None:
+                continue
+            if type(token_value) is not int:
+                raise BatchArtifactValidationError(
+                    f"completed batch item chat response usage has invalid {token_field}={token_value!r}"
+                )
+            if token_value < 0:
+                raise BatchArtifactValidationError(
+                    f"completed batch item chat response usage has negative {token_field}={token_value!r}"
+                )
+        return normalized_usage
+
+    def _sanitize_public_chat_body(self, item) -> dict[str, Any]:  # noqa: ANN001
+        response_body = item.response_body
+        if not isinstance(response_body, dict):
+            raise BatchArtifactValidationError("completed batch item is missing a chat completion response body")
+
+        sanitized = {key: value for key, value in response_body.items() if not str(key).startswith("_")}
+        object_type = sanitized.get("object")
+        if object_type is None:
+            sanitized["object"] = "chat.completion"
+        elif object_type != "chat.completion":
+            raise BatchArtifactValidationError(
+                f"completed batch item has invalid chat response object={object_type!r}"
+            )
+
+        choices = sanitized.get("choices")
+        if not isinstance(choices, list):
+            raise BatchArtifactValidationError("completed batch item chat response choices is not a list")
+        sanitized["choices"] = [dict(choice) for choice in choices if isinstance(choice, dict)]
+        if len(sanitized["choices"]) != len(choices):
+            raise BatchArtifactValidationError("completed batch item chat response contains a non-object choice")
+
+        model_name = sanitized.get("model")
+        if not isinstance(model_name, str) or not model_name.strip():
+            fallback_model = self._public_chat_model_fallback(item)
+            if fallback_model is not None:
+                sanitized["model"] = fallback_model
+        model_name = sanitized.get("model")
+        if not isinstance(model_name, str) or not model_name.strip():
+            raise BatchArtifactValidationError("completed batch item chat response is missing a valid model")
+
+        usage_value = sanitized.get("usage")
+        if usage_value is None:
+            sanitized["usage"] = self._normalized_chat_usage_or_none(item.usage) or {}
+            return sanitized
+
+        try:
+            normalized_usage = self._validate_public_chat_usage(usage_value)
+        except BatchArtifactValidationError:
+            normalized_usage = self._normalized_chat_usage_or_none(item.usage)
+            if normalized_usage is None:
+                raise
+        sanitized["usage"] = normalized_usage
+        return sanitized
+
+    def _serialize_completed_artifact_row(
+        self,
+        item,
+        *,
+        endpoint: str = BATCH_ENDPOINT_EMBEDDINGS,
+    ) -> dict[str, Any]:  # noqa: ANN001
+        if endpoint == BATCH_ENDPOINT_CHAT_COMPLETIONS:
+            body = self._sanitize_public_chat_body(item)
+        else:
+            body = self._sanitize_public_embedding_body(item)
         return {
             "id": self._public_batch_row_id(item),
             "custom_id": item.custom_id,
             "response": {
                 "status_code": 200,
                 "request_id": self._public_batch_request_id(item),
-                "body": self._sanitize_public_embedding_body(item),
+                "body": body,
             },
             "error": None,
         }
@@ -331,10 +419,15 @@ class BatchArtifactFinalizer:
         for item in await self.repository.list_items(batch_id):
             yield item
 
-    async def iter_output_lines(self, batch_id: str) -> AsyncIterator[str]:
+    async def iter_output_lines(
+        self,
+        batch_id: str,
+        *,
+        endpoint: str = BATCH_ENDPOINT_EMBEDDINGS,
+    ) -> AsyncIterator[str]:
         async for item in self._iter_batch_items(batch_id):
             if item.status == "completed":
-                yield json.dumps(self._serialize_completed_artifact_row(item))
+                yield json.dumps(self._serialize_completed_artifact_row(item, endpoint=endpoint))
 
     async def iter_error_lines(self, batch_id: str) -> AsyncIterator[str]:
         async for item in self._iter_batch_items(batch_id):
@@ -352,7 +445,7 @@ class BatchArtifactFinalizer:
                 key, size, checksum = await self.storage.write_lines_stream(
                     purpose="batch_output",
                     filename=f"{job.batch_id}-output.jsonl",
-                    lines=self.iter_output_lines(job.batch_id),
+                    lines=self.iter_output_lines(job.batch_id, endpoint=job.endpoint),
                 )
                 file_record = await self.repository.create_file(
                     purpose="batch_output",

--- a/src/batch/worker_execution.py
+++ b/src/batch/worker_execution.py
@@ -11,6 +11,12 @@ from time import perf_counter
 from typing import Any, Awaitable, Callable
 
 from src.batch.backpressure import BatchModelGroupDeferred
+from src.batch.endpoints import (
+    BATCH_ENDPOINT_CHAT_COMPLETIONS,
+    BATCH_ENDPOINT_EMBEDDINGS,
+    batch_call_type_for_endpoint,
+    router_usage_mode_for_batch_endpoint,
+)
 from src.batch.embedding_microbatch import (
     allocate_embedding_usage,
     build_embedding_execution_signature,
@@ -44,11 +50,12 @@ from src.metrics import (
     observe_batch_microbatch_size,
     set_batch_worker_saturation,
 )
-from src.models.requests import EmbeddingRequest
+from src.models.errors import InvalidRequestError
+from src.models.requests import ChatCompletionRequest, EmbeddingRequest, MCPToolDefinition
 from src.providers.resolution import resolve_provider
 from src.routers.routing_decision import route_failover_kwargs
 
-from src.batch.worker_types import _PreparedEmbeddingItem, _RequestShim, BatchWorkerConfig
+from src.batch.worker_types import _PreparedChatItem, _PreparedEmbeddingItem, _RequestShim, BatchWorkerConfig
 
 logger = logging.getLogger(__name__)
 _COMPLETION_OUTBOX_MAX_ATTEMPTS = 5
@@ -63,6 +70,7 @@ class BatchExecutionEngine:
         config: BatchWorkerConfig,
         normalize_persisted_embedding_response_body: Callable[..., dict[str, Any]],
         execute_embedding: Callable[..., Awaitable[dict[str, Any]]],
+        execute_chat: Callable[..., Awaitable[tuple[dict[str, Any], float]]],
         record_router_usage: Callable[..., Awaitable[None]],
         observe_item_execution_latency: Callable[..., None],
         start_heartbeat: Callable[..., asyncio.Task[None]],
@@ -73,13 +81,19 @@ class BatchExecutionEngine:
         self.config = config
         self._normalize_persisted_embedding_response_body = normalize_persisted_embedding_response_body
         self._execute_embedding = execute_embedding
+        self._execute_chat = execute_chat
         self._record_router_usage = record_router_usage
         self._observe_batch_item_execution_latency = observe_item_execution_latency
         self._start_heartbeat_fn = start_heartbeat
         self._stop_heartbeat_fn = stop_heartbeat
-        self._prepared_item_overrides: dict[str, _PreparedEmbeddingItem] = {}
+        self._prepared_item_overrides: dict[str, _PreparedEmbeddingItem | _PreparedChatItem] = {}
 
-    async def prepare_item_for_execution(self, job, item) -> _PreparedEmbeddingItem:  # noqa: ANN001
+    async def prepare_item_for_execution(self, job, item) -> _PreparedEmbeddingItem | _PreparedChatItem:  # noqa: ANN001
+        if job.endpoint == BATCH_ENDPOINT_CHAT_COMPLETIONS:
+            return await self.prepare_chat_item_for_execution(job, item)
+        if job.endpoint != BATCH_ENDPOINT_EMBEDDINGS:
+            raise InvalidRequestError(message=f"Unsupported batch endpoint '{job.endpoint}'")
+
         started_at_monotonic = perf_counter()
         embedding_request = EmbeddingRequest.model_validate(item.request_body)
         budget_service = getattr(self.app.state, "budget_service", None)
@@ -132,6 +146,50 @@ class BatchExecutionEngine:
                 input_kind=input_kind,
             ),
         )
+
+    async def prepare_chat_item_for_execution(self, job, item) -> _PreparedChatItem:  # noqa: ANN001
+        started_at_monotonic = perf_counter()
+        chat_request = ChatCompletionRequest.model_validate(item.request_body)
+        self._validate_batch_chat_request(chat_request)
+        budget_service = getattr(self.app.state, "budget_service", None)
+        if budget_service is not None:
+            await budget_service.check_budgets(
+                api_key=job.created_by_api_key,
+                user_id=job.created_by_user_id,
+                team_id=job.created_by_team_id,
+                organization_id=job.created_by_organization_id,
+                model=chat_request.model,
+            )
+
+        request_context: dict[str, Any] = {
+            "metadata": chat_request.metadata or {},
+            "user_id": job.created_by_user_id or job.created_by_api_key or "batch-worker",
+        }
+        app_router = self.app.state.router
+        model_group = app_router.resolve_model_group(chat_request.model)
+        await self._raise_if_model_group_deferred(model_group)
+
+        primary_deployment = app_router.require_deployment(
+            model_group=model_group,
+            deployment=await app_router.select_deployment(model_group, request_context),
+        )
+        return _PreparedChatItem(
+            item=item,
+            started_at_monotonic=started_at_monotonic,
+            payload=chat_request,
+            model_name=chat_request.model,
+            model_group=model_group,
+            primary_deployment=primary_deployment,
+            request_context=request_context,
+            failover_kwargs=route_failover_kwargs(request_context),
+            request_shim=_RequestShim(app=self.app),
+        )
+
+    def _validate_batch_chat_request(self, payload: ChatCompletionRequest) -> None:
+        if payload.stream is True:
+            raise InvalidRequestError(message="Chat batch requests support non-streaming requests only; stream must be false")
+        if any(isinstance(tool, MCPToolDefinition) for tool in payload.tools or []):
+            raise InvalidRequestError(message="MCP tools are not supported in batch chat yet")
 
     def _deployment_pricing(self, deployment) -> ModelPricing | None:  # noqa: ANN001
         if deployment.input_cost_per_token or deployment.output_cost_per_token:
@@ -704,7 +762,7 @@ class BatchExecutionEngine:
         self,
         *,
         job,
-        prepared: _PreparedEmbeddingItem,
+        prepared: _PreparedEmbeddingItem | _PreparedChatItem,
         usage: dict[str, Any],
         api_provider: str,
         billed_cost: float,
@@ -721,7 +779,7 @@ class BatchExecutionEngine:
             "team_id": job.created_by_team_id,
             "organization_id": job.created_by_organization_id,
             "model": prepared.payload.model,
-            "call_type": "embedding_batch",
+            "call_type": batch_call_type_for_endpoint(job.endpoint),
             "usage": dict(usage),
             "billed_cost": billed_cost,
             "provider_cost": provider_cost,
@@ -853,6 +911,7 @@ class BatchExecutionEngine:
             await self._record_upstream_success_runtime_hooks(
                 batch_id=job.batch_id,
                 deployment_id=served_deployment_id,
+                mode=router_usage_mode_for_batch_endpoint(job.endpoint),
                 usage=usage,
                 reference=prepared.item.item_id,
             )
@@ -904,10 +963,116 @@ class BatchExecutionEngine:
             if item_heartbeat is not None:
                 await self._stop_heartbeat_fn(item_heartbeat)
 
+    async def _execute_prepared_chat_item(self, job, prepared: _PreparedChatItem) -> None:  # noqa: ANN001
+        item_heartbeat: asyncio.Task[None] | None = None
+        try:
+            item_heartbeat = self._start_heartbeat_fn(
+                renew=lambda: self.repository.renew_item_lease(
+                    item_id=prepared.item.item_id,
+                    worker_id=self.config.worker_id,
+                    lease_seconds=self.config.item_lease_seconds,
+                ),
+                label=f"item:{prepared.item.item_id}",
+            )
+            (response_body, _api_latency_ms), served_deployment = await self.app.state.failover_manager.execute_with_failover(
+                primary_deployment=prepared.primary_deployment,
+                model_group=prepared.model_group,
+                execute=lambda dep: self._execute_chat(
+                    prepared.request_shim,
+                    prepared.payload,
+                    dep,
+                    record_usage=False,
+                ),
+                return_deployment=True,
+                **prepared.failover_kwargs,
+            )
+            response_body = dict(response_body)
+            usage = dict(response_body.get("usage") or {})
+            api_provider = resolve_provider(served_deployment.deltallm_params)
+            api_base = served_deployment.deltallm_params.get("api_base")
+            deployment_model = str(served_deployment.deltallm_params.get("model") or "") or None
+            deployment_pricing = self._deployment_pricing(served_deployment)
+            model_info = served_deployment.model_info or {}
+            billed_cost = completion_cost(
+                model=prepared.payload.model,
+                usage=usage,
+                cache_hit=False,
+                custom_pricing=deployment_pricing,
+                pricing_tier="batch",
+                model_info=model_info,
+            )
+            provider_cost = completion_cost(
+                model=prepared.payload.model,
+                usage=usage,
+                cache_hit=False,
+                custom_pricing=deployment_pricing,
+                pricing_tier="sync",
+                model_info=model_info,
+            )
+            served_deployment_id = str(
+                getattr(served_deployment, "deployment_id", None)
+                or getattr(prepared.primary_deployment, "deployment_id", None)
+                or ""
+            )
+            await self._record_upstream_success_runtime_hooks(
+                batch_id=job.batch_id,
+                deployment_id=served_deployment_id,
+                mode=router_usage_mode_for_batch_endpoint(job.endpoint),
+                usage=usage,
+                reference=prepared.item.item_id,
+            )
+            await self._renew_item_lease_once(prepared.item.item_id)
+            if item_heartbeat is not None:
+                await self._stop_heartbeat_fn(item_heartbeat)
+                item_heartbeat = None
+            persisted = await self._persist_completion_rows_with_outbox(
+                items=[
+                    {
+                        "item_id": prepared.item.item_id,
+                        "response_body": response_body,
+                        "usage": usage,
+                        "provider_cost": provider_cost,
+                        "billed_cost": billed_cost,
+                        "outbox_payload": self._build_completion_outbox_payload(
+                            job=job,
+                            prepared=prepared,
+                            usage=usage,
+                            api_provider=api_provider,
+                            billed_cost=billed_cost,
+                            provider_cost=provider_cost,
+                            api_base=api_base,
+                            deployment_model=deployment_model,
+                        ),
+                        "outbox_max_attempts": _COMPLETION_OUTBOX_MAX_ATTEMPTS,
+                    }
+                ],
+                item_ids=[prepared.item.item_id],
+                context_label="chat",
+            )
+            if persisted:
+                self._observe_item_execution_latency(
+                    status="success",
+                    latency_seconds=perf_counter() - prepared.started_at_monotonic,
+                    reference=prepared.item.item_id,
+                )
+        except Exception as exc:
+            await self._mark_item_failed(
+                job=job,
+                item=prepared.item,
+                model_name=prepared.model_name,
+                exc=exc,
+                deployment_id=str(getattr(prepared.primary_deployment, "deployment_id", None) or "") or None,
+                started_at_monotonic=prepared.started_at_monotonic,
+            )
+            return
+        finally:
+            if item_heartbeat is not None:
+                await self._stop_heartbeat_fn(item_heartbeat)
+
     async def _process_item_with_prepared_override(
         self,
         job,
-        prepared: _PreparedEmbeddingItem,
+        prepared: _PreparedEmbeddingItem | _PreparedChatItem,
         *,
         process_item: Callable[[Any, Any], Awaitable[None]],
     ) -> None:  # noqa: ANN001
@@ -1033,6 +1198,7 @@ class BatchExecutionEngine:
             await self._record_upstream_success_runtime_hooks(
                 batch_id=batch_id,
                 deployment_id=served_deployment_id,
+                mode=router_usage_mode_for_batch_endpoint(job.endpoint),
                 usage=dict(response_body.get("usage") or {}),
                 reference=",".join(item_ids),
             )
@@ -1128,7 +1294,7 @@ class BatchExecutionEngine:
         job,
         item,
         *,
-        prepare_item: Callable[[Any, Any], Awaitable[_PreparedEmbeddingItem]] | None = None,
+        prepare_item: Callable[[Any, Any], Awaitable[_PreparedEmbeddingItem | _PreparedChatItem]] | None = None,
     ) -> None:  # noqa: ANN001
         request_body = item.request_body if isinstance(item.request_body, dict) else {}
         model_name = str(request_body.get("model") or job.model or "")
@@ -1148,6 +1314,41 @@ class BatchExecutionEngine:
                 started_at_monotonic=started_at_monotonic,
             )
             return
+        if job.endpoint == BATCH_ENDPOINT_CHAT_COMPLETIONS:
+            if not isinstance(prepared, _PreparedChatItem):
+                await self._mark_item_failed(
+                    job=job,
+                    item=item,
+                    model_name=model_name,
+                    exc=InvalidRequestError(message="Prepared batch chat item has an invalid execution shape"),
+                    deployment_id=None,
+                    started_at_monotonic=started_at_monotonic,
+                )
+                return
+            await self._execute_prepared_chat_item(job, prepared)
+            return
+
+        if job.endpoint != BATCH_ENDPOINT_EMBEDDINGS:
+            await self._mark_item_failed(
+                job=job,
+                item=item,
+                model_name=model_name,
+                exc=InvalidRequestError(message=f"Unsupported batch endpoint '{job.endpoint}'"),
+                deployment_id=None,
+                started_at_monotonic=started_at_monotonic,
+            )
+            return
+
+        if not isinstance(prepared, _PreparedEmbeddingItem):
+            await self._mark_item_failed(
+                job=job,
+                item=item,
+                model_name=model_name,
+                exc=InvalidRequestError(message="Prepared embedding batch item has an invalid execution shape"),
+                deployment_id=None,
+                started_at_monotonic=started_at_monotonic,
+            )
+            return
         await self._execute_prepared_item(job, prepared)
 
     async def _stop_heartbeat_tasks(self, tasks) -> None:  # noqa: ANN001
@@ -1159,7 +1360,7 @@ class BatchExecutionEngine:
         job,
         items,
         *,
-        prepare_item: Callable[[Any, Any], Awaitable[_PreparedEmbeddingItem]] | None = None,
+        prepare_item: Callable[[Any, Any], Awaitable[_PreparedEmbeddingItem | _PreparedChatItem]] | None = None,
         process_item: Callable[[Any, Any], Awaitable[None]] | None = None,
     ) -> None:  # noqa: ANN001
         if not items:
@@ -1172,6 +1373,47 @@ class BatchExecutionEngine:
                 await self.process_item(job, item, prepare_item=prepare_item_fn)
         else:
             process_item_fn = process_item
+
+        if job.endpoint != BATCH_ENDPOINT_EMBEDDINGS:
+            raw_items: deque[Any] = deque(items)
+            queue_lock = asyncio.Lock()
+            active = 0
+            logger.info(
+                "batch non-microbatch item processing started batch_id=%s endpoint=%s claimed_items=%s",
+                job.batch_id,
+                job.endpoint,
+                len(items),
+            )
+
+            async def _runner() -> None:
+                nonlocal active
+                while True:
+                    async with queue_lock:
+                        if not raw_items:
+                            return
+                        item = raw_items.popleft()
+
+                    active += 1
+                    set_batch_worker_saturation(
+                        worker_id=self.config.worker_id,
+                        active=active,
+                        capacity=self.config.worker_concurrency,
+                    )
+                    try:
+                        await process_item_fn(job, item)
+                    finally:
+                        active -= 1
+                        set_batch_worker_saturation(
+                            worker_id=self.config.worker_id,
+                            active=active,
+                            capacity=self.config.worker_concurrency,
+                        )
+
+            runner_count = min(max(1, self.config.worker_concurrency), len(items))
+            async with asyncio.TaskGroup() as task_group:
+                for _ in range(runner_count):
+                    task_group.create_task(_runner())
+            return
 
         raw_items: deque[Any] = deque(items)
         deferred_grouped_raw_items: deque[Any] = deque()
@@ -1369,6 +1611,7 @@ class BatchExecutionEngine:
         *,
         batch_id: str,
         deployment_id: str,
+        mode: str,
         usage: dict[str, Any],
         reference: str,
     ) -> None:
@@ -1390,7 +1633,7 @@ class BatchExecutionEngine:
                 await self._record_router_usage(
                     router_state_backend,
                     deployment_id,
-                    mode="embedding",
+                    mode=mode,
                     usage=usage,
                 )
             except Exception as exc:
@@ -1467,8 +1710,13 @@ class BatchExecutionEngine:
                     organization_id=job.created_by_organization_id,
                     end_user_id=None,
                     model=model_name,
-                    call_type="embedding_batch",
-                    metadata={"batch_id": batch_id, "batch_item_id": item.item_id},
+                    call_type=batch_call_type_for_endpoint(job.endpoint),
+                    metadata={
+                        "batch_id": batch_id,
+                        "batch_item_id": item.item_id,
+                        "custom_id": item.custom_id,
+                        "endpoint": job.endpoint,
+                    },
                     cache_hit=False,
                     start_time=None,
                     end_time=datetime.now(tz=UTC),

--- a/src/batch/worker_types.py
+++ b/src/batch/worker_types.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from src.batch.embedding_microbatch import _ExecutionSignature
-from src.models.requests import EmbeddingRequest
+from src.models.requests import ChatCompletionRequest, EmbeddingRequest
 
 
 class BatchArtifactValidationError(ValueError):
@@ -57,3 +57,16 @@ class _PreparedEmbeddingItem:
     microbatch_ineligible_reason: str | None
     microbatch_weight: int | None
     execution_signature: _ExecutionSignature
+
+
+@dataclass(slots=True)
+class _PreparedChatItem:
+    item: Any
+    started_at_monotonic: float
+    payload: ChatCompletionRequest
+    model_name: str
+    model_group: str
+    primary_deployment: Any
+    request_context: dict[str, Any]
+    failover_kwargs: dict[str, Any]
+    request_shim: _RequestShim

--- a/src/chat/executor.py
+++ b/src/chat/executor.py
@@ -37,6 +37,8 @@ async def execute_chat(
     request: Request,
     payload: ChatCompletionRequest,
     deployment: Deployment,
+    *,
+    record_usage: bool = True,
 ) -> tuple[dict[str, Any], float]:
     params = deployment.deltallm_params
     upstream = resolve_chat_upstream(request, params, is_stream=bool(payload.stream))
@@ -89,12 +91,15 @@ async def execute_chat(
     canonical = await adapter.translate_response(data, payload.model)
     canonical_payload = canonical.model_dump(mode="json")
 
-    await record_router_usage(
-        request.app.state.router_state_backend,
-        deployment.deployment_id,
-        mode="chat",
-        usage=canonical_payload.get("usage"),
-    )
+    if record_usage:
+        router_state_backend = getattr(request.app.state, "router_state_backend", None)
+        if router_state_backend is not None:
+            await record_router_usage(
+                router_state_backend,
+                deployment.deployment_id,
+                mode="chat",
+                usage=canonical_payload.get("usage"),
+            )
     return canonical_payload, (perf_counter() - upstream_start) * 1000
 
 

--- a/tests/test_batch_service.py
+++ b/tests/test_batch_service.py
@@ -148,6 +148,71 @@ async def test_parse_input_jsonl_rejects_duplicate_custom_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_parse_input_jsonl_accepts_chat_completion_lines() -> None:
+    service = _service(callable_target_scope_policy_mode="shadow")
+    auth = UserAPIKeyAuth(api_key="sk-test", models=["gpt-4o-mini"])
+    payload = (
+        b'{"custom_id":"chat-1","method":"POST","url":"/v1/chat/completions",'
+        b'"body":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}}\n'
+    )
+
+    items, model = service._parse_input_jsonl(payload, endpoint="/v1/chat/completions", auth=auth)
+
+    assert len(items) == 1
+    assert model == "gpt-4o-mini"
+    assert items[0].request_body["model"] == "gpt-4o-mini"
+    assert items[0].request_body["messages"] == [{"role": "user", "content": "hello"}]
+    assert items[0].request_body["stream"] is False
+
+
+@pytest.mark.asyncio
+async def test_parse_input_jsonl_rejects_streaming_chat_completion_lines() -> None:
+    service = _service()
+    auth = UserAPIKeyAuth(api_key="sk-test")
+    payload = (
+        b'{"custom_id":"chat-1","url":"/v1/chat/completions",'
+        b'"body":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}],"stream":true}}\n'
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        service._parse_input_jsonl(payload, endpoint="/v1/chat/completions", auth=auth)
+
+    assert exc.value.status_code == 400
+    assert "non-streaming" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_parse_input_jsonl_rejects_mcp_tools_for_chat_completion_lines() -> None:
+    service = _service()
+    auth = UserAPIKeyAuth(api_key="sk-test")
+    payload = (
+        b'{"custom_id":"chat-1","url":"/v1/chat/completions",'
+        b'"body":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}],'
+        b'"tools":[{"type":"mcp","server":"internal"}]}}\n'
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        service._parse_input_jsonl(payload, endpoint="/v1/chat/completions", auth=auth)
+
+    assert exc.value.status_code == 400
+    assert "MCP tools" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_parse_input_jsonl_rejects_unsupported_batch_endpoint() -> None:
+    service = _service()
+    auth = UserAPIKeyAuth(api_key="sk-test")
+    payload = b'{"custom_id":"item-1","url":"/v1/responses","body":{"model":"gpt-4o-mini","input":"hello"}}\n'
+
+    with pytest.raises(HTTPException) as exc:
+        service._parse_input_jsonl(payload, endpoint="/v1/responses", auth=auth)
+
+    assert exc.value.status_code == 400
+    assert "/v1/embeddings" in str(exc.value.detail)
+    assert "/v1/chat/completions" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_parse_input_jsonl_rejects_model_outside_effective_scope() -> None:
     grant_service = CallableTargetGrantService(
         repository=_FakeCallableTargetBindingRepository(

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -235,6 +235,326 @@ async def test_batch_worker_logs_batch_pricing_and_spend(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_batch_worker_processes_chat_item_with_chat_batch_accounting(monkeypatch):
+    execute_calls: list[dict] = []
+    router_usage_calls: list[tuple[str, str, dict[str, int]]] = []
+    router_contexts: list[dict] = []
+
+    async def _fake_execute_chat(request, payload, deployment, *, record_usage: bool = True):
+        del request, deployment
+        execute_calls.append({"model": payload.model, "record_usage": record_usage})
+        return (
+            {
+                "id": "chatcmpl-1",
+                "object": "chat.completion",
+                "created": 1,
+                "model": payload.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "hello"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+            },
+            12.0,
+        )
+
+    async def _patched_record_router_usage(state_backend, deployment_id: str, *, mode: str, usage: dict):
+        del state_backend
+        router_usage_calls.append((deployment_id, mode, dict(usage)))
+
+    monkeypatch.setattr("src.batch.worker.execute_chat", _fake_execute_chat)
+    monkeypatch.setattr("src.batch.worker.record_router_usage", _patched_record_router_usage)
+
+    deployment = SimpleNamespace(
+        deployment_id="dep-chat",
+        deltallm_params={
+            "provider": "groq",
+            "model": "openai/gpt-oss-120b",
+            "api_base": "https://api.groq.com/openai/v1",
+        },
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.002,
+        model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.001},
+    )
+
+    class _Router:
+        def resolve_model_group(self, model: str) -> str:
+            return model
+
+        async def select_deployment(self, model_group: str, request_context: dict) -> str:
+            del model_group
+            router_contexts.append(request_context)
+            return "dep-chat"
+
+        def require_deployment(self, model_group: str, deployment: str):
+            del model_group, deployment
+            return deployment_obj
+
+    class _Failover:
+        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+            del model_group, kwargs
+            data = await execute(primary_deployment)
+            if return_deployment:
+                return data, primary_deployment
+            return data
+
+    deployment_obj = deployment
+    repo = _FakeRepository()
+    passive_health = _PassiveHealthRecorder()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(),
+            failover_manager=_Failover(),
+            spend_tracking_service=None,
+            passive_health_tracker=passive_health,
+            router_state_backend=SimpleNamespace(),
+        )
+    )
+    worker = BatchExecutorWorker(
+        app=app,
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    now = datetime.now(tz=UTC)
+    job = BatchJobRecord(
+        batch_id="b-chat",
+        endpoint="/v1/chat/completions",
+        status=BatchJobStatus.IN_PROGRESS,
+        execution_mode="managed_internal",
+        input_file_id="f1",
+        output_file_id=None,
+        error_file_id=None,
+        model="gpt-oss",
+        metadata={},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=1,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="tok-1",
+        created_by_user_id="u1",
+        created_by_team_id="t1",
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+        expires_at=None,
+        created_by_organization_id="org-1",
+    )
+    item = BatchItemRecord(
+        item_id="i-chat",
+        batch_id="b-chat",
+        line_number=1,
+        custom_id="chat-1",
+        status="in_progress",
+        request_body={
+            "model": "gpt-oss",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+            "metadata": {"tags": ["batch-blue"]},
+        },
+        response_body=None,
+        error_body=None,
+        usage=None,
+        provider_cost=0.0,
+        billed_cost=0.0,
+        attempts=0,
+        last_error=None,
+        locked_by="w1",
+        lease_expires_at=now,
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+    )
+
+    await worker._process_item(job, item)
+
+    assert router_contexts == [{"metadata": {"tags": ["batch-blue"]}, "user_id": "u1"}]
+    assert execute_calls == [{"model": "gpt-oss", "record_usage": False}]
+    assert passive_health.calls == [("dep-chat", True, None)]
+    assert router_usage_calls == [("dep-chat", "chat", {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10})]
+    assert len(repo.completed_calls) == 1
+    completed = repo.completed_calls[0]
+    assert completed["response_body"]["object"] == "chat.completion"
+    assert completed["usage"] == {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10}
+    assert completed["billed_cost"] == pytest.approx(0.0065)
+    assert completed["provider_cost"] == pytest.approx(0.013)
+    assert len(repo.completion_outbox_calls) == 1
+    outbox_payload = repo.completion_outbox_calls[0]
+    assert outbox_payload["call_type"] == "chat_batch"
+    assert outbox_payload["api_provider"] == "groq"
+    assert outbox_payload["api_base"] == "https://api.groq.com/openai/v1"
+    assert outbox_payload["deployment_model"] == "openai/gpt-oss-120b"
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_logs_chat_request_failure_with_batch_metadata(monkeypatch):
+    async def _fake_execute_chat(request, payload, deployment, *, record_usage: bool = True):
+        del request, payload, deployment, record_usage
+        raise RuntimeError("chat provider down")
+
+    monkeypatch.setattr("src.batch.worker.execute_chat", _fake_execute_chat)
+
+    class _BudgetService:
+        async def check_budgets(self, **kwargs):  # noqa: ANN003, ANN201
+            return None
+
+    class _RouterStateBackend:
+        async def increment_usage_counters(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+            return None
+
+    class _Router:
+        def resolve_model_group(self, model: str) -> str:
+            return model
+
+        async def select_deployment(self, model_group: str, request_context: dict) -> str:
+            del model_group, request_context
+            return "dep-chat"
+
+        def require_deployment(self, model_group: str, deployment: str):
+            del model_group, deployment
+            return deployment_obj
+
+    class _Failover:
+        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+            del model_group, kwargs
+            data = await execute(primary_deployment)
+            if return_deployment:
+                return data, primary_deployment
+            return data
+
+    class _FailureRepo(_FakeRepository):
+        def __init__(self) -> None:
+            super().__init__()
+            self.failed_calls: list[dict] = []
+
+        async def mark_item_failed(self, **kwargs) -> bool:
+            self.failed_calls.append(kwargs)
+            return True
+
+        async def refresh_job_progress(self, batch_id: str):
+            assert batch_id == "b-chat"
+            return None
+
+    deployment_obj = SimpleNamespace(
+        deployment_id="dep-chat",
+        deltallm_params={
+            "provider": "groq",
+            "model": "openai/gpt-oss-120b",
+            "api_base": "https://api.groq.com/openai/v1",
+        },
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.002,
+        model_info={},
+    )
+    repo = _FailureRepo()
+    spend = _SpendRecorder()
+    passive_health = _PassiveHealthRecorder()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(),
+            failover_manager=_Failover(),
+            spend_tracking_service=spend,
+            budget_service=_BudgetService(),
+            passive_health_tracker=passive_health,
+            router_state_backend=_RouterStateBackend(),
+        )
+    )
+    worker = BatchExecutorWorker(
+        app=app,
+        repository=repo,  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    now = datetime.now(tz=UTC)
+    job = BatchJobRecord(
+        batch_id="b-chat",
+        endpoint="/v1/chat/completions",
+        status=BatchJobStatus.IN_PROGRESS,
+        execution_mode="managed_internal",
+        input_file_id="f1",
+        output_file_id=None,
+        error_file_id=None,
+        model="gpt-oss",
+        metadata={},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=1,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="tok-1",
+        created_by_user_id="u1",
+        created_by_team_id="t1",
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+        expires_at=None,
+        created_by_organization_id="org-1",
+    )
+    item = BatchItemRecord(
+        item_id="i-chat",
+        batch_id="b-chat",
+        line_number=1,
+        custom_id="chat-1",
+        status="in_progress",
+        request_body={
+            "model": "gpt-oss",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+        },
+        response_body=None,
+        error_body=None,
+        usage=None,
+        provider_cost=0.0,
+        billed_cost=0.0,
+        attempts=0,
+        last_error=None,
+        locked_by="w1",
+        lease_expires_at=now,
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+    )
+
+    await worker._process_item(job, item)
+
+    assert len(repo.failed_calls) == 1
+    assert repo.failed_calls[0]["item_id"] == "i-chat"
+    assert passive_health.calls == [("dep-chat", False, "chat provider down")]
+    assert len(spend.events) == 1
+    assert spend.events[0]["status"] == "error"
+    assert spend.events[0]["request_id"] == "batch:b-chat:i-chat"
+    assert spend.events[0]["call_type"] == "chat_batch"
+    assert spend.events[0]["metadata"] == {
+        "batch_id": "b-chat",
+        "batch_item_id": "i-chat",
+        "custom_id": "chat-1",
+        "endpoint": "/v1/chat/completions",
+    }
+
+
+@pytest.mark.asyncio
 async def test_batch_worker_uses_post_construction_hook_patches(monkeypatch):
     execute_inputs: list[object] = []
     router_usage_calls: list[tuple[str, str, dict[str, int]]] = []
@@ -729,6 +1049,86 @@ async def test_batch_worker_iter_output_lines_emit_openai_batch_success_rows():
                     "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
                     "model": "provider-embedding-model",
                     "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+                },
+            },
+            "error": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_worker_iter_output_lines_emit_chat_batch_success_rows():
+    now = datetime.now(tz=UTC)
+
+    class _ArtifactRepo:
+        async def list_items(self, batch_id: str):
+            assert batch_id == "b1"
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="chat-1",
+                    status="completed",
+                    request_body={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+                    response_body={
+                        "id": "chatcmpl-1",
+                        "object": "chat.completion",
+                        "created": 1,
+                        "model": "gpt-4o-mini",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "hello"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+                        "_provider": "openai",
+                    },
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                )
+            ]
+
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_ArtifactRepo(),  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    rows = [json.loads(line) async for line in worker._iter_output_lines("b1", endpoint="/v1/chat/completions")]
+
+    assert rows == [
+        {
+            "id": "batch_req_i1",
+            "custom_id": "chat-1",
+            "response": {
+                "status_code": 200,
+                "request_id": "req_batch_i1",
+                "body": {
+                    "id": "chatcmpl-1",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "hello"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
                 },
             },
             "error": None,


### PR DESCRIPTION
## Summary

Adds PR1 of issue #133: managed internal batch support for non-streaming `/v1/chat/completions` alongside the existing embeddings batch flow.

## Changes

- Add shared batch endpoint constants and JSONL request validation for embeddings and chat completions.
- Allow public batch creation and create-session staging to accept `/v1/chat/completions`.
- Execute non-streaming chat batch items through the existing chat executor with batch-specific accounting.
- Preserve request metadata in batch chat routing so `metadata.tags` behaves like synchronous chat routing.
- Emit `chat_batch` spend/completion metadata and `chat` router usage for batch chat.
- Add chat batch output artifact serialization.
- Update docs and the embedding batch load script to use the shared validation module.

## Issue #108 Preservation

The existing embedding batch resiliency path is preserved: retry classification, no-healthy-deployment backpressure, grouped embedding microbatch retries, and reduced chunk retry behavior remain in the embedding planner. The new chat execution path is split outside that embedding microbatch planner.

## Validation

- `uv run --extra dev ruff check src/batch/worker_execution.py tests/test_batch_worker.py`
- `uv run --extra dev pytest tests/test_batch_worker.py`
- `uv run --extra dev pytest tests/test_batch_worker_microbatch.py`
- `uv run --extra dev pytest tests/test_batch_worker.py tests/test_batch_service.py`
- `uv run --extra dev pytest tests/test_batch_*.py tests/test_admin_batch_create_sessions.py tests/test_admin_batch_repairs.py tests/test_chat.py`

Broad batch/chat regression result: `301 passed, 42 skipped`.