### PR TITLE
PR1: Add ElevenLabs provider foundation

### DIFF
--- a/src/providers/healthcheck.py
+++ b/src/providers/healthcheck.py
@@ -119,6 +119,32 @@ async def probe_provider_health(
         except httpx.HTTPError as exc:
             return HealthProbeResult(healthy=False, error=f"Gemini health check failed: {exc}")
 
+    if provider == "elevenlabs":
+        api_key = str(params.get("api_key") or "").strip()
+        if not api_key:
+            return HealthProbeResult(healthy=False, error="Provider API key is missing")
+        api_base = str(params.get("api_base") or "https://api.elevenlabs.io/v1").rstrip("/")
+        try:
+            response = await http_client.get(
+                f"{api_base}/models",
+                headers={"xi-api-key": api_key},
+                timeout=request_timeout,
+            )
+            if response.status_code >= 400:
+                return HealthProbeResult(
+                    healthy=False,
+                    error=_status_error("ElevenLabs health check", response.status_code),
+                    status_code=response.status_code,
+                )
+            return HealthProbeResult(healthy=True, status_code=response.status_code)
+        except httpx.PoolTimeout:
+            error = GatewayCapacityError()
+            return HealthProbeResult(healthy=False, error=error.message, affects_deployment_health=False)
+        except httpx.TimeoutException:
+            return HealthProbeResult(healthy=False, error="ElevenLabs health check timed out")
+        except httpx.HTTPError as exc:
+            return HealthProbeResult(healthy=False, error=f"ElevenLabs health check failed: {exc}")
+
     if provider == "bedrock":
         if not str(params.get("aws_access_key_id") or "").strip():
             return HealthProbeResult(healthy=False, error="AWS access key is missing")

--- a/src/providers/resolution.py
+++ b/src/providers/resolution.py
@@ -35,6 +35,7 @@ PROVIDER_MODEL_PREFIXES_TO_STRIP: dict[str, tuple[str, ...]] = {
     "azure_openai": ("azure/", "azure_openai/"),
     "gemini": ("gemini/",),
     "bedrock": ("bedrock/",),
+    "elevenlabs": ("elevenlabs/",),
 }
 
 PROVIDER_CAPABILITIES: dict[str, set[ModelMode]] = {
@@ -50,6 +51,7 @@ PROVIDER_CAPABILITIES: dict[str, set[ModelMode]] = {
     "perplexity": {"chat"},
     "gemini": {"chat", "audio_speech"},
     "bedrock": {"chat"},
+    "elevenlabs": {"audio_speech", "audio_transcription"},
     "vllm": {"chat", "embedding", "image_generation", "audio_speech", "audio_transcription"},
     "lmstudio": {"chat", "embedding"},
     "ollama": {"chat", "embedding"},
@@ -67,6 +69,7 @@ PROVIDER_PRESETS: dict[str, dict[str, str | None]] = {
     "perplexity": {"provider": "perplexity", "api_base": "https://api.perplexity.ai", "compat": "openai"},
     "gemini": {"provider": "gemini", "api_base": "https://generativelanguage.googleapis.com/v1beta", "compat": "native"},
     "bedrock": {"provider": "bedrock", "api_base": "https://bedrock-runtime.{region}.amazonaws.com", "compat": "native"},
+    "elevenlabs": {"provider": "elevenlabs", "api_base": "https://api.elevenlabs.io/v1", "compat": "native"},
     "vllm": {"provider": "vllm", "api_base": None, "compat": "openai"},
     "lmstudio": {"provider": "lmstudio", "api_base": None, "compat": "openai"},
     "ollama": {"provider": "ollama", "api_base": None, "compat": "openai"},

--- a/src/services/named_credentials.py
+++ b/src/services/named_credentials.py
@@ -191,6 +191,8 @@ def _allowed_fields_for_provider(provider: str) -> set[str]:
         return _API_KEY_PROVIDER_FIELDS
     if provider == "gemini":
         return _API_KEY_PROVIDER_FIELDS
+    if provider == "elevenlabs":
+        return _API_KEY_PROVIDER_FIELDS
     if supports_custom_openai_compatible_auth(provider):
         return _CUSTOM_AUTH_PROVIDER_FIELDS
     if is_openai_compatible_provider(provider):

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -767,6 +767,74 @@ async def test_provider_health_check_defaults_unresolved_provider_to_openai():
 
 
 @pytest.mark.asyncio
+async def test_provider_health_check_supports_elevenlabs_with_default_base_url():
+    captured: dict[str, object] = {}
+
+    class FakeHTTPClient:
+        async def get(self, url, headers=None, timeout=None):  # noqa: ANN001, ANN201
+            captured["url"] = url
+            captured["headers"] = dict(headers or {})
+            captured["timeout"] = timeout
+            return httpx.Response(200, json={"models": []}, request=httpx.Request("GET", url))
+
+    result = await probe_provider_health(
+        FakeHTTPClient(),  # type: ignore[arg-type]
+        {"provider": "elevenlabs", "model": "elevenlabs/eleven_multilingual_v2", "api_key": "provider-key"},
+        default_openai_base_url="https://api.openai.com/v1",
+    )
+
+    assert result.healthy is True
+    assert result.status_code == 200
+    assert captured["url"] == "https://api.elevenlabs.io/v1/models"
+    assert captured["headers"] == {"xi-api-key": "provider-key"}
+    timeout = captured["timeout"]
+    assert getattr(timeout, "read") == 10.0
+
+
+@pytest.mark.asyncio
+async def test_provider_health_check_supports_elevenlabs_custom_base_url():
+    captured: dict[str, object] = {}
+
+    class FakeHTTPClient:
+        async def get(self, url, headers=None, timeout=None):  # noqa: ANN001, ANN201
+            captured["url"] = url
+            captured["headers"] = dict(headers or {})
+            del timeout
+            return httpx.Response(200, json={"models": []}, request=httpx.Request("GET", url))
+
+    result = await probe_provider_health(
+        FakeHTTPClient(),  # type: ignore[arg-type]
+        {
+            "provider": "elevenlabs",
+            "model": "elevenlabs/eleven_multilingual_v2",
+            "api_key": "provider-key",
+            "api_base": "https://elevenlabs-proxy.example/v1/",
+        },
+        default_openai_base_url="https://api.openai.com/v1",
+    )
+
+    assert result.healthy is True
+    assert captured["url"] == "https://elevenlabs-proxy.example/v1/models"
+    assert captured["headers"] == {"xi-api-key": "provider-key"}
+
+
+@pytest.mark.asyncio
+async def test_provider_health_check_marks_elevenlabs_missing_api_key_unhealthy():
+    class FakeHTTPClient:
+        async def get(self, url, headers=None, timeout=None):  # noqa: ANN001, ANN201
+            raise AssertionError("health check must not call upstream without an API key")
+
+    result = await probe_provider_health(
+        FakeHTTPClient(),  # type: ignore[arg-type]
+        {"provider": "elevenlabs", "model": "elevenlabs/eleven_multilingual_v2"},
+        default_openai_base_url="https://api.openai.com/v1",
+    )
+
+    assert result.healthy is False
+    assert result.error == "Provider API key is missing"
+
+
+@pytest.mark.asyncio
 async def test_background_health_checker_ignores_non_health_affecting_result():
     state = RedisStateBackend(redis=None)
     deployment = _deployment("dep-a")

--- a/tests/test_named_credentials_api.py
+++ b/tests/test_named_credentials_api.py
@@ -222,6 +222,41 @@ async def test_named_credentials_create_accepts_custom_auth_header_fields(client
 
 
 @pytest.mark.asyncio
+async def test_named_credentials_create_accepts_elevenlabs_api_key_config(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    repository = _FakeNamedCredentialRepository()
+    test_app.state.named_credential_repository = repository
+
+    response = await client.post(
+        "/ui/api/named-credentials",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "name": "ElevenLabs Shared",
+            "provider": "elevenlabs",
+            "connection_config": {
+                "api_key": "elevenlabs-key",
+                "api_base": "https://api.elevenlabs.io/v1",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["provider"] == "elevenlabs"
+    assert payload["connection_config"]["api_key"] == "***REDACTED***"
+    assert payload["connection_config"]["api_base"] == "https://api.elevenlabs.io/v1"
+    assert payload["credentials_present"] is True
+
+    list_response = await client.get(
+        "/ui/api/named-credentials?provider=elevenlabs",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+    assert list_response.status_code == 200
+    listed = list_response.json()["data"]
+    assert [item["name"] for item in listed] == ["ElevenLabs Shared"]
+
+
+@pytest.mark.asyncio
 async def test_named_credentials_update_reloads_runtime_when_in_use_and_delete_blocks(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
     repository = _FakeNamedCredentialRepository()
@@ -316,6 +351,23 @@ async def test_named_credentials_validate_provider_specific_fields(client, test_
     )
     assert invalid_azure_custom_auth.status_code == 400
     assert "unsupported fields" in invalid_azure_custom_auth.text
+
+    invalid_elevenlabs_custom_auth = await client.post(
+        "/ui/api/named-credentials",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "name": "ElevenLabs Prod",
+            "provider": "elevenlabs",
+            "connection_config": {
+                "api_key": "provider-key",
+                "api_base": "https://api.elevenlabs.io/v1",
+                "auth_header_name": "Authorization",
+                "auth_header_format": "Bearer {api_key}",
+            },
+        },
+    )
+    assert invalid_elevenlabs_custom_auth.status_code == 400
+    assert "unsupported fields" in invalid_elevenlabs_custom_auth.text
 
     invalid_auth_format = await client.post(
         "/ui/api/named-credentials",

--- a/tests/test_provider_presets_smoke.py
+++ b/tests/test_provider_presets_smoke.py
@@ -5,6 +5,7 @@ from typing import Any
 import httpx
 import pytest
 
+from src.db.callable_targets import CallableTargetBindingRecord
 from src.providers.anthropic import AnthropicAdapter
 from src.providers.resolution import provider_presets, provider_supports_mode
 
@@ -102,6 +103,26 @@ def _install_mock_provider_post(test_app) -> None:  # noqa: ANN001
     test_app.state.anthropic_adapter = AnthropicAdapter(test_app.state.http_client)  # type: ignore[arg-type]
 
 
+async def _grant_smoke_model(test_app, model_name: str) -> None:  # noqa: ANN001
+    key_record = next(iter(test_app.state._test_repo.records.values()))
+    key_record.models = sorted({*(key_record.models or []), model_name})
+
+    grant_service = test_app.state.callable_target_grant_service
+    repository = getattr(grant_service, "repository", None)
+    bindings = getattr(repository, "bindings", None)
+    if isinstance(bindings, list):
+        bindings.append(
+            CallableTargetBindingRecord(
+                callable_target_binding_id=f"ctb-smoke-{model_name}",
+                callable_key=model_name,
+                scope_type="organization",
+                scope_id=key_record.organization_id or "org-default",
+                enabled=True,
+            )
+        )
+        await grant_service.reload()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("preset", provider_presets(), ids=lambda x: str(x["provider"]))
 async def test_provider_presets_chat_smoke(client, test_app, preset: dict[str, Any]):
@@ -125,7 +146,14 @@ async def test_provider_presets_chat_smoke(client, test_app, preset: dict[str, A
         headers={"Authorization": "Bearer mk-test"},
         json=_deployment_payload(model_name=model_name, provider=provider, mode="chat", upstream_model=upstream_model),
     )
+
+    if not provider_supports_mode(provider, "chat"):
+        assert create_response.status_code == 400
+        assert "does not support mode" in create_response.text
+        return
+
     assert create_response.status_code == 200, create_response.text
+    await _grant_smoke_model(test_app, model_name)
 
     response = await client.post(
         "/v1/chat/completions",
@@ -156,6 +184,7 @@ async def test_provider_presets_embedding_smoke_with_capability_gate(client, tes
 
     if provider_supports_mode(provider, "embedding"):
         assert create_response.status_code == 200, create_response.text
+        await _grant_smoke_model(test_app, model_name)
         response = await client.post(
             "/v1/embeddings",
             headers={"Authorization": f"Bearer {test_app.state._test_key}"},

--- a/tests/test_provider_resolution.py
+++ b/tests/test_provider_resolution.py
@@ -27,6 +27,15 @@ def test_provider_supports_mode_unknown_is_permissive() -> None:
     assert provider_supports_mode("custom-gateway", "chat") is True
 
 
+def test_elevenlabs_supports_audio_modes_only() -> None:
+    assert provider_supports_mode("elevenlabs", "audio_speech") is True
+    assert provider_supports_mode("elevenlabs", "audio_transcription") is True
+    assert provider_supports_mode("elevenlabs", "chat") is False
+    assert provider_supports_mode("elevenlabs", "embedding") is False
+    assert provider_supports_mode("elevenlabs", "image_generation") is False
+    assert provider_supports_mode("elevenlabs", "rerank") is False
+
+
 def test_resolve_upstream_model_preserves_slash_prefixed_ids_for_groq() -> None:
     params = {"provider": "groq", "model": "openai/gpt-oss-120b"}
     assert resolve_upstream_model(params) == "openai/gpt-oss-120b"
@@ -42,10 +51,16 @@ def test_resolve_upstream_model_strips_anthropic_prefix_for_anthropic() -> None:
     assert resolve_upstream_model(params) == "claude-sonnet-4-20250514"
 
 
+def test_resolve_upstream_model_strips_elevenlabs_prefix_for_elevenlabs() -> None:
+    params = {"provider": "elevenlabs", "model": "elevenlabs/eleven_multilingual_v2"}
+    assert resolve_upstream_model(params) == "eleven_multilingual_v2"
+
+
 def test_openai_compatible_registry_contains_common_gateways() -> None:
     assert is_openai_compatible_provider("openrouter") is True
     assert is_openai_compatible_provider("groq") is True
     assert is_openai_compatible_provider("anthropic") is False
+    assert is_openai_compatible_provider("elevenlabs") is False
 
 
 def test_model_validation_rejects_unsupported_provider_mode_combo() -> None:

--- a/tests/test_ui_provider_presets.py
+++ b/tests/test_ui_provider_presets.py
@@ -15,6 +15,78 @@ async def test_provider_presets_endpoint_returns_known_presets(client, test_app)
     assert "openai" in providers
     assert "openrouter" in providers
     assert "anthropic" in providers
+    assert "elevenlabs" in providers
+
+
+@pytest.mark.asyncio
+async def test_provider_presets_endpoint_returns_elevenlabs_as_native_audio_provider(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.get("/ui/api/provider-presets", headers={"Authorization": "Bearer mk-test"})
+    assert response.status_code == 200
+    payload = response.json()
+    presets = {item["provider"]: item for item in payload["data"]}
+
+    elevenlabs = presets["elevenlabs"]
+    assert elevenlabs["api_base"] == "https://api.elevenlabs.io/v1"
+    assert elevenlabs["compat"] == "native"
+    assert set(elevenlabs["supported_modes"]) == {"audio_speech", "audio_transcription"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "upstream_model"),
+    [
+        ("audio_speech", "elevenlabs/eleven_multilingual_v2"),
+        ("audio_transcription", "elevenlabs/scribe_v2"),
+    ],
+)
+async def test_create_model_accepts_elevenlabs_audio_modes(client, test_app, mode, upstream_model):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": f"elevenlabs-{mode}",
+            "deltallm_params": {
+                "provider": "elevenlabs",
+                "model": upstream_model,
+                "api_base": "https://api.elevenlabs.io/v1",
+                "api_key": "provider-key",
+            },
+            "model_info": {"mode": mode},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["provider"] == "elevenlabs"
+    assert payload["mode"] == mode
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["chat", "embedding", "image_generation", "rerank"])
+async def test_create_model_rejects_elevenlabs_unsupported_modes(client, test_app, mode):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": f"bad-elevenlabs-{mode}",
+            "deltallm_params": {
+                "provider": "elevenlabs",
+                "model": "elevenlabs/eleven_multilingual_v2",
+                "api_base": "https://api.elevenlabs.io/v1",
+                "api_key": "provider-key",
+            },
+            "model_info": {"mode": mode},
+        },
+    )
+
+    assert response.status_code == 400
+    assert "does not support mode" in response.text
 
 
 @pytest.mark.asyncio

--- a/ui/src/assets/provider-logos/elevenlabs.svg
+++ b/ui/src/assets/provider-logos/elevenlabs.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>ElevenLabs</title><path d="M4.6035 0v24h4.9317V0zm9.8613 0v24h4.9317V0z"/></svg>

--- a/ui/src/components/ProviderBadge.tsx
+++ b/ui/src/components/ProviderBadge.tsx
@@ -11,8 +11,9 @@ import {
   Sparkles,
   SquareCode,
   Triangle,
+  Volume2,
 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 import { PROVIDER_LOGOS } from '../lib/providerLogos';
 import { normalizeProvider, providerDisplayName } from '../lib/providers';
 
@@ -35,6 +36,7 @@ const PROVIDER_STYLES: Record<string, ProviderStyle> = {
   perplexity: { Icon: Search, logoUrl: PROVIDER_LOGOS.perplexity, tone: 'bg-rose-50 text-rose-700 border-rose-100' },
   gemini: { Icon: Sparkles, logoUrl: PROVIDER_LOGOS.gemini, tone: 'bg-blue-50 text-blue-700 border-blue-100' },
   bedrock: { Icon: Triangle, tone: 'bg-stone-100 text-stone-700 border-stone-200' },
+  elevenlabs: { Icon: Volume2, logoUrl: PROVIDER_LOGOS.elevenlabs, tone: 'bg-neutral-100 text-neutral-800 border-neutral-200' },
   vllm: { Icon: Bot, logoUrl: PROVIDER_LOGOS.vllm, tone: 'bg-lime-50 text-lime-700 border-lime-100' },
   lmstudio: { Icon: Bot, tone: 'bg-slate-100 text-slate-700 border-slate-200' },
   ollama: { Icon: Bot, logoUrl: PROVIDER_LOGOS.ollama, tone: 'bg-teal-50 text-teal-700 border-teal-100' },
@@ -50,14 +52,11 @@ interface ProviderBadgeProps {
 export default function ProviderBadge({ provider, model, compact = false }: ProviderBadgeProps) {
   const key = normalizeProvider(provider, model);
   const style = PROVIDER_STYLES[key] || PROVIDER_STYLES.unknown;
-  const [logoFailed, setLogoFailed] = useState(false);
+  const [failedLogoKey, setFailedLogoKey] = useState<string | null>(null);
   const label = providerDisplayName(key);
   const FallbackIcon = style.Icon || Bot;
-  const shouldShowLogo = useMemo(() => Boolean(style.logoUrl && !logoFailed), [style.logoUrl, logoFailed]);
-
-  useEffect(() => {
-    setLogoFailed(false);
-  }, [key, style.logoUrl]);
+  const logoFailureKey = style.logoUrl ? `${key}:${style.logoUrl}` : null;
+  const shouldShowLogo = Boolean(style.logoUrl && failedLogoKey !== logoFailureKey);
 
   return (
     <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${style.tone}`}>
@@ -66,7 +65,7 @@ export default function ProviderBadge({ provider, model, compact = false }: Prov
           src={style.logoUrl}
           alt={`${label} logo`}
           className="h-3.5 w-3.5 rounded-sm object-contain"
-          onError={() => setLogoFailed(true)}
+          onError={() => setFailedLogoKey(logoFailureKey)}
           loading="lazy"
         />
       ) : (

--- a/ui/src/lib/providerLogos.ts
+++ b/ui/src/lib/providerLogos.ts
@@ -1,4 +1,5 @@
 import anthropicLogo from '../assets/provider-logos/anthropic.svg';
+import elevenlabsLogo from '../assets/provider-logos/elevenlabs.svg';
 import fireworksLogo from '../assets/provider-logos/fireworks.svg';
 import geminiLogo from '../assets/provider-logos/gemini.svg';
 import groqLogo from '../assets/provider-logos/groq.svg';
@@ -16,6 +17,7 @@ export const PROVIDER_LOGOS: Record<string, string> = {
   fireworks: fireworksLogo,
   perplexity: perplexityLogo,
   gemini: geminiLogo,
+  elevenlabs: elevenlabsLogo,
   vllm: vllmLogo,
   ollama: ollamaLogo,
 };

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -11,6 +11,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   perplexity: 'Perplexity',
   gemini: 'Google Gemini',
   bedrock: 'AWS Bedrock',
+  elevenlabs: 'ElevenLabs',
   vllm: 'vLLM',
   lmstudio: 'LM Studio',
   ollama: 'Ollama',


### PR DESCRIPTION
## Summary
- register ElevenLabs as a native audio-only provider preset
- add ElevenLabs named credential validation, health checks, UI label, badge, and logo
- add validation coverage for supported audio modes and rejected unsupported modes

## Validation
- uv run --extra dev pytest tests/test_provider_resolution.py tests/test_ui_provider_presets.py tests/test_named_credentials_api.py tests/test_failover.py tests/test_provider_presets_smoke.py -q
- uv run --extra dev ruff check src/providers/resolution.py src/providers/healthcheck.py src/services/named_credentials.py tests/test_provider_resolution.py tests/test_ui_provider_presets.py tests/test_named_credentials_api.py tests/test_failover.py tests/test_provider_presets_smoke.py
- npx eslint src/lib/providers.ts src/lib/providerLogos.ts src/components/ProviderBadge.tsx
- npm run build

Refs #129