### PR TITLE
Fix MCP streamable HTTP sessions

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -260,6 +260,9 @@ Policy fields include:
 }
 ```
 
+`transport: "http"` is accepted as a compatibility alias and normalized to `streamable_http`.
+Streamable HTTP servers may return either JSON or `text/event-stream` JSON-RPC responses; DeltaLLM also reuses upstream `MCP-Session-Id` values when a server establishes a stateful session.
+
 ### Create a Binding
 
 ```json

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -155,7 +155,10 @@ DeltaLLM currently supports:
 
 - transport: `streamable_http`
 - request format: JSON-RPC `2.0`
-- response content type: JSON, not SSE event streams
+- response content type: JSON or `text/event-stream` for Streamable HTTP POST responses
+- stateful HTTP sessions through upstream `MCP-Session-Id` headers
+
+For compatibility with common client config names, the admin API also accepts `transport: "http"` and stores it as `streamable_http`.
 
 Supported upstream auth modes:
 

--- a/docs/getting-started/mcp-quickstart.md
+++ b/docs/getting-started/mcp-quickstart.md
@@ -58,7 +58,7 @@ curl -X POST "$BASE/ui/api/mcp-servers" \
 Important fields:
 
 - `server_key`: stable identifier that clients will later reference in chat requests
-- `transport`: currently must be `streamable_http`
+- `transport`: use `streamable_http`; `http` is accepted as a compatibility alias and normalized to `streamable_http`
 - `auth_mode`: one of `none`, `bearer`, `basic`, or `header_map`
 
 Save the returned `mcp_server_id`.

