### PR TITLE
Add OpenAI-compatible Batch response fields

### DIFF
--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -231,6 +231,8 @@ curl http://localhost:8000/v1/batches \
   }'
 ```
 
+DeltaLLM supports the OpenAI-compatible `24h` batch completion window. Missing or null `completion_window` values default to `24h`; unsupported values return HTTP 400.
+
 Inspect a batch:
 
 ```bash
@@ -242,6 +244,7 @@ Current behavior:
 
 - batch endpoints are available only when `general_settings.embeddings_batch_enabled: true`
 - supported endpoints are `"/v1/embeddings"` and `"/v1/chat/completions"`
+- public batch responses include OpenAI-compatible `completion_window`, `errors`, `expires_at`, `failed_at`, and `expired_at` fields
 - chat batch requests must be non-streaming; `stream: true` is rejected
 - MCP tools are not supported in chat batch requests yet
 

--- a/docs/features/batching.md
+++ b/docs/features/batching.md
@@ -67,6 +67,8 @@ curl http://localhost:8000/v1/batches \
   }'
 ```
 
+DeltaLLM currently supports the OpenAI-compatible `24h` completion window. Missing or null values default to `24h`; other values are rejected.
+
 ### 4. Poll for completion
 
 ```bash
@@ -81,9 +83,18 @@ Watch the `status` field and `request_counts` to track progress:
   "id": "batch_xyz789",
   "object": "batch",
   "endpoint": "/v1/embeddings",
+  "completion_window": "24h",
   "status": "completed",
   "input_file_id": "file_abc123",
   "output_file_id": "file_out456",
+  "error_file_id": null,
+  "created_at": 1778064000,
+  "expires_at": 1780656000,
+  "in_progress_at": 1778064060,
+  "completed_at": 1778064300,
+  "failed_at": null,
+  "expired_at": null,
+  "errors": null,
   "request_counts": {
     "total": 3,
     "completed": 3,
@@ -177,7 +188,7 @@ queued --> in_progress --> finalizing --> completed
 | `cancelled` | Cancelled by the user or an admin; pending items are skipped |
 | `expired` | The batch exceeded its retention window |
 
-Public `/v1/batches` responses use OpenAI-compatible status values so OpenAI-compatible clients can parse them. Internal `queued` jobs are returned as `validating`, and an `in_progress` job with a pending cancel request is returned as `cancelling`. Other compatible statuses are returned unchanged.
+Public `/v1/batches` responses use OpenAI-compatible status values and response fields so OpenAI-compatible clients can parse them. Internal `queued` jobs are returned as `validating`, and an `in_progress` job with a pending cancel request is returned as `cancelling`. Other compatible statuses are returned unchanged. The public response also includes `completion_window`, `errors`, `expires_at`, `failed_at`, and `expired_at` fields.
 
 ## API Endpoints
 

--- a/src/batch/create/service.py
+++ b/src/batch/create/service.py
@@ -18,7 +18,7 @@ from src.batch.create.models import (
 from src.batch.create.promoter import BatchCreatePromotionError, BatchCreateSessionPromoter
 from src.batch.create.session_repository import BatchCreateSessionRepository
 from src.batch.create.session_stager import BatchCreateSessionStager
-from src.batch.models import BatchJobRecord
+from src.batch.models import BatchJobRecord, normalize_batch_completion_window
 from src.batch.repository import BatchRepository
 from src.batch.request_validation import parse_batch_input_line
 from src.batch.scopes import (
@@ -105,13 +105,13 @@ class BatchCreateSessionService:
         completion_window: str | None,
         idempotency_key: str | None = None,
     ) -> BatchCreateSessionServiceResult:
-        del completion_window
         endpoint = str(endpoint or "").strip()
         if endpoint not in SUPPORTED_BATCH_ENDPOINT_SET:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Unsupported batch endpoint '{endpoint}'. Supported endpoints: {supported_batch_endpoints_display()}",
             )
+        self._validate_completion_window(completion_window)
 
         normalized_metadata = self._normalize_metadata(metadata)
         idem_scope_key, idem_key = self._idempotency_pair(auth=auth, idempotency_key=idempotency_key)
@@ -372,6 +372,12 @@ class BatchCreateSessionService:
                 detail=f"Storage backend '{normalized}' is unavailable; keep create-session artifact storage configured until sessions expire",
             )
         return storage
