### PR TITLE
Split batch workers into a dedicated Helm deployment

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -99,6 +99,7 @@ general_settings:
   sso_state_ttl_seconds: 600
   embeddings_batch_enabled: false
   embeddings_batch_worker_enabled: true
+  embeddings_batch_completion_outbox_worker_enabled: true
   embeddings_batch_storage_backend: local
   embeddings_batch_storage_dir: .deltallm/batch-artifacts
   embeddings_batch_create_session_cleanup_enabled: true
@@ -301,6 +302,7 @@ These settings retain the historical `embeddings_batch_*` names for compatibilit
 |---------|---------|-------------|
 | `embeddings_batch_enabled` | `false` | Enable `/v1/files` and `/v1/batches` endpoints |
 | `embeddings_batch_worker_enabled` | `true` | Run internal batch executor worker loop |
+| `embeddings_batch_completion_outbox_worker_enabled` | `true` | Run the batch completion outbox worker loop that finalizes item accounting and spend records |
 | `embeddings_batch_storage_backend` | `local` | Artifact storage backend. Use `s3` for multi-replica production deployments |
 | `embeddings_batch_storage_dir` | `.deltallm/batch-artifacts` | Local artifact storage base directory |
 | `embeddings_batch_create_session_cleanup_enabled` | `true` | Enable cleanup for internal staged batch-create artifacts |

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -13,6 +13,8 @@ The rewritten chart supports three concrete deployment shapes:
 - standard production with external PostgreSQL and Redis
 - high-availability production with multiple replicas, HPA, PDB, topology spread, ingress, and monitoring
 
+Production batch workloads can additionally split batch workers into a dedicated Deployment so UI/API/gateway pods do not execute batch work.
+
 ## Prerequisites
 
 - Kubernetes 1.24+
