### PR TITLE
Add batch item claim fencing

### DIFF
--- a/prisma/migrations/20260516120000_batch_item_claim_epoch_failure_fencing/migration.sql
+++ b/prisma/migrations/20260516120000_batch_item_claim_epoch_failure_fencing/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "deltallm_batch_item"
+ALTER COLUMN "claim_epoch" TYPE BIGINT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1042,7 +1042,7 @@ model DeltaLLM_BatchItem {
   provider_cost      Float    @default(0)
   billed_cost        Float    @default(0)
   attempts           Int      @default(0)
-  claim_epoch        Int      @default(0)
+  claim_epoch        BigInt   @default(0)
   last_error         String?
   locked_by          String?
   lease_expires_at   DateTime?

--- a/src/batch/chat_worker_execution.py
+++ b/src/batch/chat_worker_execution.py
@@ -239,6 +239,7 @@ class ChatWorkerExecutionMixin:
                 claim_epoch=prepared.item.claim_epoch,
             ):
                 item_lease_lost.set()
+                self._observe_prepared_item_lease_lost(prepared)
                 logger.warning(
                     "batch chat completion skipped after lease loss batch_id=%s item_id=%s",
                     job.batch_id,
@@ -270,6 +271,7 @@ class ChatWorkerExecutionMixin:
                 )
                 increment_batch_chat_item_executed(mode=batch_execution_mode, status="success")
         except BatchItemLeaseLostError as exc:
+            self._observe_prepared_item_lease_lost(prepared)
             logger.warning(
                 "batch chat provider call cancelled after lease loss batch_id=%s item_id=%s error=%s",
                 job.batch_id,
@@ -688,6 +690,7 @@ class ChatWorkerExecutionMixin:
                 item_ids,
                 exc,
             )
+            self._observe_prepared_items_lease_lost(prepared_items)
             await self._stop_heartbeat_tasks(item_heartbeats.values())
             item_heartbeats.clear()
             return
@@ -835,6 +838,7 @@ class ChatWorkerExecutionMixin:
                 claim_epoch=prepared.item.claim_epoch,
             ):
                 item_lease_lost.set()
+                self._observe_prepared_items_lease_lost(success_prepared)
                 logger.warning(
                     "batch chat microbatch completion skipped after lease loss batch_id=%s item_id=%s",
                     batch_id,

--- a/src/batch/embedding_worker_execution.py
+++ b/src/batch/embedding_worker_execution.py
@@ -483,6 +483,7 @@ class EmbeddingWorkerExecutionMixin:
                 claim_epoch=prepared.item.claim_epoch,
             ):
                 item_lease_lost.set()
+                self._observe_prepared_item_lease_lost(prepared)
                 logger.warning(
                     "batch embedding completion skipped after lease loss batch_id=%s item_id=%s",
                     job.batch_id,
@@ -524,6 +525,7 @@ class EmbeddingWorkerExecutionMixin:
                     reference=prepared.item.item_id,
                 )
         except BatchItemLeaseLostError as exc:
+            self._observe_prepared_item_lease_lost(prepared)
             logger.warning(
                 "batch embedding provider call cancelled after lease loss batch_id=%s item_id=%s error=%s",
                 job.batch_id,
@@ -620,6 +622,7 @@ class EmbeddingWorkerExecutionMixin:
                 item_ids,
                 exc,
             )
+            self._observe_prepared_items_lease_lost(prepared_items)
             await self._stop_heartbeat_tasks(item_heartbeats.values())
             item_heartbeats.clear()
             return
@@ -731,6 +734,7 @@ class EmbeddingWorkerExecutionMixin:
                     claim_epoch=prepared.item.claim_epoch,
                 ):
                     item_lease_lost.set()
+                    self._observe_prepared_items_lease_lost(prepared_items)
                     logger.warning(
                         "batch embedding microbatch completion skipped after lease loss batch_id=%s size=%s item_ids=%s",
                         batch_id,

--- a/src/batch/repositories/item_repository.py
+++ b/src/batch/repositories/item_repository.py
@@ -154,33 +154,13 @@ class BatchItemRepository:
         usage: dict[str, Any] | None,
         provider_cost: float,
         billed_cost: float,
+        claim_epoch: int | None = None,
     ) -> bool:
         if self.prisma is None:
             return False