+
+    def _validate_completion_window(self, completion_window: object) -> None:
+        try:
+            normalize_batch_completion_window(completion_window)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     async def _iter_storage_lines(
         self,

--- a/src/batch/models.py
+++ b/src/batch/models.py
@@ -19,6 +19,8 @@ class BatchJobStatus(StrEnum):
 BATCH_JOB_STATUSES = tuple(BatchJobStatus)
 BATCH_JOB_STATUS_VALUES = tuple(status.value for status in BatchJobStatus)
 BATCH_JOB_STATUS_SET = frozenset(BATCH_JOB_STATUS_VALUES)
+OPENAI_BATCH_COMPLETION_WINDOW = "24h"
+SUPPORTED_BATCH_COMPLETION_WINDOWS = frozenset({OPENAI_BATCH_COMPLETION_WINDOW})
 
 
 def normalize_batch_job_status(status: str | BatchJobStatus) -> BatchJobStatus:
@@ -29,6 +31,19 @@ def normalize_batch_job_status(status: str | BatchJobStatus) -> BatchJobStatus:
         return BatchJobStatus(normalized)
     except ValueError as exc:
         raise ValueError("batch job status must be one of: " + ", ".join(BATCH_JOB_STATUS_VALUES)) from exc
+
+
+def normalize_batch_completion_window(completion_window: object) -> str:
+    if completion_window is None:
+        return OPENAI_BATCH_COMPLETION_WINDOW
+    if not isinstance(completion_window, str):
+        raise ValueError("completion_window must be '24h'")
+    normalized = completion_window.strip()
+    if not normalized:
+        return OPENAI_BATCH_COMPLETION_WINDOW
+    if normalized not in SUPPORTED_BATCH_COMPLETION_WINDOWS:
+        raise ValueError("completion_window must be '24h'")
+    return normalized
 
 
 class BatchItemStatus:

--- a/src/batch/service.py
+++ b/src/batch/service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 from fastapi import HTTPException, UploadFile, status
 
 from src.batch.access import can_access_owned_resource
-from src.batch.models import BatchItemCreate, BatchJobStatus
+from src.batch.models import BatchItemCreate, BatchJobStatus, OPENAI_BATCH_COMPLETION_WINDOW
 from src.batch.request_validation import parse_batch_input_line
 from src.batch.repository import BatchRepository
 from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorage
@@ -396,13 +396,18 @@ class BatchService:
             "id": job.batch_id,
             "object": "batch",
             "endpoint": job.endpoint,
+            "completion_window": OPENAI_BATCH_COMPLETION_WINDOW,
             "status": self._public_batch_status(job),
             "input_file_id": job.input_file_id,
             "output_file_id": job.output_file_id,
             "error_file_id": job.error_file_id,
             "created_at": int(job.created_at.timestamp()),
+            "expires_at": self._timestamp_or_none(getattr(job, "expires_at", None)),
             "in_progress_at": int(job.started_at.timestamp()) if job.started_at else None,
             "completed_at": int(job.completed_at.timestamp()) if job.completed_at else None,
+            "failed_at": self._terminal_status_timestamp(job, BatchJobStatus.FAILED),
+            "expired_at": self._terminal_status_timestamp(job, BatchJobStatus.EXPIRED),
+            "errors": None,
             "request_counts": {
                 "total": job.total_items,
                 "completed": job.completed_items,
@@ -423,6 +428,14 @@ class BatchService:
         ):
             return "cancelling"
         return status_value
+
+    def _terminal_status_timestamp(self, job, terminal_status: BatchJobStatus) -> int | None:
+        if str(getattr(job, "status", "") or "") != terminal_status.value:
+            return None
+        return self._timestamp_or_none(getattr(job, "status_last_updated_at", None))
+
+    def _timestamp_or_none(self, value: datetime | None) -> int | None:
+        return int(value.timestamp()) if value else None
 
     def _parse_input_jsonl(
         self,

--- a/tests/test_batch_create_service.py
+++ b/tests/test_batch_create_service.py
@@ -121,6 +121,34 @@ class _NeverCalledStager:
         raise AssertionError("stage_session should not be called")
 
 
+def _create_session_service_for_validation() -> BatchCreateSessionService:
+    return BatchCreateSessionService(
+        repository=SimpleNamespace(),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(),  # type: ignore[arg-type]
+        stager=SimpleNamespace(),  # type: ignore[arg-type]
+        promoter=SimpleNamespace(),  # type: ignore[arg-type]
+        storage_registry={},
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+    )
+
+
+@pytest.mark.parametrize("completion_window", [None, "", "  ", "24h"])
+def test_create_session_service_accepts_default_openai_completion_window(completion_window: object) -> None:
+    _create_session_service_for_validation()._validate_completion_window(completion_window)  # noqa: SLF001
+
+
+@pytest.mark.parametrize("completion_window", ["12h", "24H", 24])
+def test_create_session_service_rejects_unsupported_completion_window(completion_window: object) -> None:
+    with pytest.raises(HTTPException) as exc:
+        _create_session_service_for_validation()._validate_completion_window(completion_window)  # noqa: SLF001
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "completion_window must be '24h'"
+
+
 @pytest.mark.asyncio
 async def test_create_session_service_resolves_matching_existing_session_before_loading_input_file() -> None:
     existing_session = _session(status=BatchCreateSessionStatus.COMPLETED)
@@ -234,6 +262,8 @@ async def test_batch_service_create_result_delegates_to_bound_create_session_ser
 
     assert result.response["id"] == "batch-delegated"
     assert result.response["status"] == "validating"
+    assert result.response["completion_window"] == "24h"
+    assert result.response["errors"] is None
     assert result.audit_metadata["create_path"] == "create_session"
     assert create_session_service.calls[0]["idempotency_key"] == "idem-1"
 

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -653,6 +653,8 @@ async def test_db_backed_concurrent_batch_create_enforces_pending_cap(
     failures = [result for result in results if isinstance(result, Exception)]
     assert len(successes) == 1
     assert successes[0]["status"] == "validating"
+    assert successes[0]["completion_window"] == "24h"
+    assert successes[0]["errors"] is None
     assert len(failures) == 1
     assert isinstance(failures[0], HTTPException)
     assert failures[0].status_code == 429
@@ -799,6 +801,8 @@ async def test_db_backed_batch_create_cutover_returns_normal_batch_object_and_qu
 
     assert result.response["id"]
     assert result.response["status"] == "validating"
+    assert result.response["completion_window"] == "24h"
+    assert result.response["errors"] is None
     assert result.audit_metadata["create_path"] == "create_session"
     assert result.audit_metadata["idempotency_resolution"] == "not_requested"
 

--- a/tests/test_batch_models.py
+++ b/tests/test_batch_models.py
@@ -9,13 +9,26 @@ from src.batch.models import (
     BATCH_JOB_STATUS_VALUES,
     BatchJobRecord,
     BatchJobStatus,
+    OPENAI_BATCH_COMPLETION_WINDOW,
     normalize_batch_job_status,
+    normalize_batch_completion_window,
 )
 
 
 def test_batch_job_status_values_follow_enum_definition() -> None:
     assert BATCH_JOB_STATUSES == tuple(BatchJobStatus)
     assert BATCH_JOB_STATUS_VALUES == tuple(status.value for status in BatchJobStatus)
+
+
+@pytest.mark.parametrize("completion_window", [None, "", "  ", "24h"])
+def test_normalize_batch_completion_window_defaults_to_openai_window(completion_window: object) -> None:
+    assert normalize_batch_completion_window(completion_window) == OPENAI_BATCH_COMPLETION_WINDOW
+
+
+@pytest.mark.parametrize("completion_window", ["12h", "24H", 24])
+def test_normalize_batch_completion_window_rejects_unsupported_values(completion_window: object) -> None:
+    with pytest.raises(ValueError):
+        normalize_batch_completion_window(completion_window)
 
 
 @pytest.mark.parametrize("status", ["queued", BatchJobStatus.QUEUED])

--- a/tests/test_batch_service.py
+++ b/tests/test_batch_service.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 import logging
 
 import pytest
 from fastapi import HTTPException
 
-from src.batch.models import BatchFileRecord, BatchJobRecord, BatchJobStatus
+from src.batch.models import BatchFileRecord, BatchJobRecord, BatchJobStatus, OPENAI_BATCH_COMPLETION_WINDOW
 from src.batch.service import OPENAI_BATCH_STATUS_VALUES, BatchService
 from src.metrics.batch import deltallm_batch_artifact_failures_metric
 from src.db.callable_targets import CallableTargetBindingRecord
@@ -58,6 +58,8 @@ def _batch_job(
     *,
     status: BatchJobStatus = BatchJobStatus.QUEUED,
     cancel_requested_at: datetime | None = None,
+    status_last_updated_at: datetime | None = None,
+    expires_at: datetime | None = None,
 ) -> BatchJobRecord:
     now = datetime.now(tz=UTC)
     return BatchJobRecord(
@@ -82,14 +84,14 @@ def _batch_job(
         locked_by=None,
         lease_expires_at=None,
         cancel_requested_at=cancel_requested_at,
-        status_last_updated_at=now,
+        status_last_updated_at=status_last_updated_at or now,
         created_by_api_key="key-a",
         created_by_user_id=None,
         created_by_team_id=None,
         created_at=now,
         started_at=None,
         completed_at=None,
-        expires_at=None,
+        expires_at=expires_at,
     )
 
 
@@ -125,6 +127,37 @@ def test_job_to_response_preserves_openai_compatible_batch_statuses(status: Batc
 
     assert response["status"] == status.value
     assert response["status"] in OPENAI_BATCH_STATUS_VALUES
+
+
+def test_job_to_response_includes_openai_compatible_batch_fields() -> None:
+    now = datetime.now(tz=UTC).replace(microsecond=0)
+    expires_at = now + timedelta(days=1)
+    response = _service().job_to_response(
+        _batch_job(
+            status=BatchJobStatus.FAILED,
+            status_last_updated_at=now,
+            expires_at=expires_at,
+        )
+    )
+
+    assert response["completion_window"] == OPENAI_BATCH_COMPLETION_WINDOW
+    assert response["errors"] is None
+    assert response["expires_at"] == int(expires_at.timestamp())
+    assert response["failed_at"] == int(now.timestamp())
+    assert response["expired_at"] is None
+
+
+def test_job_to_response_sets_expired_at_for_expired_batches() -> None:
+    now = datetime.now(tz=UTC).replace(microsecond=0)
+    response = _service().job_to_response(
+        _batch_job(
+            status=BatchJobStatus.EXPIRED,
+            status_last_updated_at=now,
+        )
+    )
+
+    assert response["expired_at"] == int(now.timestamp())
+    assert response["failed_at"] is None
 
 
 class _FakeCallableTargetBindingRepository:

--- a/tests/test_data_plane_audit_extended.py
+++ b/tests/test_data_plane_audit_extended.py
@@ -60,12 +60,12 @@ class _FakeBatchService:
 
     async def create_embeddings_batch(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
-        return {"id": "batch-1", "status": "validating"}
+        return self._batch_response("validating")
 
     async def create_embeddings_batch_result(self, **kwargs):  # noqa: ANN003, ANN201
         idempotency_key = kwargs.get("idempotency_key")
         return self._CreateResult(
-            response={"id": "batch-1", "status": "validating"},
+            response=self._batch_response("validating"),
             audit_metadata={
                 "create_path": "create_session",
                 "idempotency_key_present": bool(idempotency_key),
@@ -75,15 +75,36 @@ class _FakeBatchService:
 
     async def get_batch(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
-        return {"id": "batch-1", "status": "in_progress"}
+        return self._batch_response("in_progress")
 
     async def list_batches(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
-        return [{"id": "batch-1", "status": "in_progress"}]
+        return [self._batch_response("in_progress")]
 
     async def cancel_batch(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
-        return {"id": "batch-1", "status": "cancelled"}
+        return self._batch_response("cancelled")
+
+    def _batch_response(self, status: str) -> dict:
+        return {
+            "id": "batch-1",
+            "object": "batch",
+            "endpoint": "/v1/embeddings",
+            "completion_window": "24h",
+            "status": status,
+            "input_file_id": "file-1",
+            "output_file_id": None,
+            "error_file_id": None,
+            "created_at": 1,
+            "expires_at": None,
+            "in_progress_at": None,
+            "completed_at": None,
+            "failed_at": None,
+            "expired_at": None,
+            "errors": None,
+            "request_counts": {"total": 1, "completed": 0, "failed": 0, "cancelled": 0, "in_progress": 0},
+            "metadata": {},
+        }
 
 
 class _SpendQueryDB:


### PR DESCRIPTION
## Summary

- return OpenAI-compatible Batch response fields including `completion_window`, `errors`, `expires_at`, `failed_at`, and `expired_at`
- validate batch create `completion_window`, defaulting missing/null/blank values to `24h` and rejecting unsupported values
- add regression coverage and docs for the public Batch response shape

Fixes #156

## Tests

- `uv run --extra dev ruff check src/batch/models.py src/batch/create/service.py src/batch/service.py tests/test_batch_models.py tests/test_batch_service.py tests/test_batch_create_service.py tests/test_batch_db_integration.py tests/test_data_plane_audit_extended.py`
- `git diff --check`
- `uv run --extra dev pytest tests/test_batch_models.py tests/test_batch_service.py tests/test_batch_create_service.py tests/test_data_plane_audit_extended.py`
- `uv run --extra dev pytest -rs tests/test_batch_db_integration.py::test_db_backed_concurrent_batch_create_enforces_pending_cap tests/test_batch_db_integration.py::test_db_backed_batch_create_cutover_returns_normal_batch_object_and_queued_job`

Note: the DB-backed tests were attempted locally but skipped because `DATABASE_URL` and Prisma client are not configured in this worktree.
