### PR TITLE
Harden batch reliability workers

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -99,7 +99,9 @@ general_settings:
   sso_state_ttl_seconds: 600
   embeddings_batch_enabled: false
   embeddings_batch_worker_enabled: true
+  embeddings_batch_storage_backend: local
   embeddings_batch_storage_dir: .deltallm/batch-artifacts
+  embeddings_batch_create_session_cleanup_enabled: true
   embeddings_batch_poll_interval_seconds: 1.0
   embeddings_batch_item_claim_limit: 20
   embeddings_batch_max_attempts: 3
@@ -299,7 +301,9 @@ These settings retain the historical `embeddings_batch_*` names for compatibilit
 |---------|---------|-------------|
 | `embeddings_batch_enabled` | `false` | Enable `/v1/files` and `/v1/batches` endpoints |
 | `embeddings_batch_worker_enabled` | `true` | Run internal batch executor worker loop |
+| `embeddings_batch_storage_backend` | `local` | Artifact storage backend. Use `s3` for multi-replica production deployments |
 | `embeddings_batch_storage_dir` | `.deltallm/batch-artifacts` | Local artifact storage base directory |
+| `embeddings_batch_create_session_cleanup_enabled` | `true` | Enable cleanup for internal staged batch-create artifacts |
 | `embeddings_batch_poll_interval_seconds` | `1.0` | Worker poll interval when queue is idle |
 | `embeddings_batch_item_claim_limit` | `20` | Max items claimed per worker iteration |
 | `embeddings_batch_max_attempts` | `3` | Max retry attempts per failed item |
@@ -316,6 +320,8 @@ These settings retain the historical `embeddings_batch_*` names for compatibilit
 | `embeddings_batch_gc_enabled` | `true` | Enable background retention cleanup for expired batch metadata/artifacts |
 | `embeddings_batch_gc_interval_seconds` | `86400` | Cleanup loop interval in seconds |
 | `embeddings_batch_gc_scan_limit` | `200` | Max expired jobs/files processed per cleanup pass |
+
+For Helm deployments with more than one replica, configure `embeddings_batch_storage_backend: s3` and the matching S3 bucket settings before enabling batch. Local batch storage is intended for development and single-replica deployments only.
 
 ## Audit Settings
 