-        if worker_id is None:
-            rows = await self.prisma.query_raw(
-                """
-                UPDATE deltallm_batch_item
-                SET status = 'completed',
-                    response_body = $2::jsonb,
-                    usage = $3::jsonb,
-                    provider_cost = $4,
-                    billed_cost = $5,
-                    lease_expires_at = NULL,
-                    not_before_at = NULL,
-                    locked_by = NULL,
-                    completed_at = NOW()
-                WHERE item_id = $1
-                  AND status = 'in_progress'
-                RETURNING item_id
-                """,
-                item_id,
-                json.dumps(response_body),
-                json.dumps(usage or {}),
-                provider_cost,
-                billed_cost,
-            )
-            return bool(rows)
+        if worker_id is None or claim_epoch is None:
+            logger.warning("refusing item completion without worker ownership and claim epoch")
+            return False
         rows = await self.prisma.query_raw(
             """
             UPDATE deltallm_batch_item
@@ -195,6 +175,7 @@ class BatchItemRepository:
                 completed_at = NOW()
             WHERE item_id = $1
               AND locked_by = $2
+              AND claim_epoch = $7::bigint
               AND status = 'in_progress'
             RETURNING item_id
             """,
@@ -204,6 +185,7 @@ class BatchItemRepository:
             json.dumps(usage or {}),
             provider_cost,
             billed_cost,
+            claim_epoch,
         )
         return bool(rows)
 
@@ -220,6 +202,9 @@ class BatchItemRepository:
         if worker_id is None:
             logger.warning("refusing bulk item completion without worker ownership")
             return False
+        if any(item.get("claim_epoch") is None for item in items):
+            logger.warning("refusing bulk item completion without claim epochs")
+            return False
 
         values_sql: list[str] = []
         params: list[Any] = []
@@ -227,7 +212,7 @@ class BatchItemRepository:
         for item in items:
             values_sql.append(
                 f"(${param_index}, ${param_index + 1}::jsonb, ${param_index + 2}::jsonb, "
-                f"${param_index + 3}, ${param_index + 4}, ${param_index + 5}::int)"
+                f"${param_index + 3}, ${param_index + 4}, ${param_index + 5}::bigint)"
             )
             params.extend(
                 [
@@ -255,7 +240,7 @@ class BatchItemRepository:
                 JOIN payload p ON i.item_id = p.item_id
                 WHERE i.status = 'in_progress'
                   AND i.locked_by = ${worker_id_param}
-                  AND (p.claim_epoch IS NULL OR i.claim_epoch = p.claim_epoch)
+                  AND i.claim_epoch = p.claim_epoch
                 FOR UPDATE SKIP LOCKED
             ),
             eligible AS (
@@ -298,13 +283,16 @@ class BatchItemRepository:
     ) -> list[str]:
         if self.prisma is None or not item_ids:
             return []
+        if item_claim_epochs is None or any(item_id not in item_claim_epochs for item_id in item_ids):
+            logger.warning("refusing retry release without claim epochs")
+            return []
 
         values_sql: list[str] = []
         params: list[Any] = []
         param_index = 1
         for item_id in item_ids:
-            values_sql.append(f"(${param_index}, ${param_index + 1}::int)")
-            params.extend([item_id, (item_claim_epochs or {}).get(item_id)])
+            values_sql.append(f"(${param_index}, ${param_index + 1}::bigint)")
+            params.extend([item_id, item_claim_epochs[item_id]])
             param_index += 2
 
         worker_id_param = param_index
@@ -342,7 +330,7 @@ class BatchItemRepository:
                 WHERE i.item_id = p.item_id
                   AND j.batch_id = i.batch_id
                   AND i.locked_by = ${worker_id_param}
-                  AND (p.claim_epoch IS NULL OR i.claim_epoch = p.claim_epoch)
+                  AND i.claim_epoch = p.claim_epoch
                   AND i.status = 'in_progress'
                   AND (j.expires_at IS NULL OR NOW() + (${retry_delay_param} || ' seconds')::interval < j.expires_at)
                 RETURNING i.item_id
@@ -362,33 +350,14 @@ class BatchItemRepository:
         last_error: str,
         retryable: bool,
         retry_delay_seconds: int = 0,
+        claim_epoch: int | None = None,
     ) -> bool:
         if self.prisma is None:
             return False
