### PR TITLE
Add notification dispatcher with Slack budget alerts

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -285,7 +285,10 @@ Governance notifications are opt-in and disabled by default.
 | `governance_notifications_enabled` | `false` | Master switch for governance emails |
 | `budget_notifications_enabled` | `false` | Enable soft-budget threshold emails |
 | `key_lifecycle_notifications_enabled` | `false` | Enable key create/regenerate/revoke/delete emails |
-| `budget_alert_ttl_seconds` | `3600` | Deduplication window for budget alert emails |
+| `budget_alert_ttl_seconds` | `3600` | Deduplication window for budget alerts (shared across all channels) |
+| `slack_alerting_enabled` | `false` | Send governance alerts to a Slack incoming webhook in addition to email |
+| `slack_webhook_url` | `null` | Slack incoming webhook URL (secret); required when `slack_alerting_enabled` is true |
+| `slack_alert_kinds` | `[]` | Alert types routed to Slack, e.g. `["budget_threshold"]`; empty routes nothing |
 
 ## Metrics Settings
 

--- a/src/billing/alerts.py
+++ b/src/billing/alerts.py
@@ -52,8 +52,10 @@ class AlertService:
         # Claim the shared dedupe slot before any recipient DB query so a
         # throttled alert does no extra work.
         alert_key = self._alert_key("budget", entity_type=entity_type, entity_id=entity_id)
-        if not await self.dispatcher.try_claim(alert_key):
-            increment_notification_enqueue(kind="budget_threshold", channel="all", status="throttled")
+        claim = await self.dispatcher.try_claim(alert_key)
+        if claim != "claimed":
+            status = "throttled" if claim == "held" else "dedupe_unavailable"
+            increment_notification_enqueue(kind="budget_threshold", channel="all", status=status)
             return
 
         # A notification failure must never surface to the inference request that

--- a/src/billing/alerts.py
+++ b/src/billing/alerts.py
@@ -6,9 +6,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 from src.audit.actions import AuditAction
-from src.metrics import increment_notification_enqueue
-from src.services.audit_service import AuditEventInput, AuditService
-from src.services.email_outbox_service import EmailOutboxService, enqueue_succeeded
+from src.notifications.dispatcher import NotificationDispatcher
+from src.notifications.types import NotificationMessage
 from src.services.notification_recipients import NotificationRecipientResolver
 
 logger = logging.getLogger(__name__)
@@ -26,17 +25,13 @@ class AlertService:
         self,
         *,
         config: AlertConfig | None = None,
-        redis_client: Any | None = None,
-        outbox_service: EmailOutboxService | None = None,
+        dispatcher: NotificationDispatcher,
         recipient_resolver: NotificationRecipientResolver | None = None,
-        audit_service: AuditService | None = None,
         config_getter=None,  # noqa: ANN001
     ) -> None:
         self.config = config or AlertConfig()
-        self.redis = redis_client
-        self.outbox_service = outbox_service
+        self.dispatcher = dispatcher
         self.recipient_resolver = recipient_resolver
-        self.audit_service = audit_service
         self._config_getter = config_getter
 
     async def send_budget_alert(
@@ -50,14 +45,11 @@ class AlertService:
     ) -> None:
         if not self._budget_notifications_enabled():
             return
-
-        alert_key = self._alert_key("budget", entity_type=entity_type, entity_id=entity_id)
-        if not await self._claim_alert_slot(alert_key):
-            increment_notification_enqueue(kind="budget_threshold", status="throttled")
+        if self.recipient_resolver is None:
             return
 
         percentage = (current_spend / hard_budget * 100.0) if hard_budget and hard_budget > 0 else 0.0