--- a/docs/features/batching.md
+++ b/docs/features/batching.md
@@ -187,6 +187,7 @@ general_settings:
 ```
 
 All other settings have sensible defaults that work for single-instance deployments with local storage.
+For Helm or Kubernetes deployments with more than one replica, configure S3-compatible storage before enabling batch.
 
 ### Storage Backend
 
@@ -278,6 +279,7 @@ Completed batches and their artifacts are automatically cleaned up by a backgrou
 | `embeddings_batch_gc_enabled` | `true` | Enable background cleanup |
 | `embeddings_batch_gc_interval_seconds` | `86400` | How often the cleanup loop runs (default: daily) |
 | `embeddings_batch_gc_scan_limit` | `200` | Maximum expired items processed per cleanup pass |
+| `embeddings_batch_create_session_cleanup_enabled` | `true` | Enable cleanup for internal staged batch-create artifacts |
 
 For the full settings reference, see [Configuration > General](../configuration/general.md#batch-settings).
 
@@ -426,6 +428,7 @@ DeltaLLM exposes Prometheus metrics for batch processing on the configured metri
 |--------|------|-------------|
 | `deltallm_batch_finalization_retries_total` | Counter | Finalization retries by result |
 | `deltallm_batch_artifact_failures_total` | Counter | Storage operation failures by operation and backend |
+| `deltallm_batch_completion_outbox_failures_total` | Counter | Completion outbox failures by bounded reason |
 | `deltallm_batch_item_reclaims_total` | Counter | Items reclaimed from expired leases |
 | `deltallm_batch_repair_actions_total` | Counter | Admin repair actions by type and status |
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -165,6 +165,13 @@ config:
     health_check_model: gpt-3.5-turbo
     model_deployment_source: hybrid
     model_deployment_bootstrap_from_config: true
+    # Batch API defaults are safe for local/single-replica deployments.
+    # If embeddings_batch_enabled is true and replicaCount > 1, configure
+    # embeddings_batch_storage_backend: s3 so every pod can read/write artifacts.
+    embeddings_batch_enabled: false
+    embeddings_batch_storage_backend: local
+    embeddings_batch_storage_dir: .deltallm/batch-artifacts
+    embeddings_batch_create_session_cleanup_enabled: true
 
 s3:
   enabled: false

--- a/src/batch/cleanup.py
+++ b/src/batch/cleanup.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class BatchCleanupConfig:
     interval_seconds: float = 86_400.0
+    failure_interval_seconds: float = 60.0
     scan_limit: int = 200
 
 
@@ -40,6 +41,7 @@ class BatchRetentionCleanupWorker:
         self.storage_registry.setdefault(active_backend, storage)
         self.config = config
         self._running = False
+        self._stop_event = asyncio.Event()
 
     def _storage_for_backend(self, backend: str | None) -> BatchArtifactStorage:
         normalized = str(backend or getattr(self.storage, "backend_name", "local") or "local").strip().lower()
@@ -60,12 +62,35 @@ class BatchRetentionCleanupWorker:
 
     async def run(self) -> None:
         self._running = True
-        while self._running:
-            await self.process_once()
-            await asyncio.sleep(self.config.interval_seconds)
+        while self._running and not self._stop_event.is_set():
+            iteration_failed = False
+            try:
+                await self.process_once()
+            except Exception:
+                iteration_failed = True
+                logger.exception("batch cleanup iteration failed")
+                if not self._running:
+                    break
+            if not self._running or self._stop_event.is_set():
+                break
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=max(
+                        0.0,
+                        float(
+                            self.config.failure_interval_seconds
+                            if iteration_failed
+                            else self.config.interval_seconds
+                        ),
+                    ),
+                )
+            except asyncio.TimeoutError:
+                continue
 
     def stop(self) -> None:
         self._running = False
+        self._stop_event.set()
 
     async def process_once(self) -> tuple[int, int]:
         now = datetime.now(tz=UTC)

--- a/src/batch/completion_outbox.py
+++ b/src/batch/completion_outbox.py
@@ -9,7 +9,12 @@ from typing import Any
 from src.batch.models import BatchCompletionOutboxRecord
 from src.batch.repository import BatchRepository
 from src.billing.spend import SpendTrackingService
-from src.metrics import increment_request, increment_spend, increment_usage
+from src.metrics import (
+    increment_batch_completion_outbox_failure,
+    increment_request,
+    increment_spend,
+    increment_usage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,15 +51,33 @@ class BatchCompletionOutboxWorker:
         self.repository = repository
         self.config = config or BatchCompletionOutboxWorkerConfig()
         self._stopped = False
+        self._stop_event = asyncio.Event()
 
     def stop(self) -> None:
         self._stopped = True
+        self._stop_event.set()
 
     async def run(self) -> None:
-        while not self._stopped:
-            processed = await self.process_once()
+        while not self._stopped and not self._stop_event.is_set():
+            try:
+                processed = await self.process_once()
+            except Exception:
+                increment_batch_completion_outbox_failure(reason="iteration")
+                logger.exception(
+                    "batch completion outbox iteration failed worker_id=%s",
+                    self.config.worker_id,
+                )
+                processed = 0
             if processed == 0:
-                await asyncio.sleep(self.config.poll_interval_seconds)
+                if self._stopped or self._stop_event.is_set():
+                    break
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(),
+                        timeout=max(0.0, float(self.config.poll_interval_seconds)),
+                    )
+                except asyncio.TimeoutError:
+                    continue
 
     async def process_once(self) -> int:
         claimed = await self.repository.claim_completion_outbox_due(
@@ -69,7 +92,16 @@ class BatchCompletionOutboxWorker:
 
         async def _run(record: BatchCompletionOutboxRecord) -> None:
             async with semaphore:
-                await self._process_record(record)
+                try:
+                    await self._process_record(record)
+                except Exception:
+                    increment_batch_completion_outbox_failure(reason="record_unhandled")
+                    logger.exception(
+                        "batch completion outbox record processing failed completion_id=%s item_id=%s worker_id=%s",
+                        record.completion_id,
+                        record.item_id,
+                        self.config.worker_id,
+                    )
 
         await asyncio.gather(*[_run(record) for record in claimed])
         return len(claimed)
@@ -98,6 +130,14 @@ class BatchCompletionOutboxWorker:
                         "batch completion outbox failed finalize skipped after lease loss completion_id=%s",
                         record.completion_id,
                     )
+                    return
+                increment_batch_completion_outbox_failure(reason="max_attempts")
+                logger.error(
+                    "batch completion outbox marked failed after max attempts completion_id=%s item_id=%s attempts=%s",
+                    record.completion_id,
+                    record.item_id,
+                    record.attempt_count,
+                )
                 return
             retry_seconds = min(
                 self.config.retry_max_seconds,

--- a/src/batch/service.py
+++ b/src/batch/service.py
@@ -100,6 +100,20 @@ class BatchService:
                 )
             yield chunk
 
+    async def _cleanup_unrecorded_artifact(self, *, storage_key: str, backend: str) -> None:
+        if not storage_key:
+            return
+        try:
+            await self.storage.delete(storage_key)
+        except Exception as exc:
+            increment_batch_artifact_failure(operation="delete_orphan", backend=backend)
+            logger.warning(
+                "batch artifact orphan cleanup failed backend=%s storage_key=%s error=%s",
+                backend,
+                storage_key,
+                exc,
+            )
+
     async def _iter_storage_lines(
         self,
         *,
@@ -161,30 +175,38 @@ class BatchService:
         )
 
     async def create_file(self, *, auth: UserAPIKeyAuth, upload: UploadFile, purpose: str) -> dict[str, Any]:
-        storage_key, bytes_size, checksum = await self.storage.write_chunks(
-            purpose=purpose,
-            filename=upload.filename or "batch.jsonl",
-            chunks=self._upload_chunks(upload),
-        )
-        if bytes_size <= 0:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uploaded file is empty")
-        filename = upload.filename or "batch.jsonl"
-        record = await self.repository.create_file(
-            purpose=purpose,
-            filename=filename,
-            bytes_size=bytes_size,
-            storage_backend=getattr(self.storage, "backend_name", "local"),
-            storage_key=storage_key,
-            checksum=checksum,
-            created_by_api_key=auth.api_key,
-            created_by_user_id=auth.user_id,
-            created_by_team_id=auth.team_id,
-            created_by_organization_id=auth.organization_id,
-            expires_at=datetime.now(tz=UTC) + timedelta(days=self.metadata_retention_days),
-        )
-        if record is None:
-            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Database unavailable")
-        return self.file_to_response(record)
+        storage_key: str | None = None
+        record = None
+        backend = str(getattr(self.storage, "backend_name", "local") or "local")
+        try:
+            storage_key, bytes_size, checksum = await self.storage.write_chunks(
+                purpose=purpose,
+                filename=upload.filename or "batch.jsonl",
+                chunks=self._upload_chunks(upload),
+            )
+            if bytes_size <= 0:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uploaded file is empty")
+            filename = upload.filename or "batch.jsonl"
+            record = await self.repository.create_file(
+                purpose=purpose,
+                filename=filename,
+                bytes_size=bytes_size,
+                storage_backend=backend,
+                storage_key=storage_key,
+                checksum=checksum,
+                created_by_api_key=auth.api_key,
+                created_by_user_id=auth.user_id,
+                created_by_team_id=auth.team_id,
+                created_by_organization_id=auth.organization_id,
+                expires_at=datetime.now(tz=UTC) + timedelta(days=self.metadata_retention_days),
+            )
+            if record is None:
+                raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Database unavailable")
+            return self.file_to_response(record)
+        except Exception:
+            if record is None and storage_key:
+                await self._cleanup_unrecorded_artifact(storage_key=storage_key, backend=backend)
+            raise
 
     async def get_file_content(self, *, file_id: str, auth: UserAPIKeyAuth) -> bytes:
         file_record = await self.repository.get_file(file_id)

--- a/src/batch/worker_artifacts.py
+++ b/src/batch/worker_artifacts.py
@@ -400,6 +400,19 @@ class BatchArtifactFinalizer:
             with contextlib.suppress(Exception):
                 await self.repository.delete_file(file_id)
 
+    async def _cleanup_unrecorded_artifacts(self, storage_keys: set[str], *, backend: str) -> None:
+        for storage_key in storage_keys:
+            try:
+                await self.storage.delete(storage_key)
+            except Exception as exc:
+                increment_batch_artifact_failure(operation="delete_orphan", backend=backend)
+                logger.warning(
+                    "batch finalization orphan artifact cleanup failed backend=%s storage_key=%s error=%s",
+                    backend,
+                    storage_key,
+                    exc,
+                )
+
     async def _iter_batch_items(self, batch_id: str) -> AsyncIterator[Any]:
         if hasattr(self.repository, "list_items_page"):
             after_line_number: int | None = None
@@ -437,6 +450,7 @@ class BatchArtifactFinalizer:
     async def finalize_artifacts(self, job) -> None:  # noqa: ANN001
         storage_backend = getattr(self.storage, "backend_name", "local")
         created_artifacts: list[tuple[str, str]] = []
+        unrecorded_artifact_keys: set[str] = set()
         output_file_id: str | None = None
         error_file_id: str | None = None
         final_status = self.resolve_final_status(job)
@@ -447,6 +461,8 @@ class BatchArtifactFinalizer:
                     filename=f"{job.batch_id}-output.jsonl",
                     lines=self.iter_output_lines(job.batch_id, endpoint=job.endpoint),
                 )
+                if key:
+                    unrecorded_artifact_keys.add(key)
                 file_record = await self.repository.create_file(
                     purpose="batch_output",
                     filename=f"{job.batch_id}-output.jsonl",
@@ -463,6 +479,7 @@ class BatchArtifactFinalizer:
                 if file_record is None:
                     increment_batch_artifact_failure(operation="create_record", backend=storage_backend)
                     raise RuntimeError(f"Failed to create output artifact record for batch {job.batch_id}")
+                unrecorded_artifact_keys.discard(key)
                 created_artifacts.append((file_record.file_id, key))
                 output_file_id = file_record.file_id
 
@@ -472,6 +489,8 @@ class BatchArtifactFinalizer:
                     filename=f"{job.batch_id}-error.jsonl",
                     lines=self.iter_error_lines(job.batch_id),
                 )
+                if key:
+                    unrecorded_artifact_keys.add(key)
                 retention_days = (
                     self.config.failed_artifact_retention_days
                     if final_status in {BatchJobStatus.FAILED, BatchJobStatus.CANCELLED}
@@ -493,6 +512,7 @@ class BatchArtifactFinalizer:
                 if file_record is None:
                     increment_batch_artifact_failure(operation="create_record", backend=storage_backend)
                     raise RuntimeError(f"Failed to create error artifact record for batch {job.batch_id}")
+                unrecorded_artifact_keys.discard(key)
                 created_artifacts.append((file_record.file_id, key))
                 error_file_id = file_record.file_id
 
@@ -507,6 +527,7 @@ class BatchArtifactFinalizer:
                 raise RuntimeError(f"Failed to finalize batch {job.batch_id}")
         except Exception:
             increment_batch_artifact_failure(operation="write_or_finalize", backend=storage_backend)
+            await self._cleanup_unrecorded_artifacts(unrecorded_artifact_keys, backend=storage_backend)
             await self._cleanup_unattached_artifacts(created_artifacts)
             raise
         logger.info(

--- a/src/bootstrap/batch.py
+++ b/src/bootstrap/batch.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
+import socket
 from asyncio import Task, create_task
 from dataclasses import dataclass
 from typing import Any
+from uuid import uuid4
 
 from src.batch import BatchCleanupConfig, BatchRetentionCleanupWorker, BatchRepository
 from src.batch.backpressure import BatchBackpressureCoordinator
@@ -30,6 +33,26 @@ logger = logging.getLogger(__name__)
 # worker task. Kept conservative so k8s pod termination grace periods are
 # respected; the worker loop's own idle poll is sub-second.
 _WORKER_SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 30.0
+_BATCH_WORKER_BOOT_ID = uuid4().hex[:12]
+
+
+def _safe_worker_id_part(value: object, *, fallback: str) -> str:
+    safe = "".join(
+        char if char.isascii() and (char.isalnum() or char in {"-", "_", "."}) else "-"
+        for char in str(value or "").strip()
+    ).strip("-._")
+    return safe or fallback
+
+
+def _batch_worker_id(role: str) -> str:
+    return "-".join(
+        (
+            _safe_worker_id_part(role, fallback="batch-worker"),
+            _safe_worker_id_part(socket.gethostname(), fallback="unknown-host"),
+            str(os.getpid()),
+            _BATCH_WORKER_BOOT_ID,
+        )
+    )
 
 
 @dataclass
@@ -223,7 +246,7 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
             repository=repository,
             storage=batch_storage,
             config=BatchWorkerConfig(
-                worker_id=f"worker-{id(app)}",
+                worker_id=_batch_worker_id("batch-executor"),
                 poll_interval_seconds=cfg.general_settings.embeddings_batch_poll_interval_seconds,
                 heartbeat_interval_seconds=cfg.general_settings.embeddings_batch_heartbeat_interval_seconds,
                 job_lease_seconds=cfg.general_settings.embeddings_batch_job_lease_seconds,
@@ -252,7 +275,7 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
         app=app,
         repository=repository,
         config=BatchCompletionOutboxWorkerConfig(
-            worker_id=f"completion-outbox-{id(app)}",
+            worker_id=_batch_worker_id("batch-completion-outbox"),
             poll_interval_seconds=cfg.general_settings.embeddings_batch_poll_interval_seconds,
             max_batch_size=max(10, int(cfg.general_settings.embeddings_batch_item_claim_limit or 20)),
             max_concurrency=min(8, max(1, int(cfg.general_settings.embeddings_batch_worker_concurrency or 4))),

--- a/src/config.py
+++ b/src/config.py
@@ -355,7 +355,7 @@ class GeneralSettings(BaseModel):
     embeddings_batch_item_buffer_multiplier: int = Field(default=2, ge=1, le=10)
     embeddings_batch_storage_chunk_size: int = Field(default=65_536, ge=1_024)
     embeddings_batch_finalization_page_size: int = Field(default=500, ge=10, le=10_000)
-    embeddings_batch_create_session_cleanup_enabled: bool = False
+    embeddings_batch_create_session_cleanup_enabled: bool = True
     embeddings_batch_create_session_cleanup_interval_seconds: float = Field(
         default=DEFAULT_CREATE_SESSION_CLEANUP_INTERVAL_SECONDS,
         gt=0,

--- a/src/metrics/__init__.py
+++ b/src/metrics/__init__.py
@@ -1,6 +1,7 @@
 from src.metrics.batch import (
     increment_batch_create_session_action,
     increment_batch_artifact_failure,
+    increment_batch_completion_outbox_failure,
     increment_batch_chat_item_executed,
     increment_batch_chat_microbatch_fallback,
     increment_batch_chat_microbatch_request,
@@ -80,6 +81,7 @@ __all__ = [
     "increment_batch_chat_microbatch_request",
     "increment_batch_finalization_retry",
     "increment_batch_artifact_failure",
+    "increment_batch_completion_outbox_failure",
     "increment_batch_repair_action",
     "increment_batch_item_reclaim",
     "increment_batch_item_retry",

--- a/src/metrics/batch.py
+++ b/src/metrics/batch.py
@@ -57,6 +57,13 @@ deltallm_batch_artifact_failures_metric = Counter(
     registry=get_prometheus_registry(),
 )
 
+deltallm_batch_completion_outbox_failures_metric = Counter(
+    "deltallm_batch_completion_outbox_failures_total",
+    "Batch completion outbox failures by bounded reason",
+    ["reason"],
+    registry=get_prometheus_registry(),
+)
+
 deltallm_batch_repair_actions_metric = Counter(
     "deltallm_batch_repair_actions_total",
     "Batch repair actions by action and status",
@@ -261,6 +268,10 @@ def increment_batch_artifact_failure(*, operation: str, backend: str) -> None:
         operation=sanitize_label(operation),
         backend=sanitize_label(backend),
     ).inc()
+
+
+def increment_batch_completion_outbox_failure(*, reason: str) -> None:
+    deltallm_batch_completion_outbox_failures_metric.labels(reason=sanitize_label(reason)).inc()
 
 
 def increment_batch_repair_action(*, action: str, status: str) -> None:

--- a/tests/bootstrap/test_optional_bootstrap.py
+++ b/tests/bootstrap/test_optional_bootstrap.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from src.bootstrap import BootstrapStatus
+from src.bootstrap import batch as batch_bootstrap
 from src.bootstrap.audit import init_audit_runtime, shutdown_audit_runtime
 from src.bootstrap.batch import _drain_worker_task, init_batch_runtime, shutdown_batch_runtime
 
@@ -91,6 +92,16 @@ def _batch_config(
             embeddings_batch_gc_scan_limit=100,
         )
     )
+
+
+def test_batch_worker_id_is_cluster_unique_and_log_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(batch_bootstrap.socket, "gethostname", lambda: "pod/name with spaces")
+    monkeypatch.setattr(batch_bootstrap.os, "getpid", lambda: 12345)
+    monkeypatch.setattr(batch_bootstrap, "_BATCH_WORKER_BOOT_ID", "abc123def456")
+
+    worker_id = batch_bootstrap._batch_worker_id("batch executor")
+
+    assert worker_id == "batch-executor-pod-name-with-spaces-12345-abc123def456"
 
 
 class _FakeCreateSessionRepository:
@@ -689,6 +700,8 @@ async def test_init_batch_runtime_selects_s3_storage(monkeypatch: pytest.MonkeyP
     assert runtime.worker is None
     assert runtime.gc_worker is None
 
+    await shutdown_batch_runtime(runtime)
+
 
 @pytest.mark.asyncio
 async def test_init_batch_runtime_allows_s3_when_local_storage_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -737,6 +750,8 @@ async def test_init_batch_runtime_allows_s3_when_local_storage_is_unavailable(mo
     assert app.state.batch_storage_registry["s3"]["backend"] == "s3"
     assert runtime.worker is None
     assert runtime.gc_worker is None
+
+    await shutdown_batch_runtime(runtime)
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_cleanup.py
+++ b/tests/test_batch_cleanup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 import logging
 
@@ -153,3 +154,31 @@ async def test_batch_cleanup_worker_refresh_runtime_metrics_logs_debug_on_publis
         await worker._refresh_batch_runtime_metrics(now=datetime.now(tz=UTC))
 
     assert "batch cleanup runtime metrics refresh failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_batch_cleanup_worker_run_survives_iteration_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    worker = BatchRetentionCleanupWorker(
+        repository=_RepoStub(),  # type: ignore[arg-type]
+        storage=_StorageStub(),  # type: ignore[arg-type]
+        config=BatchCleanupConfig(interval_seconds=999.0, failure_interval_seconds=0.01, scan_limit=10),
+    )
+    calls = 0
+
+    async def _process_once() -> tuple[int, int]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("db unavailable")
+        worker.stop()
+        return (0, 0)
+
+    worker.process_once = _process_once  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.ERROR):
+        await asyncio.wait_for(worker.run(), timeout=0.5)
+
+    assert calls == 2
+    assert "batch cleanup iteration failed" in caplog.text

--- a/tests/test_batch_completion_outbox.py
+++ b/tests/test_batch_completion_outbox.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -341,6 +342,90 @@ async def test_completion_outbox_worker_marks_failed_after_max_attempts() -> Non
     assert stored.last_error == "spend log unavailable"
     assert repository.retry_calls == []
     assert repository.failed_calls == [{"completion_id": record.completion_id, "error": "spend log unavailable"}]
+
+
+@pytest.mark.asyncio
+async def test_completion_outbox_worker_isolates_unhandled_record_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _SelectiveSpendTrackingService:
+        async def log_spend_once(self, **kwargs) -> str:
+            if kwargs["event_id"] == "completion-fail":
+                raise RuntimeError("spend log unavailable")
+            return "inserted"
+
+    class _RetryFailingRepository(_FakeRepository):
+        async def mark_completion_outbox_retry(self, completion_id: str, **kwargs) -> bool:  # noqa: ANN003
+            if completion_id == "completion-fail":
+                raise RuntimeError("retry db unavailable")
+            return await super().mark_completion_outbox_retry(completion_id, **kwargs)
+
+    metric_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.batch.completion_outbox.increment_batch_completion_outbox_failure",
+        lambda **kwargs: metric_calls.append(kwargs),
+    )
+    monkeypatch.setattr("src.batch.completion_outbox.increment_request", lambda **kwargs: None)
+    monkeypatch.setattr("src.batch.completion_outbox.increment_usage", lambda **kwargs: None)
+    monkeypatch.setattr("src.batch.completion_outbox.increment_spend", lambda **kwargs: None)
+
+    failed = _build_record(completion_id="completion-fail", payload_overrides={"item_id": "i-fail"})
+    succeeds = _build_record(completion_id="completion-ok", payload_overrides={"item_id": "i-ok"})
+    repository = _RetryFailingRepository({failed.completion_id: failed, succeeds.completion_id: succeeds})
+    worker = BatchCompletionOutboxWorker(
+        app=SimpleNamespace(state=SimpleNamespace(spend_tracking_service=_SelectiveSpendTrackingService())),
+        repository=repository,  # type: ignore[arg-type]
+        config=BatchCompletionOutboxWorkerConfig(worker_id="worker-1", max_batch_size=10, max_concurrency=2),
+    )
+
+    with caplog.at_level("ERROR"):
+        processed = await worker.process_once()
+
+    assert processed == 2
+    assert repository.records["completion-ok"].status == BatchCompletionOutboxStatus.SENT
+    assert repository.records["completion-fail"].status == BatchCompletionOutboxStatus.PROCESSING
+    assert repository.sent_calls == ["completion-ok"]
+    assert repository.retry_calls == []
+    assert metric_calls == [{"reason": "record_unhandled"}]
+    assert "batch completion outbox record processing failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_completion_outbox_worker_run_survives_iteration_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    metric_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.batch.completion_outbox.increment_batch_completion_outbox_failure",
+        lambda **kwargs: metric_calls.append(kwargs),
+    )
+
+    repository = _FakeRepository()
+    worker = BatchCompletionOutboxWorker(
+        app=SimpleNamespace(state=SimpleNamespace(spend_tracking_service=None)),
+        repository=repository,  # type: ignore[arg-type]
+        config=BatchCompletionOutboxWorkerConfig(poll_interval_seconds=0.01),
+    )
+    calls = 0
+
+    async def _process_once() -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("database unavailable")
+        worker.stop()
+        return 0
+
+    worker.process_once = _process_once  # type: ignore[method-assign]
+
+    with caplog.at_level("ERROR"):
+        await asyncio.wait_for(worker.run(), timeout=0.5)
+
+    assert calls == 2
+    assert metric_calls == [{"reason": "iteration"}]
+    assert "batch completion outbox iteration failed" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_create_session_scaffolding.py
+++ b/tests/test_batch_create_session_scaffolding.py
@@ -106,6 +106,7 @@ def test_batch_create_session_cleanup_defaults_match_general_settings() -> None:
     assert cleanup.completed_retention_seconds == DEFAULT_CREATE_SESSION_COMPLETED_RETENTION_SECONDS
     assert cleanup.retryable_retention_seconds == DEFAULT_CREATE_SESSION_RETRYABLE_RETENTION_SECONDS
     assert cleanup.failed_retention_seconds == DEFAULT_CREATE_SESSION_FAILED_RETENTION_SECONDS
+    assert settings.embeddings_batch_create_session_cleanup_enabled is True
     assert settings.embeddings_batch_create_session_cleanup_interval_seconds == cleanup.interval_seconds
     assert settings.embeddings_batch_create_session_cleanup_scan_limit == cleanup.scan_limit
     assert settings.embeddings_batch_create_stage_orphan_grace_seconds == cleanup.orphan_grace_seconds

--- a/tests/test_batch_service.py
+++ b/tests/test_batch_service.py
@@ -26,6 +26,7 @@ class _DummyStorage:
         self.reads: list[str] = []
         self.lines_by_key: dict[str, list[str]] = {}
         self.writes: list[bytes] = []
+        self.deleted: list[str] = []
 
     async def read_bytes(self, storage_key: str) -> bytes:
         self.reads.append(storage_key)
@@ -44,6 +45,9 @@ class _DummyStorage:
             payload.extend(chunk)
         self.writes.append(bytes(payload))
         return "batch/file.jsonl", len(payload), "checksum"
+
+    async def delete(self, storage_key: str) -> None:
+        self.deleted.append(storage_key)
 
 
 def _metric_counter_value(metric, **labels) -> float:  # noqa: ANN001
@@ -596,6 +600,39 @@ async def test_create_file_enforces_max_file_bytes() -> None:
         )
 
     assert exc.value.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_create_file_deletes_written_artifact_when_db_record_creation_fails() -> None:
+    class _Upload:
+        filename = "batch.jsonl"
+
+        def __init__(self) -> None:
+            self._chunks = [b'{"custom_id":"item-1"}\n', b""]
+
+        async def read(self, size: int = -1):  # noqa: ARG002
+            return self._chunks.pop(0)
+
+    class _Repo:
+        async def create_file(self, **kwargs):  # noqa: ANN003
+            del kwargs
+            return None
+
+    storage = _DummyStorage()
+    service = BatchService(
+        repository=_Repo(),  # type: ignore[arg-type]
+        storage=storage,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_file(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            upload=_Upload(),  # type: ignore[arg-type]
+            purpose="batch",
+        )
+
+    assert exc.value.status_code == 503
+    assert storage.deleted == ["batch/file.jsonl"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -4637,6 +4637,99 @@ async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows():
 
 
 @pytest.mark.asyncio
+async def test_batch_worker_finalize_artifacts_deletes_unrecorded_artifact_when_file_record_creation_fails():
+    now = datetime.now(tz=UTC)
+
+    class _FinalizingRepo:
+        async def list_items(self, batch_id: str):
+            return [
+                BatchItemRecord(
+                    item_id="i1",
+                    batch_id=batch_id,
+                    line_number=1,
+                    custom_id="req-1",
+                    status="completed",
+                    request_body={},
+                    response_body=_valid_embedding_artifact_response_body(),
+                    error_body=None,
+                    usage=None,
+                    provider_cost=0.0,
+                    billed_cost=0.0,
+                    attempts=1,
+                    last_error=None,
+                    locked_by=None,
+                    lease_expires_at=None,
+                    created_at=now,
+                    started_at=now,
+                    completed_at=now,
+                )
+            ]
+
+        async def create_file(self, **kwargs):  # noqa: ANN003
+            del kwargs
+            return None
+
+    class _Storage:
+        backend_name = "local"
+
+        def __init__(self) -> None:
+            self.deleted: list[str] = []
+
+        async def write_lines_stream(self, *, purpose: str, filename: str, lines):  # noqa: ANN001
+            async for _line in lines:
+                pass
+            return f"{purpose}/{filename}", 10, "checksum"
+
+        async def delete(self, storage_key: str) -> None:
+            self.deleted.append(storage_key)
+
+    storage = _Storage()
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_FinalizingRepo(),  # type: ignore[arg-type]
+        storage=storage,  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+    job = BatchJobRecord(
+        batch_id="b-finalize",
+        endpoint="/v1/embeddings",
+        status=BatchJobStatus.FINALIZING,
+        execution_mode="managed_internal",
+        input_file_id="f-1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m-1",
+        metadata={},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=0,
+        completed_items=1,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by="w1",
+        lease_expires_at=now,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="tok-1",
+        created_by_user_id="u1",
+        created_by_team_id="t1",
+        created_by_organization_id="org-1",
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+        expires_at=None,
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to create output artifact record"):
+        await worker._finalize_artifacts(job)
+
+    assert storage.deleted == ["batch_output/b-finalize-output.jsonl"]
+
+
+@pytest.mark.asyncio
 async def test_batch_worker_renews_job_and_item_leases_during_long_execution(monkeypatch):
     async def _slow_execute_embedding(request, payload, deployment):
         del request, payload, deployment


### PR DESCRIPTION
## Summary
- Keep the batch cleanup and completion outbox workers alive across transient iteration failures.
- Add per-record outbox failure isolation and metrics so one bad outbox record does not stall sibling work.
- Use cluster-unique batch worker IDs across replicas.
- Compensate uploaded batch input/output/error artifacts when DB file-record creation fails.
- Enable create-session staging cleanup by default and document production storage/cleanup expectations.

## Why
This is the first reliability-hardening PR for chat batch work. It focuses on failure containment, object-store consistency, and multi-replica worker identity without changing public batch API semantics.

## Validation
- uv run --extra dev ruff check src/batch tests/test_batch_cleanup.py tests/test_batch_completion_outbox.py
- uv run --extra dev pytest tests/test_batch_cleanup.py tests/test_batch_completion_outbox.py
- uv run --extra dev ruff check src/batch src/bootstrap src/metrics tests/test_batch_cleanup.py tests/test_batch_completion_outbox.py tests/test_batch_service.py tests/test_batch_worker.py tests/test_batch_create_session_scaffolding.py tests/bootstrap/test_optional_bootstrap.py
- uv run --extra dev pytest tests/test_batch_service.py tests/test_batch_worker.py tests/test_batch_create_session_scaffolding.py tests/bootstrap/test_optional_bootstrap.py tests/config/test_settings.py tests/test_batch_metrics.py tests/test_batch_create_session_cleanup.py