### PR TITLE
Fix batch status compatibility for LiteLLM

### DIFF
--- a/docs/features/batching.md
+++ b/docs/features/batching.md
@@ -157,6 +157,8 @@ Rate-limit and max-parallel slots are acquired immediately before provider execu
 
 ## Batch Lifecycle
 
+The worker and admin APIs use the internal lifecycle below:
+
 ```
 queued --> in_progress --> finalizing --> completed
    |            |                             |
@@ -174,6 +176,8 @@ queued --> in_progress --> finalizing --> completed
 | `failed` | The batch could not be completed (see `error_file_id` for details) |
 | `cancelled` | Cancelled by the user or an admin; pending items are skipped |
 | `expired` | The batch exceeded its retention window |
+
+Public `/v1/batches` responses use OpenAI-compatible status values so OpenAI-compatible clients can parse them. Internal `queued` jobs are returned as `validating`, and an `in_progress` job with a pending cancel request is returned as `cancelling`. Other compatible statuses are returned unchanged.
 
 ## API Endpoints
 

--- a/src/batch/service.py
+++ b/src/batch/service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 from fastapi import HTTPException, UploadFile, status
 
 from src.batch.access import can_access_owned_resource
-from src.batch.models import BatchItemCreate
+from src.batch.models import BatchItemCreate, BatchJobStatus
 from src.batch.request_validation import parse_batch_input_line
 from src.batch.repository import BatchRepository
 from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorage
@@ -24,6 +24,19 @@ if TYPE_CHECKING:
     from src.batch.create import BatchCreateSessionService
 
 logger = logging.getLogger(__name__)
+
+OPENAI_BATCH_STATUS_VALUES = frozenset(
+    {
+        "validating",
+        "failed",
+        "in_progress",
+        "finalizing",
+        "completed",
+        "expired",
+        "cancelling",
+        "cancelled",
+    }
+)
 
 
 @dataclass
@@ -383,7 +396,7 @@ class BatchService:
             "id": job.batch_id,
             "object": "batch",
             "endpoint": job.endpoint,
-            "status": job.status,
+            "status": self._public_batch_status(job),
             "input_file_id": job.input_file_id,
             "output_file_id": job.output_file_id,
             "error_file_id": job.error_file_id,
@@ -399,6 +412,17 @@ class BatchService:
             },
             "metadata": job.metadata or {},
         }
+
+    def _public_batch_status(self, job) -> str:
+        status_value = str(getattr(job, "status", "") or "")
+        if status_value == BatchJobStatus.QUEUED.value:
+            return "validating"
+        if (
+            status_value == BatchJobStatus.IN_PROGRESS.value
+            and getattr(job, "cancel_requested_at", None) is not None
+        ):
+            return "cancelling"
+        return status_value
 
     def _parse_input_jsonl(
         self,

--- a/tests/test_batch_create_service.py
+++ b/tests/test_batch_create_service.py
@@ -233,7 +233,7 @@ async def test_batch_service_create_result_delegates_to_bound_create_session_ser
     )
 
     assert result.response["id"] == "batch-delegated"
-    assert result.response["status"] == "queued"
+    assert result.response["status"] == "validating"
     assert result.audit_metadata["create_path"] == "create_session"
     assert create_session_service.calls[0]["idempotency_key"] == "idem-1"
 

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -798,7 +798,7 @@ async def test_db_backed_batch_create_cutover_returns_normal_batch_object_and_qu
     )
 
     assert result.response["id"]
-    assert result.response["status"] == "queued"
+    assert result.response["status"] == "validating"
     assert result.audit_metadata["create_path"] == "create_session"
     assert result.audit_metadata["idempotency_resolution"] == "not_requested"
 

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -652,7 +652,7 @@ async def test_db_backed_concurrent_batch_create_enforces_pending_cap(
     successes = [result for result in results if isinstance(result, dict)]
     failures = [result for result in results if isinstance(result, Exception)]
     assert len(successes) == 1
-    assert successes[0]["status"] == "queued"
+    assert successes[0]["status"] == "validating"
     assert len(failures) == 1
     assert isinstance(failures[0], HTTPException)
     assert failures[0].status_code == 429

--- a/tests/test_batch_service.py
+++ b/tests/test_batch_service.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import HTTPException
 
 from src.batch.models import BatchFileRecord, BatchJobRecord, BatchJobStatus
-from src.batch.service import BatchService
+from src.batch.service import OPENAI_BATCH_STATUS_VALUES, BatchService
 from src.metrics.batch import deltallm_batch_artifact_failures_metric
 from src.db.callable_targets import CallableTargetBindingRecord
 from src.db.callable_target_policies import CallableTargetScopePolicyRecord
@@ -52,6 +52,79 @@ class _DummyStorage:
 
 def _metric_counter_value(metric, **labels) -> float:  # noqa: ANN001
     return float(metric.labels(**labels)._value.get())
+
+
+def _batch_job(
+    *,
+    status: BatchJobStatus = BatchJobStatus.QUEUED,
+    cancel_requested_at: datetime | None = None,
+) -> BatchJobRecord:
+    now = datetime.now(tz=UTC)
+    return BatchJobRecord(
+        batch_id="batch-1",
+        endpoint="/v1/embeddings",
+        status=status,
+        execution_mode="managed_internal",
+        input_file_id="file-1",
+        output_file_id=None,
+        error_file_id=None,
+        model="m1",
+        metadata={"region": "eu"},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=2,
+        in_progress_items=0,
+        completed_items=0,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=cancel_requested_at,
+        status_last_updated_at=now,
+        created_by_api_key="key-a",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_at=now,
+        started_at=None,
+        completed_at=None,
+        expires_at=None,
+    )
+
+
+def test_job_to_response_maps_internal_queued_to_openai_validating_status() -> None:
+    response = _service().job_to_response(_batch_job(status=BatchJobStatus.QUEUED))
+
+    assert response["status"] == "validating"
+    assert response["status"] in OPENAI_BATCH_STATUS_VALUES
+
+
+def test_job_to_response_maps_cancel_requested_in_progress_to_openai_cancelling_status() -> None:
+    response = _service().job_to_response(
+        _batch_job(status=BatchJobStatus.IN_PROGRESS, cancel_requested_at=datetime.now(tz=UTC))
+    )
+
+    assert response["status"] == "cancelling"
+    assert response["status"] in OPENAI_BATCH_STATUS_VALUES
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        BatchJobStatus.IN_PROGRESS,
+        BatchJobStatus.FINALIZING,
+        BatchJobStatus.COMPLETED,
+        BatchJobStatus.FAILED,
+        BatchJobStatus.CANCELLED,
+        BatchJobStatus.EXPIRED,
+    ],
+)
+def test_job_to_response_preserves_openai_compatible_batch_statuses(status: BatchJobStatus) -> None:
+    response = _service().job_to_response(_batch_job(status=status))
+
+    assert response["status"] == status.value
+    assert response["status"] in OPENAI_BATCH_STATUS_VALUES
 
 
 class _FakeCallableTargetBindingRepository:

--- a/tests/test_data_plane_audit_extended.py
+++ b/tests/test_data_plane_audit_extended.py
@@ -60,12 +60,12 @@ class _FakeBatchService:
 
     async def create_embeddings_batch(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
-        return {"id": "batch-1", "status": "queued"}
+        return {"id": "batch-1", "status": "validating"}
 
     async def create_embeddings_batch_result(self, **kwargs):  # noqa: ANN003, ANN201
         idempotency_key = kwargs.get("idempotency_key")
         return self._CreateResult(
-            response={"id": "batch-1", "status": "queued"},
+            response={"id": "batch-1", "status": "validating"},
             audit_metadata={
                 "create_path": "create_session",
                 "idempotency_key_present": bool(idempotency_key),


### PR DESCRIPTION
## Summary
- map internal batch queued status to OpenAI-compatible validating in public /v1/batches responses
- map cancel-requested in_progress jobs to cancelling
- add regression tests and document the public/internal status distinction

Fixes #153

## Tests
- uv run --extra dev ruff check src/batch/service.py tests/test_batch_service.py tests/test_batch_create_service.py tests/test_batch_db_integration.py tests/test_data_plane_audit_extended.py
- uv run --extra dev pytest tests/test_batch_service.py tests/test_batch_create_service.py tests/test_data_plane_audit_extended.py
- git diff --check

Note: the targeted DB integration test was attempted but skipped locally because DATABASE_URL and Prisma client are not configured in this worktree.