-        payload = {
+        base_payload = {
             "type": "budget_alert",
             "timestamp": datetime.now(tz=UTC).isoformat(),
             "entity_type": entity_type,
@@ -67,87 +59,30 @@ class AlertService:
             "hard_budget": float(hard_budget) if hard_budget is not None else None,
             "percentage": percentage,
         }
-        try:
-            if self.outbox_service is None or self.recipient_resolver is None:
-                raise RuntimeError("notification services unavailable")
 
-            recipients = await self.recipient_resolver.resolve_budget_recipients(entity_type=entity_type, entity_id=entity_id)
-            if not recipients.emails:
-                increment_notification_enqueue(kind="budget_threshold", status="no_recipients")
-                await self._release_alert_slot(alert_key)
-                logger.info("budget notification skipped; no recipients", extra=payload)
-                await self._record_budget_notification_audit(
-                    entity_type=entity_type,
-                    entity_id=entity_id,
-                    status="skipped",
-                    metadata={"notification_kind": "budget_threshold", "reason": "no_recipients"},
-                )
-                return
-
-            queued = await self.outbox_service.enqueue_template_email(
-                template_key="budget_threshold",
-                to_addresses=recipients.emails,
-                payload_json={
-                    **payload,
-                    "instance_name": self._instance_name(),
-                    "recipient_policy": recipients.policy,
-                    "team_id": recipients.team_id,
-                    "organization_id": recipients.organization_id,
-                    "owner_account_id": recipients.owner_account_id,
-                },
-                kind="notification",
-            )
-            if not enqueue_succeeded(queued):
-                increment_notification_enqueue(kind="budget_threshold", status="undeliverable")
-                await self._release_alert_slot(alert_key)
-                logger.info(
-                    "budget notification skipped; email not queueable",
-                    extra={**payload, "email_id": queued.email_id, "outbox_status": getattr(queued, "status", None)},
-                )
-                await self._record_budget_notification_audit(
-                    entity_type=entity_type,
-                    entity_id=entity_id,
-                    status="skipped",
-                    metadata={
-                        "notification_kind": "budget_threshold",
-                        "email_id": queued.email_id,
-                        "reason": "undeliverable",
-                        "outbox_status": getattr(queued, "status", None),
-                    },
-                )
-                return
-            increment_notification_enqueue(kind="budget_threshold", status="queued")
-            logger.info(
-                "budget notification queued",
-                extra={
-                    **payload,
-                    "email_id": queued.email_id,
-                    "recipient_count": len(recipients.emails),
-                    "recipient_policy": recipients.policy,
-                },
-            )
-            await self._record_budget_notification_audit(
-                entity_type=entity_type,
-                entity_id=entity_id,
-                status="success",
-                metadata={
-                    "notification_kind": "budget_threshold",
-                    "email_id": queued.email_id,
-                    "recipient_count": len(recipients.emails),
-                    "recipient_policy": recipients.policy,
-                },
-            )
-        except Exception as exc:  # pragma: no cover - defensive path
-            increment_notification_enqueue(kind="budget_threshold", status="error")
-            await self._release_alert_slot(alert_key)
-            logger.warning("budget notification failed", extra={**payload, "error": str(exc)})
-            await self._record_budget_notification_audit(
-                entity_type=entity_type,
-                entity_id=entity_id,
-                status="error",
-                metadata={"notification_kind": "budget_threshold"},
-                error=str(exc),
-            )
+        recipients = await self.recipient_resolver.resolve_budget_recipients(
+            entity_type=entity_type, entity_id=entity_id
+        )
+        message = NotificationMessage(
+            alert_type="budget_threshold",
+            metric_kind="budget_threshold",
+            payload={
+                **base_payload,
+                "instance_name": self._instance_name(),
+                "recipient_policy": recipients.policy,
+                "team_id": recipients.team_id,
+                "organization_id": recipients.organization_id,
+                "owner_account_id": recipients.owner_account_id,
+            },
+        )
+        await self.dispatcher.dispatch(
+            message=message,
+            recipients=recipients,
+            audit_action=AuditAction.SYSTEM_BUDGET_NOTIFICATION_ENQUEUE.value,
+            resource_type=entity_type,
+            resource_id=entity_id,
+            dedupe_key=self._alert_key("budget", entity_type=entity_type, entity_id=entity_id),
+        )
 
     def _budget_notifications_enabled(self) -> bool:
         cfg = self._current_config()
@@ -171,44 +106,3 @@ class AlertService:
 
     def _alert_key(self, alert_type: str, *, entity_type: str, entity_id: str) -> str:
         return f"alert:{alert_type}:{entity_type}:{entity_id}"
-
-    async def _claim_alert_slot(self, key: str) -> bool:
-        if self.redis is None:
-            return True
-
-        if hasattr(self.redis, "set"):
-            claimed = await self.redis.set(key, "1", ex=self.config.budget_alert_ttl, nx=True)
-            return bool(claimed)
-        if await self.redis.exists(key):
-            return False
-        await self.redis.setex(key, self.config.budget_alert_ttl, "1")
-        return True
-
-    async def _release_alert_slot(self, key: str) -> None:
-        if self.redis is None or not hasattr(self.redis, "delete"):
-            return
-        await self.redis.delete(key)
-
-    async def _record_budget_notification_audit(
-        self,
-        *,
-        entity_type: str,
-        entity_id: str,
-        status: str,
-        metadata: dict[str, Any],
-        error: str | None = None,
-    ) -> None:
-        if self.audit_service is None:
-            return
-        self.audit_service.record_event(
-            AuditEventInput(
-                action=AuditAction.SYSTEM_BUDGET_NOTIFICATION_ENQUEUE.value,
-                actor_type="system",
-                resource_type=entity_type,
-                resource_id=entity_id,
-                status=status,
-                error_type="NotificationEnqueueError" if error else None,
-                metadata={**metadata, "error": error},
-            ),
-            critical=False,
-        )

--- a/src/billing/alerts.py
+++ b/src/billing/alerts.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from src.audit.actions import AuditAction
+from src.metrics import increment_notification_enqueue
 from src.notifications.dispatcher import NotificationDispatcher
 from src.notifications.types import NotificationMessage
 from src.services.notification_recipients import NotificationRecipientResolver
@@ -48,41 +49,65 @@ class AlertService:
         if self.recipient_resolver is None:
             return
 
-        percentage = (current_spend / hard_budget * 100.0) if hard_budget and hard_budget > 0 else 0.0
-        base_payload = {
-            "type": "budget_alert",
-            "timestamp": datetime.now(tz=UTC).isoformat(),
-            "entity_type": entity_type,
-            "entity_id": entity_id,
-            "current_spend": float(current_spend),
-            "soft_budget": float(soft_budget) if soft_budget is not None else None,
-            "hard_budget": float(hard_budget) if hard_budget is not None else None,
-            "percentage": percentage,
-        }
+        # Claim the shared dedupe slot before any recipient DB query so a
+        # throttled alert does no extra work.
+        alert_key = self._alert_key("budget", entity_type=entity_type, entity_id=entity_id)
+        if not await self.dispatcher.try_claim(alert_key):
+            increment_notification_enqueue(kind="budget_threshold", channel="all", status="throttled")
+            return
 
-        recipients = await self.recipient_resolver.resolve_budget_recipients(
-            entity_type=entity_type, entity_id=entity_id
-        )
-        message = NotificationMessage(
-            alert_type="budget_threshold",
-            metric_kind="budget_threshold",
-            payload={
-                **base_payload,
-                "instance_name": self._instance_name(),
-                "recipient_policy": recipients.policy,
-                "team_id": recipients.team_id,
-                "organization_id": recipients.organization_id,
-                "owner_account_id": recipients.owner_account_id,
-            },
-        )
-        await self.dispatcher.dispatch(
-            message=message,
-            recipients=recipients,
-            audit_action=AuditAction.SYSTEM_BUDGET_NOTIFICATION_ENQUEUE.value,
-            resource_type=entity_type,
-            resource_id=entity_id,
-            dedupe_key=self._alert_key("budget", entity_type=entity_type, entity_id=entity_id),
-        )
+        # A notification failure must never surface to the inference request that
+        # triggered the budget check, so the whole send is isolated here.
+        try:
+            percentage = (current_spend / hard_budget * 100.0) if hard_budget and hard_budget > 0 else 0.0
+            base_payload = {
+                "type": "budget_alert",
+                "timestamp": datetime.now(tz=UTC).isoformat(),
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "current_spend": float(current_spend),
+                "soft_budget": float(soft_budget) if soft_budget is not None else None,
+                "hard_budget": float(hard_budget) if hard_budget is not None else None,
+                "percentage": percentage,
+            }
+            recipients = await self.recipient_resolver.resolve_budget_recipients(
+                entity_type=entity_type, entity_id=entity_id
+            )
+            message = NotificationMessage(
+                alert_type="budget_threshold",
+                metric_kind="budget_threshold",
+                payload={
+                    **base_payload,
+                    "instance_name": self._instance_name(),
+                    "recipient_policy": recipients.policy,
+                    "team_id": recipients.team_id,
+                    "organization_id": recipients.organization_id,
+                    "owner_account_id": recipients.owner_account_id,
+                },
+            )
+            any_delivered = await self.dispatcher.dispatch(
+                message=message,
+                recipients=recipients,
+                audit_action=AuditAction.SYSTEM_BUDGET_NOTIFICATION_ENQUEUE.value,
+                resource_type=entity_type,
+                resource_id=entity_id,
+            )
+            if not any_delivered:
+                await self.dispatcher.release(alert_key)
+        except Exception as exc:
+            await self.dispatcher.release(alert_key)
+            logger.warning(
+                "budget notification failed",
+                extra={"entity_type": entity_type, "entity_id": entity_id, "error": str(exc)},
+            )
+            await self.dispatcher.record_error(
+                metric_kind="budget_threshold",
+                audit_action=AuditAction.SYSTEM_BUDGET_NOTIFICATION_ENQUEUE.value,
+                resource_type=entity_type,
+                resource_id=entity_id,
+                organization_id=None,
+                error=str(exc),
+            )
 
     def _budget_notifications_enabled(self) -> bool:
         cfg = self._current_config()

--- a/src/billing/alerts.py
+++ b/src/billing/alerts.py
@@ -58,6 +58,7 @@ class AlertService:
 
         # A notification failure must never surface to the inference request that
         # triggered the budget check, so the whole send is isolated here.
+        organization_id: str | None = None
         try:
             percentage = (current_spend / hard_budget * 100.0) if hard_budget and hard_budget > 0 else 0.0
             base_payload = {
@@ -73,6 +74,7 @@ class AlertService:
             recipients = await self.recipient_resolver.resolve_budget_recipients(
                 entity_type=entity_type, entity_id=entity_id
             )
+            organization_id = recipients.organization_id
             message = NotificationMessage(
                 alert_type="budget_threshold",
                 metric_kind="budget_threshold",
@@ -105,7 +107,7 @@ class AlertService:
                 audit_action=AuditAction.SYSTEM_BUDGET_NOTIFICATION_ENQUEUE.value,
                 resource_type=entity_type,
                 resource_id=entity_id,
-                organization_id=None,
+                organization_id=organization_id,
                 error=str(exc),
             )
 

--- a/src/bootstrap/runtime_services.py
+++ b/src/bootstrap/runtime_services.py
@@ -21,6 +21,7 @@ from src.mcp import (
 from src.notifications.channels import EmailChannel, SlackChannel
 from src.notifications.dispatcher import NotificationDispatcher
 from src.notifications.types import NotificationChannel
+from src.notifications.webhook import close_shared_client
 from src.services.callable_target_grants import CallableTargetGrantService
 from src.services.governance_invalidation import GovernanceInvalidationService
 from src.services.key_notifications import KeyNotificationService
@@ -161,3 +162,4 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
 async def shutdown_runtime_services(runtime: RuntimeServicesRuntime) -> None:
     await runtime.governance_invalidation_service.close()
     await runtime.callback_manager.shutdown()
+    await close_shared_client()

--- a/src/bootstrap/runtime_services.py
+++ b/src/bootstrap/runtime_services.py
@@ -18,6 +18,9 @@ from src.mcp import (
     MCPToolResultCache,
     StreamableHTTPMCPClient,
 )
+from src.notifications.channels import EmailChannel, SlackChannel
+from src.notifications.dispatcher import NotificationDispatcher
+from src.notifications.types import NotificationChannel
 from src.services.callable_target_grants import CallableTargetGrantService
 from src.services.governance_invalidation import GovernanceInvalidationService
 from src.services.key_notifications import KeyNotificationService
@@ -99,21 +102,37 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
 
     general_settings = getattr(cfg, "general_settings", None)
     app.state.notification_recipient_resolver = NotificationRecipientResolver(app.state.prisma_manager.client)
-    app.state.key_notification_service = KeyNotificationService(
-        outbox_service=getattr(app.state, "email_outbox_service", None),
-        recipient_resolver=app.state.notification_recipient_resolver,
+    budget_alert_ttl = int(getattr(general_settings, "budget_alert_ttl_seconds", 3600) or 3600)
+
+    channels: list[NotificationChannel] = []
+    email_outbox_service = getattr(app.state, "email_outbox_service", None)
+    if email_outbox_service is not None:
+        channels.append(EmailChannel(outbox_service=email_outbox_service))
+    if getattr(general_settings, "slack_alerting_enabled", False) and getattr(general_settings, "slack_webhook_url", None):
+        channels.append(
+            SlackChannel(
+                webhook_url=general_settings.slack_webhook_url,
+                allowed_alert_types=set(getattr(general_settings, "slack_alert_kinds", []) or []),
+            )
+        )
+
+    notification_dispatcher = NotificationDispatcher(
+        channels=channels,
+        redis_client=app.state.redis,
         audit_service=getattr(app.state, "audit_service", None),
+        dedupe_ttl_seconds=budget_alert_ttl,
+    )
+    app.state.notification_dispatcher = notification_dispatcher
+    app.state.key_notification_service = KeyNotificationService(
+        dispatcher=notification_dispatcher,
+        recipient_resolver=app.state.notification_recipient_resolver,
         config_getter=lambda: getattr(app.state, "app_config", cfg),
     )
     app.state.alert_service = AlertService(
-        redis_client=app.state.redis,
-        outbox_service=getattr(app.state, "email_outbox_service", None),
+        dispatcher=notification_dispatcher,
         recipient_resolver=app.state.notification_recipient_resolver,
-        audit_service=getattr(app.state, "audit_service", None),
         config_getter=lambda: getattr(app.state, "app_config", cfg),
-        config=AlertConfig(
-            budget_alert_ttl=int(getattr(general_settings, "budget_alert_ttl_seconds", 3600) or 3600),
-        ),
+        config=AlertConfig(budget_alert_ttl=budget_alert_ttl),
     )
     app.state.spend_ledger_service = SpendLedgerService(app.state.prisma_manager.client)
     app.state.spend_tracking_service = SpendTrackingService(

--- a/src/config.py
+++ b/src/config.py
@@ -561,6 +561,15 @@ class GeneralSettings(BaseModel):
             )
         if self.slack_alerting_enabled and self.slack_webhook_url is None:
             raise ValueError("slack_alerting_enabled requires slack_webhook_url to be set")
+        if self.slack_alerting_enabled:
+            from src.notifications.types import NOTIFICATION_ALERT_TYPES
+
+            unknown = [kind for kind in self.slack_alert_kinds if kind not in NOTIFICATION_ALERT_TYPES]
+            if unknown:
+                allowed = ", ".join(sorted(NOTIFICATION_ALERT_TYPES))
+                raise ValueError(
+                    f"slack_alert_kinds contains unknown alert types {unknown}; allowed values are: {allowed}"
+                )
         return self
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import yaml
-from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, Field, SecretStr, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from src.governance.access_groups import normalize_access_group_list
@@ -323,6 +323,9 @@ class GeneralSettings(BaseModel):
     budget_notifications_enabled: bool = False
     key_lifecycle_notifications_enabled: bool = False
     budget_alert_ttl_seconds: int = Field(default=3600, ge=60)
+    slack_alerting_enabled: bool = False
+    slack_webhook_url: SecretStr | None = None
+    slack_alert_kinds: list[str] = Field(default_factory=list)
     email_enabled: bool = False
     email_provider: Literal["smtp", "resend", "sendgrid"] = "smtp"
     email_from_address: str | None = None
@@ -556,6 +559,8 @@ class GeneralSettings(BaseModel):
             raise ValueError(
                 "batch scheduler shadow mode requires embeddings_batch_model_capacity_enabled=true"
             )
+        if self.slack_alerting_enabled and self.slack_webhook_url is None:
+            raise ValueError("slack_alerting_enabled requires slack_webhook_url to be set")
         return self
 
 

--- a/src/metrics/notifications.py
+++ b/src/metrics/notifications.py
@@ -6,14 +6,15 @@ from src.metrics.prometheus import get_prometheus_registry, sanitize_label
 
 deltallm_notification_enqueue_metric = Counter(
     "deltallm_notification_enqueue_total",
-    "Notification enqueue attempts by kind and status",
-    ["kind", "status"],
+    "Notification enqueue attempts by kind, channel and status",
+    ["kind", "channel", "status"],
     registry=get_prometheus_registry(),
 )
 
 
-def increment_notification_enqueue(*, kind: str, status: str) -> None:
+def increment_notification_enqueue(*, kind: str, status: str, channel: str = "email") -> None:
     deltallm_notification_enqueue_metric.labels(
         kind=sanitize_label(kind),
+        channel=sanitize_label(channel),
         status=sanitize_label(status),
     ).inc()

--- a/src/notifications/__init__.py
+++ b/src/notifications/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from src.notifications.dispatcher import NotificationDispatcher
+from src.notifications.preferences import (
+    GlobalConfigPreferenceResolver,
+    NotificationPreferenceResolver,
+)
+from src.notifications.types import (
+    ChannelResult,
+    NotificationChannel,
+    NotificationMessage,
+)
+
+__all__ = [
+    "ChannelResult",
+    "GlobalConfigPreferenceResolver",
+    "NotificationChannel",
+    "NotificationDispatcher",
+    "NotificationMessage",
+    "NotificationPreferenceResolver",
+]

--- a/src/notifications/channels/__init__.py
+++ b/src/notifications/channels/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from src.notifications.channels.email import EmailChannel
+from src.notifications.channels.slack import SlackChannel
+
+__all__ = ["EmailChannel", "SlackChannel"]

--- a/src/notifications/channels/email.py
+++ b/src/notifications/channels/email.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+
+from src.notifications.types import ChannelResult, NotificationMessage
+from src.services.email_outbox_service import EmailOutboxService, enqueue_succeeded
+from src.services.notification_recipients import NotificationRecipients
+
+logger = logging.getLogger(__name__)
+
+
+class EmailChannel:
+    """Delivers a notification by enqueueing a templated email.
+
+    Wraps `EmailOutboxService.enqueue_template_email`, preserving the exact
+    template key, payload, and outbox status semantics the producers used
+    before the dispatcher existed.
+    """
+
+    name = "email"
+
+    def __init__(self, *, outbox_service: EmailOutboxService) -> None:
+        self.outbox_service = outbox_service
+
+    def supports(self, alert_type: str) -> bool:
+        del alert_type
+        return True
+
+    async def send(
+        self,
+        *,
+        message: NotificationMessage,
+        recipients: NotificationRecipients,
+    ) -> ChannelResult:
+        if not recipients.emails:
+            return ChannelResult(outcome="no_recipients")
+
+        queued = await self.outbox_service.enqueue_template_email(
+            template_key=message.alert_type,
+            to_addresses=recipients.emails,
+            payload_json=message.payload,
+            kind="notification",
+            created_by_account_id=message.created_by_account_id,
+        )
+        if not enqueue_succeeded(queued):
+            return ChannelResult(
+                outcome="undeliverable",
+                detail={
+                    "email_id": queued.email_id,
+                    "outbox_status": getattr(queued, "status", None),
+                },
+            )
+        return ChannelResult(
+            outcome="queued",
+            detail={
+                "email_id": queued.email_id,
+                "recipient_count": len(recipients.emails),
+                "recipient_policy": recipients.policy,
+            },
+        )

--- a/src/notifications/channels/slack.py
+++ b/src/notifications/channels/slack.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+
+from pydantic import SecretStr
+
+from src.email.rendering import render_email_template
+from src.notifications.types import ChannelResult, NotificationMessage
+from src.notifications.webhook import post_webhook
+from src.services.notification_recipients import NotificationRecipients
+
+logger = logging.getLogger(__name__)
+
+
+class SlackChannel:
+    """Posts a notification to a Slack incoming webhook.
+
+    Reuses the channel-neutral `text_body` from the shared email renderer
+    rather than maintaining a parallel Slack template: only one alert type
+    reaches Slack in v1, and the plaintext body already reads cleanly in
+    Slack. Slack delivery does not depend on email recipients.
+    """
+
+    name = "slack"
+
+    def __init__(self, *, webhook_url: SecretStr, allowed_alert_types: set[str]) -> None:
+        self.webhook_url = webhook_url
+        self.allowed_alert_types = allowed_alert_types
+
+    def supports(self, alert_type: str) -> bool:
+        return alert_type in self.allowed_alert_types
+
+    async def send(
+        self,
+        *,
+        message: NotificationMessage,
+        recipients: NotificationRecipients,
+    ) -> ChannelResult:
+        del recipients
+        rendered = render_email_template(message.alert_type, message.payload)
+        text = f"*{rendered.subject}*\n{rendered.text_body}"
+        result = await post_webhook(url=self.webhook_url, json_body={"text": text})
+        if not result.ok:
+            return ChannelResult(
+                outcome="undeliverable",
+                detail={"status_code": result.status_code},
+                error=result.error,
+            )
+        return ChannelResult(outcome="queued", detail={"status_code": result.status_code})

--- a/src/notifications/dispatcher.py
+++ b/src/notifications/dispatcher.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Sequence
+
+from src.metrics import increment_notification_enqueue
+from src.notifications.preferences import GlobalConfigPreferenceResolver, NotificationPreferenceResolver
+from src.notifications.types import ChannelOutcome, ChannelResult, NotificationChannel, NotificationMessage
+from src.services.audit_service import AuditEventInput, AuditService
+from src.services.notification_recipients import NotificationRecipients
+
+logger = logging.getLogger(__name__)
+
+_METRIC_STATUS: dict[ChannelOutcome, str] = {
+    "queued": "queued",
+    "no_recipients": "no_recipients",
+    "undeliverable": "undeliverable",
+    "error": "error",
+}
+_AUDIT_STATUS: dict[ChannelOutcome, str] = {
+    "queued": "success",
+    "no_recipients": "skipped",
+    "undeliverable": "skipped",
+    "error": "error",
+}
+_SKIP_REASON: dict[ChannelOutcome, str] = {
+    "no_recipients": "no_recipients",
+    "undeliverable": "undeliverable",
+}
+
+
+class NotificationDispatcher:
+    """Fans a notification out to every applicable channel.
+
+    A single Redis dedupe slot (when `dedupe_key` is supplied) is claimed
+    before fan-out so all channels share one silence window. The slot is
+    released only when no channel achieved delivery; a partial success
+    (e.g. email queued but Slack failed) keeps the slot claimed.
+    """
+
+    def __init__(
+        self,
+        *,
+        channels: Sequence[NotificationChannel],
+        preference_resolver: NotificationPreferenceResolver | None = None,
+        redis_client: Any | None = None,
+        audit_service: AuditService | None = None,
+        dedupe_ttl_seconds: int = 3600,
+    ) -> None:
+        self.channels = list(channels)
+        self.preference_resolver = preference_resolver or GlobalConfigPreferenceResolver()
+        self.redis = redis_client
+        self.audit_service = audit_service
+        self.dedupe_ttl_seconds = dedupe_ttl_seconds
+
+    async def dispatch(
+        self,
+        *,
+        message: NotificationMessage,
+        recipients: NotificationRecipients,
+        audit_action: str,
+        resource_type: str,
+        resource_id: str,
+        organization_id: str | None = None,
+        dedupe_key: str | None = None,
+    ) -> None:
+        if dedupe_key is not None and not await self._claim_slot(dedupe_key):
+            increment_notification_enqueue(kind=message.metric_kind, channel="all", status="throttled")
+            return
+
+        targets = self.preference_resolver.channels_for(
+            alert_type=message.alert_type,
+            recipients=recipients,
+            channels=self.channels,
+        )
+
+        any_delivered = False
+        for channel in targets:
+            result = await self._send_one(channel=channel, message=message, recipients=recipients)
+            if result.outcome == "queued":
+                any_delivered = True
+            self._emit(
+                channel=channel.name,
+                message=message,
+                result=result,
+                audit_action=audit_action,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                organization_id=organization_id,
+            )
+
+        if dedupe_key is not None and not any_delivered:
+            await self._release_slot(dedupe_key)
+
+    async def record_skip(
+        self,
+        *,
+        message: NotificationMessage,
+        audit_action: str,
+        resource_type: str,
+        resource_id: str,
+        organization_id: str | None,
+        reason: str,
+        metric_status: str = "suppressed",
+    ) -> None:
+        """Record a producer-level decision not to dispatch (no channel involved)."""
+        increment_notification_enqueue(kind=message.metric_kind, channel="none", status=metric_status)
+        self._record_audit(
+            audit_action=audit_action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            organization_id=organization_id,
+            status="skipped",
+            metadata={"notification_kind": message.metric_kind, "reason": reason},
+        )
+
+    async def _send_one(
+        self,
+        *,
+        channel: NotificationChannel,
+        message: NotificationMessage,
+        recipients: NotificationRecipients,
+    ) -> ChannelResult:
+        try:
+            return await channel.send(message=message, recipients=recipients)
+        except Exception as exc:  # pragma: no cover - defensive, channel-isolated
+            logger.warning(
+                "notification channel raised",
+                extra={"channel": channel.name, "notification_kind": message.metric_kind, "error": str(exc)},
+            )
+            return ChannelResult(outcome="error", error=str(exc))
+
+    def _emit(
+        self,
+        *,
+        channel: str,
+        message: NotificationMessage,
+        result: ChannelResult,
+        audit_action: str,
+        resource_type: str,
+        resource_id: str,
+        organization_id: str | None,
+    ) -> None:
+        increment_notification_enqueue(
+            kind=message.metric_kind,
+            channel=channel,
+            status=_METRIC_STATUS[result.outcome],
+        )
+        metadata: dict[str, Any] = {
+            "notification_kind": message.metric_kind,
+            "channel": channel,
+            **result.detail,
+        }
+        reason = _SKIP_REASON.get(result.outcome)
+        if reason is not None:
+            metadata.setdefault("reason", reason)
+        self._record_audit(
+            audit_action=audit_action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            organization_id=organization_id,
+            status=_AUDIT_STATUS[result.outcome],
+            metadata=metadata,
+            error=result.error,
+        )
+
+    def _record_audit(
+        self,
+        *,
+        audit_action: str,
+        resource_type: str,
+        resource_id: str,
+        organization_id: str | None,
+        status: str,
+        metadata: dict[str, Any],
+        error: str | None = None,
+    ) -> None:
+        if self.audit_service is None:
+            return
+        self.audit_service.record_event(
+            AuditEventInput(
+                action=audit_action,
+                actor_type="system",
+                organization_id=organization_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                status=status,
+                error_type="NotificationEnqueueError" if error else None,
+                metadata={**metadata, "error": error},
+            ),
+            critical=False,
+        )
+
+    async def _claim_slot(self, key: str) -> bool:
+        if self.redis is None:
+            return True
+        if hasattr(self.redis, "set"):
+            claimed = await self.redis.set(key, "1", ex=self.dedupe_ttl_seconds, nx=True)
+            return bool(claimed)
+        if await self.redis.exists(key):
+            return False
+        await self.redis.setex(key, self.dedupe_ttl_seconds, "1")
+        return True
+
+    async def _release_slot(self, key: str) -> None:
+        if self.redis is None or not hasattr(self.redis, "delete"):
+            return
+        await self.redis.delete(key)

--- a/src/notifications/dispatcher.py
+++ b/src/notifications/dispatcher.py
@@ -32,10 +32,12 @@ _SKIP_REASON: dict[ChannelOutcome, str] = {
 class NotificationDispatcher:
     """Fans a notification out to every applicable channel.
 
-    A single Redis dedupe slot (when `dedupe_key` is supplied) is claimed
-    before fan-out so all channels share one silence window. The slot is
-    released only when no channel achieved delivery; a partial success
-    (e.g. email queued but Slack failed) keeps the slot claimed.
+    Dedupe is the producer's responsibility via `try_claim`/`release`: a budget
+    alert claims a single shared Redis slot before resolving recipients or
+    dispatching, so a throttled alert does no extra work. Any one channel
+    achieving delivery holds that one silence window for all channels (so a
+    Slack-only success with no email recipients keeps the slot claimed); the
+    producer releases the slot only when `dispatch` reports nothing delivered.
     """
 
     def __init__(
@@ -62,12 +64,13 @@ class NotificationDispatcher:
         resource_type: str,
         resource_id: str,
         organization_id: str | None = None,
-        dedupe_key: str | None = None,
-    ) -> None:
-        if dedupe_key is not None and not await self._claim_slot(dedupe_key):
-            increment_notification_enqueue(kind=message.metric_kind, channel="all", status="throttled")
-            return
+    ) -> bool:
+        """Fan a message out to every applicable channel.
 
+        Returns True if at least one channel achieved delivery. Emitting metrics
+        and audit rows for a channel must never abort the fan-out, so those are
+        isolated per channel.
+        """
         targets = self.preference_resolver.channels_for(
             alert_type=message.alert_type,
             recipients=recipients,
@@ -79,18 +82,19 @@ class NotificationDispatcher:
             result = await self._send_one(channel=channel, message=message, recipients=recipients)
             if result.outcome == "queued":
                 any_delivered = True
-            self._emit(
-                channel=channel.name,
-                message=message,
-                result=result,
-                audit_action=audit_action,
-                resource_type=resource_type,
-                resource_id=resource_id,
-                organization_id=organization_id,
-            )
-
-        if dedupe_key is not None and not any_delivered:
-            await self._release_slot(dedupe_key)
+            try:
+                self._emit(
+                    channel=channel.name,
+                    message=message,
+                    result=result,
+                    audit_action=audit_action,
+                    resource_type=resource_type,
+                    resource_id=resource_id,
+                    organization_id=organization_id,
+                )
+            except Exception:  # pragma: no cover - metrics/audit must never break fan-out
+                logger.exception("notification emit failed", extra={"channel": channel.name})
+        return any_delivered
 
     async def record_skip(
         self,
@@ -112,6 +116,33 @@ class NotificationDispatcher:
             organization_id=organization_id,
             status="skipped",
             metadata={"notification_kind": message.metric_kind, "reason": reason},
+        )
+
+    async def record_error(
+        self,
+        *,
+        metric_kind: str,
+        audit_action: str,
+        resource_type: str,
+        resource_id: str,
+        organization_id: str | None,
+        error: str,
+    ) -> None:
+        """Record a producer-level failure (e.g. recipient resolution raised).
+
+        Keeps notification failures off the caller's path: the producer catches
+        the exception, calls this, and swallows it so the originating request is
+        unaffected.
+        """
+        increment_notification_enqueue(kind=metric_kind, channel="none", status="error")
+        self._record_audit(
+            audit_action=audit_action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            organization_id=organization_id,
+            status="error",
+            metadata={"notification_kind": metric_kind, "reason": "exception"},
+            error=error,
         )
 
     async def _send_one(
@@ -191,7 +222,8 @@ class NotificationDispatcher:
             critical=False,
         )
 
-    async def _claim_slot(self, key: str) -> bool:
+    async def try_claim(self, key: str) -> bool:
+        """Claim a dedupe slot. Returns True if claimed, False if already held."""
         if self.redis is None:
             return True
         if hasattr(self.redis, "set"):
@@ -202,7 +234,7 @@ class NotificationDispatcher:
         await self.redis.setex(key, self.dedupe_ttl_seconds, "1")
         return True
 
-    async def _release_slot(self, key: str) -> None:
+    async def release(self, key: str) -> None:
         if self.redis is None or not hasattr(self.redis, "delete"):
             return
         await self.redis.delete(key)

--- a/src/notifications/dispatcher.py
+++ b/src/notifications/dispatcher.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Sequence
+from typing import Any, Literal, Sequence
 
 from src.metrics import increment_notification_enqueue
 from src.notifications.preferences import GlobalConfigPreferenceResolver, NotificationPreferenceResolver
@@ -10,6 +10,8 @@ from src.services.audit_service import AuditEventInput, AuditService
 from src.services.notification_recipients import NotificationRecipients
 
 logger = logging.getLogger(__name__)
+
+ClaimOutcome = Literal["claimed", "held", "unavailable"]
 
 _METRIC_STATUS: dict[ChannelOutcome, str] = {
     "queued": "queued",
@@ -222,26 +224,28 @@ class NotificationDispatcher:
             critical=False,
         )
 
-    async def try_claim(self, key: str) -> bool:
-        """Claim a dedupe slot. Returns True if claimed, False if already held.
+    async def try_claim(self, key: str) -> ClaimOutcome:
+        """Claim a dedupe slot.
 
-        Fails closed: a Redis error returns False (skip the alert this round)
-        rather than raising, so a notification never breaks the request that
-        triggered it.
+        Returns "claimed" if the slot was taken, "held" if a live slot already
+        exists (genuine throttle), or "unavailable" if Redis errored. Fails
+        closed: an error never raises, so a notification can't break the request
+        that triggered it, and the caller can report the outage distinctly from
+        a normal throttle.
         """
         if self.redis is None:
-            return True
+            return "claimed"
         try:
             if hasattr(self.redis, "set"):
                 claimed = await self.redis.set(key, "1", ex=self.dedupe_ttl_seconds, nx=True)
-                return bool(claimed)
+                return "claimed" if claimed else "held"
             if await self.redis.exists(key):
-                return False
+                return "held"
             await self.redis.setex(key, self.dedupe_ttl_seconds, "1")
-            return True
+            return "claimed"
         except Exception:
             logger.warning("notification dedupe claim failed; skipping alert", extra={"key": key})
-            return False
+            return "unavailable"
 
     async def release(self, key: str) -> None:
         if self.redis is None or not hasattr(self.redis, "delete"):

--- a/src/notifications/dispatcher.py
+++ b/src/notifications/dispatcher.py
@@ -223,18 +223,30 @@ class NotificationDispatcher:
         )
 
     async def try_claim(self, key: str) -> bool:
-        """Claim a dedupe slot. Returns True if claimed, False if already held."""
+        """Claim a dedupe slot. Returns True if claimed, False if already held.
+
+        Fails closed: a Redis error returns False (skip the alert this round)
+        rather than raising, so a notification never breaks the request that
+        triggered it.
+        """
         if self.redis is None:
             return True
-        if hasattr(self.redis, "set"):
-            claimed = await self.redis.set(key, "1", ex=self.dedupe_ttl_seconds, nx=True)
-            return bool(claimed)
-        if await self.redis.exists(key):
+        try:
+            if hasattr(self.redis, "set"):
+                claimed = await self.redis.set(key, "1", ex=self.dedupe_ttl_seconds, nx=True)
+                return bool(claimed)
+            if await self.redis.exists(key):
+                return False
+            await self.redis.setex(key, self.dedupe_ttl_seconds, "1")
+            return True
+        except Exception:
+            logger.warning("notification dedupe claim failed; skipping alert", extra={"key": key})
             return False
-        await self.redis.setex(key, self.dedupe_ttl_seconds, "1")
-        return True
 
     async def release(self, key: str) -> None:
         if self.redis is None or not hasattr(self.redis, "delete"):
             return
-        await self.redis.delete(key)
+        try:
+            await self.redis.delete(key)
+        except Exception:
+            logger.warning("notification dedupe release failed", extra={"key": key})

--- a/src/notifications/preferences.py
+++ b/src/notifications/preferences.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Protocol, Sequence
+
+from src.notifications.types import NotificationChannel
+from src.services.notification_recipients import NotificationRecipients
+
+
+class NotificationPreferenceResolver(Protocol):
+    """Decides which channels receive a given alert.
+
+    The signature already accepts `recipients`, so a future org-scoped resolver
+    can read per-organization preferences keyed on
+    `recipients.organization_id` without changing producers or channels.
+    """
+
+    def channels_for(
+        self,
+        *,
+        alert_type: str,
+        recipients: NotificationRecipients,
+        channels: Sequence[NotificationChannel],
+    ) -> list[NotificationChannel]: ...
+
+
+class GlobalConfigPreferenceResolver:
+    """v1 resolver: a channel applies when it declares support for the alert type.
+
+    Channel-level enablement (global flags, webhook configured) is already
+    decided at construction time in bootstrap, so by the time a channel is in
+    the list it is enabled; here we only filter on the per-channel kind
+    allowlist via `channel.supports(...)`.
+    """
+
+    def channels_for(
+        self,
+        *,
+        alert_type: str,
+        recipients: NotificationRecipients,
+        channels: Sequence[NotificationChannel],
+    ) -> list[NotificationChannel]:
+        del recipients
+        return [channel for channel in channels if channel.supports(alert_type)]

--- a/src/notifications/types.py
+++ b/src/notifications/types.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol, runtime_checkable
+
+from src.services.notification_recipients import NotificationRecipients
+
+ChannelOutcome = Literal["queued", "no_recipients", "undeliverable", "error"]
+
+
+@dataclass(frozen=True)
+class NotificationMessage:
+    """A channel-neutral notification ready to be fanned out.
+
+    `alert_type` is the routing key: it doubles as the email template key and is
+    what channel allowlists match against (e.g. "budget_threshold",
+    "api_key_lifecycle"). `metric_kind` is the granular label used for metrics
+    and audit (e.g. "budget_threshold" or "api_key_created"), preserving the
+    existing per-event metric cardinality.
+    """
+
+    alert_type: str
+    metric_kind: str
+    payload: dict[str, Any]
+    created_by_account_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ChannelResult:
+    outcome: ChannelOutcome
+    detail: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+@runtime_checkable
+class NotificationChannel(Protocol):
+    name: str
+
+    def supports(self, alert_type: str) -> bool: ...
+
+    async def send(
+        self,
+        *,
+        message: NotificationMessage,
+        recipients: NotificationRecipients,
+    ) -> ChannelResult: ...

--- a/src/notifications/types.py
+++ b/src/notifications/types.py
@@ -7,6 +7,11 @@ from src.services.notification_recipients import NotificationRecipients
 
 ChannelOutcome = Literal["queued", "no_recipients", "undeliverable", "error"]
 
+# Routing keys a channel allowlist (e.g. Slack `slack_alert_kinds`) can target.
+# These are `alert_type` values, distinct from the granular `metric_kind`
+# (e.g. "api_key_created") used for metrics and audit.
+NOTIFICATION_ALERT_TYPES: frozenset[str] = frozenset({"budget_threshold", "api_key_lifecycle"})
+
 
 @dataclass(frozen=True)
 class NotificationMessage:

--- a/src/notifications/webhook.py
+++ b/src/notifications/webhook.py
@@ -30,6 +30,14 @@ def _get_shared_client(timeout_seconds: float) -> httpx.AsyncClient:
     return _shared_client
 
 
+async def close_shared_client() -> None:
+    """Close the module-global webhook client on app shutdown."""
+    global _shared_client
+    if _shared_client is not None and not _shared_client.is_closed:
+        await _shared_client.aclose()
+    _shared_client = None
+
+
 async def post_webhook(
     *,
     url: SecretStr,

--- a/src/notifications/webhook.py
+++ b/src/notifications/webhook.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from pydantic import SecretStr
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_SECONDS = 5.0
+_shared_client: httpx.AsyncClient | None = None
+
+
+@dataclass(frozen=True)
+class WebhookResult:
+    ok: bool
+    status_code: int | None = None
+    error: str | None = None
+
+
+def _get_shared_client(timeout_seconds: float) -> httpx.AsyncClient:
+    global _shared_client
+    if _shared_client is None or _shared_client.is_closed:
+        _shared_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout_seconds),
+            limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
+        )
+    return _shared_client
+
+
+async def post_webhook(
+    *,
+    url: SecretStr,
+    json_body: dict[str, Any],
+    client: httpx.AsyncClient | None = None,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> WebhookResult:
+    """POST a JSON body to a webhook, with one retry. Never raises.
+
+    The secret URL is dereferenced only for the request and is never placed in
+    logs, so it stays redacted.
+    """
+    http = client or _get_shared_client(timeout_seconds)
+    target = url.get_secret_value()
+    last_error: str | None = None
+    for attempt in range(2):
+        try:
+            response = await http.post(target, json=json_body)
+            if response.status_code >= 500:
+                last_error = f"http_{response.status_code}"
+                continue
+            ok = response.status_code < 400
+            return WebhookResult(ok=ok, status_code=response.status_code, error=None if ok else f"http_{response.status_code}")
+        except httpx.HTTPError as exc:
+            last_error = type(exc).__name__
+            logger.warning("webhook post failed", extra={"attempt": attempt, "error": last_error})
+    return WebhookResult(ok=False, status_code=None, error=last_error)

--- a/src/services/key_notifications.py
+++ b/src/services/key_notifications.py
@@ -5,9 +5,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from src.audit.actions import AuditAction
-from src.metrics import increment_notification_enqueue
-from src.services.audit_service import AuditEventInput, AuditService
-from src.services.email_outbox_service import EmailOutboxService, enqueue_succeeded
+from src.notifications.dispatcher import NotificationDispatcher
+from src.notifications.types import NotificationMessage
 from src.services.notification_recipients import NotificationRecipientResolver
 
 logger = logging.getLogger(__name__)
@@ -29,14 +28,12 @@ class KeyNotificationService:
     def __init__(
         self,
         *,
-        outbox_service: EmailOutboxService | None,
+        dispatcher: NotificationDispatcher,
         recipient_resolver: NotificationRecipientResolver | None,
-        audit_service: AuditService | None = None,
         config_getter=None,  # noqa: ANN001
     ) -> None:
-        self.outbox_service = outbox_service
+        self.dispatcher = dispatcher
         self.recipient_resolver = recipient_resolver
-        self.audit_service = audit_service
         self._config_getter = config_getter
 
     async def notify_lifecycle(
@@ -48,109 +45,63 @@ class KeyNotificationService:
     ) -> None:
         if not self._notifications_enabled():
             return
-        if self.outbox_service is None or self.recipient_resolver is None:
+        if self.recipient_resolver is None:
             return
+
         if actor_account_id and record.owner_account_id and actor_account_id == record.owner_account_id:
-            increment_notification_enqueue(kind=event_kind, status="suppressed")
-            await self._record_audit(
-                record=record,
-                status="skipped",
-                metadata={"notification_kind": event_kind, "reason": "actor_is_owner"},
+            await self.dispatcher.record_skip(
+                message=self._message(event_kind=event_kind, payload={}),
+                audit_action=AuditAction.SYSTEM_KEY_NOTIFICATION_ENQUEUE.value,
+                resource_type="api_key",
+                resource_id=record.token_hash,
+                organization_id=record.organization_id,
+                reason="actor_is_owner",
             )
             return
 
-        try:
-            recipients = await self.recipient_resolver.resolve_key_lifecycle_recipients(
-                owner_account_id=record.owner_account_id,
-                team_id=record.team_id,
-                organization_id=record.organization_id,
-            )
-            if not recipients.emails:
-                increment_notification_enqueue(kind=event_kind, status="no_recipients")
-                await self._record_audit(
-                    record=record,
-                    status="skipped",
-                    metadata={"notification_kind": event_kind, "reason": "no_recipients"},
-                )
-                return
+        recipients = await self.recipient_resolver.resolve_key_lifecycle_recipients(
+            owner_account_id=record.owner_account_id,
+            team_id=record.team_id,
+            organization_id=record.organization_id,
+        )
+        actor_email = await self.recipient_resolver.get_account_email(actor_account_id)
+        message = self._message(
+            event_kind=event_kind,
+            payload={
+                "instance_name": self._instance_name(),
+                "event_kind": event_kind,
+                "event_label": _event_label(event_kind),
+                "key_name": record.key_name,
+                "team_name": record.team_alias or record.team_id or "unknown team",
+                "organization_id": record.organization_id,
+                "actor_email": actor_email or "an administrator",
+                "recipient_policy": recipients.policy,
+                "owner_label": record.owner_service_account_name or "account owner",
+            },
+            created_by_account_id=actor_account_id,
+        )
+        await self.dispatcher.dispatch(
+            message=message,
+            recipients=recipients,
+            audit_action=AuditAction.SYSTEM_KEY_NOTIFICATION_ENQUEUE.value,
+            resource_type="api_key",
+            resource_id=record.token_hash,
+            organization_id=record.organization_id,
+        )
 
-            actor_email = await self.recipient_resolver.get_account_email(actor_account_id)
-            queued = await self.outbox_service.enqueue_template_email(
-                template_key="api_key_lifecycle",
-                to_addresses=recipients.emails,
-                payload_json={
-                    "instance_name": self._instance_name(),
-                    "event_kind": event_kind,
-                    "event_label": _event_label(event_kind),
-                    "key_name": record.key_name,
-                    "team_name": record.team_alias or record.team_id or "unknown team",
-                    "organization_id": record.organization_id,
-                    "actor_email": actor_email or "an administrator",
-                    "recipient_policy": recipients.policy,
-                    "owner_label": record.owner_service_account_name or "account owner",
-                },
-                kind="notification",
-                created_by_account_id=actor_account_id,
-            )
-            if not enqueue_succeeded(queued):
-                increment_notification_enqueue(kind=event_kind, status="undeliverable")
-                logger.info(
-                    "key lifecycle notification skipped; email not queueable",
-                    extra={
-                        "notification_kind": event_kind,
-                        "email_id": queued.email_id,
-                        "outbox_status": getattr(queued, "status", None),
-                        "resource_id": record.token_hash,
-                    },
-                )
-                await self._record_audit(
-                    record=record,
-                    status="skipped",
-                    metadata={
-                        "notification_kind": event_kind,
-                        "email_id": queued.email_id,
-                        "reason": "undeliverable",
-                        "outbox_status": getattr(queued, "status", None),
-                    },
-                )
-                return
-            increment_notification_enqueue(kind=event_kind, status="queued")
-            logger.info(
-                "key lifecycle notification queued",
-                extra={
-                    "notification_kind": event_kind,
-                    "email_id": queued.email_id,
-                    "recipient_count": len(recipients.emails),
-                    "recipient_policy": recipients.policy,
-                    "resource_id": record.token_hash,
-                },
-            )
-            await self._record_audit(
-                record=record,
-                status="success",
-                metadata={
-                    "notification_kind": event_kind,
-                    "email_id": queued.email_id,
-                    "recipient_count": len(recipients.emails),
-                    "recipient_policy": recipients.policy,
-                },
-            )
-        except Exception as exc:  # pragma: no cover - defensive path
-            increment_notification_enqueue(kind=event_kind, status="error")
-            logger.warning(
-                "key lifecycle notification failed",
-                extra={
-                    "notification_kind": event_kind,
-                    "resource_id": record.token_hash,
-                    "error": str(exc),
-                },
-            )
-            await self._record_audit(
-                record=record,
-                status="error",
-                metadata={"notification_kind": event_kind},
-                error=str(exc),
-            )
+    def _message(
+        self,
+        *,
+        event_kind: str,
+        payload: dict[str, Any],
+        created_by_account_id: str | None = None,
+    ) -> NotificationMessage:
+        return NotificationMessage(
+            alert_type="api_key_lifecycle",
+            metric_kind=event_kind,
+            payload=payload,
+            created_by_account_id=created_by_account_id,
+        )
 
     def _notifications_enabled(self) -> bool:
         cfg = self._current_config()
@@ -171,30 +122,6 @@ class KeyNotificationService:
         cfg = self._current_config()
         general = getattr(cfg, "general_settings", None)
         return str(getattr(general, "instance_name", "DeltaLLM") or "DeltaLLM")
-
-    async def _record_audit(
-        self,
-        *,
-        record: KeyNotificationRecord,
-        status: str,
-        metadata: dict[str, Any],
-        error: str | None = None,
-    ) -> None:
-        if self.audit_service is None:
-            return
-        self.audit_service.record_event(
-            AuditEventInput(
-                action=AuditAction.SYSTEM_KEY_NOTIFICATION_ENQUEUE.value,
-                actor_type="system",
-                organization_id=record.organization_id,
-                resource_type="api_key",
-                resource_id=record.token_hash,
-                status=status,
-                error_type="NotificationEnqueueError" if error else None,
-                metadata={**metadata, "error": error},
-            ),
-            critical=False,
-        )
 
 
 def _event_label(event_kind: str) -> str:

--- a/tests/notifications/test_dispatcher.py
+++ b/tests/notifications/test_dispatcher.py
@@ -15,7 +15,7 @@ class _FakeRedis:
 
     async def set(self, key: str, value: str, *, ex: int | None = None, nx: bool | None = None):  # noqa: ANN201
         if nx and key in self.values:
-            return False
+            return None  # redis-py returns None when an nx claim fails
         self.values[key] = value
         return True
 
@@ -160,6 +160,30 @@ async def test_try_claim_throttles_repeat_within_window() -> None:
     await dispatcher.release("alert:budget:team:team-1")
     assert "alert:budget:team:team-1" in redis.deleted
     assert await dispatcher.try_claim("alert:budget:team:team-1") is True
+
+
+class _RaisingRedis:
+    async def set(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+        raise ConnectionError("redis down")
+
+    async def delete(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+        raise ConnectionError("redis down")
+
+
+@pytest.mark.asyncio
+async def test_try_claim_fails_closed_on_redis_error() -> None:
+    dispatcher = NotificationDispatcher(channels=[], redis_client=_RaisingRedis())
+
+    # Must not raise into the caller; a Redis error means "skip the alert".
+    assert await dispatcher.try_claim("alert:budget:team:team-1") is False
+
+
+@pytest.mark.asyncio
+async def test_release_swallows_redis_error() -> None:
+    dispatcher = NotificationDispatcher(channels=[], redis_client=_RaisingRedis())
+
+    # Must not raise into the caller.
+    await dispatcher.release("alert:budget:team:team-1")
 
 
 @pytest.mark.asyncio

--- a/tests/notifications/test_dispatcher.py
+++ b/tests/notifications/test_dispatcher.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import pytest
+
+from src.notifications.dispatcher import NotificationDispatcher
+from src.notifications.preferences import NotificationPreferenceResolver
+from src.notifications.types import ChannelResult, NotificationMessage
+from src.services.notification_recipients import NotificationRecipients
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.deleted: list[str] = []
+
+    async def set(self, key: str, value: str, *, ex: int | None = None, nx: bool | None = None):  # noqa: ANN201
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    async def delete(self, key: str) -> None:
+        self.values.pop(key, None)
+        self.deleted.append(key)
+
+
+class _FakeAuditService:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+
+    def record_event(self, event, *, payloads=None, critical=False) -> None:  # noqa: ANN001, ANN003
+        del payloads, critical
+        self.events.append(event)
+
+
+class _FakeChannel:
+    def __init__(self, name: str, *, outcome: str = "queued", supports_types=None, raises: bool = False) -> None:
+        self.name = name
+        self._outcome = outcome
+        self._supports = supports_types
+        self.raises = raises
+        self.calls: list[NotificationMessage] = []
+
+    def supports(self, alert_type: str) -> bool:
+        return True if self._supports is None else alert_type in self._supports
+
+    async def send(self, *, message: NotificationMessage, recipients: NotificationRecipients) -> ChannelResult:
+        self.calls.append(message)
+        if self.raises:
+            raise RuntimeError("boom")
+        return ChannelResult(outcome=self._outcome)  # type: ignore[arg-type]
+
+
+def _message() -> NotificationMessage:
+    return NotificationMessage(alert_type="budget_threshold", metric_kind="budget_threshold", payload={})
+
+
+def _recipients(emails: tuple[str, ...] = ("a@example.com",)) -> NotificationRecipients:
+    return NotificationRecipients(emails=emails, policy="test", organization_id="org-1")
+
+
+async def _dispatch(dispatcher: NotificationDispatcher, *, dedupe_key=None) -> None:
+    await dispatcher.dispatch(
+        message=_message(),
+        recipients=_recipients(),
+        audit_action="system.budget_notification.enqueue",
+        resource_type="team",
+        resource_id="team-1",
+        dedupe_key=dedupe_key,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_fans_out_to_supporting_channels() -> None:
+    email = _FakeChannel("email")
+    slack = _FakeChannel("slack", supports_types={"budget_threshold"})
+    dispatcher = NotificationDispatcher(channels=[email, slack])
+
+    await _dispatch(dispatcher)
+
+    assert len(email.calls) == 1
+    assert len(slack.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_channel_when_alert_type_not_allowed() -> None:
+    email = _FakeChannel("email")
+    slack = _FakeChannel("slack", supports_types={"api_key_lifecycle"})
+    dispatcher = NotificationDispatcher(channels=[email, slack])
+
+    await _dispatch(dispatcher)
+
+    assert len(email.calls) == 1
+    assert slack.calls == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_isolates_channel_failures() -> None:
+    redis = _FakeRedis()
+    email = _FakeChannel("email", outcome="queued")
+    slack = _FakeChannel("slack", supports_types={"budget_threshold"}, raises=True)
+    audit = _FakeAuditService()
+    dispatcher = NotificationDispatcher(channels=[email, slack], redis_client=redis, audit_service=audit)
+
+    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
+
+    assert len(email.calls) == 1
+    assert len(slack.calls) == 1
+    # email delivered, so the dedupe slot is retained despite the slack failure
+    assert redis.deleted == []
+    statuses = {event.metadata["channel"]: event.status for event in audit.events}
+    assert statuses == {"email": "success", "slack": "error"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_slack_fires_when_email_has_no_recipients() -> None:
+    redis = _FakeRedis()
+    email = _FakeChannel("email", outcome="no_recipients")
+    slack = _FakeChannel("slack", supports_types={"budget_threshold"}, outcome="queued")
+    dispatcher = NotificationDispatcher(channels=[email, slack], redis_client=redis)
+
+    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
+
+    assert len(slack.calls) == 1
+    # slack delivered, so the slot stays claimed
+    assert redis.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_releases_slot_when_no_channel_delivers() -> None:
+    redis = _FakeRedis()
+    email = _FakeChannel("email", outcome="no_recipients")
+    dispatcher = NotificationDispatcher(channels=[email], redis_client=redis)
+
+    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
+
+    assert "alert:budget:team:team-1" in redis.deleted
+
+
+@pytest.mark.asyncio
+async def test_dispatch_throttles_repeat_within_window() -> None:
+    redis = _FakeRedis()
+    email = _FakeChannel("email")
+    dispatcher = NotificationDispatcher(channels=[email], redis_client=redis)
+
+    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
+    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
+
+    assert len(email.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_preference_resolver_can_filter_channels() -> None:
+    class _EmailOnlyResolver:
+        def channels_for(self, *, alert_type, recipients, channels):  # noqa: ANN001, ANN003
+            del alert_type, recipients
+            return [c for c in channels if c.name == "email"]
+
+    email = _FakeChannel("email")
+    slack = _FakeChannel("slack", supports_types={"budget_threshold"})
+    resolver: NotificationPreferenceResolver = _EmailOnlyResolver()
+    dispatcher = NotificationDispatcher(channels=[email, slack], preference_resolver=resolver)
+
+    await _dispatch(dispatcher)
+
+    assert len(email.calls) == 1
+    assert slack.calls == []

--- a/tests/notifications/test_dispatcher.py
+++ b/tests/notifications/test_dispatcher.py
@@ -59,14 +59,13 @@ def _recipients(emails: tuple[str, ...] = ("a@example.com",)) -> NotificationRec
     return NotificationRecipients(emails=emails, policy="test", organization_id="org-1")
 
 
-async def _dispatch(dispatcher: NotificationDispatcher, *, dedupe_key=None) -> None:
-    await dispatcher.dispatch(
+async def _dispatch(dispatcher: NotificationDispatcher) -> bool:
+    return await dispatcher.dispatch(
         message=_message(),
         recipients=_recipients(),
         audit_action="system.budget_notification.enqueue",
         resource_type="team",
         resource_id="team-1",
-        dedupe_key=dedupe_key,
     )
 
 
@@ -96,57 +95,71 @@ async def test_dispatch_skips_channel_when_alert_type_not_allowed() -> None:
 
 @pytest.mark.asyncio
 async def test_dispatch_isolates_channel_failures() -> None:
-    redis = _FakeRedis()
     email = _FakeChannel("email", outcome="queued")
     slack = _FakeChannel("slack", supports_types={"budget_threshold"}, raises=True)
     audit = _FakeAuditService()
-    dispatcher = NotificationDispatcher(channels=[email, slack], redis_client=redis, audit_service=audit)
+    dispatcher = NotificationDispatcher(channels=[email, slack], audit_service=audit)
 
-    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
+    delivered = await _dispatch(dispatcher)
 
     assert len(email.calls) == 1
     assert len(slack.calls) == 1
-    # email delivered, so the dedupe slot is retained despite the slack failure
-    assert redis.deleted == []
+    # email delivered despite the slack failure, so dispatch reports delivery
+    assert delivered is True
     statuses = {event.metadata["channel"]: event.status for event in audit.events}
     assert statuses == {"email": "success", "slack": "error"}
 
 
 @pytest.mark.asyncio
-async def test_dispatch_slack_fires_when_email_has_no_recipients() -> None:
-    redis = _FakeRedis()
+async def test_dispatch_reports_delivery_when_only_slack_succeeds() -> None:
     email = _FakeChannel("email", outcome="no_recipients")
     slack = _FakeChannel("slack", supports_types={"budget_threshold"}, outcome="queued")
-    dispatcher = NotificationDispatcher(channels=[email, slack], redis_client=redis)
+    dispatcher = NotificationDispatcher(channels=[email, slack])
 
-    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
+    delivered = await _dispatch(dispatcher)
 
     assert len(slack.calls) == 1
-    # slack delivered, so the slot stays claimed
-    assert redis.deleted == []
+    # slack delivered, so the producer keeps the shared dedupe slot claimed
+    assert delivered is True
 
 
 @pytest.mark.asyncio
-async def test_dispatch_releases_slot_when_no_channel_delivers() -> None:
-    redis = _FakeRedis()
+async def test_dispatch_reports_no_delivery_when_no_channel_delivers() -> None:
     email = _FakeChannel("email", outcome="no_recipients")
-    dispatcher = NotificationDispatcher(channels=[email], redis_client=redis)
+    dispatcher = NotificationDispatcher(channels=[email])
 
-    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
+    delivered = await _dispatch(dispatcher)
 
-    assert "alert:budget:team:team-1" in redis.deleted
+    assert delivered is False
 
 
 @pytest.mark.asyncio
-async def test_dispatch_throttles_repeat_within_window() -> None:
-    redis = _FakeRedis()
-    email = _FakeChannel("email")
-    dispatcher = NotificationDispatcher(channels=[email], redis_client=redis)
+async def test_emit_failure_does_not_abort_fan_out_or_lose_delivery() -> None:
+    class _ExplodingAudit:
+        def record_event(self, event, *, payloads=None, critical=False):  # noqa: ANN001, ANN003
+            raise RuntimeError("audit down")
 
-    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
-    await _dispatch(dispatcher, dedupe_key="alert:budget:team:team-1")
+    email = _FakeChannel("email", outcome="queued")
+    slack = _FakeChannel("slack", supports_types={"budget_threshold"}, outcome="queued")
+    dispatcher = NotificationDispatcher(channels=[email, slack], audit_service=_ExplodingAudit())
+
+    delivered = await _dispatch(dispatcher)
 
     assert len(email.calls) == 1
+    assert len(slack.calls) == 1
+    assert delivered is True
+
+
+@pytest.mark.asyncio
+async def test_try_claim_throttles_repeat_within_window() -> None:
+    redis = _FakeRedis()
+    dispatcher = NotificationDispatcher(channels=[], redis_client=redis)
+
+    assert await dispatcher.try_claim("alert:budget:team:team-1") is True
+    assert await dispatcher.try_claim("alert:budget:team:team-1") is False
+    await dispatcher.release("alert:budget:team:team-1")
+    assert "alert:budget:team:team-1" in redis.deleted
+    assert await dispatcher.try_claim("alert:budget:team:team-1") is True
 
 
 @pytest.mark.asyncio

--- a/tests/notifications/test_dispatcher.py
+++ b/tests/notifications/test_dispatcher.py
@@ -155,11 +155,11 @@ async def test_try_claim_throttles_repeat_within_window() -> None:
     redis = _FakeRedis()
     dispatcher = NotificationDispatcher(channels=[], redis_client=redis)
 
-    assert await dispatcher.try_claim("alert:budget:team:team-1") is True
-    assert await dispatcher.try_claim("alert:budget:team:team-1") is False
+    assert await dispatcher.try_claim("alert:budget:team:team-1") == "claimed"
+    assert await dispatcher.try_claim("alert:budget:team:team-1") == "held"
     await dispatcher.release("alert:budget:team:team-1")
     assert "alert:budget:team:team-1" in redis.deleted
-    assert await dispatcher.try_claim("alert:budget:team:team-1") is True
+    assert await dispatcher.try_claim("alert:budget:team:team-1") == "claimed"
 
 
 class _RaisingRedis:
@@ -174,8 +174,9 @@ class _RaisingRedis:
 async def test_try_claim_fails_closed_on_redis_error() -> None:
     dispatcher = NotificationDispatcher(channels=[], redis_client=_RaisingRedis())
 
-    # Must not raise into the caller; a Redis error means "skip the alert".
-    assert await dispatcher.try_claim("alert:budget:team:team-1") is False
+    # Must not raise into the caller; a Redis error means "skip the alert" and
+    # is reported distinctly from a genuine throttle.
+    assert await dispatcher.try_claim("alert:budget:team:team-1") == "unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/notifications/test_slack_channel.py
+++ b/tests/notifications/test_slack_channel.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from src.notifications.channels import slack as slack_module
+from src.notifications.channels.slack import SlackChannel
+from src.notifications.types import NotificationMessage
+from src.notifications.webhook import WebhookResult
+from src.services.notification_recipients import NotificationRecipients
+
+
+def _budget_message() -> NotificationMessage:
+    return NotificationMessage(
+        alert_type="budget_threshold",
+        metric_kind="budget_threshold",
+        payload={
+            "instance_name": "DeltaLLM",
+            "entity_type": "team",
+            "entity_id": "team-1",
+            "current_spend": 12.0,
+            "soft_budget": 10.0,
+            "hard_budget": 20.0,
+        },
+    )
+
+
+def test_supports_respects_allowlist() -> None:
+    channel = SlackChannel(webhook_url=SecretStr("https://x"), allowed_alert_types={"budget_threshold"})
+    assert channel.supports("budget_threshold") is True
+    assert channel.supports("api_key_lifecycle") is False
+
+
+@pytest.mark.asyncio
+async def test_send_posts_rendered_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_post(*, url, json_body, **kwargs):  # noqa: ANN001, ANN003
+        captured["json_body"] = json_body
+        return WebhookResult(ok=True, status_code=200)
+
+    monkeypatch.setattr(slack_module, "post_webhook", fake_post)
+    channel = SlackChannel(webhook_url=SecretStr("https://x"), allowed_alert_types={"budget_threshold"})
+
+    result = await channel.send(
+        message=_budget_message(),
+        recipients=NotificationRecipients(emails=(), policy="none"),
+    )
+
+    assert result.outcome == "queued"
+    text = captured["json_body"]["text"]  # type: ignore[index]
+    assert "budget alert" in text
+    assert "team-1" in text
+
+
+@pytest.mark.asyncio
+async def test_send_reports_undeliverable_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(*, url, json_body, **kwargs):  # noqa: ANN001, ANN003
+        return WebhookResult(ok=False, status_code=500, error="http_500")
+
+    monkeypatch.setattr(slack_module, "post_webhook", fake_post)
+    channel = SlackChannel(webhook_url=SecretStr("https://x"), allowed_alert_types={"budget_threshold"})
+
+    result = await channel.send(
+        message=_budget_message(),
+        recipients=NotificationRecipients(emails=(), policy="none"),
+    )
+
+    assert result.outcome == "undeliverable"
+    assert result.error == "http_500"

--- a/tests/notifications/test_webhook.py
+++ b/tests/notifications/test_webhook.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from src.notifications.webhook import post_webhook
+
+_SECRET_URL = "https://hooks.slack.com/services/T000/B000/XXXXSECRETXXXX"
+
+
+@pytest.mark.asyncio
+async def test_post_webhook_success() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await post_webhook(url=SecretStr(_SECRET_URL), json_body={"text": "hi"}, client=client)
+
+    assert result.ok is True
+    assert result.status_code == 200
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_webhook_retries_once_on_server_error(caplog: pytest.LogCaptureFixture) -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(500, text="boom")
+
+    caplog.set_level(logging.WARNING)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await post_webhook(url=SecretStr(_SECRET_URL), json_body={"text": "hi"}, client=client)
+
+    assert result.ok is False
+    assert result.error == "http_500"
+    assert calls["n"] == 2
+    # the secret webhook URL must never be logged
+    assert _SECRET_URL not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_post_webhook_never_raises_on_transport_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await post_webhook(url=SecretStr(_SECRET_URL), json_body={"text": "hi"}, client=client)
+
+    assert result.ok is False
+    assert result.error == "ConnectError"

--- a/tests/services/test_key_notifications.py
+++ b/tests/services/test_key_notifications.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from src.notifications.channels.email import EmailChannel
+from src.notifications.dispatcher import NotificationDispatcher
 from src.services.key_notifications import KeyNotificationRecord, KeyNotificationService
 
 
@@ -68,14 +70,28 @@ def _record(*, owner_account_id: str | None = "acct-owner") -> KeyNotificationRe
     )
 
 
+def _build_service(
+    *,
+    enabled: bool,
+    outbox: _FakeOutboxService,
+    emails: tuple[str, ...] = ("owner@example.com",),
+    audit: _FakeAuditService | None = None,
+) -> KeyNotificationService:
+    dispatcher = NotificationDispatcher(
+        channels=[EmailChannel(outbox_service=outbox)],
+        audit_service=audit,
+    )
+    return KeyNotificationService(
+        dispatcher=dispatcher,
+        recipient_resolver=_FakeRecipientResolver(emails),
+        config_getter=lambda: _config(enabled=enabled),
+    )
+
+
 @pytest.mark.asyncio
 async def test_key_lifecycle_notifications_are_opt_in() -> None:
     outbox = _FakeOutboxService()
-    service = KeyNotificationService(
-        outbox_service=outbox,
-        recipient_resolver=_FakeRecipientResolver(("owner@example.com",)),
-        config_getter=lambda: _config(enabled=False),
-    )
+    service = _build_service(enabled=False, outbox=outbox)
 
     await service.notify_lifecycle(
         event_kind="api_key_created",
@@ -90,12 +106,7 @@ async def test_key_lifecycle_notifications_are_opt_in() -> None:
 async def test_key_lifecycle_notifications_are_suppressed_for_owner_actor() -> None:
     outbox = _FakeOutboxService()
     audit = _FakeAuditService()
-    service = KeyNotificationService(
-        outbox_service=outbox,
-        recipient_resolver=_FakeRecipientResolver(("owner@example.com",)),
-        audit_service=audit,
-        config_getter=lambda: _config(enabled=True),
-    )
+    service = _build_service(enabled=True, outbox=outbox, audit=audit)
 
     await service.notify_lifecycle(
         event_kind="api_key_deleted",
@@ -105,16 +116,13 @@ async def test_key_lifecycle_notifications_are_suppressed_for_owner_actor() -> N
 
     assert outbox.calls == []
     assert audit.events[0].status == "skipped"
+    assert audit.events[0].metadata["reason"] == "actor_is_owner"
 
 
 @pytest.mark.asyncio
 async def test_key_lifecycle_notifications_enqueue_without_secret_values() -> None:
     outbox = _FakeOutboxService()
-    service = KeyNotificationService(
-        outbox_service=outbox,
-        recipient_resolver=_FakeRecipientResolver(("owner@example.com",)),
-        config_getter=lambda: _config(enabled=True),
-    )
+    service = _build_service(enabled=True, outbox=outbox)
 
     await service.notify_lifecycle(
         event_kind="api_key_regenerated",
@@ -133,12 +141,7 @@ async def test_key_lifecycle_notifications_enqueue_without_secret_values() -> No
 async def test_key_lifecycle_notifications_skip_cancelled_outbox_records() -> None:
     outbox = _FakeOutboxService(status="cancelled")
     audit = _FakeAuditService()
-    service = KeyNotificationService(
-        outbox_service=outbox,
-        recipient_resolver=_FakeRecipientResolver(("owner@example.com",)),
-        audit_service=audit,
-        config_getter=lambda: _config(enabled=True),
-    )
+    service = _build_service(enabled=True, outbox=outbox, audit=audit)
 
     await service.notify_lifecycle(
         event_kind="api_key_created",

--- a/tests/services/test_key_notifications.py
+++ b/tests/services/test_key_notifications.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -124,19 +125,21 @@ async def test_key_lifecycle_notifications_enqueue_without_secret_values() -> No
     outbox = _FakeOutboxService()
     service = _build_service(enabled=True, outbox=outbox)
 
+    record = _record()
     await service.notify_lifecycle(
         event_kind="api_key_regenerated",
         actor_account_id="acct-actor",
-        record=_record(),
+        record=record,
     )
 
     assert outbox.calls[0]["template_key"] == "api_key_lifecycle"
     payload = outbox.calls[0]["payload_json"]
     assert payload["event_kind"] == "api_key_regenerated"
     assert payload["key_name"] == "Primary Key"
-    # the secret token hash must never reach the rendered/enqueued payload
+    # the secret token hash must never reach the rendered/enqueued payload,
+    # even nested or interpolated into another field
     assert "token_hash" not in payload
-    assert "key-1" not in payload.values()
+    assert record.token_hash not in json.dumps(payload, default=str)
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_key_notifications.py
+++ b/tests/services/test_key_notifications.py
@@ -134,7 +134,9 @@ async def test_key_lifecycle_notifications_enqueue_without_secret_values() -> No
     payload = outbox.calls[0]["payload_json"]
     assert payload["event_kind"] == "api_key_regenerated"
     assert payload["key_name"] == "Primary Key"
-    assert "raw_key" not in payload
+    # the secret token hash must never reach the rendered/enqueued payload
+    assert "token_hash" not in payload
+    assert "key-1" not in payload.values()
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_key_notifications.py
+++ b/tests/services/test_key_notifications.py
@@ -61,7 +61,7 @@ def _config(*, enabled: bool) -> SimpleNamespace:
 
 def _record(*, owner_account_id: str | None = "acct-owner") -> KeyNotificationRecord:
     return KeyNotificationRecord(
-        token_hash="key-1",
+        token_hash="SECRET_HASH_DO_NOT_LEAK",
         key_name="Primary Key",
         team_id="team-1",
         team_alias="Team One",

--- a/tests/test_billing_alerts.py
+++ b/tests/test_billing_alerts.py
@@ -25,7 +25,7 @@ class _FakeRedis:
     async def set(self, key: str, value: str, *, ex: int | None = None, nx: bool | None = None):  # noqa: ANN201
         self.set_calls.append((key, value, ex, nx))
         if nx and key in self.values:
-            return False
+            return None  # redis-py returns None when an nx claim fails
         self.values[key] = value
         return True
 
@@ -256,6 +256,7 @@ async def test_budget_alert_swallows_recipient_resolution_errors() -> None:
 
     assert outbox.calls == []
     assert "alert:budget:team:team-1" in redis.deleted
+    assert len(audit.events) == 1
     assert audit.events[0].status == "error"
     assert audit.events[0].metadata["reason"] == "exception"
 
@@ -282,23 +283,28 @@ async def test_budget_alert_skips_recipient_query_when_throttled() -> None:
 class _DeliveringChannel:
     name = "slack"
 
+    def __init__(self) -> None:
+        self.calls = 0
+
     def supports(self, alert_type: str) -> bool:
         return True
 
     async def send(self, *, message, recipients):  # noqa: ANN001, ANN201
         from src.notifications.types import ChannelResult
 
+        self.calls += 1
         return ChannelResult(outcome="queued")
 
 
 @pytest.mark.asyncio
 async def test_budget_alert_keeps_slot_when_only_slack_delivers() -> None:
     redis = _FakeRedis()
+    slack = _DeliveringChannel()
     service = _build_service(
         enabled=True,
         redis=redis,
         recipients=(),  # no email recipients
-        extra_channels=[_DeliveringChannel()],
+        extra_channels=[slack],
         audit=_FakeAuditService(),
     )
 
@@ -310,5 +316,39 @@ async def test_budget_alert_keeps_slot_when_only_slack_delivers() -> None:
         hard_budget=20.0,
     )
 
-    # Slack delivered, so the shared silence window is retained.
+    # The slot was claimed and Slack actually delivered, so the shared silence
+    # window is retained (not released).
+    assert slack.calls == 1
+    assert "alert:budget:team:team-1" in redis.values
     assert "alert:budget:team:team-1" not in redis.deleted
+
+
+class _ClaimRaisingRedis(_FakeRedis):
+    async def set(self, key: str, value: str, *, ex: int | None = None, nx: bool | None = None):  # noqa: ANN201
+        raise ConnectionError("redis down")
+
+
+@pytest.mark.asyncio
+async def test_budget_alert_skips_when_redis_claim_fails() -> None:
+    resolver = _FakeRecipientResolver(("owner@example.com",))
+    outbox = _FakeOutboxService()
+    service = _build_service(
+        enabled=True,
+        redis=_ClaimRaisingRedis(),
+        outbox=outbox,
+        resolver=resolver,
+        audit=_FakeAuditService(),
+    )
+
+    # Redis being down must not raise into the inference request that triggered
+    # the budget check; the alert is simply skipped (fail-closed).
+    await service.send_budget_alert(
+        entity_type="team",
+        entity_id="team-1",
+        current_spend=12.0,
+        soft_budget=10.0,
+        hard_budget=20.0,
+    )
+
+    assert resolver.calls == 0
+    assert outbox.calls == []

--- a/tests/test_billing_alerts.py
+++ b/tests/test_billing_alerts.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 import pytest
 
 from src.billing.alerts import AlertConfig, AlertService
+from src.notifications.channels.email import EmailChannel
+from src.notifications.dispatcher import NotificationDispatcher
 
 
 class _FakeRedis:
@@ -79,16 +81,37 @@ def _config(*, enabled: bool) -> SimpleNamespace:
     )
 
 
+def _build_service(
+    *,
+    enabled: bool,
+    redis: _FakeRedis | None = None,
+    outbox: _FakeOutboxService | None = None,
+    recipients: tuple[str, ...] = ("owner@example.com",),
+    audit: _FakeAuditService | None = None,
+    extra_channels: list | None = None,
+) -> AlertService:
+    outbox = outbox if outbox is not None else _FakeOutboxService()
+    channels = [EmailChannel(outbox_service=outbox)]
+    if extra_channels:
+        channels.extend(extra_channels)
+    dispatcher = NotificationDispatcher(
+        channels=channels,
+        redis_client=redis,
+        audit_service=audit,
+        dedupe_ttl_seconds=60,
+    )
+    return AlertService(
+        config=AlertConfig(budget_alert_ttl=60),
+        dispatcher=dispatcher,
+        recipient_resolver=_FakeRecipientResolver(recipients),
+        config_getter=lambda: _config(enabled=enabled),
+    )
+
+
 @pytest.mark.asyncio
 async def test_budget_alert_notifications_are_opt_in() -> None:
     outbox = _FakeOutboxService()
-    service = AlertService(
-        config=AlertConfig(budget_alert_ttl=60),
-        redis_client=_FakeRedis(),
-        outbox_service=outbox,
-        recipient_resolver=_FakeRecipientResolver(("owner@example.com",)),
-        config_getter=lambda: _config(enabled=False),
-    )
+    service = _build_service(enabled=False, redis=_FakeRedis(), outbox=outbox)
 
     await service.send_budget_alert(
         entity_type="team",
@@ -106,14 +129,7 @@ async def test_budget_alert_enqueues_once_per_ttl_window() -> None:
     redis = _FakeRedis()
     outbox = _FakeOutboxService()
     audit = _FakeAuditService()
-    service = AlertService(
-        config=AlertConfig(budget_alert_ttl=60),
-        redis_client=redis,
-        outbox_service=outbox,
-        recipient_resolver=_FakeRecipientResolver(("owner@example.com",)),
-        audit_service=audit,
-        config_getter=lambda: _config(enabled=True),
-    )
+    service = _build_service(enabled=True, redis=redis, outbox=outbox, audit=audit)
 
     await service.send_budget_alert(
         entity_type="team",
@@ -140,13 +156,11 @@ async def test_budget_alert_enqueues_once_per_ttl_window() -> None:
 @pytest.mark.asyncio
 async def test_budget_alert_releases_slot_when_enqueue_fails() -> None:
     redis = _FakeRedis()
-    service = AlertService(
-        config=AlertConfig(budget_alert_ttl=60),
-        redis_client=redis,
-        outbox_service=_FakeOutboxService(fail=True),
-        recipient_resolver=_FakeRecipientResolver(("owner@example.com",)),
-        audit_service=_FakeAuditService(),
-        config_getter=lambda: _config(enabled=True),
+    service = _build_service(
+        enabled=True,
+        redis=redis,
+        outbox=_FakeOutboxService(fail=True),
+        audit=_FakeAuditService(),
     )
 
     await service.send_budget_alert(
@@ -164,13 +178,11 @@ async def test_budget_alert_releases_slot_when_enqueue_fails() -> None:
 async def test_budget_alert_releases_slot_when_outbox_cancels_email() -> None:
     redis = _FakeRedis()
     audit = _FakeAuditService()
-    service = AlertService(
-        config=AlertConfig(budget_alert_ttl=60),
-        redis_client=redis,
-        outbox_service=_FakeOutboxService(status="cancelled"),
-        recipient_resolver=_FakeRecipientResolver(("owner@example.com",)),
-        audit_service=audit,
-        config_getter=lambda: _config(enabled=True),
+    service = _build_service(
+        enabled=True,
+        redis=redis,
+        outbox=_FakeOutboxService(status="cancelled"),
+        audit=audit,
     )
 
     await service.send_budget_alert(
@@ -189,13 +201,11 @@ async def test_budget_alert_releases_slot_when_outbox_cancels_email() -> None:
 @pytest.mark.asyncio
 async def test_budget_alert_releases_slot_when_no_recipients() -> None:
     redis = _FakeRedis()
-    service = AlertService(
-        config=AlertConfig(budget_alert_ttl=60),
-        redis_client=redis,
-        outbox_service=_FakeOutboxService(),
-        recipient_resolver=_FakeRecipientResolver(()),
-        audit_service=_FakeAuditService(),
-        config_getter=lambda: _config(enabled=True),
+    service = _build_service(
+        enabled=True,
+        redis=redis,
+        recipients=(),
+        audit=_FakeAuditService(),
     )
 
     await service.send_budget_alert(

--- a/tests/test_billing_alerts.py
+++ b/tests/test_billing_alerts.py
@@ -325,16 +325,18 @@ async def test_budget_alert_keeps_slot_when_only_slack_delivers() -> None:
 
 class _ClaimRaisingRedis(_FakeRedis):
     async def set(self, key: str, value: str, *, ex: int | None = None, nx: bool | None = None):  # noqa: ANN201
+        self.set_calls.append((key, value, ex, nx))
         raise ConnectionError("redis down")
 
 
 @pytest.mark.asyncio
 async def test_budget_alert_skips_when_redis_claim_fails() -> None:
+    redis = _ClaimRaisingRedis()
     resolver = _FakeRecipientResolver(("owner@example.com",))
     outbox = _FakeOutboxService()
     service = _build_service(
         enabled=True,
-        redis=_ClaimRaisingRedis(),
+        redis=redis,
         outbox=outbox,
         resolver=resolver,
         audit=_FakeAuditService(),
@@ -350,5 +352,8 @@ async def test_budget_alert_skips_when_redis_claim_fails() -> None:
         hard_budget=20.0,
     )
 
+    # The claim was actually attempted (so the skip happened at the claim step,
+    # not an earlier short-circuit) and nothing downstream ran.
+    assert len(redis.set_calls) == 1
     assert resolver.calls == 0
     assert outbox.calls == []

--- a/tests/test_billing_alerts.py
+++ b/tests/test_billing_alerts.py
@@ -48,11 +48,22 @@ class _FakeOutboxService:
 
 
 class _FakeRecipientResolver:
-    def __init__(self, emails: tuple[str, ...], *, policy: str = "team_admins_and_org_admins") -> None:
+    def __init__(
+        self,
+        emails: tuple[str, ...],
+        *,
+        policy: str = "team_admins_and_org_admins",
+        raise_on_resolve: bool = False,
+    ) -> None:
         self.emails = emails
         self.policy = policy
+        self.raise_on_resolve = raise_on_resolve
+        self.calls = 0
 
     async def resolve_budget_recipients(self, *, entity_type: str, entity_id: str):  # noqa: ANN201
+        self.calls += 1
+        if self.raise_on_resolve:
+            raise RuntimeError("db unavailable")
         return SimpleNamespace(
             emails=self.emails,
             policy=self.policy,
@@ -89,6 +100,7 @@ def _build_service(
     recipients: tuple[str, ...] = ("owner@example.com",),
     audit: _FakeAuditService | None = None,
     extra_channels: list | None = None,
+    resolver: _FakeRecipientResolver | None = None,
 ) -> AlertService:
     outbox = outbox if outbox is not None else _FakeOutboxService()
     channels = [EmailChannel(outbox_service=outbox)]
@@ -103,7 +115,7 @@ def _build_service(
     return AlertService(
         config=AlertConfig(budget_alert_ttl=60),
         dispatcher=dispatcher,
-        recipient_resolver=_FakeRecipientResolver(recipients),
+        recipient_resolver=resolver or _FakeRecipientResolver(recipients),
         config_getter=lambda: _config(enabled=enabled),
     )
 
@@ -217,3 +229,86 @@ async def test_budget_alert_releases_slot_when_no_recipients() -> None:
     )
 
     assert "alert:budget:org:org-1" in redis.deleted
+
+
+@pytest.mark.asyncio
+async def test_budget_alert_swallows_recipient_resolution_errors() -> None:
+    redis = _FakeRedis()
+    audit = _FakeAuditService()
+    outbox = _FakeOutboxService()
+    service = _build_service(
+        enabled=True,
+        redis=redis,
+        outbox=outbox,
+        audit=audit,
+        resolver=_FakeRecipientResolver((), raise_on_resolve=True),
+    )
+
+    # Must not raise into the caller (the inference request that triggered the
+    # budget check).
+    await service.send_budget_alert(
+        entity_type="team",
+        entity_id="team-1",
+        current_spend=12.0,
+        soft_budget=10.0,
+        hard_budget=20.0,
+    )
+
+    assert outbox.calls == []
+    assert "alert:budget:team:team-1" in redis.deleted
+    assert audit.events[0].status == "error"
+    assert audit.events[0].metadata["reason"] == "exception"
+
+
+@pytest.mark.asyncio
+async def test_budget_alert_skips_recipient_query_when_throttled() -> None:
+    redis = _FakeRedis()
+    resolver = _FakeRecipientResolver(("owner@example.com",))
+    service = _build_service(enabled=True, redis=redis, resolver=resolver, audit=_FakeAuditService())
+
+    for _ in range(2):
+        await service.send_budget_alert(
+            entity_type="team",
+            entity_id="team-1",
+            current_spend=12.0,
+            soft_budget=10.0,
+            hard_budget=20.0,
+        )
+
+    # The second alert is throttled before any recipient DB query.
+    assert resolver.calls == 1
+
+
+class _DeliveringChannel:
+    name = "slack"
+
+    def supports(self, alert_type: str) -> bool:
+        return True
+
+    async def send(self, *, message, recipients):  # noqa: ANN001, ANN201
+        from src.notifications.types import ChannelResult
+
+        return ChannelResult(outcome="queued")
+
+
+@pytest.mark.asyncio
+async def test_budget_alert_keeps_slot_when_only_slack_delivers() -> None:
+    redis = _FakeRedis()
+    service = _build_service(
+        enabled=True,
+        redis=redis,
+        recipients=(),  # no email recipients
+        extra_channels=[_DeliveringChannel()],
+        audit=_FakeAuditService(),
+    )
+
+    await service.send_budget_alert(
+        entity_type="team",
+        entity_id="team-1",
+        current_spend=12.0,
+        soft_budget=10.0,
+        hard_budget=20.0,
+    )
+
+    # Slack delivered, so the shared silence window is retained.
+    assert "alert:budget:team:team-1" not in redis.deleted


### PR DESCRIPTION
## Summary

Introduces a channel-agnostic notification dispatcher and routes the existing budget-alert and API-key-lifecycle producers through it, then adds a Slack channel for budget alerts. Adding a new channel or alert type is now a localized change instead of a per-producer edit.

- **New `src/notifications/` package**: a `NotificationDispatcher` that fans a message out to pluggable channels, a `NotificationChannel` protocol, an `EmailChannel` (wrapping the existing outbox), a `SlackChannel` (incoming webhook, gated by a per-channel alert-type allowlist), a tiny non-raising webhook helper, and a `NotificationPreferenceResolver` seam for future per-org opt-in/out.
- **Producers refactored**: `AlertService.send_budget_alert` and `KeyNotificationService.notify_lifecycle` delegate fan-out, metrics, and audit to the dispatcher while keeping their config gates and the actor-is-owner suppression.
- **Config**: `slack_alerting_enabled`, `slack_webhook_url` (secret), and `slack_alert_kinds`, validated against known alert types. The notification metric gained a `channel` label.

## Reliability hardening (follow-up commits)

- **Request-path isolation**: a notification failure can no longer 500 the inference request that triggered the budget check — recipient resolution and dispatch are wrapped, and the dedupe slot is claimed before any DB query so throttled alerts do no extra work.
- **Redis fail-closed**: `try_claim`/`release` never raise on a Redis error. `try_claim` returns a tri-state (`claimed`/`held`/`unavailable`) so a Redis outage is recorded as `status="dedupe_unavailable"` rather than masked as a normal `throttled` dedupe hit.
- **Shared dedupe window**: any channel delivering holds one silence window for all channels (documented and tested).

## Test plan

- [x] `pytest tests/notifications tests/test_billing_alerts.py tests/services/test_key_notifications.py` — dispatcher fan-out/isolation, channel mapping, webhook retry/secret-redaction, throttle + Redis-down behavior, and per-channel metrics/audit.
- [x] `pytest tests/test_billing.py tests/config` — no regressions in budget enforcement or config validation.
- [x] `ruff check` clean across changed modules.
- [ ] Manual smoke with a real Slack webhook: enable `slack_alerting_enabled` + `slack_alert_kinds=["budget_threshold"]`, drive an org past its soft budget, confirm email enqueued, Slack posted, one audit row per channel, and a second hit within the TTL emits only `throttled`.