--- a/src/api/admin/endpoints/mcp/validators.py
+++ b/src/api/admin/endpoints/mcp/validators.py
@@ -1,4 +1,5 @@
 """Pure validation/normalization helpers for the admin MCP endpoints."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -26,7 +27,9 @@ from src.api.admin.endpoints.mcp.constants import (
 def _normalize_server_key(value: Any) -> str:
     key = str(value or "").strip().lower()
     if not key:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="server_key is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="server_key is required"
+        )
     if any(ch not in _SERVER_KEY_ALLOWED for ch in key):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -37,8 +40,12 @@ def _normalize_server_key(value: Any) -> str:
 
 def _normalize_transport(value: Any) -> str:
     transport = str(value or "streamable_http").strip().lower()
+    if transport == "http":
+        return "streamable_http"
     if transport not in _ALLOWED_TRANSPORTS:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="transport must be streamable_http")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="transport must be streamable_http"
+        )
     return transport
 
 
@@ -46,7 +53,9 @@ def _normalize_auth_mode(value: Any) -> str:
     mode = str(value or "none").strip().lower()
     if mode not in _ALLOWED_AUTH_MODES:
         allowed = ", ".join(sorted(_ALLOWED_AUTH_MODES))
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"auth_mode must be one of: {allowed}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"auth_mode must be one of: {allowed}"
+        )
     return mode
 
 
@@ -54,7 +63,9 @@ def _normalize_metadata(value: Any) -> dict[str, Any] | None:
     if value is None:
         return None
     if not isinstance(value, dict):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="metadata must be an object")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="metadata must be an object"
+        )
     return dict(value)
 
 
@@ -67,14 +78,20 @@ def _credentials_present(auth_mode: str, auth_config: dict[str, Any] | None) -> 
     if auth_mode == "basic":
         return bool(str(config.get("username") or "") and str(config.get("password") or ""))
     headers = config.get("headers")
-    return isinstance(headers, dict) and any(str(key).strip() and value is not None for key, value in headers.items())
+    return isinstance(headers, dict) and any(
+        str(key).strip() and value is not None for key, value in headers.items()
+    )
 
 
-def _sanitize_auth_payload(payload: dict[str, Any] | None, *, auth_mode: str | None = None) -> dict[str, Any] | None:
+def _sanitize_auth_payload(
+    payload: dict[str, Any] | None, *, auth_mode: str | None = None
+) -> dict[str, Any] | None:
     if payload is None:
         return None
     sanitized = dict(payload)
-    effective_mode = _normalize_auth_mode(auth_mode if auth_mode is not None else sanitized.get("auth_mode"))
+    effective_mode = _normalize_auth_mode(
+        auth_mode if auth_mode is not None else sanitized.get("auth_mode")
+    )
     auth_config = sanitized.pop("auth_config", None)
     sanitized["auth_mode"] = effective_mode
     sanitized["auth_config_redacted"] = auth_config is not None
@@ -85,7 +102,10 @@ def _normalize_allowlist(value: Any) -> list[str]:
     if value is None:
         return []
     if not isinstance(value, list):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="forwarded_headers_allowlist must be an array")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="forwarded_headers_allowlist must be an array",
+        )
     out: list[str] = []
     for item in value:
         header = str(item or "").strip().lower()
@@ -100,7 +120,10 @@ def _validate_url(value: Any) -> str:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="base_url is required")
     parsed = urlparse(raw)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="base_url must be a valid http or https URL")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="base_url must be a valid http or https URL",
+        )
     return raw.rstrip("/")
 
 
@@ -110,14 +133,19 @@ def _validate_auth_config(auth_mode: str, value: Any) -> dict[str, Any]:
     elif isinstance(value, dict):
         config = dict(value)
     else:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="auth_config must be an object")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="auth_config must be an object"
+        )
 
     if auth_mode == "none":
         return {}
     if auth_mode == "bearer":
         token = str(config.get("token") or "").strip()
         if not token:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="auth_config.token is required for bearer auth")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="auth_config.token is required for bearer auth",
+            )
         return {"token": token}
     if auth_mode == "basic":
         username = str(config.get("username") or "")
@@ -130,14 +158,20 @@ def _validate_auth_config(auth_mode: str, value: Any) -> dict[str, Any]:
         return {"username": username, "password": password}
     headers = config.get("headers")
     if not isinstance(headers, dict) or not headers:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="auth_config.headers is required for header_map auth")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="auth_config.headers is required for header_map auth",
+        )
     normalized_headers = {
         str(key).strip(): str(item)
         for key, item in headers.items()
         if str(key).strip() and item is not None
     }
     if not normalized_headers:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="auth_config.headers must include at least one header")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="auth_config.headers must include at least one header",
+        )
     return {"headers": normalized_headers}
 
 
@@ -145,7 +179,9 @@ def _validate_scope_type(value: Any) -> str:
     scope_type = str(value or "").strip().lower()
     if scope_type not in _ALLOWED_SCOPE_TYPES:
         allowed = ", ".join(sorted(_ALLOWED_SCOPE_TYPES))
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"scope_type must be one of: {allowed}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"scope_type must be one of: {allowed}"
+        )
     return scope_type
 
 
@@ -153,7 +189,9 @@ def _validate_mcp_scope_policy_scope_type(value: Any) -> str:
     scope_type = str(value or "").strip().lower()
     if scope_type not in _MCP_SCOPE_POLICY_SCOPE_TYPES:
         allowed = ", ".join(sorted(_MCP_SCOPE_POLICY_SCOPE_TYPES))
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"scope_type must be one of: {allowed}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"scope_type must be one of: {allowed}"
+        )
     return scope_type
 
 
@@ -161,7 +199,9 @@ def _validate_mcp_scope_policy_mode(value: Any) -> str:
     mode = str(value or "").strip().lower()
     if mode not in _MCP_SCOPE_POLICY_MODES:
         allowed = ", ".join(sorted(_MCP_SCOPE_POLICY_MODES))
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"mode must be one of: {allowed}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"mode must be one of: {allowed}"
+        )
     return mode
 
 
@@ -169,14 +209,19 @@ def _validate_mcp_migration_rollout_states(values: list[str] | None) -> set[str]
     if not values:
         return set()
     normalized = {
-        MCP_MIGRATION_ROLLOUT_STATE_ALIASES.get(str(value or "").strip().lower(), str(value or "").strip().lower())
+        MCP_MIGRATION_ROLLOUT_STATE_ALIASES.get(
+            str(value or "").strip().lower(), str(value or "").strip().lower()
+        )
         for value in values
         if str(value or "").strip()
     }
     invalid = sorted(value for value in normalized if value not in MCP_MIGRATION_ROLLOUT_STATES)
     if invalid:
         allowed = ", ".join(sorted(MCP_MIGRATION_ROLLOUT_STATES))
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"rollout_state must be one of: {allowed}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"rollout_state must be one of: {allowed}",
+        )
     return normalized
 
 
@@ -184,14 +229,19 @@ def _validate_owner_scope_type(value: Any) -> str:
     owner_scope_type = str(value or "global").strip().lower()
     if owner_scope_type not in _ALLOWED_OWNER_SCOPE_TYPES:
         allowed = ", ".join(sorted(_ALLOWED_OWNER_SCOPE_TYPES))
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"owner_scope_type must be one of: {allowed}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"owner_scope_type must be one of: {allowed}",
+        )
     return owner_scope_type
 
 
 def _normalize_scope_id(value: Any, *, field_name: str = "scope_id") -> str:
     scope_id = str(value or "").strip()
     if not scope_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} is required"
+        )
     return scope_id
 
 
@@ -207,7 +257,10 @@ def _validate_require_approval(value: Any) -> str | None:
         return None
     approval = str(value).strip().lower()
     if approval not in {"never", "manual"}:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='require_approval must be "never" or "manual"')
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='require_approval must be "never" or "manual"',
+        )
     return approval
 
 
@@ -217,7 +270,9 @@ def _normalize_tool_policy_metadata(payload: dict[str, Any]) -> dict[str, Any] |
     if timeout_value is None:
         timeout_value = payload.get("max_total_mcp_execution_time_ms")
     if timeout_value is not None:
-        metadata["max_total_mcp_execution_time_ms"] = optional_int(timeout_value, "max_total_execution_time_ms")
+        metadata["max_total_mcp_execution_time_ms"] = optional_int(
+            timeout_value, "max_total_execution_time_ms"
+        )
     elif "max_total_mcp_execution_time_ms" in metadata:
         metadata["max_total_mcp_execution_time_ms"] = optional_int(
             metadata.get("max_total_mcp_execution_time_ms"),

--- a/src/mcp/approvals.py
+++ b/src/mcp/approvals.py
@@ -9,7 +9,7 @@ from typing import Any
 from src.db.mcp import MCPApprovalRequestRecord, MCPRepository, MCPToolPolicyRecord
 from src.models.responses import UserAPIKeyAuth
 
-from .auth import build_forwarded_headers
+from .auth import build_effective_mcp_forwarded_headers
 from .metrics import record_mcp_approval_request
 from .models import MCPServerConfig
 
@@ -60,7 +60,9 @@ class MCPApprovalService:
         active = await self.repository.find_active_approval_request(request_fingerprint=fingerprint)
         if active is not None:
             if active.status == "pending":
-                record_mcp_approval_request(server_key=server.server_key, tool_name=tool_name, created=False)
+                record_mcp_approval_request(
+                    server_key=server.server_key, tool_name=tool_name, created=False
+                )
             return MCPApprovalAuthorization(status=active.status, approval_request=active)
         created = await self.repository.create_approval_request(
             server_id=server.server_id,
@@ -82,7 +84,9 @@ class MCPApprovalService:
             },
         )
         if created is not None:
-            record_mcp_approval_request(server_key=server.server_key, tool_name=tool_name, created=True)
+            record_mcp_approval_request(
+                server_key=server.server_key, tool_name=tool_name, created=True
+            )
             return MCPApprovalAuthorization(status=created.status, approval_request=created)
         return None
 
@@ -111,7 +115,7 @@ class MCPApprovalService:
             "scope_type": policy.scope_type,
             "scope_id": policy.scope_id,
             "api_key": getattr(auth, "api_key", None),
-            "forwarded_headers": build_forwarded_headers(
+            "forwarded_headers": build_effective_mcp_forwarded_headers(
                 request_headers=request_headers,
                 server_key=server.server_key,
                 allowlist=server.forwarded_headers_allowlist,

--- a/src/mcp/auth.py
+++ b/src/mcp/auth.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 import base64
 from typing import Any
 
+PROTECTED_MCP_REQUEST_HEADERS = frozenset(
+    {
+        "accept",
+        "content-type",
+        "mcp-protocol-version",
+        "mcp-session-id",
+    }
+)
+
 
 def _normalize_header_name(value: str) -> str:
     return "-".join(part for part in value.strip().lower().split("-") if part)
 
 
-def build_server_headers(*, auth_mode: str, auth_config: dict[str, Any] | None = None) -> dict[str, str]:
+def build_server_headers(
+    *, auth_mode: str, auth_config: dict[str, Any] | None = None
+) -> dict[str, str]:
     config = auth_config or {}
     mode = str(auth_mode or "none").strip().lower()
     if mode in {"", "none"}:
@@ -24,7 +35,11 @@ def build_server_headers(*, auth_mode: str, auth_config: dict[str, Any] | None =
     if mode == "header_map":
         headers = config.get("headers")
         if isinstance(headers, dict):
-            return {str(key): str(value) for key, value in headers.items() if str(key).strip() and value is not None}
+            return {
+                str(key): str(value)
+                for key, value in headers.items()
+                if str(key).strip() and value is not None
+            }
     return {}
 
 
@@ -49,3 +64,46 @@ def build_forwarded_headers(
         if forwarded_name in allowed:
             out[forwarded_name] = str(value)
     return out
+
+
+def filter_protected_mcp_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.strip().lower() not in PROTECTED_MCP_REQUEST_HEADERS
+    }
+
+
+def build_effective_mcp_forwarded_headers(
+    *,
+    request_headers: dict[str, str] | None,
+    server_key: str,
+    allowlist: list[str] | None,
+) -> dict[str, str]:
+    return filter_protected_mcp_headers(
+        build_forwarded_headers(
+            request_headers=request_headers,
+            server_key=server_key,
+            allowlist=allowlist,
+        )
+    )
+
+
+def build_effective_mcp_upstream_headers(
+    *,
+    auth_mode: str,
+    auth_config: dict[str, Any] | None,
+    request_headers: dict[str, str] | None,
+    server_key: str,
+    allowlist: list[str] | None,
+) -> dict[str, str]:
+    return filter_protected_mcp_headers(
+        {
+            **build_server_headers(auth_mode=auth_mode, auth_config=auth_config),
+            **build_forwarded_headers(
+                request_headers=request_headers,
+                server_key=server_key,
+                allowlist=allowlist,
+            ),
+        }
+    )

--- a/src/mcp/result_cache.py
+++ b/src/mcp/result_cache.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from src.cache import CacheBackend, CacheEntry
 
-from .auth import build_forwarded_headers
+from .auth import build_effective_mcp_forwarded_headers
 from .models import MCPServerConfig, MCPToolCallResult
 
 
@@ -91,7 +91,7 @@ class MCPToolResultCache:
         request_headers: dict[str, str] | None,
         auth_api_key: str | None,
     ) -> str:
-        forwarded_headers = build_forwarded_headers(
+        forwarded_headers = build_effective_mcp_forwarded_headers(
             request_headers=request_headers,
             server_key=server.server_key,
             allowlist=server.forwarded_headers_allowlist,

--- a/src/mcp/transport_http.py
+++ b/src/mcp/transport_http.py
@@ -1,39 +1,76 @@
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import json
+from dataclasses import dataclass, field
 from itertools import count
+from time import monotonic
 from typing import Any
 
 import httpx
 
-from .auth import build_forwarded_headers, build_server_headers
+from .auth import build_effective_mcp_upstream_headers
 from .exceptions import MCPAuthError, MCPInvalidResponseError, MCPTransportError
 from .models import MCPRequestEnvelope, MCPServerConfig, MCPToolCallResult, MCPToolSchema
 from .capabilities import extract_tool_schemas
 from src.upstream_http import build_upstream_request_timeout
 
 _request_ids = count(1)
+MCP_PROTOCOL_VERSION = "2025-11-25"
+_MCP_ACCEPT = "application/json, text/event-stream"
+_MCP_SESSION_TTL_SECONDS = 30 * 60
+_MCP_MAX_SESSION_STATES = 1024
+
+
+@dataclass
+class _MCPSessionState:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    session_id: str | None = None
+    protocol_version: str = MCP_PROTOCOL_VERSION
+    initialized: bool = False
+    initialize_result: dict[str, Any] | None = None
+    last_used_at: float = field(default_factory=monotonic)
+
+
+@dataclass(frozen=True)
+class _MCPTransportResponse:
+    result: dict[str, Any]
+    headers: httpx.Headers
+
+
+class _StaleMCPSessionError(Exception):
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        super().__init__("MCP server rejected session")
 
 
 class StreamableHTTPMCPClient:
-    def __init__(self, http_client: httpx.AsyncClient, *, general_settings: Any | None = None) -> None:
+    def __init__(
+        self, http_client: httpx.AsyncClient, *, general_settings: Any | None = None
+    ) -> None:
         self.http_client = http_client
         self.general_settings = general_settings
+        self._sessions: dict[tuple[object, ...], _MCPSessionState] = {}
 
     async def initialize(
         self,
         server: MCPServerConfig,
         *,
         request_headers: dict[str, str] | None = None,
+        force: bool = False,
     ) -> dict[str, Any]:
-        return await self._send(
-            server,
-            MCPRequestEnvelope(
-                method="initialize",
-                params={"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "deltallm", "version": "0.1.0"}},
-                request_id=next(_request_ids),
-            ),
-            request_headers=request_headers,
-        )
+        key = self._session_key(server, request_headers=request_headers)
+        state = self._session_for_key(key)
+        if force:
+            async with state.lock:
+                return await self._initialize_locked_with_retry(
+                    server, request_headers=request_headers, state=state
+                )
+        state = await self._ensure_initialized(server, request_headers=request_headers, key=key)
+        if state.initialize_result is None:
+            raise MCPTransportError("MCP session initialized without initialize result")
+        return state.initialize_result
 
     async def list_tools(
         self,
@@ -41,12 +78,14 @@ class StreamableHTTPMCPClient:
         *,
         request_headers: dict[str, str] | None = None,
     ) -> list[MCPToolSchema]:
-        payload = await self._send(
+        response = await self._send_with_session(
             server,
-            MCPRequestEnvelope(method="tools/list", params={}, request_id=next(_request_ids)),
             request_headers=request_headers,
+            envelope=MCPRequestEnvelope(
+                method="tools/list", params={}, request_id=next(_request_ids)
+            ),
         )
-        return extract_tool_schemas(payload)
+        return extract_tool_schemas(response.result)
 
     async def call_tool(
         self,
@@ -56,15 +95,16 @@ class StreamableHTTPMCPClient:
         arguments: dict[str, Any] | None = None,
         request_headers: dict[str, str] | None = None,
     ) -> MCPToolCallResult:
-        payload = await self._send(
+        response = await self._send_with_session(
             server,
-            MCPRequestEnvelope(
+            request_headers=request_headers,
+            envelope=MCPRequestEnvelope(
                 method="tools/call",
                 params={"name": tool_name, "arguments": arguments or {}},
                 request_id=next(_request_ids),
             ),
-            request_headers=request_headers,
         )
+        payload = response.result
         content = payload.get("content")
         structured = payload.get("structuredContent")
         return MCPToolCallResult(
@@ -74,31 +114,153 @@ class StreamableHTTPMCPClient:
             metadata=payload if isinstance(payload, dict) else {},
         )
 
+    async def _send_with_session(
+        self,
+        server: MCPServerConfig,
+        *,
+        request_headers: dict[str, str] | None,
+        envelope: MCPRequestEnvelope,
+    ) -> _MCPTransportResponse:
+        key = self._session_key(server, request_headers=request_headers)
+        state = await self._ensure_initialized(server, request_headers=request_headers, key=key)
+        try:
+            return await self._send(
+                server,
+                envelope,
+                request_headers=request_headers,
+                state=state,
+            )
+        except _StaleMCPSessionError as exc:
+            await self._clear_session(key, state, stale_session_id=exc.session_id)
+            state = await self._ensure_initialized(server, request_headers=request_headers, key=key)
+            try:
+                return await self._send(
+                    server,
+                    envelope,
+                    request_headers=request_headers,
+                    state=state,
+                )
+            except _StaleMCPSessionError as exc:
+                await self._clear_session(key, state, stale_session_id=exc.session_id)
+                raise MCPTransportError("MCP server rejected refreshed MCP session") from exc
+
+    async def _ensure_initialized(
+        self,
+        server: MCPServerConfig,
+        *,
+        request_headers: dict[str, str] | None,
+        key: tuple[object, ...],
+    ) -> _MCPSessionState:
+        state = self._session_for_key(key)
+        if state.initialized and state.initialize_result is not None:
+            self._touch_session(state)
+            return state
+        async with state.lock:
+            if not state.initialized or state.initialize_result is None:
+                await self._initialize_locked_with_retry(
+                    server, request_headers=request_headers, state=state
+                )
+        return state
+
+    async def _initialize_locked_with_retry(
+        self,
+        server: MCPServerConfig,
+        *,
+        request_headers: dict[str, str] | None,
+        state: _MCPSessionState,
+    ) -> dict[str, Any]:
+        last_stale: _StaleMCPSessionError | None = None
+        for _ in range(2):
+            try:
+                return await self._initialize_locked(
+                    server, request_headers=request_headers, state=state
+                )
+            except _StaleMCPSessionError as exc:
+                last_stale = exc
+                self._reset_session_state_if_current(state, exc.session_id)
+        raise MCPTransportError(
+            "MCP server rejected initialized notification for MCP session"
+        ) from last_stale
+
+    async def _initialize_locked(
+        self,
+        server: MCPServerConfig,
+        *,
+        request_headers: dict[str, str] | None,
+        state: _MCPSessionState,
+    ) -> dict[str, Any]:
+        self._reset_session_state(state)
+        response = await self._send(
+            server,
+            MCPRequestEnvelope(
+                method="initialize",
+                params={
+                    "protocolVersion": MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "deltallm", "version": "0.1.0"},
+                },
+                request_id=next(_request_ids),
+            ),
+            request_headers=request_headers,
+            state=None,
+            include_protocol_header=False,
+        )
+        session_id = response.headers.get("MCP-Session-Id") or response.headers.get(
+            "mcp-session-id"
+        )
+        if session_id:
+            state.session_id = session_id
+        negotiated_protocol = response.result.get("protocolVersion")
+        if isinstance(negotiated_protocol, str) and negotiated_protocol.strip():
+            state.protocol_version = negotiated_protocol.strip()
+        try:
+            await self._send(
+                server,
+                MCPRequestEnvelope(method="notifications/initialized"),
+                request_headers=request_headers,
+                state=state,
+                expect_response=False,
+            )
+        except _StaleMCPSessionError as exc:
+            self._reset_session_state_if_current(state, exc.session_id)
+            raise
+        except Exception:
+            self._reset_session_state(state)
+            raise
+        state.initialized = True
+        state.initialize_result = response.result
+        self._touch_session(state)
+        return response.result
+
     async def _send(
         self,
         server: MCPServerConfig,
         envelope: MCPRequestEnvelope,
         *,
         request_headers: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            **build_server_headers(auth_mode=server.auth_mode, auth_config=server.auth_config),
-            **build_forwarded_headers(
-                request_headers=request_headers,
-                server_key=server.server_key,
-                allowlist=server.forwarded_headers_allowlist,
-            ),
-        }
+        state: _MCPSessionState | None = None,
+        include_protocol_header: bool = True,
+        expect_response: bool = True,
+    ) -> _MCPTransportResponse:
+        session_id = state.session_id if state is not None else None
+        protocol_version = state.protocol_version if state is not None else MCP_PROTOCOL_VERSION
+        headers = self._upstream_headers(server, request_headers=request_headers)
+        headers["Content-Type"] = "application/json"
+        headers["Accept"] = _MCP_ACCEPT
+        if session_id:
+            headers["MCP-Session-Id"] = session_id
+        if state is not None and include_protocol_header:
+            headers["MCP-Protocol-Version"] = protocol_version
         body = {
             "jsonrpc": "2.0",
-            "id": envelope.request_id,
             "method": envelope.method,
             "params": envelope.params,
         }
+        if envelope.request_id is not None:
+            body["id"] = envelope.request_id
         try:
-            response = await self.http_client.post(
+            async with self.http_client.stream(
+                "POST",
                 server.base_url.rstrip("/"),
                 json=body,
                 headers=headers,
@@ -106,25 +268,211 @@ class StreamableHTTPMCPClient:
                     self.general_settings,
                     max(1.0, float(server.request_timeout_ms) / 1000.0),
                 ),
-            )
+            ) as response:
+                if response.status_code in {401, 403}:
+                    raise MCPAuthError(
+                        f"MCP server rejected request with status {response.status_code}"
+                    )
+                if response.status_code == 404 and session_id:
+                    raise _StaleMCPSessionError(session_id)
+                if response.status_code >= 400:
+                    raise MCPTransportError(await _http_error_message(response))
+                if not expect_response:
+                    return _MCPTransportResponse(result={}, headers=response.headers)
+                payload = await _decode_response_payload(response, request_id=envelope.request_id)
+                return _MCPTransportResponse(
+                    result=_result_from_payload(payload), headers=response.headers
+                )
         except httpx.HTTPError as exc:
             raise MCPTransportError(str(exc)) from exc
-        if response.status_code in {401, 403}:
-            raise MCPAuthError(f"MCP server rejected request with status {response.status_code}")
-        if response.status_code >= 400:
-            raise MCPTransportError(f"MCP server returned status {response.status_code}")
-        if "text/event-stream" in response.headers.get("content-type", "").lower():
-            raise MCPInvalidResponseError("MCP server returned unsupported event-stream response")
-        try:
-            payload = response.json()
-        except ValueError as exc:
-            raise MCPInvalidResponseError("MCP server returned invalid JSON") from exc
-        if not isinstance(payload, dict):
-            raise MCPInvalidResponseError("MCP server returned unexpected response shape")
-        if isinstance(payload.get("error"), dict):
-            message = str(payload["error"].get("message") or "MCP server returned an error")
-            raise MCPTransportError(message)
-        result = payload.get("result")
-        if not isinstance(result, dict):
-            raise MCPInvalidResponseError("MCP server response missing result payload")
-        return result
+
+    def _session_for_key(self, key: tuple[object, ...]) -> _MCPSessionState:
+        self._prune_sessions()
+        state = self._sessions.get(key)
+        if state is None:
+            state = _MCPSessionState()
+            self._sessions[key] = state
+            self._prune_sessions(protected_key=key)
+        self._touch_session(state)
+        return state
+
+    async def _clear_session(
+        self,
+        key: tuple[object, ...],
+        state: _MCPSessionState,
+        *,
+        stale_session_id: str | None = None,
+    ) -> None:
+        async with state.lock:
+            if self._sessions.get(key) is state and (
+                stale_session_id is None or state.session_id == stale_session_id
+            ):
+                self._reset_session_state(state)
+
+    @staticmethod
+    def _reset_session_state(state: _MCPSessionState) -> None:
+        state.session_id = None
+        state.protocol_version = MCP_PROTOCOL_VERSION
+        state.initialized = False
+        state.initialize_result = None
+        state.last_used_at = monotonic()
+
+    @staticmethod
+    def _reset_session_state_if_current(state: _MCPSessionState, session_id: str) -> None:
+        if state.session_id == session_id:
+            StreamableHTTPMCPClient._reset_session_state(state)
+
+    @staticmethod
+    def _touch_session(state: _MCPSessionState) -> None:
+        state.last_used_at = monotonic()
+
+    def _prune_sessions(self, *, protected_key: tuple[object, ...] | None = None) -> None:
+        if not self._sessions:
+            return
+        now = monotonic()
+        for key, state in list(self._sessions.items()):
+            if key == protected_key:
+                continue
+            if state.lock.locked():
+                continue
+            if now - state.last_used_at > _MCP_SESSION_TTL_SECONDS:
+                self._sessions.pop(key, None)
+        overflow = len(self._sessions) - _MCP_MAX_SESSION_STATES
+        if overflow <= 0:
+            return
+        unlocked = sorted(
+            (
+                (key, state)
+                for key, state in self._sessions.items()
+                if key != protected_key and not state.lock.locked()
+            ),
+            key=lambda item: item[1].last_used_at,
+        )
+        for key, _state in unlocked[:overflow]:
+            self._sessions.pop(key, None)
+
+    def _session_key(
+        self,
+        server: MCPServerConfig,
+        *,
+        request_headers: dict[str, str] | None,
+    ) -> tuple[object, ...]:
+        headers = self._upstream_headers(server, request_headers=request_headers)
+        normalized_headers = tuple(
+            sorted((key.strip().lower(), value) for key, value in headers.items())
+        )
+        headers_digest = hashlib.sha256(
+            json.dumps(normalized_headers, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return (server.server_id, server.base_url.rstrip("/"), headers_digest)
+
+    @staticmethod
+    def _upstream_headers(
+        server: MCPServerConfig,
+        *,
+        request_headers: dict[str, str] | None,
+    ) -> dict[str, str]:
+        return build_effective_mcp_upstream_headers(
+            auth_mode=server.auth_mode,
+            auth_config=server.auth_config,
+            request_headers=request_headers,
+            server_key=server.server_key,
+            allowlist=server.forwarded_headers_allowlist,
+        )
+
+
+async def _decode_response_payload(
+    response: httpx.Response, *, request_id: str | int | None
+) -> dict[str, Any]:
+    content_type = response.headers.get("content-type", "").lower()
+    if "text/event-stream" in content_type:
+        return await _decode_sse_payload(response, request_id=request_id)
+    try:
+        content = await response.aread()
+        payload = json.loads(content)
+    except ValueError as exc:
+        raise MCPInvalidResponseError("MCP server returned invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise MCPInvalidResponseError("MCP server returned unexpected response shape")
+    return payload
+
+
+async def _decode_sse_payload(
+    response: httpx.Response, *, request_id: str | int | None
+) -> dict[str, Any]:
+    data_lines: list[str] = []
+    async for raw_line in response.aiter_lines():
+        line = raw_line.rstrip("\r")
+        payload = _maybe_decode_sse_line(line, data_lines=data_lines, request_id=request_id)
+        if payload is not None:
+            return payload
+    payload = _maybe_decode_sse_line("", data_lines=data_lines, request_id=request_id)
+    if payload is not None:
+        return payload
+    raise MCPInvalidResponseError(
+        "MCP server event-stream ended before a matching JSON-RPC response"
+    )
+
+
+def _maybe_decode_sse_line(
+    line: str,
+    *,
+    data_lines: list[str],
+    request_id: str | int | None,
+) -> dict[str, Any] | None:
+    if line == "":
+        payload = _decode_sse_data(data_lines, request_id=request_id)
+        if data_lines:
+            data_lines.clear()
+        return payload
+    if line.startswith(":"):
+        return None
+    field, separator, value = line.partition(":")
+    if separator and field == "data":
+        data_lines.append(value[1:] if value.startswith(" ") else value)
+    return None
+
+
+def _decode_sse_data(
+    data_lines: list[str], *, request_id: str | int | None
+) -> dict[str, Any] | None:
+    if not data_lines:
+        return None
+    data = "\n".join(data_lines).strip()
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except ValueError as exc:
+        raise MCPInvalidResponseError("MCP server returned invalid JSON in event-stream") from exc
+    if not isinstance(payload, dict):
+        raise MCPInvalidResponseError("MCP server returned unexpected event-stream payload")
+    if request_id is None or payload.get("id") == request_id:
+        return payload
+    return None
+
+
+def _result_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(payload.get("error"), dict):
+        message = str(payload["error"].get("message") or "MCP server returned an error")
+        raise MCPTransportError(message)
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        raise MCPInvalidResponseError("MCP server response missing result payload")
+    return result
+
+
+async def _http_error_message(response: httpx.Response) -> str:
+    try:
+        content = await response.aread()
+        payload = json.loads(content)
+    except ValueError:
+        payload = None
+    message = None
+    if isinstance(payload, dict) and isinstance(payload.get("error"), dict):
+        message = payload["error"].get("message")
+    return (
+        f"MCP server returned status {response.status_code}: {message}"
+        if message
+        else f"MCP server returned status {response.status_code}"
+    )

--- a/tests/mcp/test_auth.py
+++ b/tests/mcp/test_auth.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import base64
 
-from src.mcp.auth import build_forwarded_headers, build_server_headers
+from src.mcp.auth import (
+    build_effective_mcp_forwarded_headers,
+    build_effective_mcp_upstream_headers,
+    build_forwarded_headers,
+    build_server_headers,
+)
 
 
 def test_build_server_headers_for_bearer_auth() -> None:
@@ -11,7 +16,9 @@ def test_build_server_headers_for_bearer_auth() -> None:
 
 
 def test_build_server_headers_for_basic_auth() -> None:
-    headers = build_server_headers(auth_mode="basic", auth_config={"username": "user", "password": "pass"})
+    headers = build_server_headers(
+        auth_mode="basic", auth_config={"username": "user", "password": "pass"}
+    )
     expected = base64.b64encode(b"user:pass").decode("ascii")
     assert headers == {"Authorization": f"Basic {expected}"}
 
@@ -27,3 +34,49 @@ def test_build_forwarded_headers_filters_by_server_prefix_and_allowlist() -> Non
         allowlist=["authorization"],
     )
     assert headers == {"authorization": "Bearer token"}
+
+
+def test_build_effective_mcp_forwarded_headers_drops_protected_headers() -> None:
+    headers = build_effective_mcp_forwarded_headers(
+        request_headers={
+            "x-deltallm-mcp-github-accept": "application/json",
+            "x-deltallm-mcp-github-authorization": "Bearer token",
+            "x-deltallm-mcp-github-content-type": "text/plain",
+            "x-deltallm-mcp-github-mcp-protocol-version": "1900-01-01",
+            "x-deltallm-mcp-github-mcp-session-id": "bad-session",
+            "x-deltallm-mcp-github-x-api-key": "secret",
+        },
+        server_key="github",
+        allowlist=[
+            "accept",
+            "authorization",
+            "content-type",
+            "mcp-protocol-version",
+            "mcp-session-id",
+            "x-api-key",
+        ],
+    )
+
+    assert headers == {"authorization": "Bearer token", "x-api-key": "secret"}
+
+
+def test_build_effective_mcp_upstream_headers_keeps_auth_and_drops_protected_headers() -> None:
+    headers = build_effective_mcp_upstream_headers(
+        auth_mode="header_map",
+        auth_config={
+            "headers": {
+                "Accept": "application/json",
+                "Authorization": "Bearer upstream",
+                "Content-Type": "text/plain",
+                "MCP-Session-Id": "bad-session",
+            }
+        },
+        request_headers={
+            "x-deltallm-mcp-github-authorization": "Bearer forwarded",
+            "x-deltallm-mcp-github-mcp-protocol-version": "1900-01-01",
+        },
+        server_key="github",
+        allowlist=["authorization", "mcp-protocol-version"],
+    )
+
+    assert headers == {"Authorization": "Bearer upstream", "authorization": "Bearer forwarded"}

--- a/tests/mcp/test_transport_http.py
+++ b/tests/mcp/test_transport_http.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncIterator
+from collections.abc import Callable
+import json
+from time import monotonic
+
 import httpx
 import pytest
 
@@ -8,23 +14,117 @@ from src.mcp.models import MCPServerConfig
 from src.mcp.transport_http import StreamableHTTPMCPClient
 
 
-class _FakeHTTPClient:
-    def __init__(self, response: httpx.Response | None = None, *, exc: Exception | None = None) -> None:
+class _FakeStreamContext:
+    def __init__(self, response: httpx.Response) -> None:
         self.response = response
+
+    async def __aenter__(self) -> httpx.Response:
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:  # noqa: ANN001
+        return None
+
+
+class _StreamingSSEBody(httpx.AsyncByteStream):
+    def __init__(self, lines: list[str], *, tail_event: asyncio.Event | None = None) -> None:
+        self.lines = lines
+        self.tail_event = tail_event
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for line in self.lines:
+            yield line.encode("utf-8")
+        if self.tail_event is not None:
+            await self.tail_event.wait()
+
+
+class _FakeHTTPClient:
+    def __init__(
+        self,
+        response: httpx.Response | Callable[[dict[str, object]], httpx.Response] | None = None,
+        *,
+        responses: list[httpx.Response | Callable[[dict[str, object]], httpx.Response]]
+        | None = None,
+        exc: Exception | None = None,
+    ) -> None:
+        self.responses = list(responses or ([response] if response is not None else []))
         self.exc = exc
         self.calls: list[dict[str, object]] = []
 
-    async def post(self, url: str, *, json: dict[str, object], headers: dict[str, str], timeout: object) -> httpx.Response:
+    def stream(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: dict[str, object],
+        headers: dict[str, str],
+        timeout: object,
+    ) -> _FakeStreamContext:
+        self.calls.append(
+            {"method": method, "url": url, "json": json, "headers": headers, "timeout": timeout}
+        )
+        if self.exc is not None:
+            raise self.exc
+        assert self.responses
+        response = self.responses.pop(0)
+        return _FakeStreamContext(response(json) if callable(response) else response)
+
+    async def post(
+        self, url: str, *, json: dict[str, object], headers: dict[str, str], timeout: object
+    ) -> httpx.Response:
         self.calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
         if self.exc is not None:
             raise self.exc
-        assert self.response is not None
-        return self.response
+        assert self.responses
+        response = self.responses.pop(0)
+        return response(json) if callable(response) else response
 
 
-def _response(status_code: int, payload: dict[str, object]) -> httpx.Response:
+def _response(
+    status_code: int, payload: dict[str, object], *, headers: dict[str, str] | None = None
+) -> httpx.Response:
     request = httpx.Request("POST", "https://mcp.example.com")
-    return httpx.Response(status_code, json=payload, request=request)
+    return httpx.Response(status_code, json=payload, headers=headers, request=request)
+
+
+def _accepted_response() -> httpx.Response:
+    request = httpx.Request("POST", "https://mcp.example.com")
+    return httpx.Response(202, request=request)
+
+
+def _sse_response(
+    status_code: int,
+    payload: dict[str, object],
+    *,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    request = httpx.Request("POST", "https://mcp.example.com")
+    merged_headers = {"content-type": "text/event-stream", **(headers or {})}
+    text = f"event: message\ndata: {json.dumps(payload)}\n\n"
+    return httpx.Response(status_code, text=text, headers=merged_headers, request=request)
+
+
+def _open_sse_response(payload: dict[str, object], *, tail_event: asyncio.Event) -> httpx.Response:
+    request = httpx.Request("POST", "https://mcp.example.com")
+    lines = ["event: message\n", f"data: {json.dumps(payload)}\n", "\n"]
+    return httpx.Response(
+        200,
+        stream=_StreamingSSEBody(lines, tail_event=tail_event),
+        headers={"content-type": "text/event-stream"},
+        request=request,
+    )
+
+
+def _sse_result_response(
+    result: dict[str, object],
+    *,
+    headers: dict[str, str] | None = None,
+) -> Callable[[dict[str, object]], httpx.Response]:
+    def _factory(body: dict[str, object]) -> httpx.Response:
+        return _sse_response(
+            200, {"jsonrpc": "2.0", "id": body.get("id"), "result": result}, headers=headers
+        )
+
+    return _factory
 
 
 def _server(**overrides: object) -> MCPServerConfig:
@@ -48,7 +148,18 @@ def _server(**overrides: object) -> MCPServerConfig:
 @pytest.mark.asyncio
 async def test_initialize_sends_jsonrpc_request_and_returns_result() -> None:
     client = _FakeHTTPClient(
-        _response(200, {"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "github"}}})
+        responses=[
+            _response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"protocolVersion": "2025-11-25", "serverInfo": {"name": "github"}},
+                },
+                headers={"MCP-Session-Id": "session-1"},
+            ),
+            _accepted_response(),
+        ]
     )
     general_settings = type("GeneralSettings", (), {"upstream_http_pool_timeout_seconds": 2})()
     transport = StreamableHTTPMCPClient(client, general_settings=general_settings)  # type: ignore[arg-type]
@@ -58,8 +169,8 @@ async def test_initialize_sends_jsonrpc_request_and_returns_result() -> None:
         request_headers={"x-deltallm-mcp-github-authorization": "Bearer forwarded"},
     )
 
-    assert payload == {"serverInfo": {"name": "github"}}
-    assert len(client.calls) == 1
+    assert payload == {"protocolVersion": "2025-11-25", "serverInfo": {"name": "github"}}
+    assert len(client.calls) == 2
     call = client.calls[0]
     assert call["url"] == "https://mcp.example.com"
     timeout = call["timeout"]
@@ -67,29 +178,214 @@ async def test_initialize_sends_jsonrpc_request_and_returns_result() -> None:
     assert getattr(timeout, "pool") == 2.0
     headers = call["headers"]
     assert isinstance(headers, dict)
+    assert headers["Accept"] == "application/json, text/event-stream"
     assert headers["Authorization"] == "Bearer secret-token"
     assert headers["authorization"] == "Bearer forwarded"
+    assert "MCP-Session-Id" not in headers
+    assert "MCP-Protocol-Version" not in headers
     body = call["json"]
     assert isinstance(body, dict)
     assert body["jsonrpc"] == "2.0"
     assert body["method"] == "initialize"
+    assert body["params"]["protocolVersion"] == "2025-11-25"  # type: ignore[index]
+
+    initialized_call = client.calls[1]
+    initialized_headers = initialized_call["headers"]
+    assert isinstance(initialized_headers, dict)
+    assert initialized_headers["MCP-Session-Id"] == "session-1"
+    assert initialized_headers["MCP-Protocol-Version"] == "2025-11-25"
+    initialized_body = initialized_call["json"]
+    assert isinstance(initialized_body, dict)
+    assert initialized_body["method"] == "notifications/initialized"
+    assert "id" not in initialized_body
+
+
+@pytest.mark.asyncio
+async def test_initialize_reuses_cached_session_result() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"protocolVersion": "2025-11-25", "serverInfo": {"name": "github"}},
+                },
+                headers={"MCP-Session-Id": "session-1"},
+            ),
+            _accepted_response(),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+    server = _server(auth_mode="none", auth_config={})
+
+    first = await transport.initialize(server)
+    second = await transport.initialize(server)
+
+    assert first == second
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_initialize_force_refreshes_session() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"protocolVersion": "2025-11-25", "serverInfo": {"name": "old"}},
+                },
+                headers={"MCP-Session-Id": "session-1"},
+            ),
+            _accepted_response(),
+            _response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {"protocolVersion": "2025-11-25", "serverInfo": {"name": "new"}},
+                },
+                headers={"MCP-Session-Id": "session-2"},
+            ),
+            _accepted_response(),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+    server = _server(auth_mode="none", auth_config={})
+
+    first = await transport.initialize(server)
+    second = await transport.initialize(server, force=True)
+
+    assert first["serverInfo"] == {"name": "old"}
+    assert second["serverInfo"] == {"name": "new"}
+    assert len(client.calls) == 4
+    refreshed_initialized_headers = client.calls[3]["headers"]
+    assert isinstance(refreshed_initialized_headers, dict)
+    assert refreshed_initialized_headers["MCP-Session-Id"] == "session-2"
+
+
+@pytest.mark.asyncio
+async def test_mcp_transport_headers_override_header_map_config() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "session-1"},
+            ),
+            _accepted_response(),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+    server = _server(
+        auth_mode="header_map",
+        auth_config={
+            "headers": {
+                "Accept": "application/json",
+                "Authorization": "Bearer upstream",
+                "Content-Type": "text/plain",
+                "MCP-Protocol-Version": "1900-01-01",
+                "MCP-Session-Id": "bad-session",
+            }
+        },
+    )
+
+    await transport.initialize(server)
+
+    initialize_headers = client.calls[0]["headers"]
+    initialized_headers = client.calls[1]["headers"]
+    assert isinstance(initialize_headers, dict)
+    assert isinstance(initialized_headers, dict)
+    assert initialize_headers["Accept"] == "application/json, text/event-stream"
+    assert initialize_headers["Authorization"] == "Bearer upstream"
+    assert initialize_headers["Content-Type"] == "application/json"
+    assert "MCP-Protocol-Version" not in initialize_headers
+    assert "MCP-Session-Id" not in initialize_headers
+    assert initialized_headers["Accept"] == "application/json, text/event-stream"
+    assert initialized_headers["Content-Type"] == "application/json"
+    assert initialized_headers["MCP-Protocol-Version"] == "2025-11-25"
+    assert initialized_headers["MCP-Session-Id"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_headers_cannot_override_mcp_transport_headers() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "session-1"},
+            ),
+            _accepted_response(),
+            _response(200, {"jsonrpc": "2.0", "id": 2, "result": {"tools": []}}),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+    server = _server(
+        auth_mode="none",
+        auth_config={},
+        forwarded_headers_allowlist=[
+            "accept",
+            "authorization",
+            "content-type",
+            "mcp-protocol-version",
+            "mcp-session-id",
+        ],
+    )
+
+    await transport.list_tools(
+        server,
+        request_headers={
+            "x-deltallm-mcp-github-accept": "application/json",
+            "x-deltallm-mcp-github-authorization": "Bearer forwarded",
+            "x-deltallm-mcp-github-content-type": "text/plain",
+            "x-deltallm-mcp-github-mcp-protocol-version": "1900-01-01",
+            "x-deltallm-mcp-github-mcp-session-id": "bad-session",
+        },
+    )
+
+    list_headers = client.calls[2]["headers"]
+    assert isinstance(list_headers, dict)
+    assert list_headers["Accept"] == "application/json, text/event-stream"
+    assert list_headers["authorization"] == "Bearer forwarded"
+    assert list_headers["Content-Type"] == "application/json"
+    assert list_headers["MCP-Protocol-Version"] == "2025-11-25"
+    assert list_headers["MCP-Session-Id"] == "session-1"
+    assert "accept" not in list_headers
+    assert "content-type" not in list_headers
+    assert "mcp-protocol-version" not in list_headers
+    assert "mcp-session-id" not in list_headers
 
 
 @pytest.mark.asyncio
 async def test_list_tools_parses_tools_from_result() -> None:
     client = _FakeHTTPClient(
-        _response(
-            200,
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "result": {
-                    "tools": [
-                        {"name": "search", "description": "Search", "inputSchema": {"type": "object"}},
-                    ]
+        responses=[
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "session-tools"},
+            ),
+            _accepted_response(),
+            _response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "search",
+                                "description": "Search",
+                                "inputSchema": {"type": "object"},
+                            },
+                        ]
+                    },
                 },
-            },
-        )
+            ),
+        ]
     )
     transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
 
@@ -98,23 +394,35 @@ async def test_list_tools_parses_tools_from_result() -> None:
     assert len(tools) == 1
     assert tools[0].name == "search"
     assert tools[0].input_schema == {"type": "object"}
+    list_headers = client.calls[2]["headers"]
+    assert isinstance(list_headers, dict)
+    assert list_headers["MCP-Session-Id"] == "session-tools"
+    assert list_headers["MCP-Protocol-Version"] == "2025-11-25"
 
 
 @pytest.mark.asyncio
 async def test_call_tool_returns_content_and_structured_content() -> None:
     client = _FakeHTTPClient(
-        _response(
-            200,
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "result": {
-                    "content": [{"type": "text", "text": "ok"}],
-                    "structuredContent": {"status": "ok"},
-                    "isError": False,
+        responses=[
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "session-call"},
+            ),
+            _accepted_response(),
+            _response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {
+                        "content": [{"type": "text", "text": "ok"}],
+                        "structuredContent": {"status": "ok"},
+                        "isError": False,
+                    },
                 },
-            },
-        )
+            ),
+        ]
     )
     transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
 
@@ -123,6 +431,10 @@ async def test_call_tool_returns_content_and_structured_content() -> None:
     assert result.content == [{"type": "text", "text": "ok"}]
     assert result.structured_content == {"status": "ok"}
     assert result.is_error is False
+    call_body = client.calls[2]["json"]
+    assert isinstance(call_body, dict)
+    assert call_body["method"] == "tools/call"
+    assert call_body["params"] == {"name": "search", "arguments": {"q": "test"}}
 
 
 @pytest.mark.asyncio
@@ -154,14 +466,43 @@ async def test_send_maps_httpx_failure_to_transport_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_rejects_event_stream_response() -> None:
-    request = httpx.Request("POST", "https://mcp.example.com")
-    response = httpx.Response(200, text="event: message\n\ndata: {}\n\n", headers={"content-type": "text/event-stream"}, request=request)
-    client = _FakeHTTPClient(response)
+async def test_send_parses_event_stream_response() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _sse_result_response(
+                {"protocolVersion": "2025-11-25", "serverInfo": {"name": "github"}},
+                headers={"MCP-Session-Id": "session-sse"},
+            ),
+            _accepted_response(),
+        ]
+    )
     transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
 
-    with pytest.raises(MCPInvalidResponseError, match="event-stream"):
-        await transport.initialize(_server())
+    payload = await transport.initialize(_server())
+
+    assert payload["serverInfo"] == {"name": "github"}
+    initialized_headers = client.calls[1]["headers"]
+    assert isinstance(initialized_headers, dict)
+    assert initialized_headers["MCP-Session-Id"] == "session-sse"
+
+
+@pytest.mark.asyncio
+async def test_send_returns_from_open_event_stream_after_matching_response() -> None:
+    tail_event = asyncio.Event()
+
+    def _open_initialize_response(body: dict[str, object]) -> httpx.Response:
+        return _open_sse_response(
+            {"jsonrpc": "2.0", "id": body.get("id"), "result": {"protocolVersion": "2025-11-25"}},
+            tail_event=tail_event,
+        )
+
+    client = _FakeHTTPClient(responses=[_open_initialize_response, _accepted_response()])
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+
+    payload = await asyncio.wait_for(transport.initialize(_server()), timeout=1)
+
+    assert payload == {"protocolVersion": "2025-11-25"}
+    assert tail_event.is_set() is False
 
 
 @pytest.mark.asyncio
@@ -171,3 +512,226 @@ async def test_send_rejects_missing_result_payload() -> None:
 
     with pytest.raises(MCPInvalidResponseError):
         await transport.initialize(_server())
+
+
+@pytest.mark.asyncio
+async def test_initialize_does_not_cache_initialized_state_when_initialized_notification_fails() -> (
+    None
+):
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "failed-session"},
+            ),
+            _response(
+                500,
+                {
+                    "jsonrpc": "2.0",
+                    "id": "server-error",
+                    "error": {"message": "notification failed"},
+                },
+            ),
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 2, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "fresh-session"},
+            ),
+            _accepted_response(),
+            _response(200, {"jsonrpc": "2.0", "id": 3, "result": {"tools": []}}),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+    server = _server(auth_mode="none", auth_config={})
+
+    with pytest.raises(MCPTransportError, match="notification failed"):
+        await transport.initialize(server)
+
+    tools = await transport.list_tools(server)
+
+    assert tools == []
+    second_attempt_body = client.calls[2]["json"]
+    assert isinstance(second_attempt_body, dict)
+    assert second_attempt_body["method"] == "initialize"
+
+
+@pytest.mark.asyncio
+async def test_initialize_retries_once_when_initialized_notification_rejects_session() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"protocolVersion": "2025-11-25", "serverInfo": {"name": "first"}},
+                },
+                headers={"MCP-Session-Id": "stale-session"},
+            ),
+            _response(
+                404,
+                {"jsonrpc": "2.0", "id": "server-error", "error": {"message": "session expired"}},
+            ),
+            _response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {"protocolVersion": "2025-11-25", "serverInfo": {"name": "fresh"}},
+                },
+                headers={"MCP-Session-Id": "fresh-session"},
+            ),
+            _accepted_response(),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+
+    payload = await transport.initialize(_server(auth_mode="none", auth_config={}))
+
+    assert payload["serverInfo"] == {"name": "fresh"}
+    assert len(client.calls) == 4
+    first_initialized_headers = client.calls[1]["headers"]
+    second_initialized_headers = client.calls[3]["headers"]
+    assert isinstance(first_initialized_headers, dict)
+    assert isinstance(second_initialized_headers, dict)
+    assert first_initialized_headers["MCP-Session-Id"] == "stale-session"
+    assert second_initialized_headers["MCP-Session-Id"] == "fresh-session"
+
+
+@pytest.mark.asyncio
+async def test_initialize_maps_second_initialized_notification_stale_session() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "stale-session"},
+            ),
+            _response(
+                404,
+                {"jsonrpc": "2.0", "id": "server-error", "error": {"message": "session expired"}},
+            ),
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 2, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "still-stale-session"},
+            ),
+            _response(
+                404, {"jsonrpc": "2.0", "id": "server-error", "error": {"message": "still expired"}}
+            ),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+
+    with pytest.raises(MCPTransportError, match="initialized notification"):
+        await transport.initialize(_server(auth_mode="none", auth_config={}))
+
+
+def test_session_cache_prunes_expired_forwarded_auth_sessions() -> None:
+    transport = StreamableHTTPMCPClient(_FakeHTTPClient())  # type: ignore[arg-type]
+    server = _server(
+        auth_mode="none", auth_config={}, forwarded_headers_allowlist=["authorization"]
+    )
+    first_headers = {"x-deltallm-mcp-github-authorization": "Bearer first"}
+    second_headers = {"x-deltallm-mcp-github-authorization": "Bearer second"}
+    first_key = transport._session_key(server, request_headers=first_headers)  # noqa: SLF001
+    first_state = transport._session_for_key(first_key)  # noqa: SLF001
+    first_state.last_used_at = monotonic() - 31 * 60
+
+    second_key = transport._session_key(server, request_headers=second_headers)  # noqa: SLF001
+    transport._session_for_key(second_key)  # noqa: SLF001
+
+    assert first_key not in transport._sessions  # noqa: SLF001
+    assert second_key in transport._sessions  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_clear_session_only_resets_matching_stale_session() -> None:
+    transport = StreamableHTTPMCPClient(_FakeHTTPClient())  # type: ignore[arg-type]
+    server = _server(auth_mode="none", auth_config={})
+    key = transport._session_key(server, request_headers=None)  # noqa: SLF001
+    state = transport._session_for_key(key)  # noqa: SLF001
+    state.session_id = "fresh-session"
+    state.protocol_version = "2025-11-25"
+    state.initialized = True
+    state.initialize_result = {"protocolVersion": "2025-11-25"}
+
+    await transport._clear_session(key, state, stale_session_id="stale-session")  # noqa: SLF001
+
+    assert state.session_id == "fresh-session"
+    assert state.initialized is True
+    assert state.initialize_result == {"protocolVersion": "2025-11-25"}
+
+    await transport._clear_session(key, state, stale_session_id="fresh-session")  # noqa: SLF001
+
+    assert state.session_id is None
+    assert state.initialized is False
+    assert state.initialize_result is None
+
+
+@pytest.mark.asyncio
+async def test_send_reinitializes_once_after_stale_session() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "stale-session"},
+            ),
+            _accepted_response(),
+            _response(
+                404,
+                {"jsonrpc": "2.0", "id": "server-error", "error": {"message": "session expired"}},
+            ),
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 2, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "fresh-session"},
+            ),
+            _accepted_response(),
+            _response(200, {"jsonrpc": "2.0", "id": 3, "result": {"tools": []}}),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+
+    tools = await transport.list_tools(_server(auth_mode="none", auth_config={}))
+
+    assert tools == []
+    stale_list_headers = client.calls[2]["headers"]
+    assert isinstance(stale_list_headers, dict)
+    assert stale_list_headers["MCP-Session-Id"] == "stale-session"
+    retried_list_headers = client.calls[5]["headers"]
+    assert isinstance(retried_list_headers, dict)
+    assert retried_list_headers["MCP-Session-Id"] == "fresh-session"
+
+
+@pytest.mark.asyncio
+async def test_send_maps_second_stale_session_to_transport_error() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "stale-session"},
+            ),
+            _accepted_response(),
+            _response(
+                404,
+                {"jsonrpc": "2.0", "id": "server-error", "error": {"message": "session expired"}},
+            ),
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 2, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "fresh-session"},
+            ),
+            _accepted_response(),
+            _response(
+                404, {"jsonrpc": "2.0", "id": "server-error", "error": {"message": "still expired"}}
+            ),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+
+    with pytest.raises(MCPTransportError, match="refreshed MCP session"):
+        await transport.list_tools(_server(auth_mode="none", auth_config={}))

--- a/tests/test_mcp_gateway.py
+++ b/tests/test_mcp_gateway.py
@@ -13,7 +13,12 @@ from src.db.mcp_scope_policies import MCPScopePolicyRecord
 from src.metrics import get_prometheus_registry
 from src.mcp.approvals import MCPApprovalService
 from src.mcp.capabilities import namespace_tools
-from src.mcp.exceptions import MCPApprovalDeniedError, MCPApprovalRequiredError, MCPRateLimitError, MCPToolTimeoutError
+from src.mcp.exceptions import (
+    MCPApprovalDeniedError,
+    MCPApprovalRequiredError,
+    MCPRateLimitError,
+    MCPToolTimeoutError,
+)
 from src.mcp.gateway import MCPGatewayService
 from src.mcp.governance import MCPGovernanceService
 from src.mcp.models import MCPToolCallResult, MCPToolSchema
@@ -56,7 +61,12 @@ def _server(
 
 
 class _FakeRegistry:
-    def __init__(self, servers: list[MCPServerRecord], bindings: list[MCPServerBindingRecord], policies: list[MCPToolPolicyRecord]) -> None:
+    def __init__(
+        self,
+        servers: list[MCPServerRecord],
+        bindings: list[MCPServerBindingRecord],
+        policies: list[MCPToolPolicyRecord],
+    ) -> None:
         self.servers = {server.mcp_server_id: server for server in servers}
         self.bindings = list(bindings)
         self.policies = list(policies)
@@ -65,7 +75,11 @@ class _FakeRegistry:
         items = list(self.servers.values())
         if search:
             query = str(search).lower()
-            items = [item for item in items if query in item.server_key.lower() or query in item.name.lower()]
+            items = [
+                item
+                for item in items
+                if query in item.server_key.lower() or query in item.name.lower()
+            ]
         if enabled is not None:
             items = [item for item in items if item.enabled is enabled]
         return items[offset : offset + limit], len(items)
@@ -75,11 +89,17 @@ class _FakeRegistry:
 
     async def list_effective_bindings(self, *, scopes):  # noqa: ANN001, ANN201
         scope_set = {(scope_type, scope_id) for scope_type, scope_id in scopes}
-        return [binding for binding in self.bindings if binding.enabled and (binding.scope_type, binding.scope_id) in scope_set]
+        return [
+            binding
+            for binding in self.bindings
+            if binding.enabled and (binding.scope_type, binding.scope_id) in scope_set
+        ]
 
     async def list_effective_tool_policies(self, *, scopes, server_id=None):  # noqa: ANN001, ANN201
         scope_set = {(scope_type, scope_id) for scope_type, scope_id in scopes}
-        policies = [policy for policy in self.policies if (policy.scope_type, policy.scope_id) in scope_set]
+        policies = [
+            policy for policy in self.policies if (policy.scope_type, policy.scope_id) in scope_set
+        ]
         if server_id:
             policies = [policy for policy in policies if policy.mcp_server_id == server_id]
         return policies
@@ -88,9 +108,15 @@ class _FakeRegistry:
         schemas = [
             MCPToolSchema(
                 name=str(item.get("name") or ""),
-                description=str(item.get("description")) if item.get("description") is not None else None,
-                input_schema=item.get("inputSchema") if isinstance(item.get("inputSchema"), dict) else {},
-                annotations=item.get("annotations") if isinstance(item.get("annotations"), dict) else {},
+                description=str(item.get("description"))
+                if item.get("description") is not None
+                else None,
+                input_schema=item.get("inputSchema")
+                if isinstance(item.get("inputSchema"), dict)
+                else {},
+                annotations=item.get("annotations")
+                if isinstance(item.get("annotations"), dict)
+                else {},
             )
             for item in (server.capabilities_json or {}).get("tools", [])
             if isinstance(item, dict)
@@ -117,7 +143,9 @@ class _FakeGovernanceRepository:
             items = [item for item in items if item.enabled is enabled]
         return items[offset : offset + limit], len(items)
 
-    async def list_bindings(self, *, server_id=None, scope_type=None, scope_id=None, enabled=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+    async def list_bindings(
+        self, *, server_id=None, scope_type=None, scope_id=None, enabled=None, limit=200, offset=0
+    ):  # noqa: ANN001, ANN201
         items = list(self.bindings)
         if server_id is not None:
             items = [item for item in items if item.mcp_server_id == server_id]
@@ -129,7 +157,9 @@ class _FakeGovernanceRepository:
             items = [item for item in items if item.enabled is enabled]
         return items[offset : offset + limit], len(items)
 
-    async def list_tool_policies(self, *, server_id=None, scope_type=None, scope_id=None, enabled=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+    async def list_tool_policies(
+        self, *, server_id=None, scope_type=None, scope_id=None, enabled=None, limit=200, offset=0
+    ):  # noqa: ANN001, ANN201
         items = list(self.policies)
         if server_id is not None:
             items = [item for item in items if item.mcp_server_id == server_id]
@@ -158,7 +188,11 @@ class _FakeTransport:
         self.calls.append((server.server_key, tool_name, request_headers, arguments or {}))
         return MCPToolCallResult(
             content=[{"type": "text", "text": f"{server.server_key}:{tool_name}"}],
-            structured_content={"server": server.server_key, "tool": tool_name, "arguments": arguments or {}},
+            structured_content={
+                "server": server.server_key,
+                "tool": tool_name,
+                "arguments": arguments or {},
+            },
             is_error=False,
         )
 
@@ -179,7 +213,11 @@ class _FakeApprovalRepository:
         now = datetime.now(tz=UTC)
         updated = 0
         for record in self.records_by_fingerprint.get(request_fingerprint, []):
-            if record.status in {"pending", "approved", "rejected"} and record.expires_at is not None and record.expires_at <= now:
+            if (
+                record.status in {"pending", "approved", "rejected"}
+                and record.expires_at is not None
+                and record.expires_at <= now
+            ):
                 record.status = "expired"
                 updated += 1
         return updated
@@ -226,7 +264,11 @@ class _BlockingTransport(_FakeTransport):
         await self.release.wait()
         return MCPToolCallResult(
             content=[{"type": "text", "text": f"{server.server_key}:{tool_name}"}],
-            structured_content={"server": server.server_key, "tool": tool_name, "arguments": arguments or {}},
+            structured_content={
+                "server": server.server_key,
+                "tool": tool_name,
+                "arguments": arguments or {},
+            },
             is_error=False,
         )
 
@@ -241,7 +283,11 @@ class _SleepingTransport(_FakeTransport):
         await asyncio.sleep(self.delay_seconds)
         return MCPToolCallResult(
             content=[{"type": "text", "text": f"{server.server_key}:{tool_name}"}],
-            structured_content={"server": server.server_key, "tool": tool_name, "arguments": arguments or {}},
+            structured_content={
+                "server": server.server_key,
+                "tool": tool_name,
+                "arguments": arguments or {},
+            },
             is_error=False,
         )
 
@@ -258,17 +304,23 @@ async def test_mcp_gateway_initialize_and_tools_list(client, test_app):
     docs_server = _server(
         "srv-docs",
         "docs",
-        capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+        capabilities=[
+            MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})
+        ],
     )
     github_server = _server(
         "srv-github",
         "github",
-        capabilities=[MCPToolSchema(name="search", description="Search code", input_schema={"type": "object"})],
+        capabilities=[
+            MCPToolSchema(name="search", description="Search code", input_schema={"type": "object"})
+        ],
     )
     hidden_server = _server(
         "srv-hidden",
         "hidden",
-        capabilities=[MCPToolSchema(name="secret", description="Secret tool", input_schema={"type": "object"})],
+        capabilities=[
+            MCPToolSchema(name="secret", description="Secret tool", input_schema={"type": "object"})
+        ],
     )
     registry = _FakeRegistry(
         servers=[docs_server, github_server, hidden_server],
@@ -284,11 +336,19 @@ async def test_mcp_gateway_initialize_and_tools_list(client, test_app):
 
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
 
-    initialize = await client.post("/mcp", headers=headers, json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+    initialize = await client.post(
+        "/mcp",
+        headers=headers,
+        json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+    )
     assert initialize.status_code == 200
     assert initialize.json()["result"]["serverInfo"]["name"] == "DeltaLLM MCP Gateway"
 
-    tool_list = await client.post("/mcp", headers=headers, json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+    tool_list = await client.post(
+        "/mcp",
+        headers=headers,
+        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+    )
     assert tool_list.status_code == 200
     names = [tool["name"] for tool in tool_list.json()["result"]["tools"]]
     assert names == ["docs.search", "github.search"]
@@ -307,10 +367,16 @@ async def test_mcp_gateway_tools_call_routes_to_namespaced_upstream_tool(client,
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
-        bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, ["search"])],
+        bindings=[
+            MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, ["search"])
+        ],
         policies=[],
     )
     transport = _FakeTransport()
@@ -351,24 +417,41 @@ async def test_mcp_gateway_denies_policy_disabled_tool(client, test_app):
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
-        policies=[MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", False, None, None, None, None)],
+        policies=[
+            MCPToolPolicyRecord(
+                "policy-1", "srv-docs", "search", "team", "team-ops", False, None, None, None, None
+            )
+        ],
     )
     transport = _FakeTransport()
     test_app.state.mcp_gateway_service = MCPGatewayService(registry, transport)  # type: ignore[arg-type]
 
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
-    tool_list = await client.post("/mcp", headers=headers, json={"jsonrpc": "2.0", "id": 4, "method": "tools/list", "params": {}})
+    tool_list = await client.post(
+        "/mcp",
+        headers=headers,
+        json={"jsonrpc": "2.0", "id": 4, "method": "tools/list", "params": {}},
+    )
     assert tool_list.status_code == 200
     assert tool_list.json()["result"]["tools"] == []
 
     response = await client.post(
         "/mcp",
         headers=headers,
-        json={"jsonrpc": "2.0", "id": 5, "method": "tools/call", "params": {"name": "docs.search", "arguments": {}}},
+        json={
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {"name": "docs.search", "arguments": {}},
+        },
     )
     assert response.status_code == 200
     assert response.json()["error"]["code"] == -32004
@@ -376,16 +459,31 @@ async def test_mcp_gateway_denies_policy_disabled_tool(client, test_app):
 
 @pytest.mark.asyncio
 async def test_gateway_service_enforces_policy_execution_timeout() -> None:
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": "org-acme", "metadata": {}})()
+    auth = type(
+        "Auth",
+        (),
+        {
+            "api_key": "sk-test",
+            "team_id": "team-ops",
+            "organization_id": "org-acme",
+            "metadata": {},
+        },
+    )()
     registry = _FakeRegistry(
         servers=[
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
-        bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, ["search"])],
+        bindings=[
+            MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, ["search"])
+        ],
         policies=[
             MCPToolPolicyRecord(
                 "policy-timeout",
@@ -401,7 +499,9 @@ async def test_gateway_service_enforces_policy_execution_timeout() -> None:
     gateway = MCPGatewayService(registry, _SleepingTransport(0.05))  # type: ignore[arg-type]
 
     with pytest.raises(MCPToolTimeoutError):
-        await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "delta"})
+        await gateway.call_tool(
+            auth, namespaced_tool_name="docs.search", arguments={"query": "delta"}
+        )
 
 
 @pytest.mark.asyncio
@@ -420,12 +520,22 @@ async def test_gateway_service_jwt_auth_does_not_use_pseudo_api_key_scope() -> N
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             ),
             _server(
                 "srv-team",
                 "teamdocs",
-                capabilities=[MCPToolSchema(name="search", description="Search team docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search",
+                        description="Search team docs",
+                        input_schema={"type": "object"},
+                    )
+                ],
             ),
         ],
         bindings=[
@@ -458,12 +568,24 @@ async def test_gateway_service_user_scope_affects_mcp_visibility_and_policy_reso
             _server(
                 "srv-user",
                 "userdocs",
-                capabilities=[MCPToolSchema(name="search", description="Search user docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search",
+                        description="Search user docs",
+                        input_schema={"type": "object"},
+                    )
+                ],
             ),
             _server(
                 "srv-team",
                 "teamdocs",
-                capabilities=[MCPToolSchema(name="search", description="Search team docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search",
+                        description="Search team docs",
+                        input_schema={"type": "object"},
+                    )
+                ],
             ),
         ],
         bindings=[
@@ -471,8 +593,32 @@ async def test_gateway_service_user_scope_affects_mcp_visibility_and_policy_reso
             MCPServerBindingRecord("bind-team", "srv-team", "team", "team-ops", True, None),
         ],
         policies=[
-            MCPToolPolicyRecord("policy-team", "srv-team", "search", "team", "team-ops", True, "never", None, None, None, None),
-            MCPToolPolicyRecord("policy-user", "srv-team", "search", "user", "user-1", False, "never", None, None, None, None),
+            MCPToolPolicyRecord(
+                "policy-team",
+                "srv-team",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                "never",
+                None,
+                None,
+                None,
+                None,
+            ),
+            MCPToolPolicyRecord(
+                "policy-user",
+                "srv-team",
+                "search",
+                "user",
+                "user-1",
+                False,
+                "never",
+                None,
+                None,
+                None,
+                None,
+            ),
         ],
     )
 
@@ -483,7 +629,9 @@ async def test_gateway_service_user_scope_affects_mcp_visibility_and_policy_reso
 
 
 @pytest.mark.asyncio
-async def test_gateway_service_uses_governance_snapshot_instead_of_registry_binding_queries() -> None:
+async def test_gateway_service_uses_governance_snapshot_instead_of_registry_binding_queries() -> (
+    None
+):
     auth = annotate_auth_metadata(
         UserAPIKeyAuth(
             api_key="hashed-key",
@@ -497,14 +645,22 @@ async def test_gateway_service_uses_governance_snapshot_instead_of_registry_bind
         _server(
             "srv-docs",
             "docs",
-            capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+            capabilities=[
+                MCPToolSchema(
+                    name="search", description="Search docs", input_schema={"type": "object"}
+                )
+            ],
         )
     ]
     bindings = [
         MCPServerBindingRecord("bind-org", "srv-docs", "organization", "org-acme", True, None),
         MCPServerBindingRecord("bind-team", "srv-docs", "team", "team-ops", True, ["search"]),
     ]
-    policies = [MCPToolPolicyRecord("policy-team", "srv-docs", "search", "team", "team-ops", True, None, 1, None, None, None)]
+    policies = [
+        MCPToolPolicyRecord(
+            "policy-team", "srv-docs", "search", "team", "team-ops", True, None, 1, None, None, None
+        )
+    ]
     governance = MCPGovernanceService(_FakeGovernanceRepository(servers, bindings, policies))  # type: ignore[arg-type]
     await governance.reload()
 
@@ -530,7 +686,9 @@ async def test_gateway_service_uses_governance_snapshot_instead_of_registry_bind
 
     await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
     with pytest.raises(MCPRateLimitError):
-        await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "again"})
+        await gateway.call_tool(
+            auth, namespaced_tool_name="docs.search", arguments={"query": "again"}
+        )
 
 
 @pytest.mark.asyncio
@@ -548,17 +706,27 @@ async def test_gateway_service_governance_respects_org_ceiling_and_team_restrict
         _server(
             "srv-docs",
             "docs",
-            capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+            capabilities=[
+                MCPToolSchema(
+                    name="search", description="Search docs", input_schema={"type": "object"}
+                )
+            ],
         ),
         _server(
             "srv-github",
             "github",
-            capabilities=[MCPToolSchema(name="search", description="Search code", input_schema={"type": "object"})],
+            capabilities=[
+                MCPToolSchema(
+                    name="search", description="Search code", input_schema={"type": "object"}
+                )
+            ],
         ),
     ]
     bindings = [
         MCPServerBindingRecord("bind-org-docs", "srv-docs", "organization", "org-acme", True, None),
-        MCPServerBindingRecord("bind-org-github", "srv-github", "organization", "org-acme", True, None),
+        MCPServerBindingRecord(
+            "bind-org-github", "srv-github", "organization", "org-acme", True, None
+        ),
         MCPServerBindingRecord("bind-team-docs", "srv-docs", "team", "team-ops", True, ["search"]),
     ]
     scope_policies = [
@@ -570,7 +738,9 @@ async def test_gateway_service_governance_respects_org_ceiling_and_team_restrict
         )
     ]
     governance_repository = _FakeGovernanceRepository(servers, bindings, [], scope_policies)
-    governance = MCPGovernanceService(governance_repository, policy_repository=governance_repository)  # type: ignore[arg-type]
+    governance = MCPGovernanceService(
+        governance_repository, policy_repository=governance_repository
+    )  # type: ignore[arg-type]
     await governance.reload()
 
     gateway = MCPGatewayService(
@@ -581,7 +751,9 @@ async def test_gateway_service_governance_respects_org_ceiling_and_team_restrict
 
     visible = await gateway.list_visible_servers(auth)
 
-    assert [(item.server.server_key, item.binding.scope_type, item.tool_names) for item in visible] == [
+    assert [
+        (item.server.server_key, item.binding.scope_type, item.tool_names) for item in visible
+    ] == [
         ("docs", "team", ("search",)),
     ]
 
@@ -599,7 +771,11 @@ async def test_mcp_gateway_emits_metrics(client, test_app):
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
@@ -609,19 +785,28 @@ async def test_mcp_gateway_emits_metrics(client, test_app):
     test_app.state.mcp_gateway_service = MCPGatewayService(registry, transport)  # type: ignore[arg-type]
 
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
-    list_response = await client.post("/mcp", headers=headers, json={"jsonrpc": "2.0", "id": 6, "method": "tools/list", "params": {}})
+    list_response = await client.post(
+        "/mcp",
+        headers=headers,
+        json={"jsonrpc": "2.0", "id": 6, "method": "tools/list", "params": {}},
+    )
     assert list_response.status_code == 200
 
     call_response = await client.post(
         "/mcp",
         headers=headers,
-        json={"jsonrpc": "2.0", "id": 7, "method": "tools/call", "params": {"name": "docs.search", "arguments": {"query": "hello"}}},
+        json={
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {"name": "docs.search", "arguments": {"query": "hello"}},
+        },
     )
     assert call_response.status_code == 200
 
     metrics_text = generate_latest(get_prometheus_registry()).decode("utf-8")
-    assert 'deltallm_mcp_tools_list_total' in metrics_text
-    assert 'deltallm_mcp_tool_call_total' in metrics_text
+    assert "deltallm_mcp_tools_list_total" in metrics_text
+    assert "deltallm_mcp_tool_call_total" in metrics_text
     assert 'server_key="docs"' in metrics_text
 
 
@@ -632,24 +817,50 @@ async def test_mcp_gateway_enforces_tool_rpm_limit() -> None:
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
-        policies=[MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", True, None, 1, None, None, None)],
+        policies=[
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                None,
+                1,
+                None,
+                None,
+                None,
+            )
+        ],
     )
     gateway = MCPGatewayService(
         registry,
         _FakeTransport(),
         MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
     )  # type: ignore[arg-type]
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None})()
+    auth = type(
+        "Auth",
+        (),
+        {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None},
+    )()
 
-    first = await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
+    first = await gateway.call_tool(
+        auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+    )
     assert first.structured_content["tool"] == "search"
 
     with pytest.raises(MCPRateLimitError, match="Rate limit exceeded"):
-        await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
+        await gateway.call_tool(
+            auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+        )
 
 
 @pytest.mark.asyncio
@@ -660,12 +871,28 @@ async def test_mcp_gateway_enforces_tool_concurrency_limit() -> None:
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
         policies=[
-            MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", True, None, None, 1, None, None)
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                None,
+                None,
+                1,
+                None,
+                None,
+            )
         ],
     )
     gateway = MCPGatewayService(
@@ -673,9 +900,15 @@ async def test_mcp_gateway_enforces_tool_concurrency_limit() -> None:
         transport,
         MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
     )  # type: ignore[arg-type]
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None})()
+    auth = type(
+        "Auth",
+        (),
+        {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None},
+    )()
 
-    first_task = asyncio.create_task(gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "a"}))
+    first_task = asyncio.create_task(
+        gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "a"})
+    )
     await transport.started.wait()
 
     with pytest.raises(MCPRateLimitError, match="Parallel request limit exceeded"):
@@ -693,13 +926,41 @@ async def test_mcp_gateway_uses_most_specific_policy() -> None:
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
         policies=[
-            MCPToolPolicyRecord("policy-org", "srv-docs", "search", "organization", "org-acme", True, None, 100, None, None, None),
-            MCPToolPolicyRecord("policy-team", "srv-docs", "search", "team", "team-ops", True, None, 1, None, None, None),
+            MCPToolPolicyRecord(
+                "policy-org",
+                "srv-docs",
+                "search",
+                "organization",
+                "org-acme",
+                True,
+                None,
+                100,
+                None,
+                None,
+                None,
+            ),
+            MCPToolPolicyRecord(
+                "policy-team",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                None,
+                1,
+                None,
+                None,
+                None,
+            ),
         ],
     )
     gateway = MCPGatewayService(
@@ -707,11 +968,22 @@ async def test_mcp_gateway_uses_most_specific_policy() -> None:
         _FakeTransport(),
         MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
     )  # type: ignore[arg-type]
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": "org-acme", "metadata": None})()
+    auth = type(
+        "Auth",
+        (),
+        {
+            "api_key": "sk-test",
+            "team_id": "team-ops",
+            "organization_id": "org-acme",
+            "metadata": None,
+        },
+    )()
 
     await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
     with pytest.raises(MCPRateLimitError):
-        await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "again"})
+        await gateway.call_tool(
+            auth, namespaced_tool_name="docs.search", arguments={"query": "again"}
+        )
 
 
 @pytest.mark.asyncio
@@ -722,12 +994,28 @@ async def test_mcp_gateway_caches_tool_result_when_policy_ttl_is_set() -> None:
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
         policies=[
-            MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", True, None, None, None, 60, None)
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                None,
+                None,
+                None,
+                60,
+                None,
+            )
         ],
     )
     gateway = MCPGatewayService(
@@ -736,10 +1024,18 @@ async def test_mcp_gateway_caches_tool_result_when_policy_ttl_is_set() -> None:
         MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
         MCPToolResultCache(InMemoryBackend()),
     )  # type: ignore[arg-type]
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None})()
+    auth = type(
+        "Auth",
+        (),
+        {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None},
+    )()
 
-    first = await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
-    second = await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
+    first = await gateway.call_tool(
+        auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+    )
+    second = await gateway.call_tool(
+        auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+    )
 
     assert first.structured_content["tool"] == "search"
     assert second.structured_content["tool"] == "search"
@@ -754,13 +1050,29 @@ async def test_mcp_gateway_cache_key_includes_forwarded_headers() -> None:
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
                 forwarded_headers_allowlist=["authorization"],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
         policies=[
-            MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", True, None, None, None, 60, None)
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                None,
+                None,
+                None,
+                60,
+                None,
+            )
         ],
     )
     gateway = MCPGatewayService(
@@ -769,7 +1081,11 @@ async def test_mcp_gateway_cache_key_includes_forwarded_headers() -> None:
         MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
         MCPToolResultCache(InMemoryBackend()),
     )  # type: ignore[arg-type]
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None})()
+    auth = type(
+        "Auth",
+        (),
+        {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None},
+    )()
 
     await gateway.call_tool(
         auth,
@@ -788,18 +1104,113 @@ async def test_mcp_gateway_cache_key_includes_forwarded_headers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mcp_gateway_cache_key_ignores_protected_forwarded_mcp_headers() -> None:
+    transport = _FakeTransport()
+    registry = _FakeRegistry(
+        servers=[
+            _server(
+                "srv-docs",
+                "docs",
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
+                forwarded_headers_allowlist=[
+                    "accept",
+                    "authorization",
+                    "content-type",
+                    "mcp-protocol-version",
+                    "mcp-session-id",
+                ],
+            )
+        ],
+        bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
+        policies=[
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                None,
+                None,
+                None,
+                60,
+                None,
+            )
+        ],
+    )
+    gateway = MCPGatewayService(
+        registry,
+        transport,
+        MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
+        MCPToolResultCache(InMemoryBackend()),
+    )  # type: ignore[arg-type]
+    auth = type(
+        "Auth",
+        (),
+        {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None},
+    )()
+
+    await gateway.call_tool(
+        auth,
+        namespaced_tool_name="docs.search",
+        arguments={"query": "hello"},
+        request_headers={
+            "x-deltallm-mcp-docs-accept": "application/json",
+            "x-deltallm-mcp-docs-authorization": "Bearer same",
+            "x-deltallm-mcp-docs-content-type": "text/plain",
+            "x-deltallm-mcp-docs-mcp-protocol-version": "1900-01-01",
+            "x-deltallm-mcp-docs-mcp-session-id": "bad-session-1",
+        },
+    )
+    await gateway.call_tool(
+        auth,
+        namespaced_tool_name="docs.search",
+        arguments={"query": "hello"},
+        request_headers={
+            "x-deltallm-mcp-docs-accept": "text/event-stream",
+            "x-deltallm-mcp-docs-authorization": "Bearer same",
+            "x-deltallm-mcp-docs-content-type": "application/xml",
+            "x-deltallm-mcp-docs-mcp-protocol-version": "2000-01-01",
+            "x-deltallm-mcp-docs-mcp-session-id": "bad-session-2",
+        },
+    )
+
+    assert len(transport.calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_mcp_gateway_manual_approval_creates_pending_request() -> None:
     registry = _FakeRegistry(
         servers=[
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
         policies=[
-            MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", True, "manual", None, None, None, None)
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                "manual",
+                None,
+                None,
+                None,
+                None,
+            )
         ],
     )
     approval_repo = _FakeApprovalRepository()
@@ -809,7 +1220,11 @@ async def test_mcp_gateway_manual_approval_creates_pending_request() -> None:
         MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
         approval_service=MCPApprovalService(approval_repo),  # type: ignore[arg-type]
     )  # type: ignore[arg-type]
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None})()
+    auth = type(
+        "Auth",
+        (),
+        {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None},
+    )()
 
     with pytest.raises(MCPApprovalRequiredError) as exc:
         await gateway.call_tool(
@@ -827,18 +1242,180 @@ async def test_mcp_gateway_manual_approval_creates_pending_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mcp_gateway_approval_fingerprint_ignores_protected_forwarded_mcp_headers() -> None:
+    registry = _FakeRegistry(
+        servers=[
+            _server(
+                "srv-docs",
+                "docs",
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
+                forwarded_headers_allowlist=[
+                    "accept",
+                    "authorization",
+                    "content-type",
+                    "mcp-protocol-version",
+                    "mcp-session-id",
+                ],
+            )
+        ],
+        bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
+        policies=[
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                "manual",
+                None,
+                None,
+                None,
+                None,
+            )
+        ],
+    )
+    approval_repo = _FakeApprovalRepository()
+    gateway = MCPGatewayService(
+        registry,
+        _FakeTransport(),
+        MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
+        approval_service=MCPApprovalService(approval_repo),  # type: ignore[arg-type]
+    )  # type: ignore[arg-type]
+    auth = type(
+        "Auth",
+        (),
+        {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None},
+    )()
+
+    with pytest.raises(MCPApprovalRequiredError):
+        await gateway.call_tool(
+            auth,
+            namespaced_tool_name="docs.search",
+            arguments={"query": "hello"},
+            request_headers={
+                "x-deltallm-mcp-docs-accept": "application/json",
+                "x-deltallm-mcp-docs-authorization": "Bearer same",
+                "x-deltallm-mcp-docs-content-type": "text/plain",
+                "x-deltallm-mcp-docs-mcp-protocol-version": "1900-01-01",
+                "x-deltallm-mcp-docs-mcp-session-id": "bad-session-1",
+            },
+        )
+    with pytest.raises(MCPApprovalRequiredError):
+        await gateway.call_tool(
+            auth,
+            namespaced_tool_name="docs.search",
+            arguments={"query": "hello"},
+            request_headers={
+                "x-deltallm-mcp-docs-accept": "text/event-stream",
+                "x-deltallm-mcp-docs-authorization": "Bearer same",
+                "x-deltallm-mcp-docs-content-type": "application/xml",
+                "x-deltallm-mcp-docs-mcp-protocol-version": "2000-01-01",
+                "x-deltallm-mcp-docs-mcp-session-id": "bad-session-2",
+            },
+        )
+
+    assert approval_repo.create_calls == 1
+    assert len(approval_repo.records_by_fingerprint) == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_gateway_approval_fingerprint_includes_effective_forwarded_headers() -> None:
+    registry = _FakeRegistry(
+        servers=[
+            _server(
+                "srv-docs",
+                "docs",
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
+                forwarded_headers_allowlist=["authorization"],
+            )
+        ],
+        bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
+        policies=[
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                "manual",
+                None,
+                None,
+                None,
+                None,
+            )
+        ],
+    )
+    approval_repo = _FakeApprovalRepository()
+    gateway = MCPGatewayService(
+        registry,
+        _FakeTransport(),
+        MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
+        approval_service=MCPApprovalService(approval_repo),  # type: ignore[arg-type]
+    )  # type: ignore[arg-type]
+    auth = type(
+        "Auth",
+        (),
+        {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None},
+    )()
+
+    with pytest.raises(MCPApprovalRequiredError):
+        await gateway.call_tool(
+            auth,
+            namespaced_tool_name="docs.search",
+            arguments={"query": "hello"},
+            request_headers={"x-deltallm-mcp-docs-authorization": "Bearer one"},
+        )
+    with pytest.raises(MCPApprovalRequiredError):
+        await gateway.call_tool(
+            auth,
+            namespaced_tool_name="docs.search",
+            arguments={"query": "hello"},
+            request_headers={"x-deltallm-mcp-docs-authorization": "Bearer two"},
+        )
+
+    assert approval_repo.create_calls == 2
+    assert len(approval_repo.records_by_fingerprint) == 2
+
+
+@pytest.mark.asyncio
 async def test_mcp_gateway_manual_approval_approved_retry_executes() -> None:
     registry = _FakeRegistry(
         servers=[
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
         policies=[
-            MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", True, "manual", None, None, None, None)
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                "manual",
+                None,
+                None,
+                None,
+                None,
+            )
         ],
     )
     approval_repo = _FakeApprovalRepository()
@@ -850,16 +1427,31 @@ async def test_mcp_gateway_manual_approval_approved_retry_executes() -> None:
         MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
         approval_service=approval_service,  # type: ignore[arg-type]
     )  # type: ignore[arg-type]
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": "org-acme", "metadata": None})()
+    auth = type(
+        "Auth",
+        (),
+        {
+            "api_key": "sk-test",
+            "team_id": "team-ops",
+            "organization_id": "org-acme",
+            "metadata": None,
+        },
+    )()
 
     with pytest.raises(MCPApprovalRequiredError):
-        await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
+        await gateway.call_tool(
+            auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+        )
 
     fingerprint = next(iter(approval_repo.records_by_fingerprint))
     approval_repo.records_by_fingerprint[fingerprint][-1].status = "approved"
-    approval_repo.records_by_fingerprint[fingerprint][-1].expires_at = datetime.now(tz=UTC) + timedelta(minutes=5)
+    approval_repo.records_by_fingerprint[fingerprint][-1].expires_at = datetime.now(
+        tz=UTC
+    ) + timedelta(minutes=5)
 
-    result = await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
+    result = await gateway.call_tool(
+        auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+    )
 
     assert result.structured_content["tool"] == "search"
     assert transport.calls == [("docs", "search", None, {"query": "hello"})]
@@ -872,12 +1464,28 @@ async def test_mcp_gateway_manual_approval_rejected_retry_denies() -> None:
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
         policies=[
-            MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", True, "manual", None, None, None, None)
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                "manual",
+                None,
+                None,
+                None,
+                None,
+            )
         ],
     )
     approval_repo = _FakeApprovalRepository()
@@ -887,17 +1495,32 @@ async def test_mcp_gateway_manual_approval_rejected_retry_denies() -> None:
         MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
         approval_service=MCPApprovalService(approval_repo),  # type: ignore[arg-type]
     )  # type: ignore[arg-type]
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": "org-acme", "metadata": None})()
+    auth = type(
+        "Auth",
+        (),
+        {
+            "api_key": "sk-test",
+            "team_id": "team-ops",
+            "organization_id": "org-acme",
+            "metadata": None,
+        },
+    )()
 
     with pytest.raises(MCPApprovalRequiredError):
-        await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
+        await gateway.call_tool(
+            auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+        )
 
     fingerprint = next(iter(approval_repo.records_by_fingerprint))
     approval_repo.records_by_fingerprint[fingerprint][-1].status = "rejected"
-    approval_repo.records_by_fingerprint[fingerprint][-1].expires_at = datetime.now(tz=UTC) + timedelta(minutes=5)
+    approval_repo.records_by_fingerprint[fingerprint][-1].expires_at = datetime.now(
+        tz=UTC
+    ) + timedelta(minutes=5)
 
     with pytest.raises(MCPApprovalDeniedError):
-        await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
+        await gateway.call_tool(
+            auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+        )
 
 
 @pytest.mark.asyncio
@@ -907,12 +1530,28 @@ async def test_mcp_gateway_manual_approval_expired_creates_new_request() -> None
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
         policies=[
-            MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", True, "manual", None, None, None, None)
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                "manual",
+                None,
+                None,
+                None,
+                None,
+            )
         ],
     )
     approval_repo = _FakeApprovalRepository()
@@ -923,17 +1562,32 @@ async def test_mcp_gateway_manual_approval_expired_creates_new_request() -> None
         MCPToolPolicyEnforcer(LimitCounter(redis_client=None)),
         approval_service=approval_service,  # type: ignore[arg-type]
     )  # type: ignore[arg-type]
-    auth = type("Auth", (), {"api_key": "sk-test", "team_id": "team-ops", "organization_id": "org-acme", "metadata": None})()
+    auth = type(
+        "Auth",
+        (),
+        {
+            "api_key": "sk-test",
+            "team_id": "team-ops",
+            "organization_id": "org-acme",
+            "metadata": None,
+        },
+    )()
 
     with pytest.raises(MCPApprovalRequiredError):
-        await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
+        await gateway.call_tool(
+            auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+        )
 
     fingerprint = next(iter(approval_repo.records_by_fingerprint))
     approval_repo.records_by_fingerprint[fingerprint][-1].status = "expired"
-    approval_repo.records_by_fingerprint[fingerprint][-1].expires_at = datetime.now(tz=UTC) - timedelta(seconds=1)
+    approval_repo.records_by_fingerprint[fingerprint][-1].expires_at = datetime.now(
+        tz=UTC
+    ) - timedelta(seconds=1)
 
     with pytest.raises(MCPApprovalRequiredError) as exc:
-        await gateway.call_tool(auth, namespaced_tool_name="docs.search", arguments={"query": "hello"})
+        await gateway.call_tool(
+            auth, namespaced_tool_name="docs.search", arguments={"query": "hello"}
+        )
 
     assert exc.value.approval_request_id == "approval-2"
     assert approval_repo.create_calls == 2
@@ -952,12 +1606,28 @@ async def test_mcp_jsonrpc_manual_approval_returns_request_id(client, test_app):
             _server(
                 "srv-docs",
                 "docs",
-                capabilities=[MCPToolSchema(name="search", description="Search docs", input_schema={"type": "object"})],
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
             )
         ],
         bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
         policies=[
-            MCPToolPolicyRecord("policy-1", "srv-docs", "search", "team", "team-ops", True, "manual", None, None, None, None)
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                "manual",
+                None,
+                None,
+                None,
+                None,
+            )
         ],
     )
     test_app.state.mcp_gateway_service = MCPGatewayService(

--- a/tests/test_ui_mcp.py
+++ b/tests/test_ui_mcp.py
@@ -8,7 +8,13 @@ from prometheus_client import generate_latest
 
 from src.audit.actions import AuditAction
 from src.auth.roles import OrganizationRole, TeamRole
-from src.db.mcp import MCPApprovalRequestRecord, MCPRepository, MCPServerBindingRecord, MCPServerRecord, MCPToolPolicyRecord
+from src.db.mcp import (
+    MCPApprovalRequestRecord,
+    MCPRepository,
+    MCPServerBindingRecord,
+    MCPServerRecord,
+    MCPToolPolicyRecord,
+)
 from src.db.mcp_scope_policies import MCPScopePolicyRecord
 from src.metrics import get_prometheus_registry
 from src.mcp.capabilities import extract_tool_schemas, namespace_tools
@@ -37,7 +43,11 @@ class _FakeMCPRepository(MCPRepository):
         items = list(self.servers.values())
         if search:
             query = str(search).lower()
-            items = [item for item in items if query in item.server_key.lower() or query in item.name.lower()]
+            items = [
+                item
+                for item in items
+                if query in item.server_key.lower() or query in item.name.lower()
+            ]
         if enabled is not None:
             items = [item for item in items if item.enabled is enabled]
         items.sort(key=lambda item: ((item.created_at or _utcnow()), item.server_key), reverse=True)
@@ -99,12 +109,20 @@ class _FakeMCPRepository(MCPRepository):
         removed = self.servers.pop(server_id, None)
         if removed is None:
             return False
-        self.bindings = {key: value for key, value in self.bindings.items() if value.mcp_server_id != server_id}
-        self.policies = {key: value for key, value in self.policies.items() if value.mcp_server_id != server_id}
-        self.approvals = {key: value for key, value in self.approvals.items() if value.mcp_server_id != server_id}
+        self.bindings = {
+            key: value for key, value in self.bindings.items() if value.mcp_server_id != server_id
+        }
+        self.policies = {
+            key: value for key, value in self.policies.items() if value.mcp_server_id != server_id
+        }
+        self.approvals = {
+            key: value for key, value in self.approvals.items() if value.mcp_server_id != server_id
+        }
         return True
 
-    async def update_server_capabilities(self, server_id: str, *, capabilities_json, capabilities_etag=None):  # noqa: ANN001, ANN201
+    async def update_server_capabilities(
+        self, server_id: str, *, capabilities_json, capabilities_etag=None
+    ):  # noqa: ANN001, ANN201
         existing = self.servers.get(server_id)
         if existing is None:
             return None
@@ -133,7 +151,9 @@ class _FakeMCPRepository(MCPRepository):
         self.servers[server_id] = updated
         return updated
 
-    async def list_bindings(self, *, server_id=None, scope_type=None, scope_id=None, enabled=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+    async def list_bindings(
+        self, *, server_id=None, scope_type=None, scope_id=None, enabled=None, limit=200, offset=0
+    ):  # noqa: ANN001, ANN201
         items = list(self.bindings.values())
         if server_id:
             items = [item for item in items if item.mcp_server_id == server_id]
@@ -143,15 +163,21 @@ class _FakeMCPRepository(MCPRepository):
             items = [item for item in items if item.scope_id == scope_id]
         if enabled is not None:
             items = [item for item in items if item.enabled is enabled]
-        items.sort(key=lambda item: ((item.created_at or _utcnow()), item.mcp_binding_id), reverse=True)
+        items.sort(
+            key=lambda item: ((item.created_at or _utcnow()), item.mcp_binding_id), reverse=True
+        )
         return items[offset : offset + limit], len(items)
 
-    async def upsert_binding(self, *, server_id, scope_type, scope_id, enabled, tool_allowlist, metadata):  # noqa: ANN001, ANN201
+    async def upsert_binding(
+        self, *, server_id, scope_type, scope_id, enabled, tool_allowlist, metadata
+    ):  # noqa: ANN001, ANN201
         existing = next(
             (
                 item
                 for item in self.bindings.values()
-                if item.mcp_server_id == server_id and item.scope_type == scope_type and item.scope_id == scope_id
+                if item.mcp_server_id == server_id
+                and item.scope_type == scope_type
+                and item.scope_id == scope_id
             ),
             None,
         )
@@ -186,7 +212,9 @@ class _FakeMCPRepository(MCPRepository):
     async def get_binding(self, binding_id: str):  # noqa: ANN201
         return self.bindings.get(binding_id)
 
-    async def list_tool_policies(self, *, server_id=None, scope_type=None, scope_id=None, enabled=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+    async def list_tool_policies(
+        self, *, server_id=None, scope_type=None, scope_id=None, enabled=None, limit=200, offset=0
+    ):  # noqa: ANN001, ANN201
         items = list(self.policies.values())
         if server_id:
             items = [item for item in items if item.mcp_server_id == server_id]
@@ -196,7 +224,9 @@ class _FakeMCPRepository(MCPRepository):
             items = [item for item in items if item.scope_id == scope_id]
         if enabled is not None:
             items = [item for item in items if item.enabled is enabled]
-        items.sort(key=lambda item: ((item.created_at or _utcnow()), item.mcp_tool_policy_id), reverse=True)
+        items.sort(
+            key=lambda item: ((item.created_at or _utcnow()), item.mcp_tool_policy_id), reverse=True
+        )
         return items[offset : offset + limit], len(items)
 
     async def upsert_tool_policy(  # noqa: ANN201
@@ -268,13 +298,24 @@ class _FakeMCPRepository(MCPRepository):
             items = [item for item in items if item.mcp_server_id == server_id]
         if status:
             items = [item for item in items if item.status == status]
-        items.sort(key=lambda item: ((item.created_at or _utcnow()), item.mcp_approval_request_id), reverse=True)
+        items.sort(
+            key=lambda item: ((item.created_at or _utcnow()), item.mcp_approval_request_id),
+            reverse=True,
+        )
         return items[offset : offset + limit], len(items)
 
     async def get_approval_request(self, approval_request_id: str):  # noqa: ANN201
         return self.approvals.get(approval_request_id)
 
-    async def decide_approval_request(self, approval_request_id: str, *, status, decided_by_account_id, decision_comment, expires_at):  # noqa: ANN001, ANN201
+    async def decide_approval_request(
+        self,
+        approval_request_id: str,
+        *,
+        status,
+        decided_by_account_id,
+        decision_comment,
+        expires_at,
+    ):  # noqa: ANN001, ANN201
         existing = self.approvals.get(approval_request_id)
         if existing is None or existing.status != "pending":
             return None
@@ -302,17 +343,27 @@ class _FakeMCPScopePolicyRepository:
             items = [item for item in items if item.scope_type == scope_type]
         if scope_id is not None:
             items = [item for item in items if item.scope_id == scope_id]
-        items.sort(key=lambda item: ((item.created_at or _utcnow()), item.mcp_scope_policy_id), reverse=True)
+        items.sort(
+            key=lambda item: ((item.created_at or _utcnow()), item.mcp_scope_policy_id),
+            reverse=True,
+        )
         return items[offset : offset + limit], len(items)
 
     async def upsert_policy(self, *, scope_type, scope_id, mode, metadata):  # noqa: ANN001, ANN201
         existing = next(
-            (item for item in self.policies if item.scope_type == scope_type and item.scope_id == scope_id),
+            (
+                item
+                for item in self.policies
+                if item.scope_type == scope_type and item.scope_id == scope_id
+            ),
             None,
         )
         if existing is not None:
             updated = replace(existing, mode=mode, metadata=metadata, updated_at=_utcnow())
-            self.policies = [updated if item.mcp_scope_policy_id == updated.mcp_scope_policy_id else item for item in self.policies]
+            self.policies = [
+                updated if item.mcp_scope_policy_id == updated.mcp_scope_policy_id else item
+                for item in self.policies
+            ]
             return updated
         self._counter += 1
         record = MCPScopePolicyRecord(
@@ -345,16 +396,24 @@ class _FakeMCPRegistryService:
         self.invalidate_all_calls = 0
 
     async def list_servers(self, *, search=None, enabled=None, limit=100, offset=0):  # noqa: ANN001, ANN201
-        return await self.repository.list_servers(search=search, enabled=enabled, limit=limit, offset=offset)
+        return await self.repository.list_servers(
+            search=search, enabled=enabled, limit=limit, offset=offset
+        )
 
     async def store_server_capabilities(self, server_id: str, *, capabilities, etag=None):  # noqa: ANN001, ANN201
-        return await self.repository.update_server_capabilities(server_id, capabilities_json=capabilities, capabilities_etag=etag)
+        return await self.repository.update_server_capabilities(
+            server_id, capabilities_json=capabilities, capabilities_etag=etag
+        )
 
     async def list_namespaced_tools(self, server: MCPServerRecord):  # noqa: ANN201
-        return namespace_tools(server.server_key, extract_tool_schemas(server.capabilities_json or {}))
+        return namespace_tools(
+            server.server_key, extract_tool_schemas(server.capabilities_json or {})
+        )
 
     async def record_health(self, server_id: str, *, status, error, latency_ms):  # noqa: ANN001, ANN201
-        return await self.repository.record_health_check(server_id, status=status, error=error, latency_ms=latency_ms)
+        return await self.repository.record_health_check(
+            server_id, status=status, error=error, latency_ms=latency_ms
+        )
 
     async def invalidate_server(self, server_key: str) -> None:
         self.invalidated_server_keys.append(server_key)
@@ -404,8 +463,18 @@ class _FakeAuditQueryClient:
         normalized = " ".join(str(query).split())
         if "GROUP BY resource_id" in normalized:
             return [
-                {"tool_name": "docs.search", "total_calls": 6, "failed_calls": 1, "avg_latency_ms": 120.0},
-                {"tool_name": "docs.fetch", "total_calls": 3, "failed_calls": 1, "avg_latency_ms": 187.0},
+                {
+                    "tool_name": "docs.search",
+                    "total_calls": 6,
+                    "failed_calls": 1,
+                    "avg_latency_ms": 120.0,
+                },
+                {
+                    "tool_name": "docs.fetch",
+                    "total_calls": 3,
+                    "failed_calls": 1,
+                    "avg_latency_ms": 187.0,
+                },
             ]
         if "status = 'error'" in normalized and "ORDER BY occurred_at DESC" in normalized:
             return [
@@ -420,7 +489,14 @@ class _FakeAuditQueryClient:
                 }
             ]
         if "FROM deltallm_mcpapprovalrequest" in normalized:
-            return [{"total_requests": 4, "pending_requests": 1, "approved_requests": 2, "rejected_requests": 1}]
+            return [
+                {
+                    "total_requests": 4,
+                    "pending_requests": 1,
+                    "approved_requests": 2,
+                    "rejected_requests": 1,
+                }
+            ]
         if "COUNT(*)::int AS total_calls" in normalized:
             return [{"total_calls": 9, "failed_calls": 2, "avg_latency_ms": 142.4}]
         raise AssertionError(f"Unexpected query: {normalized} params={params}")
@@ -452,13 +528,25 @@ class _FakeMCPScopeQueryClient:
             key = self.keys.get(token)
             if key is None:
                 return []
-            return [{"token": token, "team_id": key["team_id"], "organization_id": key["organization_id"]}]
+            return [
+                {
+                    "token": token,
+                    "team_id": key["team_id"],
+                    "organization_id": key["organization_id"],
+                }
+            ]
         if "FROM deltallm_usertable u" in normalized:
             user_id = str(params[0] or "")
             user = self.users.get(user_id)
             if user is None:
                 return []
-            return [{"user_id": user_id, "team_id": user["team_id"], "organization_id": user["organization_id"]}]
+            return [
+                {
+                    "user_id": user_id,
+                    "team_id": user["team_id"],
+                    "organization_id": user["organization_id"],
+                }
+            ]
         raise AssertionError(f"Unexpected query: {normalized} params={params}")
 
 
@@ -466,33 +554,71 @@ class _FakeMCPMigrationQueryClient:
     def __init__(self) -> None:
         self.organizations = {"org-main": {"organization_name": "Main Org"}}
         self.teams = {"team-ops": {"organization_id": "org-main", "team_alias": "Ops"}}
-        self.keys = {"sk-key-1": {"team_id": "team-ops", "organization_id": "org-main", "key_name": "Ops Key"}}
-        self.users = {"user-1": {"team_id": "team-ops", "organization_id": "org-main", "user_email": "user-1@example.com"}}
+        self.keys = {
+            "sk-key-1": {
+                "team_id": "team-ops",
+                "organization_id": "org-main",
+                "key_name": "Ops Key",
+            }
+        }
+        self.users = {
+            "user-1": {
+                "team_id": "team-ops",
+                "organization_id": "org-main",
+                "user_email": "user-1@example.com",
+            }
+        }
 
     async def query_raw(self, query: str, *params):  # noqa: ANN201
         normalized = " ".join(str(query).split())
-        if "SELECT organization_id, organization_name FROM deltallm_organizationtable" in normalized:
+        if (
+            "SELECT organization_id, organization_name FROM deltallm_organizationtable"
+            in normalized
+        ):
             if "WHERE organization_id = $1" in normalized:
                 organization_id = str(params[0] or "")
                 organization = self.organizations.get(organization_id)
-                return [{"organization_id": organization_id, "organization_name": organization["organization_name"]}] if organization else []
+                return (
+                    [
+                        {
+                            "organization_id": organization_id,
+                            "organization_name": organization["organization_name"],
+                        }
+                    ]
+                    if organization
+                    else []
+                )
             return [
-                {"organization_id": organization_id, "organization_name": organization["organization_name"]}
+                {
+                    "organization_id": organization_id,
+                    "organization_name": organization["organization_name"],
+                }
                 for organization_id, organization in sorted(self.organizations.items())
             ]
         if "SELECT team_id, team_alias, organization_id FROM deltallm_teamtable" in normalized:
             if "WHERE organization_id = $1" in normalized:
                 organization_id = str(params[0] or "")
                 return [
-                    {"team_id": team_id, "team_alias": team["team_alias"], "organization_id": team["organization_id"]}
+                    {
+                        "team_id": team_id,
+                        "team_alias": team["team_alias"],
+                        "organization_id": team["organization_id"],
+                    }
                     for team_id, team in sorted(self.teams.items())
                     if team["organization_id"] == organization_id
                 ]
             return [
-                {"team_id": team_id, "team_alias": team["team_alias"], "organization_id": team["organization_id"]}
+                {
+                    "team_id": team_id,
+                    "team_alias": team["team_alias"],
+                    "organization_id": team["organization_id"],
+                }
                 for team_id, team in sorted(self.teams.items())
             ]
-        if "SELECT vt.token, vt.key_name, vt.team_id, t.organization_id FROM deltallm_verificationtoken vt" in normalized:
+        if (
+            "SELECT vt.token, vt.key_name, vt.team_id, t.organization_id FROM deltallm_verificationtoken vt"
+            in normalized
+        ):
             if "WHERE t.organization_id = $1" in normalized:
                 organization_id = str(params[0] or "")
                 return [
@@ -550,7 +676,10 @@ class _FakeApprovalScopeQueryClient:
         normalized = " ".join(str(query).split())
         if "SELECT COUNT(*)::int AS total FROM deltallm_mcpapprovalrequest r" in normalized:
             return [{"total": len(self.approvals)}]
-        if "FROM deltallm_mcpapprovalrequest r" in normalized and "ORDER BY r.created_at DESC" in normalized:
+        if (
+            "FROM deltallm_mcpapprovalrequest r" in normalized
+            and "ORDER BY r.created_at DESC" in normalized
+        ):
             return list(self.approvals)
         if "FROM deltallm_teamtable" in normalized:
             team_id = str(params[0] or "")
@@ -574,7 +703,12 @@ class _FakeApprovalScopeQueryClient:
 
 
 class _FakeBindingPolicyListQueryClient:
-    def __init__(self, *, bindings: list[dict[str, object]] | None = None, policies: list[dict[str, object]] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        bindings: list[dict[str, object]] | None = None,
+        policies: list[dict[str, object]] | None = None,
+    ) -> None:
         now = _utcnow()
         self.bindings = bindings or [
             {
@@ -665,11 +799,17 @@ class _FakeBindingPolicyListQueryClient:
         self.calls.append((normalized, params))
         if "COUNT(*)::int AS total FROM deltallm_mcpbinding b" in normalized:
             return [{"total": len(self.bindings)}]
-        if "FROM deltallm_mcpbinding b" in normalized and "ORDER BY b.created_at DESC" in normalized:
+        if (
+            "FROM deltallm_mcpbinding b" in normalized
+            and "ORDER BY b.created_at DESC" in normalized
+        ):
             return list(self.bindings)
         if "COUNT(*)::int AS total FROM deltallm_mcptoolpolicy p" in normalized:
             return [{"total": len(self.policies)}]
-        if "FROM deltallm_mcptoolpolicy p" in normalized and "ORDER BY p.created_at DESC" in normalized:
+        if (
+            "FROM deltallm_mcptoolpolicy p" in normalized
+            and "ORDER BY p.created_at DESC" in normalized
+        ):
             return list(self.policies)
         raise AssertionError(f"Unexpected query: {normalized} params={params}")
 
@@ -751,11 +891,17 @@ class _FakeScopedServerQueryClient:
             return list(self.servers)
         if "COUNT(*)::int AS total FROM deltallm_mcpbinding b" in normalized:
             return [{"total": len(self.bindings)}]
-        if "FROM deltallm_mcpbinding b" in normalized and "ORDER BY b.created_at DESC" in normalized:
+        if (
+            "FROM deltallm_mcpbinding b" in normalized
+            and "ORDER BY b.created_at DESC" in normalized
+        ):
             return list(self.bindings)
         if "COUNT(*)::int AS total FROM deltallm_mcptoolpolicy p" in normalized:
             return [{"total": len(self.policies)}]
-        if "FROM deltallm_mcptoolpolicy p" in normalized and "ORDER BY p.created_at DESC" in normalized:
+        if (
+            "FROM deltallm_mcptoolpolicy p" in normalized
+            and "ORDER BY p.created_at DESC" in normalized
+        ):
             return list(self.policies)
         if "COUNT(*)::int AS total_calls" in normalized:
             assert "metadata->>'scope_type'" in normalized
@@ -764,22 +910,53 @@ class _FakeScopedServerQueryClient:
         if "GROUP BY resource_id" in normalized:
             assert "metadata->>'scope_type'" in normalized
             assert "metadata->>'scope_id'" in normalized
-            return [{"tool_name": "docs.search", "total_calls": 4, "failed_calls": 1, "avg_latency_ms": 110.0}]
+            return [
+                {
+                    "tool_name": "docs.search",
+                    "total_calls": 4,
+                    "failed_calls": 1,
+                    "avg_latency_ms": 110.0,
+                }
+            ]
         if "status = 'error'" in normalized and "ORDER BY occurred_at DESC" in normalized:
             assert "metadata->>'scope_type'" in normalized
             assert "metadata->>'scope_id'" in normalized
-            return [{"event_id": "evt-1", "occurred_at": _utcnow(), "tool_name": "docs.search", "error_type": "TimeoutError", "error_code": None, "latency_ms": 180, "request_id": "req-1"}]
+            return [
+                {
+                    "event_id": "evt-1",
+                    "occurred_at": _utcnow(),
+                    "tool_name": "docs.search",
+                    "error_type": "TimeoutError",
+                    "error_code": None,
+                    "latency_ms": 180,
+                    "request_id": "req-1",
+                }
+            ]
         if "FROM deltallm_mcpapprovalrequest" in normalized:
-            return [{"total_requests": 2, "pending_requests": 1, "approved_requests": 1, "rejected_requests": 0}]
+            return [
+                {
+                    "total_requests": 2,
+                    "pending_requests": 1,
+                    "approved_requests": 1,
+                    "rejected_requests": 0,
+                }
+            ]
         raise AssertionError(f"Unexpected query: {normalized} params={params}")
 
 
 def _set_auth_context(monkeypatch: pytest.MonkeyPatch, context: PlatformAuthContext | None) -> None:
-    monkeypatch.setattr("src.middleware.platform_auth.get_platform_auth_context", lambda request: context)
+    monkeypatch.setattr(
+        "src.middleware.platform_auth.get_platform_auth_context", lambda request: context
+    )
     monkeypatch.setattr("src.middleware.admin.get_platform_auth_context", lambda request: context)
 
 
-def _make_context(*, platform_role: str = "platform_user", org_role: str | None = None, team_role: str | None = None) -> PlatformAuthContext:
+def _make_context(
+    *,
+    platform_role: str = "platform_user",
+    org_role: str | None = None,
+    team_role: str | None = None,
+) -> PlatformAuthContext:
     org_memberships = [{"organization_id": "org-main", "role": org_role}] if org_role else []
     team_memberships = [{"team_id": "team-ops", "role": team_role}] if team_role else []
     return PlatformAuthContext(
@@ -811,6 +988,7 @@ async def test_mcp_server_admin_crud_refresh_and_health(client, test_app):
         json={
             "server_key": "docs",
             "name": "Docs MCP",
+            "transport": "http",
             "base_url": "https://mcp.example.com",
             "auth_mode": "bearer",
             "auth_config": {"token": "secret-token"},
@@ -820,6 +998,7 @@ async def test_mcp_server_admin_crud_refresh_and_health(client, test_app):
     assert create.status_code == 200
     created = create.json()
     assert created["server_key"] == "docs"
+    assert created["transport"] == "streamable_http"
     assert created["tool_count"] == 0
     assert created["auth_credentials_present"] is True
     assert "auth_config" not in created
@@ -830,7 +1009,9 @@ async def test_mcp_server_admin_crud_refresh_and_health(client, test_app):
     assert list_response.json()["data"][0]["auth_credentials_present"] is True
     assert "auth_config" not in list_response.json()["data"][0]
 
-    refresh = await client.post(f"/ui/api/mcp-servers/{created['mcp_server_id']}/refresh-capabilities", headers=headers)
+    refresh = await client.post(
+        f"/ui/api/mcp-servers/{created['mcp_server_id']}/refresh-capabilities", headers=headers
+    )
     assert refresh.status_code == 200
     assert refresh.json()["server"]["tool_count"] == 1
     assert refresh.json()["tools"][0]["namespaced_name"] == "docs.search"
@@ -841,7 +1022,9 @@ async def test_mcp_server_admin_crud_refresh_and_health(client, test_app):
     assert detail.json()["server"]["auth_credentials_present"] is True
     assert "auth_config" not in detail.json()["server"]
 
-    health = await client.post(f"/ui/api/mcp-servers/{created['mcp_server_id']}/health-check", headers=headers)
+    health = await client.post(
+        f"/ui/api/mcp-servers/{created['mcp_server_id']}/health-check", headers=headers
+    )
     assert health.status_code == 200
     assert health.json()["health"]["status"] == "healthy"
     assert health.json()["server"]["last_health_status"] == "healthy"
@@ -869,9 +1052,9 @@ async def test_mcp_server_admin_crud_refresh_and_health(client, test_app):
     assert AuditAction.ADMIN_MCP_SERVER_DELETE in actions
 
     metrics_text = generate_latest(get_prometheus_registry()).decode("utf-8")
-    assert 'deltallm_mcp_capability_refresh_total' in metrics_text
-    assert 'deltallm_mcp_health_check_total' in metrics_text
-    assert 'deltallm_mcp_server_health_status' in metrics_text
+    assert "deltallm_mcp_capability_refresh_total" in metrics_text
+    assert "deltallm_mcp_health_check_total" in metrics_text
+    assert "deltallm_mcp_server_health_status" in metrics_text
     assert 'server_key="docs"' in metrics_text
 
 
@@ -898,7 +1081,9 @@ async def test_mcp_binding_and_tool_policy_admin_lifecycle(client, test_app):
     registry = _FakeMCPRegistryService(repository)
     test_app.state.mcp_repository = repository
     test_app.state.mcp_registry_service = registry
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeMCPScopeQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeMCPScopeQueryClient()}
+    )()
     headers = {"Authorization": "Bearer mk-test"}
 
     binding = await client.post(
@@ -914,7 +1099,9 @@ async def test_mcp_binding_and_tool_policy_admin_lifecycle(client, test_app):
     assert binding.status_code == 200
     assert binding.json()["scope_type"] == "team"
 
-    binding_list = await client.get("/ui/api/mcp-bindings?server_id=" + server.mcp_server_id, headers=headers)
+    binding_list = await client.get(
+        "/ui/api/mcp-bindings?server_id=" + server.mcp_server_id, headers=headers
+    )
     assert binding_list.status_code == 200
     assert binding_list.json()["data"][0]["scope_id"] == "team-ops"
 
@@ -936,14 +1123,20 @@ async def test_mcp_binding_and_tool_policy_admin_lifecycle(client, test_app):
     assert policy.json()["max_total_execution_time_ms"] == 1500
     assert policy.json()["metadata"]["max_total_mcp_execution_time_ms"] == 1500
 
-    policy_list = await client.get("/ui/api/mcp-tool-policies?server_id=" + server.mcp_server_id, headers=headers)
+    policy_list = await client.get(
+        "/ui/api/mcp-tool-policies?server_id=" + server.mcp_server_id, headers=headers
+    )
     assert policy_list.status_code == 200
     assert policy_list.json()["data"][0]["tool_name"] == "search"
     assert policy_list.json()["data"][0]["max_total_execution_time_ms"] == 1500
 
-    delete_policy = await client.delete(f"/ui/api/mcp-tool-policies/{policy.json()['mcp_tool_policy_id']}", headers=headers)
+    delete_policy = await client.delete(
+        f"/ui/api/mcp-tool-policies/{policy.json()['mcp_tool_policy_id']}", headers=headers
+    )
     assert delete_policy.status_code == 200
-    delete_binding = await client.delete(f"/ui/api/mcp-bindings/{binding.json()['mcp_binding_id']}", headers=headers)
+    delete_binding = await client.delete(
+        f"/ui/api/mcp-bindings/{binding.json()['mcp_binding_id']}", headers=headers
+    )
     assert delete_binding.status_code == 200
     assert registry.invalidate_all_calls == 4
 
@@ -971,7 +1164,9 @@ async def test_mcp_binding_and_tool_policy_admin_lifecycle_accepts_user_scope(cl
     registry = _FakeMCPRegistryService(repository)
     test_app.state.mcp_repository = repository
     test_app.state.mcp_registry_service = registry
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeMCPScopeQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeMCPScopeQueryClient()}
+    )()
     headers = {"Authorization": "Bearer mk-test"}
 
     binding = await client.post(
@@ -1008,7 +1203,9 @@ async def test_mcp_scope_policy_admin_lifecycle_accepts_user_scope(client, test_
     setattr(test_app.state.settings, "master_key", "mk-test")
     test_app.state.mcp_scope_policy_repository = _FakeMCPScopePolicyRepository()
     test_app.state.mcp_registry_service = _FakeMCPRegistryService(_FakeMCPRepository())
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeMCPScopeQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeMCPScopeQueryClient()}
+    )()
     headers = {"Authorization": "Bearer mk-test"}
 
     create = await client.post(
@@ -1030,7 +1227,9 @@ async def test_mcp_scope_policy_admin_lifecycle_accepts_user_scope(client, test_
     assert listing.status_code == 200
     assert listing.json()["data"][0]["scope_id"] == "user-1"
 
-    delete = await client.delete(f"/ui/api/mcp-scope-policies/{payload['mcp_scope_policy_id']}", headers=headers)
+    delete = await client.delete(
+        f"/ui/api/mcp-scope-policies/{payload['mcp_scope_policy_id']}", headers=headers
+    )
     assert delete.status_code == 200
     assert delete.json()["deleted"] is True
 
@@ -1074,9 +1273,13 @@ async def test_mcp_migration_report_identifies_org_bootstrap_and_scope_backfill(
     )
     test_app.state.mcp_repository = repository
     test_app.state.mcp_scope_policy_repository = policy_repository
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeMCPMigrationQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeMCPMigrationQueryClient()}
+    )()
 
-    response = await client.get("/ui/api/mcp-migration/report", headers={"Authorization": "Bearer mk-test"})
+    response = await client.get(
+        "/ui/api/mcp-migration/report", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -1128,7 +1331,9 @@ async def test_mcp_migration_backfill_bootstraps_org_ceiling_and_scope_policies(
     test_app.state.mcp_repository = repository
     test_app.state.mcp_scope_policy_repository = policy_repository
     test_app.state.mcp_registry_service = registry
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeMCPMigrationQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeMCPMigrationQueryClient()}
+    )()
 
     response = await client.post(
         "/ui/api/mcp-migration/backfill",
@@ -1171,7 +1376,9 @@ async def test_mcp_binding_and_policy_validation_reject_unknown_scope_targets(cl
     )
     test_app.state.mcp_repository = repository
     test_app.state.mcp_registry_service = _FakeMCPRegistryService(repository)
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeMCPScopeQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeMCPScopeQueryClient()}
+    )()
     headers = {"Authorization": "Bearer mk-test"}
 
     missing_team = await client.post(
@@ -1247,7 +1454,9 @@ async def test_mcp_server_validation_rejects_invalid_phase1_config(client, test_
     )
     test_app.state.mcp_repository = repository
     test_app.state.mcp_registry_service = _FakeMCPRegistryService(test_app.state.mcp_repository)
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeMCPScopeQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeMCPScopeQueryClient()}
+    )()
     headers = {"Authorization": "Bearer mk-test"}
 
     create = await client.post(
@@ -1382,7 +1591,9 @@ async def test_mcp_approval_request_list_and_decision(client, test_app):
 
 
 @pytest.mark.asyncio
-async def test_scoped_org_admin_can_list_and_decide_visible_approval_requests(client, test_app, monkeypatch):
+async def test_scoped_org_admin_can_list_and_decide_visible_approval_requests(
+    client, test_app, monkeypatch
+):
     repository = _FakeMCPRepository()
     server = await repository.create_server(
         server_key="docs",
@@ -1416,7 +1627,9 @@ async def test_scoped_org_admin_can_list_and_decide_visible_approval_requests(cl
     )
     repository.approvals[approval.mcp_approval_request_id] = approval
     test_app.state.mcp_repository = repository
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeApprovalScopeQueryClient([approval.__dict__])})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeApprovalScopeQueryClient([approval.__dict__])}
+    )()
     audit = _RecordingAuditService()
     test_app.state.audit_service = audit
     _set_auth_context(monkeypatch, _make_context(org_role=OrganizationRole.ADMIN))
@@ -1438,7 +1651,9 @@ async def test_scoped_org_admin_can_list_and_decide_visible_approval_requests(cl
 
 
 @pytest.mark.asyncio
-async def test_scoped_org_admin_can_list_and_decide_user_scoped_approval_requests(client, test_app, monkeypatch):
+async def test_scoped_org_admin_can_list_and_decide_user_scoped_approval_requests(
+    client, test_app, monkeypatch
+):
     repository = _FakeMCPRepository()
     server = await repository.create_server(
         server_key="docs",
@@ -1473,7 +1688,9 @@ async def test_scoped_org_admin_can_list_and_decide_user_scoped_approval_request
     )
     repository.approvals[approval.mcp_approval_request_id] = approval
     test_app.state.mcp_repository = repository
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeApprovalScopeQueryClient([approval.__dict__])})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeApprovalScopeQueryClient([approval.__dict__])}
+    )()
     _set_auth_context(monkeypatch, _make_context(org_role=OrganizationRole.ADMIN))
 
     list_response = await client.get("/ui/api/mcp-approval-requests")
@@ -1489,7 +1706,9 @@ async def test_scoped_org_admin_can_list_and_decide_user_scoped_approval_request
 
 
 @pytest.mark.asyncio
-async def test_mcp_admin_lists_enabled_rows_by_default_and_include_disabled_for_platform_admin(client, test_app):
+async def test_mcp_admin_lists_enabled_rows_by_default_and_include_disabled_for_platform_admin(
+    client, test_app
+):
     setattr(test_app.state.settings, "master_key", "mk-test")
     repository = _FakeMCPRepository()
     server = await repository.create_server(
@@ -1551,9 +1770,13 @@ async def test_mcp_admin_lists_enabled_rows_by_default_and_include_disabled_for_
     test_app.state.mcp_repository = repository
     test_app.state.mcp_registry_service = _FakeMCPRegistryService(repository)
 
-    bindings_default = await client.get("/ui/api/mcp-bindings", headers={"Authorization": "Bearer mk-test"})
+    bindings_default = await client.get(
+        "/ui/api/mcp-bindings", headers={"Authorization": "Bearer mk-test"}
+    )
     assert bindings_default.status_code == 200
-    assert [item["mcp_binding_id"] for item in bindings_default.json()["data"]] == [enabled_binding.mcp_binding_id]
+    assert [item["mcp_binding_id"] for item in bindings_default.json()["data"]] == [
+        enabled_binding.mcp_binding_id
+    ]
 
     bindings_all = await client.get(
         "/ui/api/mcp-bindings?include_disabled=true",
@@ -1562,9 +1785,13 @@ async def test_mcp_admin_lists_enabled_rows_by_default_and_include_disabled_for_
     assert bindings_all.status_code == 200
     assert len(bindings_all.json()["data"]) == 2
 
-    policies_default = await client.get("/ui/api/mcp-tool-policies", headers={"Authorization": "Bearer mk-test"})
+    policies_default = await client.get(
+        "/ui/api/mcp-tool-policies", headers={"Authorization": "Bearer mk-test"}
+    )
     assert policies_default.status_code == 200
-    assert [item["mcp_tool_policy_id"] for item in policies_default.json()["data"]] == [enabled_policy.mcp_tool_policy_id]
+    assert [item["mcp_tool_policy_id"] for item in policies_default.json()["data"]] == [
+        enabled_policy.mcp_tool_policy_id
+    ]
 
     policies_all = await client.get(
         "/ui/api/mcp-tool-policies?include_disabled=true",
@@ -1573,7 +1800,9 @@ async def test_mcp_admin_lists_enabled_rows_by_default_and_include_disabled_for_
     assert policies_all.status_code == 200
     assert len(policies_all.json()["data"]) == 2
 
-    server_detail = await client.get(f"/ui/api/mcp-servers/{server.mcp_server_id}", headers={"Authorization": "Bearer mk-test"})
+    server_detail = await client.get(
+        f"/ui/api/mcp-servers/{server.mcp_server_id}", headers={"Authorization": "Bearer mk-test"}
+    )
     assert server_detail.status_code == 200
     assert len(server_detail.json()["bindings"]) == 1
     assert len(server_detail.json()["tool_policies"]) == 1
@@ -1622,7 +1851,9 @@ async def test_scoped_team_developer_cannot_decide_approval_requests(client, tes
     )
     repository.approvals[approval.mcp_approval_request_id] = approval
     test_app.state.mcp_repository = repository
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeApprovalScopeQueryClient([approval.__dict__])})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeApprovalScopeQueryClient([approval.__dict__])}
+    )()
     _set_auth_context(monkeypatch, _make_context(team_role=TeamRole.DEVELOPER))
 
     response = await client.post(
@@ -1633,7 +1864,9 @@ async def test_scoped_team_developer_cannot_decide_approval_requests(client, tes
 
 
 @pytest.mark.asyncio
-async def test_scoped_org_admin_can_list_visible_bindings_and_policies(client, test_app, monkeypatch):
+async def test_scoped_org_admin_can_list_visible_bindings_and_policies(
+    client, test_app, monkeypatch
+):
     test_app.state.mcp_repository = _FakeMCPRepository()
     fake_db = _FakeBindingPolicyListQueryClient()
     test_app.state.prisma_manager = type("PrismaManager", (), {"client": fake_db})()
@@ -1647,8 +1880,12 @@ async def test_scoped_org_admin_can_list_visible_bindings_and_policies(client, t
     assert policies_response.status_code == 200
     assert len(policies_response.json()["data"]) == 3
 
-    binding_query = next(query for query, _ in fake_db.calls if "FROM deltallm_mcpbinding b" in query)
-    policy_query = next(query for query, _ in fake_db.calls if "FROM deltallm_mcptoolpolicy p" in query)
+    binding_query = next(
+        query for query, _ in fake_db.calls if "FROM deltallm_mcpbinding b" in query
+    )
+    policy_query = next(
+        query for query, _ in fake_db.calls if "FROM deltallm_mcptoolpolicy p" in query
+    )
     assert "deltallm_teamtable" in binding_query
     assert "deltallm_verificationtoken" in binding_query
     assert "deltallm_usertable" in binding_query
@@ -1658,7 +1895,9 @@ async def test_scoped_org_admin_can_list_visible_bindings_and_policies(client, t
 
 
 @pytest.mark.asyncio
-async def test_scoped_team_developer_reads_team_and_key_bound_rows_only(client, test_app, monkeypatch):
+async def test_scoped_team_developer_reads_team_and_key_bound_rows_only(
+    client, test_app, monkeypatch
+):
     now = _utcnow()
     test_app.state.mcp_repository = _FakeMCPRepository()
     fake_db = _FakeBindingPolicyListQueryClient(
@@ -1732,7 +1971,9 @@ async def test_scoped_team_developer_reads_team_and_key_bound_rows_only(client, 
 
 
 @pytest.mark.asyncio
-async def test_scoped_org_admin_can_access_mcp_server_read_surfaces_and_health_check(client, test_app, monkeypatch):
+async def test_scoped_org_admin_can_access_mcp_server_read_surfaces_and_health_check(
+    client, test_app, monkeypatch
+):
     repository = _FakeMCPRepository()
     server = await repository.create_server(
         server_key="docs",
@@ -1764,7 +2005,9 @@ async def test_scoped_org_admin_can_access_mcp_server_read_surfaces_and_health_c
     test_app.state.mcp_registry_service = registry
     test_app.state.mcp_transport_client = transport
     test_app.state.mcp_health_probe = MCPHealthProbe(registry, transport)
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeScopedServerQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeScopedServerQueryClient()}
+    )()
     _set_auth_context(monkeypatch, _make_context(org_role=OrganizationRole.ADMIN))
 
     list_response = await client.get("/ui/api/mcp-servers")
@@ -1801,11 +2044,15 @@ async def test_scoped_org_admin_can_access_mcp_server_read_surfaces_and_health_c
 
 
 @pytest.mark.asyncio
-async def test_scoped_org_admin_can_create_org_owned_server_but_not_global_server(client, test_app, monkeypatch):
+async def test_scoped_org_admin_can_create_org_owned_server_but_not_global_server(
+    client, test_app, monkeypatch
+):
     repository = _FakeMCPRepository()
     test_app.state.mcp_repository = repository
     test_app.state.mcp_registry_service = _FakeMCPRegistryService(repository)
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeMCPScopeQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeMCPScopeQueryClient()}
+    )()
     _set_auth_context(monkeypatch, _make_context(org_role=OrganizationRole.ADMIN))
 
     create_owned = await client.post(
@@ -1833,7 +2080,9 @@ async def test_scoped_org_admin_can_create_org_owned_server_but_not_global_serve
 
 
 @pytest.mark.asyncio
-async def test_scoped_org_admin_can_update_owned_server_and_scope_global_server_bindings(client, test_app, monkeypatch):
+async def test_scoped_org_admin_can_update_owned_server_and_scope_global_server_bindings(
+    client, test_app, monkeypatch
+):
     repository = _FakeMCPRepository()
     owned_server = await repository.create_server(
         server_key="org-docs",
@@ -1870,7 +2119,9 @@ async def test_scoped_org_admin_can_update_owned_server_and_scope_global_server_
     test_app.state.mcp_repository = repository
     registry = _FakeMCPRegistryService(repository)
     test_app.state.mcp_registry_service = registry
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeMCPScopeQueryClient()})()
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeMCPScopeQueryClient()}
+    )()
     _set_auth_context(monkeypatch, _make_context(org_role=OrganizationRole.ADMIN))
 
     update_owned = await client.patch(
@@ -1938,8 +2189,12 @@ async def test_scoped_team_developer_cannot_run_mcp_health_check(client, test_ap
     test_app.state.mcp_repository = repository
     test_app.state.mcp_registry_service = _FakeMCPRegistryService(repository)
     test_app.state.mcp_transport_client = _FakeTransportClient()
-    test_app.state.mcp_health_probe = MCPHealthProbe(test_app.state.mcp_registry_service, test_app.state.mcp_transport_client)
-    test_app.state.prisma_manager = type("PrismaManager", (), {"client": _FakeScopedServerQueryClient()})()
+    test_app.state.mcp_health_probe = MCPHealthProbe(
+        test_app.state.mcp_registry_service, test_app.state.mcp_transport_client
+    )
+    test_app.state.prisma_manager = type(
+        "PrismaManager", (), {"client": _FakeScopedServerQueryClient()}
+    )()
     _set_auth_context(monkeypatch, _make_context(team_role=TeamRole.DEVELOPER))
 
     response = await client.post(f"/ui/api/mcp-servers/{server.mcp_server_id}/health-check")


### PR DESCRIPTION
## Summary

Fixes the MCP Streamable HTTP integration so DeltaLLM can connect to stateful HTTP MCP servers that behave like the reported endpoint in issue #158.

## Root Cause

DeltaLLM was treating Streamable HTTP as simple JSON-over-HTTP. It sent an overly narrow `Accept: application/json` header, rejected `text/event-stream` responses, and did not preserve upstream `MCP-Session-Id` values across the initialize/list/call lifecycle. That made endpoints work in LiteLLM while failing through DeltaLLM.

## Changes

- Accept `transport: "http"` as a compatibility alias and normalize it to `streamable_http`.
- Send MCP-compatible `Accept: application/json, text/event-stream` headers.
- Parse JSON-RPC responses delivered as `text/event-stream`.
- Preserve upstream `MCP-Session-Id` and negotiated `MCP-Protocol-Version` across requests.
- Send `notifications/initialized` after successful initialize.
- Retry once after stale session rejection and clear only the matching stale session.
- Filter protected MCP protocol headers from forwarded headers so callers cannot poison transport state, cache keys, or approval fingerprints.
- Update docs and add focused tests for Streamable HTTP session behavior.

## Validation

- `uv run --extra dev ruff check src/mcp/auth.py src/mcp/transport_http.py src/mcp/result_cache.py src/mcp/approvals.py src/api/admin/endpoints/mcp/validators.py tests/mcp/test_auth.py tests/mcp/test_transport_http.py tests/test_mcp_gateway.py tests/test_ui_mcp.py`
- `git diff --check`
- `uv run --extra dev pytest tests/mcp/test_auth.py tests/mcp/test_transport_http.py tests/test_mcp_gateway.py tests/test_ui_mcp.py`

Focused tests passed: 67 passed.