### PR TITLE
Add ElevenLabs model catalog discovery

### DIFF
--- a/src/providers/catalogs/elevenlabs.models.json
+++ b/src/providers/catalogs/elevenlabs.models.json
@@ -1,0 +1,66 @@
+{
+  "provider": "elevenlabs",
+  "last_verified_at": "2026-06-13",
+  "source_type": "mixed",
+  "sources": [
+    {
+      "label": "ElevenLabs models",
+      "url": "https://elevenlabs.io/docs/models"
+    },
+    {
+      "label": "ElevenLabs list models API",
+      "url": "https://elevenlabs.io/docs/api-reference/models/list"
+    },
+    {
+      "label": "ElevenLabs API pricing",
+      "url": "https://elevenlabs.io/pricing/api"
+    }
+  ],
+  "models": [
+    {
+      "id": "eleven_v3",
+      "label": "Eleven v3",
+      "status": "active",
+      "supported_modes": ["audio_speech"],
+      "metadata": {
+        "input_cost_per_character": 0.0001
+      }
+    },
+    {
+      "id": "eleven_multilingual_v2",
+      "label": "Eleven Multilingual v2",
+      "status": "active",
+      "supported_modes": ["audio_speech"],
+      "metadata": {
+        "input_cost_per_character": 0.0001
+      }
+    },
+    {
+      "id": "eleven_flash_v2_5",
+      "label": "Eleven Flash v2.5",
+      "status": "active",
+      "supported_modes": ["audio_speech"],
+      "metadata": {
+        "input_cost_per_character": 0.00005
+      }
+    },
+    {
+      "id": "scribe_v2",
+      "label": "Scribe v2",
+      "status": "active",
+      "supported_modes": ["audio_transcription"],
+      "metadata": {
+        "input_cost_per_second": 0.0000611111111111
+      }
+    },
+    {
+      "id": "scribe_v1",
+      "label": "Scribe v1",
+      "status": "deprecated",
+      "supported_modes": ["audio_transcription"],
+      "metadata": {
+        "input_cost_per_second": 0.0000611111111111
+      }
+    }
+  ]
+}

--- a/src/providers/model_discovery.py
+++ b/src/providers/model_discovery.py
@@ -10,6 +10,8 @@ from src.providers.resolution import PROVIDER_PRESETS, is_openai_compatible_prov
 from src.upstream_auth import build_openai_compatible_auth_headers
 from src.upstream_http import build_upstream_request_timeout
 
+_ELEVENLABS_BATCH_TRANSCRIPTION_MODELS = frozenset({"scribe_v1", "scribe_v2"})
+
 
 def _normalized_provider(provider: str | None) -> str:
     return canonical_catalog_provider(provider)
@@ -31,6 +33,23 @@ def _default_api_base(provider: str, *, default_openai_base_url: str) -> str | N
     return api_base or None
 
 
+def _provider_model_option(
+    *,
+    model_id: str,
+    label: str,
+    provider: str,
+    supported_modes: list[ModelMode] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": model_id,
+        "label": label,
+        "provider": provider,
+        "source": "provider_api",
+        "supported_modes": list(supported_modes or []),
+        "known_metadata": catalog_model_metadata(provider, model_id),
+    }
+
+
 def _extract_openai_style_models(payload: Any, *, provider: str) -> list[dict[str, Any]]:
     items = payload.get("data") if isinstance(payload, dict) else None
     if not isinstance(items, list):