+        if worker_id is None or claim_epoch is None:
+            logger.warning("refusing item failure update without worker ownership and claim epoch")
+            return False
         if retryable:
-            if worker_id is None:
-                rows = await self.prisma.query_raw(
-                    """
-                    UPDATE deltallm_batch_item i
-                    SET status = 'pending',
-                        error_body = $2::jsonb,
-                        last_error = $3,
-                        lease_expires_at = NOW() + ($4 || ' seconds')::interval,
-                        not_before_at = NOW() + ($4 || ' seconds')::interval,
-                        locked_by = NULL
-                    FROM deltallm_batch_job j
-                    WHERE i.item_id = $1
-                      AND i.status = 'in_progress'
-                      AND j.batch_id = i.batch_id
-                      AND (j.expires_at IS NULL OR NOW() + ($4 || ' seconds')::interval < j.expires_at)
-                    RETURNING i.item_id
-                    """,
-                    item_id,
-                    json.dumps(error_body),
-                    last_error,
-                    max(0, retry_delay_seconds),
-                )
-                return bool(rows)
             rows = await self.prisma.query_raw(
                 """
                 UPDATE deltallm_batch_item i
@@ -401,6 +370,7 @@ class BatchItemRepository:
                 FROM deltallm_batch_job j
                 WHERE i.item_id = $1
                   AND i.locked_by = $5
+                  AND i.claim_epoch = $6::bigint
                   AND i.status = 'in_progress'
                   AND j.batch_id = i.batch_id
                   AND (j.expires_at IS NULL OR NOW() + ($4 || ' seconds')::interval < j.expires_at)
@@ -411,26 +381,7 @@ class BatchItemRepository:
                 last_error,
                 max(0, retry_delay_seconds),
                 worker_id,
-            )
-            return bool(rows)
-        if worker_id is None:
-            rows = await self.prisma.query_raw(
-                """
-                UPDATE deltallm_batch_item
-                SET status = 'failed',
-                    error_body = $2::jsonb,
-                    last_error = $3,
-                    lease_expires_at = NULL,
-                    not_before_at = NULL,
-                    locked_by = NULL,
-                    completed_at = NOW()
-                WHERE item_id = $1
-                  AND status = 'in_progress'
-                RETURNING item_id
-                """,
-                item_id,
-                json.dumps(error_body),
-                last_error,
+                claim_epoch,
             )
             return bool(rows)
         rows = await self.prisma.query_raw(
@@ -445,6 +396,7 @@ class BatchItemRepository:
                 completed_at = NOW()
             WHERE item_id = $1
               AND locked_by = $2
+              AND claim_epoch = $5::bigint
               AND status = 'in_progress'
             RETURNING item_id
             """,
@@ -452,6 +404,7 @@ class BatchItemRepository:
             worker_id,
             json.dumps(error_body),
             last_error,
+            claim_epoch,
         )
         return bool(rows)
 
@@ -472,7 +425,7 @@ class BatchItemRepository:
             WHERE item_id = $1
               AND locked_by = $2
               AND status = 'in_progress'