@@ -296,7 +298,46 @@ envFrom:
       name: deltallm-runtime-secrets
 ```
 
-### 3. Provider credentials and platform settings
+### 3. Split batch workers from API/UI pods
+
+For production batch workloads, keep the API/UI/gateway Deployment latency-focused and run batch execution in a dedicated worker Deployment. The chart uses the same image for both roles, but renders separate ConfigMaps so each role can run different `general_settings`.
+
+```yaml
+config:
+  general_settings:
+    embeddings_batch_enabled: true
+    embeddings_batch_storage_backend: s3
+    embeddings_batch_s3_bucket: deltallm-batch-artifacts
+    embeddings_batch_s3_region: us-east-1
+
+batchWorker:
+  enabled: true
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+  config:
+    general_settings:
+      embeddings_batch_worker_concurrency: 2
+      embeddings_batch_item_claim_limit: 10
+```
+
+When `batchWorker.enabled=true`, the chart automatically disables batch executor, completion outbox, and cleanup loops in the API ConfigMap and enables them in the worker ConfigMap. `config` remains the shared base config, `api.config` overrides only API/UI/gateway pods, and `batchWorker.config` overrides only worker pods.
+
+The Service keeps the legacy API selector for upgrade safety. Worker pods use a distinct `app.kubernetes.io/name`, so they are not routed by the public Service. When `prometheus.serviceMonitor.enabled=true`, split mode also renders a worker-only metrics Service and ServiceMonitor so API and worker metrics can be scraped separately.
+
+Shared mode is acceptable for evaluation and small single-replica deployments. For platform workloads that serve UI navigation, synchronous gateway traffic, and batches at the same time, split mode gives each workload its own scaling envelope:
+
+- shared mode upper bound: `api replicas * embeddings_batch_worker_concurrency`
+- split mode upper bound: `batchWorker replicas * embeddings_batch_worker_concurrency`
+
+Use S3 batch artifact storage for split mode. The chart rejects enabled batching with local artifact storage in split mode because API pods and worker pods cannot safely share local files. For single-node development only, set `batchWorker.allowUnsafeLocalStorage=true` to bypass the guard.
+
+### 4. Provider credentials and platform settings
 
 Use `env` and `envFrom` directly:
 
@@ -312,7 +353,7 @@ env:
 
 This covers provider API keys, bootstrap admin credentials, SSO client credentials, JWT settings, and any other runtime env.
 
-### 4. Model deployment lifecycle
+### 5. Model deployment lifecycle
 
 DeltaLLM stores model deployments in the database at runtime. On first install you can seed them from `config.model_list` using the bootstrap mechanism.
 

--- a/docs/features/batching.md
+++ b/docs/features/batching.md
@@ -272,6 +272,7 @@ The batch worker runs as a background loop that claims jobs and executes items.
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `embeddings_batch_worker_enabled` | `true` | Run the batch worker in this instance |
+| `embeddings_batch_completion_outbox_worker_enabled` | `true` | Run the completion outbox worker in this instance |
 | `embeddings_batch_poll_interval_seconds` | `1.0` | How often the worker checks for new work when idle |
 | `embeddings_batch_worker_concurrency` | `4` | Maximum concurrent item executions per worker iteration |
 | `embeddings_batch_item_claim_limit` | `20` | Maximum items claimed per worker iteration |
@@ -309,6 +310,8 @@ Completed batches and their artifacts are automatically cleaned up by a backgrou
 | `embeddings_batch_gc_interval_seconds` | `86400` | How often the cleanup loop runs (default: daily) |
 | `embeddings_batch_gc_scan_limit` | `200` | Maximum expired items processed per cleanup pass |
 | `embeddings_batch_create_session_cleanup_enabled` | `true` | Enable cleanup for internal staged batch-create artifacts |
+
+In Kubernetes production deployments, prefer a split worker deployment over running these worker loops inside every API/UI pod. In shared mode, upper-bound executor pressure is roughly `api replicas * embeddings_batch_worker_concurrency`. In split mode, it becomes `batchWorker replicas * embeddings_batch_worker_concurrency`, so gateway and UI traffic can scale independently from batch throughput.
 
 For the full settings reference, see [Configuration > General](../configuration/general.md#batch-settings).
 

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -31,6 +31,30 @@ app.kubernetes.io/name: {{ include "deltallm.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{- define "deltallm.batchWorkerName" -}}
+{{- $base := include "deltallm.name" . | trunc 50 | trimSuffix "-" -}}
+{{- printf "%s-batch-worker" $base -}}
+{{- end -}}
+
+{{- define "deltallm.batchWorkerFullname" -}}
+{{- $base := include "deltallm.fullname" . | trunc 50 | trimSuffix "-" -}}
+{{- printf "%s-batch-worker" $base -}}
+{{- end -}}
+
+{{- define "deltallm.batchWorkerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "deltallm.batchWorkerName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: batch-worker
+{{- end -}}
+
+{{- define "deltallm.batchWorkerLabels" -}}
+helm.sh/chart: {{ include "deltallm.chart" . }}
+{{ include "deltallm.batchWorkerSelectorLabels" . }}
+app.kubernetes.io/part-of: {{ include "deltallm.name" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
 {{- define "deltallm.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "deltallm.fullname" .) .Values.serviceAccount.name -}}

--- a/helm/templates/_pod.tpl
+++ b/helm/templates/_pod.tpl
@@ -1,0 +1,221 @@
+{{- define "deltallm.hasRuntimeDependencies" -}}
+{{- $dbSecretName := .Values.runtime.database.existingSecret.name -}}
+{{- $redisSecretName := .Values.runtime.redis.existingSecret.name -}}
+{{- if or $dbSecretName .Values.runtime.database.url .Values.postgresql.enabled $redisSecretName .Values.runtime.redis.url .Values.redis.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{- define "deltallm.databaseEnv" -}}
+{{- $dbSecretName := .Values.runtime.database.existingSecret.name -}}
+{{- if or $dbSecretName .Values.runtime.database.url .Values.postgresql.enabled -}}
+- name: DATABASE_URL
+  {{- if $dbSecretName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $dbSecretName }}
+      key: {{ .Values.runtime.database.existingSecret.urlKey }}
+  {{- else if .Values.runtime.database.url }}
+  value: {{ .Values.runtime.database.url | quote }}
+  {{- else }}
+  value: {{ include "deltallm.bundledDatabaseUrl" . | quote }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "deltallm.redisEnv" -}}
+{{- $redisSecretName := .Values.runtime.redis.existingSecret.name -}}
+{{- if or $redisSecretName .Values.runtime.redis.url .Values.redis.enabled -}}
+- name: REDIS_URL
+  {{- if $redisSecretName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $redisSecretName }}
+      key: {{ .Values.runtime.redis.existingSecret.urlKey }}
+  {{- else if .Values.runtime.redis.url }}
+  value: {{ .Values.runtime.redis.url | quote }}
+  {{- else }}
+  value: {{ include "deltallm.bundledRedisUrl" . | quote }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "deltallm.deltallmRedisEnv" -}}
+{{- $redisSecretName := .Values.runtime.redis.existingSecret.name -}}
+{{- if or $redisSecretName .Values.runtime.redis.url .Values.redis.enabled -}}
+- name: DELTALLM_REDIS_URL
+  {{- if $redisSecretName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $redisSecretName }}
+      key: {{ .Values.runtime.redis.existingSecret.urlKey }}
+  {{- else if .Values.runtime.redis.url }}
+  value: {{ .Values.runtime.redis.url | quote }}
+  {{- else }}
+  value: {{ include "deltallm.bundledRedisUrl" . | quote }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "deltallm.s3Env" -}}
+{{- $s3SecretName := include "deltallm.s3SecretName" . -}}
+{{- if .Values.s3.enabled -}}
+- name: AWS_DEFAULT_REGION
+  value: {{ .Values.s3.region | quote }}
+- name: DELTALLM_S3_BUCKET
+  value: {{ .Values.s3.bucket | quote }}
+{{- if or .Values.s3.existingSecret.name .Values.s3.accessKeyId }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ $s3SecretName }}
+      key: {{ .Values.s3.existingSecret.accessKeyIdKey }}
+{{- end }}
+{{- if or .Values.s3.existingSecret.name .Values.s3.secretAccessKey }}
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $s3SecretName }}
+      key: {{ .Values.s3.existingSecret.secretAccessKeyKey }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "deltallm.runtimeEnv" -}}
+{{- $root := .root -}}
+{{- $extraEnv := default (list) .extraEnv -}}
+{{- $databaseEnv := include "deltallm.databaseEnv" $root -}}
+{{- $redisEnv := include "deltallm.redisEnv" $root -}}
+{{- $deltallmRedisEnv := include "deltallm.deltallmRedisEnv" $root -}}
+{{- $s3Env := include "deltallm.s3Env" $root -}}
+- name: HOST
+  value: "0.0.0.0"
+- name: PORT
+  value: {{ $root.Values.service.port | quote }}
+- name: DELTALLM_CONFIG_PATH
+  value: /app/config/config.yaml
+- name: DELTALLM_MASTER_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "deltallm.appSecretName" $root }}
+      key: {{ $root.Values.secret.keys.masterKey }}
+- name: DELTALLM_SALT_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "deltallm.appSecretName" $root }}
+      key: {{ $root.Values.secret.keys.saltKey }}
+{{- if $databaseEnv }}
+{{ $databaseEnv }}
+{{- end }}
+{{- if $redisEnv }}
+{{ $redisEnv }}
+{{- end }}
+{{- if $deltallmRedisEnv }}
+{{ $deltallmRedisEnv }}
+{{- end }}
+{{- if $s3Env }}
+{{ $s3Env }}
+{{- end }}
+{{- with $root.Values.env }}
+{{ toYaml . }}
+{{- end }}
+{{- with $extraEnv }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "deltallm.envFrom" -}}
+{{- $root := .root -}}
+{{- $extraEnvFrom := default (list) .extraEnvFrom -}}
+{{- if or $root.Values.envFrom $extraEnvFrom -}}
+envFrom:
+{{- with $root.Values.envFrom -}}
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- with $extraEnvFrom -}}
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "deltallm.dependencyWaitInitContainers" -}}
+{{- if and .Values.dependencyWait.enabled (include "deltallm.hasRuntimeDependencies" .) -}}
+{{- $databaseEnv := include "deltallm.databaseEnv" . -}}
+{{- $redisEnv := include "deltallm.redisEnv" . -}}
+initContainers:
+  - name: wait-for-runtime-dependencies
+    image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    securityContext:
+      {{- toYaml .Values.securityContext | nindent 6 }}
+    command:
+      - python
+      - -c
+      - |
+        import os
+        import socket
+        import sys
+        import time
+        from urllib.parse import urlparse
+
+        deadline = time.time() + {{ .Values.dependencyWait.timeoutSeconds }}
+        interval = {{ .Values.dependencyWait.periodSeconds }}
+        targets = []
+
+        database_url = os.getenv("DATABASE_URL", "").strip()
+        if database_url:
+            parsed = urlparse(database_url)
+            targets.append(("database", parsed.hostname, parsed.port or 5432))
+
+        redis_url = os.getenv("REDIS_URL", "").strip()
+        if redis_url:
+            parsed = urlparse(redis_url)
+            targets.append(("redis", parsed.hostname, parsed.port or 6379))
+
+        for name, host, port in targets:
+            while True:
+                try:
+                    with socket.create_connection((host, port), timeout=5):
+                        print(f"{name} is reachable at {host}:{port}", flush=True)
+                        break
+                except OSError as exc:
+                    if time.time() >= deadline:
+                        print(f"Timed out waiting for {name} at {host}:{port}: {exc}", file=sys.stderr, flush=True)
+                        raise SystemExit(1)
+                    print(f"Waiting for {name} at {host}:{port}: {exc}", flush=True)
+                    time.sleep(interval)
+    env:
+      {{- if $databaseEnv -}}
+{{ $databaseEnv | nindent 6 }}
+      {{- end }}
+      {{- if $redisEnv -}}
+{{ $redisEnv | nindent 6 }}
+      {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "deltallm.probes" -}}
+{{- if .Values.probes.startup.enabled -}}
+startupProbe:
+  httpGet:
+    path: {{ .Values.probes.startup.path }}
+    port: http
+  failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+  periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+  timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+{{- end }}
+livenessProbe:
+  httpGet:
+    path: {{ .Values.probes.liveness.path }}
+    port: http
+  initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+  periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+  timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+  failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+readinessProbe:
+  httpGet:
+    path: {{ .Values.probes.readiness.path }}
+    port: http
+  initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+  periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+  timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+  failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+{{- end -}}

--- a/helm/templates/batch-worker-deployment.yaml
+++ b/helm/templates/batch-worker-deployment.yaml
@@ -1,16 +1,17 @@
+{{- if .Values.batchWorker.enabled }}
 {{- $hasGeneratedAppSecret := not .Values.secret.existingSecret -}}
 {{- $hasGeneratedS3Secret := and .Values.s3.enabled (not .Values.s3.existingSecret.name) (or .Values.s3.accessKeyId .Values.s3.secretAccessKey) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "deltallm.fullname" . }}
+  name: {{ include "deltallm.batchWorkerFullname" . }}
   labels:
-    {{- include "deltallm.labels" . | nindent 4 }}
+    {{- include "deltallm.batchWorkerLabels" . | nindent 4 }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   minReadySeconds: {{ .Values.minReadySeconds }}
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  {{- if not .Values.batchWorker.autoscaling.enabled }}
+  replicas: {{ .Values.batchWorker.replicaCount }}
   {{- end }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -21,17 +22,16 @@ spec:
     {{- end }}
   selector:
     matchLabels:
-      {{- include "deltallm.selectorLabels" . | nindent 6 }}
+      {{- include "deltallm.batchWorkerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "deltallm.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: api
-        {{- with .Values.podLabels }}
+        {{- include "deltallm.batchWorkerSelectorLabels" . | nindent 8 }}
+        {{- with .Values.batchWorker.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ include "deltallm.apiConfigYaml" . | sha256sum }}
+        checksum/config: {{ include "deltallm.batchWorkerConfigYaml" . | sha256sum }}
         {{- if $hasGeneratedAppSecret }}
         checksum/app-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
@@ -43,7 +43,7 @@ spec:
         prometheus.io/port: {{ .Values.service.port | quote }}
         prometheus.io/path: "/metrics"
         {{- end }}
-        {{- with .Values.podAnnotations }}
+        {{- with .Values.batchWorker.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -53,8 +53,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+      {{- $priorityClassName := default .Values.priorityClassName .Values.batchWorker.priorityClassName }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -63,16 +64,18 @@ spec:
 {{ $dependencyWaitInitContainers | nindent 6 }}
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: batch-worker
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- with .Values.command }}
+          {{- $command := default .Values.command .Values.batchWorker.command }}
+          {{- with $command }}
           command:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.args }}
+          {{- $args := default .Values.args .Values.batchWorker.args }}
+          {{- with $args }}
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -81,8 +84,8 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
-{{ include "deltallm.runtimeEnv" (dict "root" .) | indent 12 }}
-          {{- $envFrom := include "deltallm.envFrom" (dict "root" .) }}
+{{ include "deltallm.runtimeEnv" (dict "root" . "extraEnv" .Values.batchWorker.env) | indent 12 }}
+          {{- $envFrom := include "deltallm.envFrom" (dict "root" . "extraEnvFrom" .Values.batchWorker.envFrom) }}
           {{- if $envFrom -}}
 {{ $envFrom | nindent 10 }}
           {{- end }}
@@ -93,25 +96,34 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.batchWorker.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
 {{- include "deltallm.probes" . | nindent 10 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml (default .Values.resources .Values.batchWorker.resources) | nindent 12 }}
       volumes:
         - name: config
           configMap:
-            name: {{ include "deltallm.fullname" . }}-config
+            name: {{ include "deltallm.batchWorkerFullname" . }}-config
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+        {{- with .Values.batchWorker.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- $nodeSelector := default .Values.nodeSelector .Values.batchWorker.nodeSelector }}
+      {{- with $nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- $affinity := default .Values.affinity .Values.batchWorker.affinity }}
+      {{- with $affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
+      {{- $topologySpreadConstraints := default .Values.topologySpreadConstraints .Values.batchWorker.topologySpreadConstraints }}
+      {{- with $topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- range . }}
         - maxSkew: {{ .maxSkew }}
@@ -135,11 +147,13 @@ spec:
 {{ toYaml .labelSelector | indent 12 }}
             {{- else }}
               matchLabels:
-                {{- include "deltallm.selectorLabels" $ | nindent 16 }}
+                {{- include "deltallm.batchWorkerSelectorLabels" $ | nindent 16 }}
             {{- end }}
         {{- end }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- $tolerations := default .Values.tolerations .Values.batchWorker.tolerations }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/templates/batch-worker-hpa.yaml
+++ b/helm/templates/batch-worker-hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.batchWorker.enabled .Values.batchWorker.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "deltallm.batchWorkerFullname" . }}
+  labels:
+    {{- include "deltallm.batchWorkerLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "deltallm.batchWorkerFullname" . }}
+  minReplicas: {{ .Values.batchWorker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.batchWorker.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.batchWorker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.batchWorker.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/helm/templates/batch-worker-networkpolicy.yaml
+++ b/helm/templates/batch-worker-networkpolicy.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.networkPolicy.enabled .Values.batchWorker.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "deltallm.batchWorkerFullname" . }}
+  labels:
+    {{- include "deltallm.batchWorkerLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "deltallm.batchWorkerSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if or .Values.networkPolicy.allowDns .Values.networkPolicy.egress }}
+    - Egress
+    {{- end }}
+  {{- with .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.networkPolicy.allowDns .Values.networkPolicy.egress }}
+  egress:
+    {{- if .Values.networkPolicy.allowDns }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- end }}
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/batch-worker-pdb.yaml
+++ b/helm/templates/batch-worker-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.batchWorker.enabled .Values.batchWorker.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "deltallm.batchWorkerFullname" . }}
+  labels:
+    {{- include "deltallm.batchWorkerLabels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.batchWorker.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "deltallm.batchWorkerSelectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/templates/batch-worker-service.yaml
+++ b/helm/templates/batch-worker-service.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.batchWorker.enabled .Values.batchWorker.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "deltallm.batchWorkerFullname" . }}
+  labels:
+    {{- include "deltallm.batchWorkerLabels" . | nindent 4 }}
+    {{- with .Values.batchWorker.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.batchWorker.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.batchWorker.service.type }}
+  ports:
+    - port: {{ .Values.batchWorker.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "deltallm.batchWorkerSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/templates/batch-worker-servicemonitor.yaml
+++ b/helm/templates/batch-worker-servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.batchWorker.enabled .Values.batchWorker.service.enabled .Values.prometheus.serviceMonitor.enabled .Values.batchWorker.serviceMonitor.enabled }}
+{{- $monitorNamespace := default .Values.prometheus.serviceMonitor.namespace .Values.batchWorker.serviceMonitor.namespace -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "deltallm.batchWorkerFullname" . }}
+  labels:
+    {{- include "deltallm.batchWorkerLabels" . | nindent 4 }}
+    {{- with .Values.prometheus.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.batchWorker.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if $monitorNamespace }}
+  namespace: {{ $monitorNamespace }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "deltallm.batchWorkerSelectorLabels" . | nindent 6 }}
+  {{- if and $monitorNamespace (ne $monitorNamespace .Release.Namespace) }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ default .Values.prometheus.serviceMonitor.interval .Values.batchWorker.serviceMonitor.interval }}
+      scrapeTimeout: {{ default .Values.prometheus.serviceMonitor.scrapeTimeout .Values.batchWorker.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,3 +1,118 @@
+{{- define "deltallm.configYaml" -}}
+{{- $root := .root -}}
+{{- $cfg := .config -}}
+model_list:
+{{ toYaml $cfg.model_list | indent 2 }}
+
+router_settings:
+{{ toYaml $cfg.router_settings | indent 2 }}
+
+deltallm_settings:
+  fallbacks:
+{{ toYaml $cfg.deltallm_settings.fallbacks | indent 4 }}
+  context_window_fallbacks:
+{{ toYaml $cfg.deltallm_settings.context_window_fallbacks | indent 4 }}
+  content_policy_fallbacks:
+{{ toYaml $cfg.deltallm_settings.content_policy_fallbacks | indent 4 }}
+  guardrails:
+{{ toYaml $cfg.deltallm_settings.guardrails | indent 4 }}
+  turn_off_message_logging: {{ $cfg.deltallm_settings.turn_off_message_logging }}
+  success_callback:
+    {{- $successCallbacks := default (list) $cfg.deltallm_settings.success_callback }}
+    {{- if not (has "prometheus" $successCallbacks) }}
+    {{- $successCallbacks = append $successCallbacks "prometheus" }}
+    {{- end }}
+    {{- if and $root.Values.s3.enabled (not (has "s3" $successCallbacks)) }}
+    {{- $successCallbacks = append $successCallbacks "s3" }}
+    {{- end }}
+{{ toYaml $successCallbacks | indent 4 }}
+  failure_callback:
+    {{- $failureCallbacks := default (list) $cfg.deltallm_settings.failure_callback }}
+    {{- if not (has "prometheus" $failureCallbacks) }}
+    {{- $failureCallbacks = append $failureCallbacks "prometheus" }}
+    {{- end }}
+    {{- if and $root.Values.s3.enabled (not (has "s3" $failureCallbacks)) }}
+    {{- $failureCallbacks = append $failureCallbacks "s3" }}
+    {{- end }}
+{{ toYaml $failureCallbacks | indent 4 }}
+  callbacks:
+    {{- $callbacks := default (list) $cfg.deltallm_settings.callbacks }}
+    {{- if not (has "prometheus" $callbacks) }}
+    {{- $callbacks = append $callbacks "prometheus" }}
+    {{- end }}
+{{ toYaml $callbacks | indent 4 }}
+  {{- $callbackSettings := deepCopy (default (dict) $cfg.deltallm_settings.callback_settings) }}
+  {{- if $root.Values.s3.enabled }}
+  {{- $s3Callback := dict "bucket" $root.Values.s3.bucket "region" $root.Values.s3.region "prefix" $root.Values.s3.prefix }}
+  {{- if $root.Values.s3.compression }}
+  {{- $_ := set $s3Callback "compression" $root.Values.s3.compression }}
+  {{- end }}
+  {{- $_ := set $callbackSettings "s3" $s3Callback }}
+  {{- end }}
+  callback_settings:
+    {{- if $callbackSettings }}
+{{ toYaml $callbackSettings | indent 4 }}
+    {{- else }}
+    {}
+    {{- end }}
+
+general_settings:
+{{ toYaml $cfg.general_settings | indent 2 }}
+{{- end -}}
+{{- define "deltallm.apiConfigYaml" -}}
+{{- $apiConfig := deepCopy .Values.config -}}
+{{- if .Values.batchWorker.enabled -}}
+{{- $apiDefaults := dict "general_settings" (dict "embeddings_batch_worker_enabled" false "embeddings_batch_completion_outbox_worker_enabled" false "embeddings_batch_gc_enabled" false "embeddings_batch_create_session_cleanup_enabled" false) -}}
+{{- $apiConfig = mergeOverwrite $apiConfig $apiDefaults -}}
+{{- end -}}
+{{- $apiValues := default (dict) (get .Values "api") -}}
+{{- $apiConfig = mergeOverwrite $apiConfig (default (dict) (get $apiValues "config")) -}}
+{{ include "deltallm.configYaml" (dict "root" . "config" $apiConfig) }}
+{{- end -}}
+{{- define "deltallm.batchWorkerConfigYaml" -}}
+{{- $workerConfig := deepCopy .Values.config -}}
+{{- $workerGeneral := default (dict) (get $workerConfig "general_settings") -}}
+{{- if not (hasKey $workerConfig "general_settings") -}}
+{{- $_ := set $workerConfig "general_settings" $workerGeneral -}}
+{{- end -}}
+{{- $workerDefaults := dict "embeddings_batch_worker_enabled" true "embeddings_batch_completion_outbox_worker_enabled" true "embeddings_batch_gc_enabled" true "embeddings_batch_create_session_cleanup_enabled" true "embeddings_batch_worker_concurrency" 2 "embeddings_batch_item_claim_limit" 10 -}}
+{{- range $key, $value := $workerDefaults -}}
+{{- if not (hasKey $workerGeneral $key) -}}
+{{- $_ := set $workerGeneral $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- $batchWorkerValues := default (dict) (get .Values "batchWorker") -}}
+{{- $workerConfig = mergeOverwrite $workerConfig (default (dict) (get $batchWorkerValues "config")) -}}
+{{ include "deltallm.configYaml" (dict "root" . "config" $workerConfig) }}
+{{- end -}}
+{{- define "deltallm.validateBatchConfig" -}}
+{{- $apiConfig := include "deltallm.apiConfigYaml" . | fromYaml -}}
+{{- $apiGeneral := default (dict) (get $apiConfig "general_settings") -}}
+{{- $apiBatchEnabled := default false (get $apiGeneral "embeddings_batch_enabled") -}}
+{{- $apiStorageBackend := lower (toString (default "local" (get $apiGeneral "embeddings_batch_storage_backend"))) -}}
+{{- $apiS3Bucket := trim (toString (default "" (get $apiGeneral "embeddings_batch_s3_bucket"))) -}}
+{{- $apiUsesS3WithoutBucket := and $apiBatchEnabled (eq $apiStorageBackend "s3") (eq $apiS3Bucket "") -}}
+{{- if $apiUsesS3WithoutBucket -}}
+{{- fail "embeddings_batch_s3_bucket is required when embeddings_batch_storage_backend=s3 and embeddings_batch_enabled=true" -}}
+{{- end -}}
+{{- if .Values.batchWorker.enabled -}}
+{{- $workerConfig := include "deltallm.batchWorkerConfigYaml" . | fromYaml -}}
+{{- $workerGeneral := default (dict) (get $workerConfig "general_settings") -}}
+{{- $workerBatchEnabled := default false (get $workerGeneral "embeddings_batch_enabled") -}}
+{{- $workerStorageBackend := lower (toString (default "local" (get $workerGeneral "embeddings_batch_storage_backend"))) -}}
+{{- $workerS3Bucket := trim (toString (default "" (get $workerGeneral "embeddings_batch_s3_bucket"))) -}}
+{{- $apiUsesLocalStorage := and $apiBatchEnabled (eq $apiStorageBackend "local") -}}
+{{- $workerUsesLocalStorage := and $workerBatchEnabled (eq $workerStorageBackend "local") -}}
+{{- $workerUsesS3WithoutBucket := and $workerBatchEnabled (eq $workerStorageBackend "s3") (eq $workerS3Bucket "") -}}
+{{- if and (not .Values.batchWorker.allowUnsafeLocalStorage) (or $apiUsesLocalStorage $workerUsesLocalStorage) -}}
+{{- fail "batchWorker.enabled=true with embeddings_batch_enabled=true requires shared batch artifact storage; configure embeddings_batch_storage_backend=s3 for API and worker roles, or set batchWorker.allowUnsafeLocalStorage=true for single-node/dev only" -}}
+{{- end -}}
+{{- if $workerUsesS3WithoutBucket -}}
+{{- fail "embeddings_batch_s3_bucket is required when embeddings_batch_storage_backend=s3 and embeddings_batch_enabled=true" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{ include "deltallm.validateBatchConfig" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,63 +121,16 @@ metadata:
     {{- include "deltallm.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    model_list:
-{{ toYaml .Values.config.model_list | indent 6 }}
-
-    router_settings:
-{{ toYaml .Values.config.router_settings | indent 6 }}
-
-    deltallm_settings:
-      fallbacks:
-{{ toYaml .Values.config.deltallm_settings.fallbacks | indent 8 }}
-      context_window_fallbacks:
-{{ toYaml .Values.config.deltallm_settings.context_window_fallbacks | indent 8 }}
-      content_policy_fallbacks:
-{{ toYaml .Values.config.deltallm_settings.content_policy_fallbacks | indent 8 }}
-      guardrails:
-{{ toYaml .Values.config.deltallm_settings.guardrails | indent 8 }}
-      turn_off_message_logging: {{ .Values.config.deltallm_settings.turn_off_message_logging }}
-      success_callback:
-        {{- $successCallbacks := .Values.config.deltallm_settings.success_callback }}
-        {{- if not (has "prometheus" $successCallbacks) }}
-        {{- $successCallbacks = append $successCallbacks "prometheus" }}
-        {{- end }}
-        {{- if and .Values.s3.enabled (not (has "s3" $successCallbacks)) }}
-        {{- $successCallbacks = append $successCallbacks "s3" }}
-        {{- end }}
-{{ toYaml $successCallbacks | indent 8 }}
-      failure_callback:
-        {{- $failureCallbacks := .Values.config.deltallm_settings.failure_callback }}
-        {{- if not (has "prometheus" $failureCallbacks) }}
-        {{- $failureCallbacks = append $failureCallbacks "prometheus" }}
-        {{- end }}
-        {{- if and .Values.s3.enabled (not (has "s3" $failureCallbacks)) }}
-        {{- $failureCallbacks = append $failureCallbacks "s3" }}
-        {{- end }}
-{{ toYaml $failureCallbacks | indent 8 }}
-      callbacks:
-        {{- $callbacks := .Values.config.deltallm_settings.callbacks }}
-        {{- if not (has "prometheus" $callbacks) }}
-        {{- $callbacks = append $callbacks "prometheus" }}
-        {{- end }}
-{{ toYaml $callbacks | indent 8 }}
-      {{- $callbackSettings := deepCopy .Values.config.deltallm_settings.callback_settings }}
-      {{- if not $callbackSettings }}
-      {{- $callbackSettings = dict }}
-      {{- end }}
-      {{- if .Values.s3.enabled }}
-      {{- $s3Callback := dict "bucket" .Values.s3.bucket "region" .Values.s3.region "prefix" .Values.s3.prefix }}
-      {{- if .Values.s3.compression }}
-      {{- $_ := set $s3Callback "compression" .Values.s3.compression }}
-      {{- end }}
-      {{- $_ := set $callbackSettings "s3" $s3Callback }}
-      {{- end }}
-      callback_settings:
-        {{- if $callbackSettings }}
-{{ toYaml $callbackSettings | indent 8 }}
-        {{- else }}
-        {}
-        {{- end }}
-
-    general_settings:
-{{ toYaml .Values.config.general_settings | indent 6 }}
+{{ include "deltallm.apiConfigYaml" . | indent 4 }}
+{{- if .Values.batchWorker.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "deltallm.batchWorkerFullname" . }}-config
+  labels:
+    {{- include "deltallm.batchWorkerLabels" . | nindent 4 }}
+data:
+  config.yaml: |
+{{ include "deltallm.batchWorkerConfigYaml" . | indent 4 }}
+{{- end }}

--- a/helm/values-production.yaml
+++ b/helm/values-production.yaml
@@ -46,6 +46,28 @@ prometheus:
     interval: 15s
     scrapeTimeout: 10s
 
+batchWorker:
+  # Enable this when production batch processing is required. Keep API pods
+  # worker-free so UI/gateway traffic can scale independently from batch load.
+  enabled: false
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
 config:
   general_settings:
     cache_backend: redis

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -75,6 +75,83 @@
     },
     "env": { "type": "array" },
     "envFrom": { "type": "array" },
+    "api": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "config": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "batchWorker": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "allowUnsafeLocalStorage": { "type": "boolean" },
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "podAnnotations": { "type": "object" },
+        "podLabels": { "type": "object" },
+        "priorityClassName": { "type": "string" },
+        "command": { "type": "array" },
+        "args": { "type": "array" },
+        "env": { "type": "array" },
+        "envFrom": { "type": "array" },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
+        "service": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "type": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "annotations": { "type": "object" },
+            "labels": { "type": "object" }
+          }
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namespace": { "type": "string" },
+            "interval": { "type": "string" },
+            "scrapeTimeout": { "type": "string" },
+            "labels": { "type": "object" }
+          }
+        },
+        "resources": { "type": "object", "additionalProperties": true },
+        "autoscaling": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minReplicas": { "type": "integer", "minimum": 1 },
+            "maxReplicas": { "type": "integer", "minimum": 1 },
+            "targetCPUUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 },
+            "targetMemoryUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 }
+          }
+        },
+        "podDisruptionBudget": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minAvailable": {
+              "oneOf": [
+                { "type": "integer", "minimum": 0 },
+                { "type": "string" }
+              ]
+            }
+          }
+        },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" },
+        "topologySpreadConstraints": { "type": "array" },
+        "config": { "type": "object", "additionalProperties": true }
+      }
+    },
     "dependencyWait": {
       "type": "object",
       "additionalProperties": true,

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -100,6 +100,64 @@ envFrom: []
 extraVolumes: []
 extraVolumeMounts: []
 
+api:
+  # Per-role config overrides for the API/UI/gateway Deployment.
+  # When batchWorker.enabled=true, Helm automatically disables batch
+  # background loops for API pods unless explicitly overridden here.
+  config: {}
+
+batchWorker:
+  enabled: false
+  # Local batch artifact storage is unsafe when API and worker run in separate pods.
+  # Set only for single-node/dev split-mode experiments.
+  allowUnsafeLocalStorage: false
+  replicaCount: 1
+  podAnnotations: {}
+  podLabels: {}
+  priorityClassName: ""
+  command: []
+  args: []
+  env: []
+  envFrom: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  service:
+    enabled: true
+    type: ClusterIP
+    port: 4000
+    annotations: {}
+    labels: {}
+  serviceMonitor:
+    enabled: true
+    namespace: ""
+    interval: ""
+    scrapeTimeout: ""
+    labels: {}
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  # Per-role config overrides for the batch worker Deployment.
+  # Shared config.general_settings is used first, then worker-safe defaults
+  # are filled for missing keys, then this map is applied last.
+  config: {}
+
 dependencyWait:
   enabled: true
   timeoutSeconds: 180
@@ -169,9 +227,12 @@ config:
     # If embeddings_batch_enabled is true and replicaCount > 1, configure
     # embeddings_batch_storage_backend: s3 so every pod can read/write artifacts.
     embeddings_batch_enabled: false
+    embeddings_batch_worker_enabled: true
+    embeddings_batch_completion_outbox_worker_enabled: true
     embeddings_batch_storage_backend: local
     embeddings_batch_storage_dir: .deltallm/batch-artifacts
     embeddings_batch_create_session_cleanup_enabled: true
+    embeddings_batch_gc_enabled: true
 
 s3:
   enabled: false

--- a/src/bootstrap/batch.py
+++ b/src/bootstrap/batch.py
@@ -271,22 +271,23 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
         )
         runtime.worker_task = create_task(runtime.worker.run())
 
-    runtime.completion_outbox_worker = BatchCompletionOutboxWorker(
-        app=app,
-        repository=repository,
-        config=BatchCompletionOutboxWorkerConfig(
-            worker_id=_batch_worker_id("batch-completion-outbox"),
-            poll_interval_seconds=cfg.general_settings.embeddings_batch_poll_interval_seconds,
-            max_batch_size=max(10, int(cfg.general_settings.embeddings_batch_item_claim_limit or 20)),
-            max_concurrency=min(8, max(1, int(cfg.general_settings.embeddings_batch_worker_concurrency or 4))),
-            lease_seconds=max(15, int(cfg.general_settings.embeddings_batch_item_lease_seconds or 60)),
-            heartbeat_interval_seconds=max(
-                1.0,
-                float(cfg.general_settings.embeddings_batch_heartbeat_interval_seconds or 10.0),
+    if cfg.general_settings.embeddings_batch_completion_outbox_worker_enabled:
+        runtime.completion_outbox_worker = BatchCompletionOutboxWorker(
+            app=app,
+            repository=repository,
+            config=BatchCompletionOutboxWorkerConfig(
+                worker_id=_batch_worker_id("batch-completion-outbox"),
+                poll_interval_seconds=cfg.general_settings.embeddings_batch_poll_interval_seconds,
+                max_batch_size=max(10, int(cfg.general_settings.embeddings_batch_item_claim_limit or 20)),
+                max_concurrency=min(8, max(1, int(cfg.general_settings.embeddings_batch_worker_concurrency or 4))),
+                lease_seconds=max(15, int(cfg.general_settings.embeddings_batch_item_lease_seconds or 60)),
+                heartbeat_interval_seconds=max(
+                    1.0,
+                    float(cfg.general_settings.embeddings_batch_heartbeat_interval_seconds or 10.0),
+                ),
             ),
-        ),
-    )
-    runtime.completion_outbox_task = create_task(runtime.completion_outbox_worker.run())
+        )
+        runtime.completion_outbox_task = create_task(runtime.completion_outbox_worker.run())
 
     if cfg.general_settings.embeddings_batch_gc_enabled:
         runtime.gc_worker = BatchRetentionCleanupWorker(

--- a/src/config.py
+++ b/src/config.py
@@ -337,6 +337,7 @@ class GeneralSettings(BaseModel):
     model_deployment_bootstrap_from_config: bool = True
     embeddings_batch_enabled: bool = False
     embeddings_batch_worker_enabled: bool = True
+    embeddings_batch_completion_outbox_worker_enabled: bool = True
     embeddings_batch_storage_backend: Literal["local", "s3"] = "local"
     embeddings_batch_storage_dir: str = ".deltallm/batch-artifacts"
     embeddings_batch_s3_bucket: str | None = None

--- a/tests/bootstrap/test_optional_bootstrap.py
+++ b/tests/bootstrap/test_optional_bootstrap.py
@@ -29,6 +29,7 @@ def _batch_config(
     enabled: bool,
     worker_enabled: bool,
     gc_enabled: bool,
+    completion_outbox_worker_enabled: bool = True,
     create_session_cleanup_enabled: bool = False,
     storage_backend: str = "local",
     s3_bucket: str | None = None,
@@ -37,6 +38,7 @@ def _batch_config(
         general_settings=SimpleNamespace(
             embeddings_batch_enabled=enabled,
             embeddings_batch_worker_enabled=worker_enabled,
+            embeddings_batch_completion_outbox_worker_enabled=completion_outbox_worker_enabled,
             embeddings_batch_gc_enabled=gc_enabled,
             embeddings_batch_storage_backend=storage_backend,
             embeddings_batch_storage_dir="/tmp/batch-artifacts",
@@ -378,6 +380,70 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
     assert created["worker"].stopped is True
     assert created["completion_outbox_worker"].stopped is True
     assert created["gc_worker"].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_init_batch_runtime_can_disable_completion_outbox_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeBatchService:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            del args, kwargs
+
+        def bind_create_session_service(self, create_session_service) -> None:  # noqa: ANN001
+            del create_session_service
+
+    class FakeStagingBackend:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            del args, kwargs
+
+    class FakePromoter:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            del args, kwargs
+
+    class FakeCreateSessionAdminService:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            del args, kwargs
+
+    def _unexpected_outbox_worker(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        del args, kwargs
+        raise AssertionError("completion outbox worker should not start")
+
+    monkeypatch.setattr("src.bootstrap.batch.LocalBatchArtifactStorage", lambda path: {"path": path})
+    monkeypatch.setattr("src.bootstrap.batch.BatchService", FakeBatchService)
+    monkeypatch.setattr("src.bootstrap.batch.BatchCompletionOutboxWorker", _unexpected_outbox_worker)
+    monkeypatch.setattr("src.bootstrap.batch.BatchCreateArtifactStorageBackend", FakeStagingBackend)
+    monkeypatch.setattr("src.bootstrap.batch.BatchCreateSessionPromoter", FakePromoter)
+    monkeypatch.setattr("src.bootstrap.batch.BatchCreateSessionAdminService", FakeCreateSessionAdminService)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    repository = SimpleNamespace(create_sessions=_FakeCreateSessionRepository())
+
+    runtime = await init_batch_runtime(
+        app,
+        _batch_config(
+            enabled=True,
+            worker_enabled=False,
+            gc_enabled=False,
+            completion_outbox_worker_enabled=False,
+        ),
+        repository=repository,
+    )
+
+    assert runtime.worker is None
+    assert runtime.worker_task is None
+    assert runtime.completion_outbox_worker is None
+    assert runtime.completion_outbox_task is None
+    assert runtime.statuses == (
+        BootstrapStatus("embeddings_batch", "ready"),
+        BootstrapStatus("embeddings_batch_worker", "disabled"),
+        BootstrapStatus("embeddings_batch_completion_outbox", "disabled"),
+        BootstrapStatus("embeddings_batch_gc", "disabled"),
+        BootstrapStatus("embeddings_batch_create_session_admin", "ready"),
+        BootstrapStatus("embeddings_batch_create_session_cleanup", "disabled"),
+    )
+
+    await shutdown_batch_runtime(runtime)
 
 
 @pytest.mark.asyncio

--- a/tests/helm/test_batch_worker_split.py
+++ b/tests/helm/test_batch_worker_split.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELM = shutil.which("helm")
+
+
+def _render(*args: str) -> list[dict[str, Any]]:
+    if HELM is None:
+        pytest.skip("helm is not installed")
+    command = [
+        HELM,
+        "template",
+        "deltallm",
+        "./helm",
+        "--set",
+        "secret.values.masterKey=sk-testmasterkey1234567890A1",
+        "--set",
+        "secret.values.saltKey=test-salt-key-1234567890",
+        *args,
+    ]
+    result = subprocess.run(command, cwd=REPO_ROOT, check=True, capture_output=True, text=True)
+    return [doc for doc in yaml.safe_load_all(result.stdout) if isinstance(doc, dict)]
+
+
+def _render_error(*args: str) -> str:
+    if HELM is None:
+        pytest.skip("helm is not installed")
+    command = [
+        HELM,
+        "template",
+        "deltallm",
+        "./helm",
+        "--set",
+        "secret.values.masterKey=sk-testmasterkey1234567890A1",
+        "--set",
+        "secret.values.saltKey=test-salt-key-1234567890",
+        *args,
+    ]
+    result = subprocess.run(command, cwd=REPO_ROOT, check=False, capture_output=True, text=True)
+    assert result.returncode != 0
+    return result.stderr
+
+
+def _by_kind_and_name(docs: list[dict[str, Any]], kind: str, name: str) -> dict[str, Any]:
+    for doc in docs:
+        if doc.get("kind") == kind and doc.get("metadata", {}).get("name") == name:
+            return doc
+    raise AssertionError(f"missing {kind}/{name}")
+
+
+def _config_yaml(config_map: dict[str, Any]) -> dict[str, Any]:
+    return yaml.safe_load(config_map["data"]["config.yaml"])
+
+
+def _deployment_checksum(deployment: dict[str, Any]) -> str:
+    return deployment["spec"]["template"]["metadata"]["annotations"]["checksum/config"]
+
+
+def _selector_matches(selector: dict[str, str], labels: dict[str, str]) -> bool:
+    return all(labels.get(key) == value for key, value in selector.items())
+
+
+def _deployment_by_pod_component(docs: list[dict[str, Any]], component: str) -> dict[str, Any]:
+    for doc in docs:
+        if doc.get("kind") != "Deployment":
+            continue
+        labels = doc["spec"]["template"]["metadata"]["labels"]
+        if labels.get("app.kubernetes.io/component") == component:
+            return doc
+    raise AssertionError(f"missing Deployment with pod component {component}")
+
+
+def _service_by_component(docs: list[dict[str, Any]], component: str | None) -> dict[str, Any]:
+    for doc in docs:
+        if doc.get("kind") != "Service":
+            continue
+        labels = doc.get("metadata", {}).get("labels", {})
+        if labels.get("app.kubernetes.io/component") == component:
+            return doc
+    raise AssertionError(f"missing Service with component {component}")
+
+
+def test_default_service_selector_remains_upgrade_safe() -> None:
+    service = _by_kind_and_name(_render("--show-only", "templates/service.yaml"), "Service", "deltallm")
+
+    assert service["spec"]["selector"] == {
+        "app.kubernetes.io/name": "deltallm",
+        "app.kubernetes.io/instance": "deltallm",
+    }
+
+
+def test_default_does_not_render_worker_metrics_service() -> None:
+    docs = _render("--set", "prometheus.serviceMonitor.enabled=true")
+
+    assert not any(doc.get("metadata", {}).get("name") == "deltallm-batch-worker" for doc in docs)
+
+
+def test_split_mode_separates_api_and_worker_configs() -> None:
+    docs = _render("--set", "batchWorker.enabled=true", "--show-only", "templates/configmap.yaml")
+
+    api_config = _config_yaml(_by_kind_and_name(docs, "ConfigMap", "deltallm-config"))
+    worker_config = _config_yaml(_by_kind_and_name(docs, "ConfigMap", "deltallm-batch-worker-config"))
+
+    api_general = api_config["general_settings"]
+    assert api_general["embeddings_batch_worker_enabled"] is False
+    assert api_general["embeddings_batch_completion_outbox_worker_enabled"] is False
+    assert api_general["embeddings_batch_gc_enabled"] is False
+    assert api_general["embeddings_batch_create_session_cleanup_enabled"] is False
+
+    worker_general = worker_config["general_settings"]
+    assert worker_general["embeddings_batch_worker_enabled"] is True
+    assert worker_general["embeddings_batch_completion_outbox_worker_enabled"] is True
+    assert worker_general["embeddings_batch_gc_enabled"] is True
+    assert worker_general["embeddings_batch_create_session_cleanup_enabled"] is True
+    assert worker_general["embeddings_batch_worker_concurrency"] == 2
+    assert worker_general["embeddings_batch_item_claim_limit"] == 10
+
+
+def test_split_mode_long_name_override_keeps_worker_out_of_api_service() -> None:
+    docs = _render(
+        "--set",
+        f"nameOverride={'a' * 63}",
+        "--set",
+        "batchWorker.enabled=true",
+        "--show-only",
+        "templates/deployment.yaml",
+        "--show-only",
+        "templates/batch-worker-deployment.yaml",
+        "--show-only",
+        "templates/service.yaml",
+        "--show-only",
+        "templates/batch-worker-service.yaml",
+    )
+
+    api_deployment = _deployment_by_pod_component(docs, "api")
+    worker_deployment = _deployment_by_pod_component(docs, "batch-worker")
+    api_service = _service_by_component(docs, None)
+    worker_service = _service_by_component(docs, "batch-worker")
+    worker_labels = worker_deployment["spec"]["template"]["metadata"]["labels"]
+
+    assert api_deployment["spec"]["selector"]["matchLabels"] != worker_deployment["spec"]["selector"]["matchLabels"]
+    assert not _selector_matches(api_service["spec"]["selector"], worker_labels)
+    assert _selector_matches(worker_service["spec"]["selector"], worker_labels)
+
+
+def test_split_mode_long_fullname_override_keeps_worker_resource_names_distinct() -> None:
+    docs = _render(
+        "--set",
+        f"fullnameOverride={'a' * 63}",
+        "--set",
+        "batchWorker.enabled=true",
+        "--show-only",
+        "templates/configmap.yaml",
+        "--show-only",
+        "templates/deployment.yaml",
+        "--show-only",
+        "templates/batch-worker-deployment.yaml",
+        "--show-only",
+        "templates/service.yaml",
+        "--show-only",
+        "templates/batch-worker-service.yaml",
+    )
+
+    api_deployment = _deployment_by_pod_component(docs, "api")
+    worker_deployment = _deployment_by_pod_component(docs, "batch-worker")
+    api_service = _service_by_component(docs, None)
+    worker_service = _service_by_component(docs, "batch-worker")
+    api_config = _by_kind_and_name(docs, "ConfigMap", f"{api_deployment['metadata']['name']}-config")
+    worker_config = _by_kind_and_name(docs, "ConfigMap", f"{worker_deployment['metadata']['name']}-config")
+
+    assert api_deployment["metadata"]["name"] != worker_deployment["metadata"]["name"]
+    assert api_service["metadata"]["name"] != worker_service["metadata"]["name"]
+    assert api_config["metadata"]["name"] != worker_config["metadata"]["name"]
+    assert len(worker_deployment["metadata"]["name"]) <= 63
+    assert worker_deployment["metadata"]["name"].endswith("-batch-worker")
+
+
+def test_shared_mode_allows_enabled_batching_with_local_storage() -> None:
+    docs = _render(
+        "--set",
+        "config.general_settings.embeddings_batch_enabled=true",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    api_config = _config_yaml(_by_kind_and_name(docs, "ConfigMap", "deltallm-config"))
+    assert api_config["general_settings"]["embeddings_batch_enabled"] is True
+    assert api_config["general_settings"]["embeddings_batch_storage_backend"] == "local"
+
+
+def test_shared_mode_rejects_s3_storage_without_bucket() -> None:
+    error = _render_error(
+        "--set",
+        "config.general_settings.embeddings_batch_enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_storage_backend=s3",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    assert "embeddings_batch_s3_bucket is required" in error
+
+
+def test_shared_mode_allows_enabled_batching_with_s3_storage() -> None:
+    docs = _render(
+        "--set",
+        "config.general_settings.embeddings_batch_enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_storage_backend=s3",
+        "--set",
+        "config.general_settings.embeddings_batch_s3_bucket=deltallm-batch-artifacts",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    api_config = _config_yaml(_by_kind_and_name(docs, "ConfigMap", "deltallm-config"))
+    assert api_config["general_settings"]["embeddings_batch_enabled"] is True
+    assert api_config["general_settings"]["embeddings_batch_storage_backend"] == "s3"
+    assert api_config["general_settings"]["embeddings_batch_s3_bucket"] == "deltallm-batch-artifacts"
+
+
+def test_split_mode_rejects_enabled_batching_with_local_storage() -> None:
+    error = _render_error(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_enabled=true",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    assert "requires shared batch artifact storage" in error
+
+
+def test_split_mode_allows_enabled_batching_with_s3_storage() -> None:
+    docs = _render(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_storage_backend=s3",
+        "--set",
+        "config.general_settings.embeddings_batch_s3_bucket=deltallm-batch-artifacts",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    worker_config = _config_yaml(_by_kind_and_name(docs, "ConfigMap", "deltallm-batch-worker-config"))
+    assert worker_config["general_settings"]["embeddings_batch_enabled"] is True
+    assert worker_config["general_settings"]["embeddings_batch_storage_backend"] == "s3"
+
+
+def test_split_mode_rejects_s3_storage_without_bucket() -> None:
+    error = _render_error(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_storage_backend=s3",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    assert "embeddings_batch_s3_bucket is required" in error
+
+
+def test_split_mode_rejects_role_override_that_clears_s3_bucket() -> None:
+    error = _render_error(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_storage_backend=s3",
+        "--set",
+        "config.general_settings.embeddings_batch_s3_bucket=deltallm-batch-artifacts",
+        "--set-string",
+        "batchWorker.config.general_settings.embeddings_batch_s3_bucket=",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    assert "embeddings_batch_s3_bucket is required" in error
+
+
+def test_split_mode_can_explicitly_allow_unsafe_local_storage() -> None:
+    docs = _render(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "batchWorker.allowUnsafeLocalStorage=true",
+        "--set",
+        "config.general_settings.embeddings_batch_enabled=true",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    worker_config = _config_yaml(_by_kind_and_name(docs, "ConfigMap", "deltallm-batch-worker-config"))
+    assert worker_config["general_settings"]["embeddings_batch_storage_backend"] == "local"
+
+
+def test_split_mode_worker_tuning_uses_shared_config_unless_role_overridden() -> None:
+    shared_docs = _render(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_worker_concurrency=8",
+        "--set",
+        "config.general_settings.embeddings_batch_item_claim_limit=40",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+    role_override_docs = _render(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "config.general_settings.embeddings_batch_worker_concurrency=8",
+        "--set",
+        "batchWorker.config.general_settings.embeddings_batch_worker_concurrency=3",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    shared_worker_general = _config_yaml(
+        _by_kind_and_name(shared_docs, "ConfigMap", "deltallm-batch-worker-config")
+    )["general_settings"]
+    role_worker_general = _config_yaml(
+        _by_kind_and_name(role_override_docs, "ConfigMap", "deltallm-batch-worker-config")
+    )["general_settings"]
+
+    assert shared_worker_general["embeddings_batch_worker_concurrency"] == 8
+    assert shared_worker_general["embeddings_batch_item_claim_limit"] == 40
+    assert role_worker_general["embeddings_batch_worker_concurrency"] == 3
+
+
+def test_production_default_does_not_disable_batch_workers_without_worker_deployment() -> None:
+    docs = _render(
+        "-f",
+        "helm/values-production.yaml",
+        "--set",
+        "secret.existingSecret=deltallm-app-secrets",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+
+    api_config = _config_yaml(_by_kind_and_name(docs, "ConfigMap", "deltallm-config"))
+    assert api_config["general_settings"]["embeddings_batch_worker_enabled"] is True
+    assert api_config["general_settings"]["embeddings_batch_completion_outbox_worker_enabled"] is True
+    assert api_config["general_settings"]["embeddings_batch_gc_enabled"] is True
+
+    assert not any(doc.get("metadata", {}).get("name") == "deltallm-batch-worker-config" for doc in docs)
+
+
+def test_split_mode_renders_worker_network_policy() -> None:
+    docs = _render(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "networkPolicy.enabled=true",
+        "--show-only",
+        "templates/networkpolicy.yaml",
+        "--show-only",
+        "templates/batch-worker-networkpolicy.yaml",
+    )
+
+    worker_policy = _by_kind_and_name(docs, "NetworkPolicy", "deltallm-batch-worker")
+    assert worker_policy["spec"]["podSelector"]["matchLabels"] == {
+        "app.kubernetes.io/name": "deltallm-batch-worker",
+        "app.kubernetes.io/instance": "deltallm",
+        "app.kubernetes.io/component": "batch-worker",
+    }
+
+
+def test_split_mode_renders_worker_metrics_service_monitor() -> None:
+    docs = _render(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "prometheus.serviceMonitor.enabled=true",
+        "--set",
+        "prometheus.serviceMonitor.interval=15s",
+        "--set",
+        "prometheus.serviceMonitor.scrapeTimeout=5s",
+        "--show-only",
+        "templates/batch-worker-service.yaml",
+        "--show-only",
+        "templates/batch-worker-servicemonitor.yaml",
+    )
+
+    selector_labels = {
+        "app.kubernetes.io/name": "deltallm-batch-worker",
+        "app.kubernetes.io/instance": "deltallm",
+        "app.kubernetes.io/component": "batch-worker",
+    }
+    service = _by_kind_and_name(docs, "Service", "deltallm-batch-worker")
+    service_monitor = _by_kind_and_name(docs, "ServiceMonitor", "deltallm-batch-worker")
+
+    assert service["spec"]["selector"] == selector_labels
+    assert service["spec"]["ports"][0]["targetPort"] == "http"
+
+    service_labels = service["metadata"]["labels"]
+    assert service_monitor["spec"]["selector"]["matchLabels"] == selector_labels
+    assert "namespaceSelector" not in service_monitor["spec"]
+    assert all(service_labels[key] == value for key, value in selector_labels.items())
+    assert service_monitor["spec"]["endpoints"] == [
+        {
+            "port": "http",
+            "path": "/metrics",
+            "interval": "15s",
+            "scrapeTimeout": "5s",
+        }
+    ]
+
+
+def test_split_mode_worker_service_monitor_selects_release_namespace_when_centralized() -> None:
+    docs = _render(
+        "--namespace",
+        "deltallm",
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "prometheus.serviceMonitor.enabled=true",
+        "--set",
+        "prometheus.serviceMonitor.namespace=monitoring",
+        "--show-only",
+        "templates/batch-worker-servicemonitor.yaml",
+    )
+
+    service_monitor = _by_kind_and_name(docs, "ServiceMonitor", "deltallm-batch-worker")
+    assert service_monitor["metadata"]["namespace"] == "monitoring"
+    assert service_monitor["spec"]["namespaceSelector"] == {"matchNames": ["deltallm"]}
+
+
+def test_role_specific_config_checksums_are_isolated() -> None:
+    base_docs = _render(
+        "--set",
+        "batchWorker.enabled=true",
+        "--show-only",
+        "templates/deployment.yaml",
+        "--show-only",
+        "templates/batch-worker-deployment.yaml",
+    )
+    worker_override_docs = _render(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "batchWorker.config.general_settings.embeddings_batch_worker_concurrency=9",
+        "--show-only",
+        "templates/deployment.yaml",
+        "--show-only",
+        "templates/batch-worker-deployment.yaml",
+    )
+    api_override_docs = _render(
+        "--set",
+        "batchWorker.enabled=true",
+        "--set",
+        "api.config.general_settings.upstream_http_max_connections=777",
+        "--show-only",
+        "templates/deployment.yaml",
+        "--show-only",
+        "templates/batch-worker-deployment.yaml",
+    )
+
+    base_api = _deployment_checksum(_by_kind_and_name(base_docs, "Deployment", "deltallm"))
+    base_worker = _deployment_checksum(_by_kind_and_name(base_docs, "Deployment", "deltallm-batch-worker"))
+
+    assert _deployment_checksum(_by_kind_and_name(worker_override_docs, "Deployment", "deltallm")) == base_api
+    assert (
+        _deployment_checksum(_by_kind_and_name(worker_override_docs, "Deployment", "deltallm-batch-worker"))
+        != base_worker
+    )
+
+    assert _deployment_checksum(_by_kind_and_name(api_override_docs, "Deployment", "deltallm")) != base_api
+    assert (
+        _deployment_checksum(_by_kind_and_name(api_override_docs, "Deployment", "deltallm-batch-worker"))
+        == base_worker
+    )


### PR DESCRIPTION
## Summary

- Add a dedicated Helm batch worker deployment, service, HPA, PDB, NetworkPolicy, ServiceMonitor, and role-specific ConfigMap.
- Keep API/UI/gateway pods latency-focused by disabling batch executor, completion outbox, GC, and staged-create cleanup loops in the API config when split mode is enabled.
- Add worker-safe defaults and `batchWorker.config` overrides for worker tuning.
- Add split-mode storage validation so production batch workers require shared artifact storage unless explicitly allowed for dev.
- Document Kubernetes split-worker guidance and batch worker settings.

Closes #159.

Follow-up hardening tracked in #161.

## Validation

- `uv run --extra dev pytest tests/bootstrap/test_optional_bootstrap.py tests/helm/test_batch_worker_split.py`
- `uv run ruff check src/config.py src/bootstrap/batch.py tests/bootstrap/test_optional_bootstrap.py tests/helm/test_batch_worker_split.py`
- `helm lint ./helm`
- `helm lint ./helm --set nameOverride=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --set batchWorker.enabled=true --set secret.values.masterKey=sk-testmasterkey1234567890A1 --set secret.values.saltKey=test-salt-key-1234567890`
- `helm lint ./helm --set fullnameOverride=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --set batchWorker.enabled=true --set secret.values.masterKey=sk-testmasterkey1234567890A1 --set secret.values.saltKey=test-salt-key-1234567890`
- `helm lint ./helm --set batchWorker.enabled=true --set prometheus.serviceMonitor.enabled=true --set networkPolicy.enabled=true --set config.general_settings.embeddings_batch_enabled=true --set config.general_settings.embeddings_batch_storage_backend=s3 --set config.general_settings.embeddings_batch_s3_bucket=deltallm-batch-artifacts --set secret.values.masterKey=sk-testmasterkey1234567890A1 --set secret.values.saltKey=test-salt-key-1234567890`
- `helm lint ./helm -f helm/values-production.yaml --set secret.existingSecret=deltallm-app-secrets --set batchWorker.enabled=true --set config.general_settings.embeddings_batch_enabled=true --set config.general_settings.embeddings_batch_storage_backend=s3 --set config.general_settings.embeddings_batch_s3_bucket=deltallm-batch-artifacts`
- `git diff --check`