@@ -43,15 +62,13 @@ def _extract_openai_style_models(payload: Any, *, provider: str) -> list[dict[st
         model_id = str(item.get("id") or item.get("name") or "").strip()
         if not model_id:
             continue
+        label = str(item.get("display_name") or item.get("name") or model_id).strip() or model_id
         models.append(
-            {
-                "id": model_id,
-                "label": str(item.get("display_name") or item.get("name") or model_id).strip() or model_id,
-                "provider": provider,
-                "source": "provider_api",
-                "supported_modes": [],
-                "known_metadata": catalog_model_metadata(provider, model_id),
-            }
+            _provider_model_option(
+                model_id=model_id,
+                label=label,
+                provider=provider,
+            )
         )
     return models
 
@@ -70,14 +87,11 @@ def _extract_anthropic_models(payload: Any, *, provider: str) -> list[dict[str, 
             continue
         label = str(item.get("display_name") or item.get("name") or model_id).strip() or model_id
         models.append(
-            {
-                "id": model_id,
-                "label": label,
-                "provider": provider,
-                "source": "provider_api",
-                "supported_modes": [],
-                "known_metadata": catalog_model_metadata(provider, model_id),
-            }
+            _provider_model_option(
+                model_id=model_id,
+                label=label,
+                provider=provider,
+            )
         )
     return models
 
@@ -97,14 +111,64 @@ def _extract_gemini_models(payload: Any, *, provider: str) -> list[dict[str, Any
             continue
         label = str(item.get("displayName") or model_id).strip() or model_id
         models.append(
-            {
-                "id": model_id,
-                "label": label,
-                "provider": provider,
-                "source": "provider_api",
-                "supported_modes": [],
-                "known_metadata": catalog_model_metadata(provider, model_id),
-            }
+            _provider_model_option(
+                model_id=model_id,
+                label=label,
+                provider=provider,
+            )
+        )
+    return models
+
+
+def _elevenlabs_model_items(payload: Any) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return []
+    for key in ("models", "data"):
+        items = payload.get(key)
+        if isinstance(items, list):
+            return items
+    return []
+
+
+def _truthy_provider_flag(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
+def _extract_elevenlabs_supported_modes(item: dict[str, Any], *, model_id: str) -> list[ModelMode]:
+    modes: list[ModelMode] = []
+    normalized_id = model_id.strip().lower()
+    if _truthy_provider_flag(item.get("can_do_text_to_speech")):
+        modes.append("audio_speech")
+    if normalized_id in _ELEVENLABS_BATCH_TRANSCRIPTION_MODELS:
+        modes.append("audio_transcription")
+    return modes
+
+
+def _extract_elevenlabs_models(payload: Any, *, provider: str) -> list[dict[str, Any]]:
+    models: list[dict[str, Any]] = []
+    for item in _elevenlabs_model_items(payload):
+        if not isinstance(item, dict):
+            continue
+        model_id = str(item.get("model_id") or item.get("id") or item.get("name") or "").strip()
+        if not model_id:
+            continue
+        supported_modes = _extract_elevenlabs_supported_modes(item, model_id=model_id)
+        if not supported_modes:
+            continue
+        label = str(item.get("name") or item.get("display_name") or model_id).strip() or model_id
+        models.append(
+            _provider_model_option(
+                model_id=model_id,
+                label=label,
+                provider=provider,
+                supported_modes=supported_modes,
+            )
         )
     return models
 
@@ -185,6 +249,17 @@ async def _discover_live_models(
         )
         return _extract_gemini_models(payload, provider=response_provider)
 
+    if provider == "elevenlabs":
+        if not api_key:
+            return []
+        payload = await _load_json(
+            http_client,
+            url=f"{str(api_base or '').rstrip('/')}/models",
+            headers={"xi-api-key": api_key},
+            general_settings=general_settings,
+        )
+        return _extract_elevenlabs_models(payload, provider=response_provider)
+
     if not is_openai_compatible_provider(provider):
         return []
     if not api_key or not api_base:
@@ -207,6 +282,8 @@ async def _discover_live_models(
 def _merge_model_options(
     catalog_options: list[dict[str, Any]],
     live_options: list[dict[str, Any]],
+    *,
+    mode: ModelMode | None = None,
 ) -> list[dict[str, Any]]:
     merged: dict[tuple[str, str], dict[str, Any]] = {}
 
@@ -215,6 +292,9 @@ def _merge_model_options(
         model_id = str(option.get("id") or "").strip()
         if not provider or not model_id:
             continue
+        option_modes = list(option.get("supported_modes") or [])
+        if mode is not None and option_modes and mode not in option_modes:
+            continue
 
         key = (provider, model_id.lower())
         existing = merged.get(key)
@@ -222,7 +302,7 @@ def _merge_model_options(
             merged[key] = {
                 **option,
                 "known_metadata": dict(option.get("known_metadata") or {}) or None,
-                "supported_modes": list(option.get("supported_modes") or []),
+                "supported_modes": option_modes,
             }
             continue
 
@@ -297,6 +377,6 @@ async def discover_provider_models(
         warnings.append(str(exc))
 
     return {
-        "data": _merge_model_options(catalog_options, live_options),
+        "data": _merge_model_options(catalog_options, live_options, mode=mode),
         "warnings": warnings,
     }

--- a/tests/test_elevenlabs_model_discovery.py
+++ b/tests/test_elevenlabs_model_discovery.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.db.named_credentials import NamedCredentialRecord
+
+
+class _FakeNamedCredentialRepository:
+    def __init__(self, records: list[NamedCredentialRecord]) -> None:
+        self.records = {record.credential_id: record for record in records}
+
+    async def get_by_id(self, credential_id: str) -> NamedCredentialRecord | None:
+        return self.records.get(credential_id)
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_returns_tts_catalog_without_credentials(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_speech"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+    models = {item["id"]: item for item in payload["data"]}
+    assert set(models) == {"eleven_v3", "eleven_multilingual_v2", "eleven_flash_v2_5"}
+    assert models["eleven_flash_v2_5"]["known_metadata"]["input_cost_per_character"] == 0.00005
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_returns_stt_catalog_without_credentials(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_transcription"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+    models = {item["id"]: item for item in payload["data"]}
+    assert set(models) == {"scribe_v2", "scribe_v1"}
+    assert models["scribe_v2"]["known_metadata"]["input_cost_per_second"] == 0.0000611111111111
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_uses_xi_api_key_and_merges_live_catalog(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    captured: dict[str, object] = {}
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "model_id": "eleven_multilingual_v2",
+                    "name": "Eleven Multilingual v2",
+                    "can_do_text_to_speech": True,
+                },
+                {
+                    "model_id": "eleven_turbo_v2_5",
+                    "name": "Eleven Turbo v2.5",
+                    "can_do_text_to_speech": True,
+                },
+                {
+                    "model_id": "eleven_music_v1",
+                    "name": "Eleven Music v1",
+                    "can_do_text_to_speech": False,
+                },
+            ],
+        )
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_speech", "api_key": "provider-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+    assert captured["url"] == "https://api.elevenlabs.io/v1/models"
+    assert captured["headers"] == {"xi-api-key": "provider-key"}
+    assert "Authorization" not in captured["headers"]
+    models = {item["id"]: item for item in payload["data"]}
+    assert models["eleven_multilingual_v2"]["source"] == "catalog+provider_api"
+    assert models["eleven_multilingual_v2"]["supported_modes"] == ["audio_speech"]
+    assert models["eleven_multilingual_v2"]["known_metadata"]["input_cost_per_character"] == 0.0001
+    assert models["eleven_turbo_v2_5"]["source"] == "provider_api"
+    assert models["eleven_turbo_v2_5"]["known_metadata"] is None
+    assert models["eleven_turbo_v2_5"]["supported_modes"] == ["audio_speech"]
+    assert "eleven_music_v1" not in models
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_supports_named_credentials(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.named_credential_repository = _FakeNamedCredentialRepository(
+        [
+            NamedCredentialRecord(
+                credential_id="cred-1",
+                name="ElevenLabs prod",
+                provider="elevenlabs",
+                connection_config={
+                    "api_key": "credential-key",
+                    "api_base": "https://elevenlabs-proxy.example/v1",
+                },
+            )
+        ]
+    )
+    captured: dict[str, object] = {}
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        captured["url"] = url
+        captured["headers"] = headers
+        del timeout
+        return httpx.Response(
+            200,
+            json={"models": [{"model_id": "eleven_v3", "name": "Eleven v3", "can_do_text_to_speech": True}]},
+        )
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_speech", "named_credential_id": "cred-1"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["warnings"] == []
+    assert captured["url"] == "https://elevenlabs-proxy.example/v1/models"
+    assert captured["headers"] == {"xi-api-key": "credential-key"}
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_filters_live_results_to_supported_batch_stt(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        del url, headers, timeout
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "model_id": "eleven_turbo_v2_5",
+                    "name": "Eleven Turbo v2.5",
+                    "can_do_text_to_speech": True,
+                },
+                {
+                    "model_id": "scribe_v2",
+                    "name": "Scribe v2",
+                    "can_do_text_to_speech": False,
+                },
+                {
+                    "model_id": "scribe_v2_realtime",
+                    "name": "Scribe v2 Realtime",
+                    "can_do_text_to_speech": False,
+                },
+                {
+                    "model_id": "eleven_music_v1",
+                    "name": "Eleven Music v1",
+                },
+            ],
+        )
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_transcription", "api_key": "provider-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+    models = {item["id"]: item for item in payload["data"]}
+    assert "eleven_turbo_v2_5" not in models
+    assert "scribe_v2_realtime" not in models
+    assert "eleven_music_v1" not in models
+    assert models["scribe_v2"]["source"] == "catalog+provider_api"
+    assert models["scribe_v2"]["supported_modes"] == ["audio_transcription"]
+    assert models["scribe_v2"]["known_metadata"]["input_cost_per_second"] == 0.0000611111111111
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_keeps_catalog_on_live_failure(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        del url, headers, timeout
+        return httpx.Response(503, json={"detail": "unavailable"})
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_transcription", "api_key": "provider-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"]
+    assert {item["id"] for item in payload["data"]} == {"scribe_v2", "scribe_v1"}
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_keeps_catalog_on_invalid_live_json(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        del url, headers, timeout
+        return httpx.Response(200, content=b"not-json")
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_speech", "api_key": "provider-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert any("invalid JSON" in warning for warning in payload["warnings"])
+    assert {"eleven_v3", "eleven_multilingual_v2", "eleven_flash_v2_5"}.issubset(
+        {item["id"] for item in payload["data"]}
+    )

--- a/tests/test_provider_model_catalog_loader.py
+++ b/tests/test_provider_model_catalog_loader.py
@@ -19,7 +19,7 @@ from src.providers.model_catalog_loader import (
 def test_provider_catalog_loader_returns_expected_providers() -> None:
     catalogs = reload_provider_catalogs()
 
-    assert {"openai", "anthropic", "groq", "gemini"}.issubset(catalogs.keys())
+    assert {"openai", "anthropic", "groq", "gemini", "elevenlabs"}.issubset(catalogs.keys())
     assert get_provider_catalog("openai") is not None
 
 
@@ -28,6 +28,8 @@ def test_provider_catalog_summary_includes_provenance() -> None:
 
     assert summary["openai"]["last_verified_at"] == "2026-04-01"
     assert summary["openai"]["model_count"] >= 10
+    assert summary["elevenlabs"]["last_verified_at"] == "2026-06-13"
+    assert summary["elevenlabs"]["model_count"] == 5
 
 
 def test_catalog_model_metadata_supports_aliases() -> None:
@@ -43,11 +45,39 @@ def test_catalog_models_for_provider_filters_by_mode() -> None:
     assert models == {"gemini-embedding-001"}
 
 
+def test_catalog_models_for_elevenlabs_filters_audio_modes() -> None:
+    speech_models = {item["id"] for item in catalog_models_for_provider("elevenlabs", mode="audio_speech")}
+    transcription_models = {
+        item["id"] for item in catalog_models_for_provider("elevenlabs", mode="audio_transcription")
+    }
+
+    assert speech_models == {"eleven_v3", "eleven_multilingual_v2", "eleven_flash_v2_5"}
+    assert transcription_models == {"scribe_v2", "scribe_v1"}
+
+
 def test_catalog_provider_sources_returns_official_urls() -> None:
     sources = catalog_provider_sources("openai")
 
     assert sources
     assert any(source["url"].startswith("https://developers.openai.com/") for source in sources)
+
+
+def test_elevenlabs_catalog_exposes_official_sources_and_metadata() -> None:
+    catalog = get_provider_catalog("elevenlabs")
+    assert catalog is not None
+
+    sources = catalog_provider_sources("elevenlabs")
+    speech_metadata = catalog_model_metadata("elevenlabs", "eleven_flash_v2_5")
+    transcription_metadata = catalog_model_metadata("elevenlabs", "scribe_v2")
+    model_statuses = {model.id: model.status for model in catalog.models}
+
+    assert any(source["url"].startswith("https://elevenlabs.io/docs/") for source in sources)
+    assert any(source["url"].startswith("https://elevenlabs.io/pricing/") for source in sources)
+    assert model_statuses["scribe_v1"] == "deprecated"
+    assert speech_metadata is not None
+    assert speech_metadata["input_cost_per_character"] == 0.00005
+    assert transcription_metadata is not None
+    assert transcription_metadata["input_cost_per_second"] == 0.0000611111111111
 
 
 def test_canonical_catalog_provider_maps_azure_alias() -> None:


### PR DESCRIPTION
## Summary
- Add the ElevenLabs provider catalog with initial TTS and STT model entries.
- Add ElevenLabs live model discovery through GET /v1/models using xi-api-key.
- Merge live provider results with catalog metadata while keeping Scribe STT catalog suggestions available.
- Add catalog and mocked discovery coverage for catalog-only, auth, named credentials, merge behavior, filtering, and warning fallbacks.

## Scope
Part of #129, PR 4: Catalog and discovery.

## Validation
- uv run --extra dev ruff check src/providers/model_discovery.py tests/test_provider_model_catalog_loader.py tests/test_elevenlabs_model_discovery.py
- uv run --extra dev pytest tests/test_provider_model_catalog_loader.py tests/test_provider_model_discovery.py tests/test_elevenlabs_model_discovery.py tests/test_ui_provider_presets.py tests/test_failover.py tests/test_elevenlabs_tts.py tests/test_elevenlabs_stt.py -q
- git diff --check