### PR TITLE
Add ElevenLabs TTS runtime

### DIFF
--- a/src/billing/audio_usage.py
+++ b/src/billing/audio_usage.py
@@ -32,9 +32,13 @@ def normalize_speech_usage(
     provider: str | None = None,
 ) -> dict[str, Any]:
     usage: dict[str, Any] = {"input_characters": len(request_text)}
+    if isinstance(response_payload, Mapping):
+        usage.update(_extract_speech_character_usage(response_payload))
+
     provider_usage = response_payload.get("usage") if isinstance(response_payload, Mapping) else None
     if isinstance(provider_usage, Mapping):
         usage.update(_extract_speech_token_usage(provider_usage))
+        usage.update(_extract_speech_character_usage(provider_usage))
 
     duration_seconds = (
         _extract_duration_seconds(response_payload, provider_usage)
@@ -96,6 +100,22 @@ def _extract_speech_token_usage(provider_usage: Mapping[str, Any]) -> dict[str, 
     return usage
 
 
+def _extract_speech_character_usage(payload: Mapping[str, Any]) -> dict[str, int]:
+    usage: dict[str, int] = {}
+    input_characters = _first_int(
+        payload.get("input_characters"),
+        payload.get("characters"),
+        payload.get("character_count"),
+    )
+    if input_characters is not None:
+        usage["input_characters"] = input_characters
+
+    output_characters = _first_int(payload.get("output_characters"))
+    if output_characters is not None:
+        usage["output_characters"] = output_characters
+    return usage
+
+
 def _extract_duration_seconds(
     response_payload: Mapping[str, Any],
     provider_usage: Mapping[str, Any] | None,
@@ -129,6 +149,17 @@ def _extract_duration_seconds(
         if duration_seconds is not None:
             return duration_seconds
 
+    return None
+
+
+def _first_int(*values: Any) -> int | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            continue
     return None
 
 

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import base64
 import json
 import wave
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from io import BytesIO
 from time import perf_counter
 from typing import Any
+from urllib.parse import quote, urlencode
 
 import httpx
 from fastapi import APIRouter, Depends, Request
@@ -60,6 +62,30 @@ AUDIO_CONTENT_TYPES = {
 
 SSE_USAGE_PROVIDERS = {"openai", "azure", "azure_openai"}
 GEMINI_SUPPORTED_RESPONSE_FORMATS = {"wav", "pcm"}
+ELEVENLABS_DEFAULT_OUTPUT_FORMAT = "mp3_44100_128"
+ELEVENLABS_RESPONSE_FORMAT_MAP = {
+    "mp3": "mp3_44100_128",
+    "opus": "opus_48000_128",
+    "wav": "wav_44100",
+    "pcm": "pcm_24000",
+}
+ELEVENLABS_REQUEST_DEFAULT_KEYS = {
+    "language_code",
+    "voice_settings",
+    "pronunciation_dictionary_locators",
+    "seed",
+    "previous_text",
+    "next_text",
+    "previous_request_ids",
+    "next_request_ids",
+    "apply_text_normalization",
+    "apply_language_text_normalization",
+    "use_pvc_as_ivc",
+}
+ELEVENLABS_QUERY_DEFAULT_KEYS = {
+    "enable_logging",
+    "optimize_streaming_latency",
+}
 
 
 async def _execute_tts(
@@ -76,6 +102,14 @@ async def _execute_tts(
     provider = resolve_provider(params)
     if provider == "gemini":
         return await _execute_gemini_tts(
+            request=request,
+            payload=payload,
+            deployment=deployment,
+            api_base=api_base,
+            api_key=str(api_key),
+        )
+    if provider == "elevenlabs":
+        return await _execute_elevenlabs_tts(
             request=request,
             payload=payload,
             deployment=deployment,
@@ -467,6 +501,60 @@ async def _execute_gemini_tts(
     }
 
 
+async def _execute_elevenlabs_tts(
+    *,
+    request: Request,
+    payload: AudioSpeechRequest,
+    deployment: Deployment,
+    api_base: str,
+    api_key: str,
+) -> dict[str, Any]:
+    defaults = _model_default_params(deployment.model_info)
+    voice_id = _resolve_elevenlabs_voice_id(payload=payload, default_params=defaults)
+    provider_output_format = _resolve_elevenlabs_output_format(
+        payload=payload, default_params=defaults
+    )
+    response_format = _elevenlabs_response_format(provider_output_format)
+    upstream_payload = _build_elevenlabs_tts_payload(
+        payload=payload,
+        default_params=defaults,
+        upstream_model=resolve_upstream_model(deployment.deltallm_params),
+    )
+    endpoint = f"{api_base}/text-to-speech/{quote(voice_id, safe='')}"
+    query = _build_elevenlabs_tts_query(
+        provider_output_format=provider_output_format, default_params=defaults
+    )
+    if query:
+        endpoint = f"{endpoint}?{query}"
+
+    upstream_start = perf_counter()
+    response = await request.app.state.http_client.post(
+        endpoint,
+        headers={"xi-api-key": api_key, "Content-Type": "application/json"},
+        json=upstream_payload,
+        timeout=build_upstream_request_timeout_for_request(
+            request,
+            configured_timeout_seconds(deployment.deltallm_params.get("timeout")),
+        ),
+    )
+    if response.status_code >= 400:
+        raise httpx.HTTPStatusError(
+            _format_elevenlabs_tts_error(response),
+            request=httpx.Request("POST", endpoint),
+            response=response,
+        )
+
+    return {
+        "_audio_bytes": response.content,
+        "_billing_payload": _extract_elevenlabs_billing_payload(response),
+        "_api_latency_ms": (perf_counter() - upstream_start) * 1000,
+        "_api_base": api_base,
+        "_deployment_model": deployment.deltallm_params.get("model"),
+        "_model_info": deployment.model_info,
+        "_response_format": response_format,
+    }
+
+
 def _should_force_tts_sse(*, model_info: dict[str, Any] | None, provider: str) -> bool:
     normalized_provider = (provider or "").strip().lower()
     if normalized_provider not in SSE_USAGE_PROVIDERS:
@@ -489,6 +577,142 @@ def _should_force_tts_sse(*, model_info: dict[str, Any] | None, provider: str) -
         for field in ("input_cost_per_character", "output_cost_per_character")
     )
     return has_token_or_second_pricing and not has_character_pricing
+
+
+def _model_default_params(model_info: dict[str, Any] | None) -> dict[str, Any]:
+    defaults = (model_info or {}).get("default_params")
+    return dict(defaults) if isinstance(defaults, Mapping) else {}
+
+
+def _resolve_elevenlabs_voice_id(
+    *,
+    payload: AudioSpeechRequest,
+    default_params: Mapping[str, Any],
+) -> str:
+    if "voice" in payload.model_fields_set:
+        voice_id = str(payload.voice or "").strip()
+    else:
+        voice_id = str(default_params.get("voice_id") or "").strip()
+
+    if not voice_id:
+        raise InvalidRequestError(
+            message="ElevenLabs TTS requires a request voice or model_info.default_params.voice_id"
+        )
+    return voice_id
+
+
+def _resolve_elevenlabs_output_format(
+    *,
+    payload: AudioSpeechRequest,
+    default_params: Mapping[str, Any],
+) -> str:
+    default_output_format = str(default_params.get("output_format") or "").strip().lower()
+    if "response_format" not in payload.model_fields_set:
+        return (
+            ELEVENLABS_RESPONSE_FORMAT_MAP.get(default_output_format)
+            or default_output_format
+            or ELEVENLABS_DEFAULT_OUTPUT_FORMAT
+        )
+
+    requested_format = str(payload.response_format or "mp3").strip().lower()
+    mapped_format = ELEVENLABS_RESPONSE_FORMAT_MAP.get(requested_format)
+    if mapped_format:
+        return mapped_format
+
+    raise InvalidRequestError(
+        message=(
+            "ElevenLabs TTS supports 'mp3', 'opus', 'wav', and 'pcm' response_format values. "
+            "Configure model_info.default_params.output_format for provider-specific formats."
+        )
+    )
+
+
+def _build_elevenlabs_tts_payload(
+    *,
+    payload: AudioSpeechRequest,
+    default_params: Mapping[str, Any],
+    upstream_model: str | None,
+) -> dict[str, Any]:
+    upstream_payload: dict[str, Any] = {"text": payload.input}
+    if upstream_model:
+        upstream_payload["model_id"] = upstream_model
+
+    for key in ELEVENLABS_REQUEST_DEFAULT_KEYS:
+        if key in default_params:
+            upstream_payload[key] = default_params[key]
+
+    if "speed" in payload.model_fields_set and payload.speed is not None:
+        voice_settings = upstream_payload.get("voice_settings")
+        if not isinstance(voice_settings, Mapping):
+            voice_settings = {}
+        upstream_payload["voice_settings"] = {**dict(voice_settings), "speed": payload.speed}
+
+    return upstream_payload
+
+
+def _build_elevenlabs_tts_query(
+    *,
+    provider_output_format: str,
+    default_params: Mapping[str, Any],
+) -> str:
+    query_params: dict[str, str] = {"output_format": provider_output_format}
+    for key in ELEVENLABS_QUERY_DEFAULT_KEYS:
+        if key not in default_params:
+            continue
+        value = default_params[key]
+        if value is None:
+            continue
+        query_params[key] = _elevenlabs_query_value(value)
+    return urlencode(query_params)
+
+
+def _elevenlabs_query_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _elevenlabs_response_format(provider_output_format: str) -> str:
+    normalized = provider_output_format.strip().lower()
+    if normalized.startswith("mp3_"):
+        return "mp3"
+    if normalized.startswith("opus_"):
+        return "opus"
+    if normalized.startswith("wav_"):
+        return "wav"
+    if normalized.startswith(("pcm_", "ulaw_", "alaw_")):
+        return "pcm"
+    return "mp3"
+
+
+def _extract_elevenlabs_billing_payload(response: httpx.Response) -> dict[str, Any] | None:
+    character_count = _first_int(
+        response.headers.get("x-character-count"),
+        response.headers.get("x-characters-count"),
+        response.headers.get("character-count"),
+    )
+    if character_count is None:
+        return None
+    return {"input_characters": character_count}
+
+
+def _format_elevenlabs_tts_error(response: httpx.Response) -> str:
+    upstream_msg = response.text
+    try:
+        upstream_body = response.json()
+    except Exception:
+        upstream_body = None
+
+    if isinstance(upstream_body, Mapping):
+        detail = upstream_body.get("detail")
+        if isinstance(detail, Mapping):
+            upstream_msg = str(detail.get("message") or detail.get("detail") or upstream_msg)
+        elif detail:
+            upstream_msg = str(detail)
+        else:
+            upstream_msg = str(upstream_body.get("message") or upstream_msg)
+
+    return f"Upstream ElevenLabs TTS call failed with status {response.status_code}: {upstream_msg}"
 
 
 def _resolve_gemini_response_format(payload: AudioSpeechRequest) -> str:
@@ -637,6 +861,17 @@ def _extract_sse_audio_and_usage(payload: bytes) -> tuple[bytes, dict[str, Any] 
     if duration_seconds is not None and duration_seconds > 0:
         billing_payload["duration"] = duration_seconds
     return b"".join(audio_chunks), billing_payload or None
+
+
+def _first_int(*values: Any) -> int | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 def _parse_sse_events(payload: bytes) -> list[dict[str, Any]]:

--- a/tests/test_elevenlabs_tts.py
+++ b/tests/test_elevenlabs_tts.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import asyncio
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from src.billing.audio_usage import normalize_speech_usage
+
+
+class _SpendRecorder:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def log_spend(self, **kwargs):  # noqa: ANN003, ANN201
+        self.events.append({"status": "success", **kwargs})
+
+    async def log_request_failure(self, **kwargs):  # noqa: ANN003, ANN201
+        self.events.append({"status": "error", **kwargs})
+
+
+def _configure_elevenlabs_deployment(test_app, *, default_params: dict | None = None) -> None:  # noqa: ANN001
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = "elevenlabs"
+    deployment.deltallm_params["model"] = "elevenlabs/eleven_multilingual_v2"
+    deployment.deltallm_params["api_base"] = "https://api.elevenlabs.io/v1"
+    deployment.deltallm_params["api_key"] = "elevenlabs-key"
+    deployment.model_info = {
+        "input_cost_per_character": 0.01,
+        "default_params": dict(default_params or {}),
+    }
+
+
+def test_normalize_speech_usage_prefers_provider_character_count() -> None:
+    usage = normalize_speech_usage(
+        request_text="short",
+        response_payload={"input_characters": 123},
+        provider="elevenlabs",
+    )
+
+    assert usage["input_characters"] == 123
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "api_base", "upstream_model"),
+    [
+        ("groq", "https://api.groq.com/openai/v1", "openai/playai-tts"),
+        ("vllm", "https://vllm.example/v1", "vllm/custom-tts"),
+    ],
+)
+async def test_audio_speech_openai_compatible_tts_providers_stay_on_audio_speech_path(
+    client,
+    test_app,
+    provider: str,
+    api_base: str,
+    upstream_model: str,
+):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = provider
+    deployment.deltallm_params["model"] = upstream_model
+    deployment.deltallm_params["api_base"] = api_base
+    deployment.deltallm_params["api_key"] = "provider-key"
+    captured: dict[str, object] = {}
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del timeout
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        return httpx.Response(200, content=b"audio-bytes", request=httpx.Request("POST", url))
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "voice": "alloy",
+            "response_format": "mp3",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"audio-bytes"
+    assert captured["url"] == f"{api_base}/audio/speech"
+    assert captured["headers"] == {
+        "Authorization": "Bearer provider-key",
+        "Content-Type": "application/json",
+    }
+    assert "xi-api-key" not in captured["headers"]
+    assert captured["json"]["model"] == upstream_model
+    assert captured["json"]["input"] == "hello world"
+    assert captured["json"]["voice"] == "alloy"
+    assert captured["json"]["response_format"] == "mp3"
+    assert "stream_format" not in captured["json"]
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_uses_elevenlabs_native_endpoint_defaults_and_billing(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    _configure_elevenlabs_deployment(
+        test_app,
+        default_params={
+            "voice_id": "voice-default",
+            "output_format": "opus_48000_128",
+            "voice_settings": {"stability": 0.4},
+            "language_code": "en",
+            "enable_logging": False,
+            "optimize_streaming_latency": 2,
+            "available_voices": ["should-not-forward"],
+        },
+    )
+    captured: dict[str, object] = {}
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del timeout
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        return httpx.Response(
+            200,
+            content=b"eleven-audio",
+            headers={"x-character-count": "123"},
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "input": "hello world"},
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"eleven-audio"
+    assert response.headers["content-type"].startswith("audio/opus")
+
+    parsed_url = urlparse(str(captured["url"]))
+    assert parsed_url.path == "/v1/text-to-speech/voice-default"
+    query = parse_qs(parsed_url.query)
+    assert query["output_format"] == ["opus_48000_128"]
+    assert query["enable_logging"] == ["false"]
+    assert query["optimize_streaming_latency"] == ["2"]
+
+    headers = captured["headers"]
+    assert headers["xi-api-key"] == "elevenlabs-key"
+    assert "Authorization" not in headers
+
+    upstream_json = captured["json"]
+    assert upstream_json == {
+        "text": "hello world",
+        "model_id": "eleven_multilingual_v2",
+        "voice_settings": {"stability": 0.4},
+        "language_code": "en",
+    }
+
+    await asyncio.sleep(0.05)
+    last_spend = test_app.state.spend_tracking_service.events[-1]
+    billing = (last_spend.get("metadata") or {}).get("billing") or {}
+    assert billing["billing_unit"] == "character"
+    assert billing["cost"] == 1.23
+    assert billing["usage_snapshot"]["input_characters"] == 123
+
+    route_deployment = response.headers["x-deltallm-route-deployment"]
+    route_usage = await test_app.state.router_state_backend.get_usage(route_deployment)
+    assert route_usage["char_pm"] == 123
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_elevenlabs_explicit_voice_format_and_speed_override(client, test_app):
+    _configure_elevenlabs_deployment(
+        test_app,
+        default_params={
+            "voice_id": "voice-default",
+            "voice_settings": {"stability": 0.7, "similarity_boost": 0.9},
+        },
+    )
+    captured: dict[str, object] = {}
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del headers, timeout
+        captured["url"] = url
+        captured["json"] = json
+        return httpx.Response(200, content=b"wav-audio", request=httpx.Request("POST", url))
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "voice": "voice/request id",
+            "response_format": "wav",
+            "speed": 1.2,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("audio/wav")
+
+    parsed_url = urlparse(str(captured["url"]))
+    assert parsed_url.path == "/v1/text-to-speech/voice%2Frequest%20id"
+    assert parse_qs(parsed_url.query)["output_format"] == ["wav_44100"]
+    assert captured["json"]["voice_settings"] == {
+        "stability": 0.7,
+        "similarity_boost": 0.9,
+        "speed": 1.2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_elevenlabs_requires_voice_or_deployment_default(client, test_app):
+    _configure_elevenlabs_deployment(test_app)
+    called = False
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        nonlocal called
+        del url, headers, json, timeout
+        called = True
+        return httpx.Response(200, content=b"audio")
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "input": "hello world"},
+    )
+
+    assert response.status_code == 400
+    assert "requires a request voice or model_info.default_params.voice_id" in response.text
+    assert called is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response_format", ["aac", "flac"])
+async def test_audio_speech_elevenlabs_rejects_unsupported_openai_formats(
+    client,
+    test_app,
+    response_format: str,
+):
+    _configure_elevenlabs_deployment(test_app, default_params={"voice_id": "voice-default"})
+    called = False
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        nonlocal called
+        del url, headers, json, timeout
+        called = True
+        return httpx.Response(200, content=b"audio")
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "response_format": response_format,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "supports 'mp3', 'opus', 'wav', and 'pcm'" in response.text
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_elevenlabs_surfaces_upstream_errors(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    _configure_elevenlabs_deployment(test_app, default_params={"voice_id": "voice-default"})
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        return httpx.Response(
+            422,
+            json={"detail": {"message": "bad voice"}},
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "input": "hello world"},
+    )
+
+    assert response.status_code == 400
+    assert "bad voice" in response.text
+
+    await asyncio.sleep(0.05)
+    last_event = test_app.state.spend_tracking_service.events[-1]
+    assert last_event["status"] == "error"
+    assert last_event["call_type"] == "audio_speech"


### PR DESCRIPTION
## Summary
- add native ElevenLabs handling for POST /v1/audio/speech
- map OpenAI-compatible speech requests to ElevenLabs text-to-speech path, auth, body, query params, and content type
- capture ElevenLabs character-count response metadata for TTS billing and router char counters
- add mocked ElevenLabs TTS coverage plus named Groq/vLLM/OpenAI-compatible TTS regression coverage

## Scope
- PR2 of #129 only: TTS runtime
- no STT runtime, catalog/discovery, UI, or docs changes

## Validation
- uv run --extra dev ruff check src/routers/audio_speech.py src/billing/audio_usage.py tests/test_elevenlabs_tts.py
- uv run --extra dev pytest tests/test_elevenlabs_tts.py -q
- uv run --extra dev pytest tests/test_elevenlabs_tts.py tests/test_uniformity_hardening.py tests/test_route_decision_multimodal.py tests/test_billing_cost.py tests/test_billing.py tests/test_provider_presets_smoke.py -q
- git diff --check

Closes part of #129