-              AND ($4::int IS NULL OR claim_epoch = $4::int)
+              AND claim_epoch = $4::bigint
             RETURNING item_id
             """,
             item_id,
@@ -541,6 +494,7 @@ class BatchItemRepository:
                 i.provider_cost,
                 i.billed_cost,
                 i.attempts,
+                i.claim_epoch,
                 i.last_error,
                 i.locked_by,
                 i.lease_expires_at,

--- a/src/batch/repository.py
+++ b/src/batch/repository.py
@@ -533,10 +533,12 @@ class BatchRepository:
         usage: dict[str, Any] | None,
         provider_cost: float,
         billed_cost: float,
+        claim_epoch: int | None = None,
     ) -> bool:
         return await self.items.mark_item_completed(
             item_id=item_id,
             worker_id=worker_id,
+            claim_epoch=claim_epoch,
             response_body=response_body,
             usage=usage,
             provider_cost=provider_cost,
@@ -563,6 +565,7 @@ class BatchRepository:
         last_error: str,
         retryable: bool,
         retry_delay_seconds: int = 0,
+        claim_epoch: int | None = None,
     ) -> bool:
         return await self.items.mark_item_failed(
             item_id=item_id,
@@ -571,6 +574,7 @@ class BatchRepository:
             last_error=last_error,
             retryable=retryable,
             retry_delay_seconds=retry_delay_seconds,
+            claim_epoch=claim_epoch,
         )
 
     async def refresh_job_progress(self, batch_id: str) -> BatchJobRecord | None:
@@ -747,11 +751,13 @@ class BatchRepository:
         billed_cost: float,
         outbox_payload: dict[str, Any],
         outbox_max_attempts: int = 5,
+        claim_epoch: int | None = None,
     ) -> Literal["completed", "already_completed", "not_owned"]:
         return await self.complete_items_with_outbox_bulk(
             items=[
                 {
                     "item_id": item_id,
+                    "claim_epoch": claim_epoch,
                     "response_body": response_body,
                     "usage": usage,
                     "provider_cost": provider_cost,

--- a/src/batch/worker_failure_handling.py
+++ b/src/batch/worker_failure_handling.py
@@ -81,6 +81,7 @@ class WorkerFailureHandlingMixin:
             last_error=str(exc),
             retryable=retryable,
             retry_delay_seconds=retry_delay,
+            claim_epoch=item.claim_epoch,
         )
         if not updated and retryable:
             retryable = False
@@ -101,6 +102,7 @@ class WorkerFailureHandlingMixin:
                 last_error=str(exc),
                 retryable=retryable,
                 retry_delay_seconds=retry_delay,
+                claim_epoch=item.claim_epoch,
             )
         if not updated:
             logger.warning(

--- a/src/batch/worker_persistence.py
+++ b/src/batch/worker_persistence.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 from datetime import UTC, datetime
 import logging
+from time import perf_counter
 from typing import Any, Awaitable
 
 from src.batch.endpoints import batch_call_type_for_endpoint
@@ -37,6 +38,23 @@ class WorkerPersistenceMixin:
                 status,
                 exc,
             )
+
+    def _observe_prepared_item_lease_lost(
+        self,
+        prepared: _PreparedEmbeddingItem | _PreparedChatItem,
+    ) -> None:
+        self._observe_item_execution_latency(
+            status="lease_lost",
+            latency_seconds=perf_counter() - prepared.started_at_monotonic,
+            reference=prepared.item.item_id,
+        )
+
+    def _observe_prepared_items_lease_lost(
+        self,
+        prepared_items: list[_PreparedEmbeddingItem] | list[_PreparedChatItem],
+    ) -> None:
+        for prepared in prepared_items:
+            self._observe_prepared_item_lease_lost(prepared)
 
     async def _acquire_prepared_policy_lease(self, *, prepared: _PreparedEmbeddingItem | _PreparedChatItem) -> None:
         if prepared.policy_lease is not None:

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -3979,6 +3979,9 @@ async def test_db_backed_claim_next_work_skips_item_with_future_not_before_after
     assert first is not None
     assert len(first.item_ids) == 1
     retried_item_id = first.item_ids[0]
+    first_items = await repository.load_claim_items(first.item_ids)
+    assert len(first_items) == 1
+    assert first_items[0].claim_epoch > 0
 
     # Mark the claimed item as a retryable failure with a 1h backoff.
     marked = await repository.mark_item_failed(
@@ -3988,6 +3991,7 @@ async def test_db_backed_claim_next_work_skips_item_with_future_not_before_after
         last_error="transient upstream",
         retryable=True,
         retry_delay_seconds=3600,
+        claim_epoch=first_items[0].claim_epoch,
     )
     assert marked is True
 
@@ -4239,6 +4243,7 @@ async def test_db_backed_expired_item_can_be_reclaimed_after_crash(batch_db) -> 
         usage={"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1},
         provider_cost=0.01,
         billed_cost=0.01,
+        claim_epoch=reclaimed[0].claim_epoch,
     )
     assert updated is True
 
@@ -4321,6 +4326,24 @@ async def test_db_backed_item_claim_epoch_fences_stale_completion_and_retry(batc
     )
     assert stale_completed is False
 
+    assert await repository.mark_item_failed(
+        item_id=item_id,
+        worker_id="w1",
+        error_body={"error": {"message": "stale retry"}},
+        last_error="stale retry",
+        retryable=True,
+        retry_delay_seconds=1,
+        claim_epoch=first_epoch,
+    ) is False
+    assert await repository.mark_item_failed(
+        item_id=item_id,
+        worker_id="w1",
+        error_body={"error": {"message": "stale terminal"}},
+        last_error="stale terminal",
+        retryable=False,
+        claim_epoch=first_epoch,
+    ) is False
+
     current_completed = await repository.mark_items_completed_bulk(
         items=[
             {
@@ -4394,6 +4417,7 @@ async def test_db_backed_bulk_completion_is_all_or_nothing_when_any_item_is_no_l
         items=[
             {
                 "item_id": claimed[0].item_id,
+                "claim_epoch": claimed[0].claim_epoch,
                 "response_body": {"object": "list", "data": [{"index": 0, "embedding": [0.1]}]},
                 "usage": {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1},
                 "provider_cost": 0.01,
@@ -4401,6 +4425,7 @@ async def test_db_backed_bulk_completion_is_all_or_nothing_when_any_item_is_no_l
             },
             {
                 "item_id": claimed[1].item_id,
+                "claim_epoch": claimed[1].claim_epoch,
                 "response_body": {"object": "list", "data": [{"index": 0, "embedding": [0.2]}]},
                 "usage": {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1},
                 "provider_cost": 0.01,
@@ -4457,6 +4482,7 @@ async def test_db_backed_bulk_completion_with_outbox_persists_completed_items_an
     items = [
         {
             "item_id": claimed[0].item_id,
+            "claim_epoch": claimed[0].claim_epoch,
             "response_body": {"object": "list", "data": [{"index": 0, "embedding": [0.1]}]},
             "usage": {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1},
             "provider_cost": 0.01,
@@ -4472,6 +4498,7 @@ async def test_db_backed_bulk_completion_with_outbox_persists_completed_items_an
         },
         {
             "item_id": claimed[1].item_id,
+            "claim_epoch": claimed[1].claim_epoch,
             "response_body": {"object": "list", "data": [{"index": 0, "embedding": [0.2]}]},
             "usage": {"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2},
             "provider_cost": 0.02,
@@ -4552,6 +4579,7 @@ async def test_db_backed_bulk_completion_with_outbox_reports_already_completed_a
     items = [
         {
             "item_id": claimed[0].item_id,
+            "claim_epoch": claimed[0].claim_epoch,
             "response_body": {"object": "list", "data": [{"index": 0, "embedding": [0.1]}]},
             "usage": {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1},
             "provider_cost": 0.01,
@@ -4561,6 +4589,7 @@ async def test_db_backed_bulk_completion_with_outbox_reports_already_completed_a
         },
         {
             "item_id": claimed[1].item_id,
+            "claim_epoch": claimed[1].claim_epoch,
             "response_body": {"object": "list", "data": [{"index": 0, "embedding": [0.2]}]},
             "usage": {"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2},
             "provider_cost": 0.02,

--- a/tests/test_batch_repository.py
+++ b/tests/test_batch_repository.py
@@ -65,6 +65,28 @@ async def test_bulk_item_completion_requires_worker_owner() -> None:
     assert prisma.calls == []
 
 
+@pytest.mark.asyncio
+async def test_bulk_item_completion_requires_claim_epoch() -> None:
+    prisma = _PrismaSpy()
+    repository = BatchItemRepository(prisma)
+
+    updated = await repository.mark_items_completed_bulk(
+        items=[
+            {
+                "item_id": "item-1",
+                "response_body": {"ok": True},
+                "usage": {},
+                "provider_cost": 0.0,
+                "billed_cost": 0.0,
+            }
+        ],
+        worker_id="worker-1",
+    )
+
+    assert updated is False
+    assert prisma.calls == []
+
+
 def _job_row(**overrides):
     row = {
         "batch_id": "batch-1",
@@ -2499,12 +2521,54 @@ async def test_retryable_mark_item_failed_uses_database_deadline_guard():
         last_error="rate limited",
         retryable=True,
         retry_delay_seconds=60,
+        claim_epoch=7,
     )
 
     assert updated is False
+    assert prisma.params == (
+        "item-1",
+        json.dumps({"message": "rate limited"}),
+        "rate limited",
+        60,
+        "worker-1",
+        7,
+    )
     assert "FROM deltallm_batch_job j" in prisma.sql
     assert "j.batch_id = i.batch_id" in prisma.sql
     assert "NOW() + ($4 || ' seconds')::interval < j.expires_at" in prisma.sql
+    assert "i.claim_epoch = $6::bigint" in prisma.sql
+
+
+@pytest.mark.asyncio
+async def test_mark_item_failed_requires_claim_epoch():
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    updated = await repository.mark_item_failed(
+        item_id="item-1",
+        worker_id="worker-1",
+        error_body={"message": "rate limited"},
+        last_error="rate limited",
+        retryable=True,
+        retry_delay_seconds=60,
+    )
+
+    assert updated is False
+    assert prisma.calls == []
+
+
+@pytest.mark.asyncio
+async def test_release_items_for_retry_requires_claim_epochs():
+    prisma = _PrismaSpy()
+    repository = BatchRepository(prisma_client=prisma)
+
+    item_ids = await repository.release_items_for_retry(
+        item_ids=["item-1"],
+        worker_id="worker-1",
+    )
+
+    assert item_ids == []
+    assert prisma.calls == []
 
 
 @pytest.mark.asyncio
@@ -2515,10 +2579,11 @@ async def test_release_items_for_retry_preserves_immediate_requeue_defaults():
     item_ids = await repository.release_items_for_retry(
         item_ids=["item-1"],
         worker_id="worker-1",
+        item_claim_epochs={"item-1": 3},
     )
 
     assert item_ids == []
-    assert prisma.params == ("item-1", None, "worker-1", 0, None, None)
+    assert prisma.params == ("item-1", 3, "worker-1", 0, None, None)
     assert "status = 'pending'" in prisma.sql
     assert "ELSE NULL" in prisma.sql
     assert "error_body = COALESCE($5::jsonb, i.error_body)" in prisma.sql
@@ -2526,7 +2591,7 @@ async def test_release_items_for_retry_preserves_immediate_requeue_defaults():
     assert "j.batch_id = i.batch_id" in prisma.sql
     assert "NOW() + ($4 || ' seconds')::interval < j.expires_at" in prisma.sql
     assert "i.locked_by = $3" in prisma.sql
-    assert "(p.claim_epoch IS NULL OR i.claim_epoch = p.claim_epoch)" in prisma.sql
+    assert "i.claim_epoch = p.claim_epoch" in prisma.sql
 
 
 @pytest.mark.asyncio
@@ -2540,9 +2605,10 @@ async def test_release_items_for_retry_can_store_retry_metadata_and_delay():
         retry_delay_seconds=30,
         error_body={"retry_category": "upstream_5xx"},
         last_error="upstream unavailable",
+        item_claim_epochs={"item-1": 11, "item-2": 12},
     )
 
-    assert prisma.params[0:4] == ("item-1", None, "item-2", None)
+    assert prisma.params[0:4] == ("item-1", 11, "item-2", 12)
     assert prisma.params[4] == "worker-1"
     assert prisma.params[5] == 30
     assert json.loads(prisma.params[6]) == {"retry_category": "upstream_5xx"}

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -103,6 +103,7 @@ class _FakeRepository:
                 usage=item["usage"],
                 provider_cost=item["provider_cost"],
                 billed_cost=item["billed_cost"],
+                claim_epoch=item.get("claim_epoch"),
             )
             if not updated:
                 return "not_owned"
@@ -5417,6 +5418,30 @@ async def test_provider_call_wait_is_cancelled_when_item_lease_is_lost():
     with pytest.raises(BatchItemLeaseLostError):
         await asyncio.wait_for(wait_task, timeout=1.0)
     assert cancelled.is_set()
+
+
+def test_lease_loss_metric_helper_records_each_prepared_item():
+    observed: list[dict[str, float | str]] = []
+    worker = BatchExecutorWorker(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        repository=_FakeRepository(),  # type: ignore[arg-type]
+        storage=_FakeStorage(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="w1"),
+    )
+
+    def _observe(*, status: str, latency_seconds: float) -> None:
+        observed.append({"status": status, "latency_seconds": latency_seconds})
+
+    worker._execution_engine._observe_batch_item_execution_latency = _observe
+    worker._execution_engine._observe_prepared_items_lease_lost(
+        [
+            SimpleNamespace(item=SimpleNamespace(item_id="i1"), started_at_monotonic=0.0),
+            SimpleNamespace(item=SimpleNamespace(item_id="i2"), started_at_monotonic=0.0),
+        ]
+    )
+
+    assert [entry["status"] for entry in observed] == ["lease_lost", "lease_lost"]
+    assert all(float(entry["latency_seconds"]) >= 0 for entry in observed)
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_worker_microbatch.py
+++ b/tests/test_batch_worker_microbatch.py
@@ -367,6 +367,7 @@ async def test_batch_retries_no_healthy_deployments_with_backoff(monkeypatch):
             "last_error": "No healthy deployments available for model 'text-embedding-3-small'",
             "retryable": True,
             "retry_delay_seconds": 5,
+            "claim_epoch": 0,
         }
     ]
 


### PR DESCRIPTION
## Summary
- add BigInt item claim epochs and require them for stale-sensitive item mutations
- propagate claim epochs through work-slice loads, outbox completion, retries, failure handling, and lease renewal
- record lease-loss cancellation through item execution metrics and cover stale-worker fencing in tests

Closes #174

## Validation
- uv run ruff check src/batch/repositories/item_repository.py src/batch/embedding_worker_execution.py src/batch/chat_worker_execution.py src/batch/worker_persistence.py tests/test_batch_db_integration.py tests/test_batch_worker.py
- DATABASE_URL='postgresql://postgres:postgres@localhost:5432/deltallm' uv run pytest -q tests/test_batch_db_integration.py::test_db_backed_claim_next_work_skips_item_with_future_not_before_after_retry tests/test_batch_db_integration.py::test_db_backed_bulk_completion_with_outbox_persists_completed_items_and_outbox_rows tests/test_batch_db_integration.py::test_db_backed_bulk_completion_with_outbox_reports_already_completed_after_prior_commit tests/test_batch_db_integration.py::test_db_backed_item_claim_epoch_fences_stale_completion_and_retry tests/test_batch_worker.py::test_provider_call_wait_is_cancelled_when_item_lease_is_lost tests/test_batch_worker.py::test_lease_loss_metric_helper_records_each_prepared_item
- uv run pytest -q tests/test_batch_repository.py tests/test_batch_worker.py tests/test_batch_worker_microbatch.py
- DATABASE_URL='postgresql://postgres:postgres@localhost:5432/deltallm' uv run prisma validate --schema=./prisma/schema.prisma