### PR TITLE
Add ElevenLabs UI and docs polish

### DIFF
--- a/docs/admin-ui/models.md
+++ b/docs/admin-ui/models.md
@@ -43,6 +43,58 @@ For a simple first deployment:
 
 If you do not set a `deployment_id`, DeltaLLM creates one automatically.
 
+## ElevenLabs Audio Deployments
+
+ElevenLabs deployments use the same public DeltaLLM audio routes as other providers, but DeltaLLM calls the native ElevenLabs upstream APIs behind the scenes.
+
+For shared credentials and key rotation, create an ElevenLabs [Named Credential](named-credentials.md) with provider `elevenlabs`, the ElevenLabs API key, and the default API base `https://api.elevenlabs.io/v1`. Inline credentials also work for deployment-specific keys.
+
+### Text-to-Speech
+
+1. Open **AI Gateway > Models**
+2. Choose **Text-to-Speech**
+3. Set the public model name, for example `elevenlabs-tts`
+4. Choose provider **ElevenLabs**
+5. Set provider model to `eleven_multilingual_v2`, `eleven_v3`, or another ElevenLabs TTS model
+6. Select the ElevenLabs named credential, or choose **Inline Credentials** and enter the API key and API base
+7. Add default parameter `voice_id` when clients will not send a `voice` value
+8. Optionally add default parameter `output_format`, for example `mp3_44100_128`
+9. Save the deployment
+
+If the public request includes `voice`, that value is used as the ElevenLabs voice ID. If the public request omits `voice`, DeltaLLM uses `model_info.default_params.voice_id`. A TTS deployment without either value returns a request error instead of making an upstream call.
+
+### Speech-to-Text
+
+1. Open **AI Gateway > Models**
+2. Choose **Speech-to-Text**
+3. Set the public model name, for example `elevenlabs-stt`
+4. Choose provider **ElevenLabs**
+5. Set provider model to `scribe_v2` or `scribe_v1`
+6. Select the ElevenLabs named credential, or choose **Inline Credentials** and enter the API key and API base
+7. Optionally add safe default parameters such as `language_code`, `timestamps_granularity`, `diarize`, `num_speakers`, or `tag_audio_events`
+8. Save the deployment
+
+DeltaLLM maps public transcription fields such as `language` and `temperature` to the native ElevenLabs multipart fields. It does not send OpenAI-only fields such as `prompt` or `response_format` upstream to ElevenLabs.
+
+### ElevenLabs Default Parameters
+
+| Key | Mode | Use |
+|-----|------|-----|
+| `voice_id` | TTS | Fallback voice ID when the public request omits `voice` |
+| `output_format` | TTS | Native ElevenLabs output format such as `mp3_44100_128` |
+| `language_code` | STT | Default transcription language when the public request omits `language` |
+| `timestamps_granularity` | STT | Word or character timestamp granularity, when supported by the upstream model |
+| `diarize` | STT | Enables speaker diarization |
+| `num_speakers` | STT | Expected number of speakers for diarization |
+| `tag_audio_events` | STT | Controls audio-event tags in transcription results |
+
+### Troubleshooting
+
+- Missing voice ID: add `model_info.default_params.voice_id` or require clients to send `voice`
+- Auth failures: verify the named credential has `provider: elevenlabs`, a valid `api_key`, and no custom OpenAI auth fields
+- Output format errors: use public `response_format` values such as `mp3`, `opus`, `wav`, or `pcm`, or configure a valid ElevenLabs `output_format` default
+- STT duration billing: DeltaLLM derives billable duration from ElevenLabs timing metadata, then applies `input_cost_per_second` when configured
+
 ## Chat Batch Execution
 
 For chat deployments, the model form includes **Batch Execution** controls in

--- a/docs/admin-ui/named-credentials.md
+++ b/docs/admin-ui/named-credentials.md
@@ -9,7 +9,7 @@ Use them when you want to:
 - avoid repeating inline `api_key`, `api_base`, and similar connection fields in every model
 - convert repeated inline credentials into a reusable shared object
 
-This is especially useful for providers such as OpenAI-compatible gateways, Groq, Anthropic, Gemini, Azure OpenAI, and Bedrock.
+This is especially useful for providers such as OpenAI-compatible gateways, Groq, Anthropic, Gemini, Azure OpenAI, Bedrock, and ElevenLabs.
 
 ## What a Named Credential Contains
 
@@ -63,6 +63,16 @@ Validation rules:
 - reserved header names such as `Content-Type` are rejected
 
 If you leave both fields unset, DeltaLLM keeps the default upstream behavior: `Authorization: Bearer {api_key}`.
+
+## ElevenLabs Credentials
+
+For ElevenLabs, create a named credential with:
+
+- `provider: elevenlabs`
+- `connection_config.api_key`
+- `connection_config.api_base`, usually `https://api.elevenlabs.io/v1`
+
+Do not set `auth_header_name` or `auth_header_format` for ElevenLabs. ElevenLabs is a native provider in DeltaLLM, and upstream calls use `xi-api-key` automatically instead of OpenAI-compatible bearer auth.
 
 ## UI Workflow
 
@@ -155,6 +165,22 @@ Example response shape:
   "credentials_present": true,
   "usage_count": 0
 }
+```
+
+Example ElevenLabs credential:
+
+```bash
+curl http://localhost:4002/ui/api/named-credentials \
+  -H "Authorization: Bearer $DELTALLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "ElevenLabs production",
+    "provider": "elevenlabs",
+    "connection_config": {
+      "api_key": "elevenlabs-key",
+      "api_base": "https://api.elevenlabs.io/v1"
+    }
+  }'
 ```
 
 ### 2. Create deployments that reference it

--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -139,6 +139,8 @@ POST /v1/audio/speech
 
 This endpoint returns audio bytes, not JSON.
 
+Public speech requests remain OpenAI-compatible even when the selected deployment is ElevenLabs. For ElevenLabs, DeltaLLM maps `input` to native `text`, resolves the ElevenLabs voice ID from request `voice` or deployment `model_info.default_params.voice_id`, and calls `POST /v1/text-to-speech/{voice_id}` upstream with `xi-api-key`.
+
 ```bash
 curl http://localhost:8000/v1/audio/speech \
   -H "Authorization: Bearer YOUR_API_KEY" \
@@ -152,6 +154,21 @@ curl http://localhost:8000/v1/audio/speech \
   --output speech.mp3
 ```
 
+Example using an ElevenLabs-backed public model:
+
+```bash
+curl http://localhost:8000/v1/audio/speech \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "elevenlabs-tts",
+    "input": "Hello from ElevenLabs through DeltaLLM",
+    "voice": "21m00Tcm4TlvDq8ikWAM",
+    "response_format": "mp3"
+  }' \
+  --output elevenlabs-speech.mp3
+```
+
 ### Audio Transcription
 
 ```text
@@ -160,12 +177,25 @@ POST /v1/audio/transcriptions
 
 This endpoint accepts multipart form data.
 
+Public transcription requests remain OpenAI-compatible even when the selected deployment is ElevenLabs. For ElevenLabs, DeltaLLM sends the uploaded audio to native `POST /v1/speech-to-text`, maps public `language` to `language_code`, maps `temperature`, and reshapes the provider response back into the requested public response format.
+
 ```bash
 curl http://localhost:8000/v1/audio/transcriptions \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -F "file=@sample.wav" \
   -F "model=whisper-large" \
   -F "response_format=json"
+```
+
+Example using an ElevenLabs-backed public model:
+
+```bash
+curl http://localhost:8000/v1/audio/transcriptions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@sample.wav" \
+  -F "model=elevenlabs-stt" \
+  -F "language=en" \
+  -F "response_format=verbose_json"
 ```
 
 ### Rerank

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -64,9 +64,10 @@ After the initial seed, set `model_deployment_bootstrap_from_config` back to `fa
 | Field | Status | What it means |
 |-------|--------|---------------|
 | `model_name` | Required | Public model name clients send in API requests |
+| `named_credential_id` | Optional | Shared provider credential to merge into this deployment |
 | `deltallm_params.provider` | Recommended for new config; required by the admin UI/API | Authoritative provider identity for routing visibility, dashboards, spend, callbacks, and metrics |
 | `deltallm_params.model` | Required | Upstream model ID sent to the provider; provider prefixes remain supported as legacy/import fallback |
-| `deltallm_params.api_key` | Required | Provider API key |
+| `deltallm_params.api_key` | Required unless supplied by `named_credential_id` | Provider API key |
 | `deltallm_params.api_base` | Optional | Custom provider base URL |
 | `deltallm_params.auth_header_name` | Optional | Custom upstream auth header key for supported OpenAI-compatible providers |
 | `deltallm_params.auth_header_format` | Optional | Custom upstream auth header value template, must include `{api_key}` |
@@ -167,6 +168,69 @@ model_list:
     model_info:
       mode: audio_transcription
 ```
+
+## ElevenLabs Audio Examples
+
+ElevenLabs is a native audio provider. Public clients still call the OpenAI-compatible DeltaLLM routes, while DeltaLLM translates upstream calls to ElevenLabs native endpoints with `xi-api-key` auth.
+
+Text-to-speech deployment with inline credentials:
+
+```yaml
+model_list:
+  - model_name: elevenlabs-tts
+    deltallm_params:
+      provider: elevenlabs
+      model: elevenlabs/eleven_multilingual_v2
+      api_key: os.environ/ELEVENLABS_API_KEY
+      api_base: https://api.elevenlabs.io/v1
+    model_info:
+      mode: audio_speech
+      default_params:
+        voice_id: 21m00Tcm4TlvDq8ikWAM
+        output_format: mp3_44100_128
+```
+
+Speech-to-text deployment with inline credentials:
+
+```yaml
+model_list:
+  - model_name: elevenlabs-stt
+    deltallm_params:
+      provider: elevenlabs
+      model: elevenlabs/scribe_v2
+      api_key: os.environ/ELEVENLABS_API_KEY
+      api_base: https://api.elevenlabs.io/v1
+    model_info:
+      mode: audio_transcription
+      default_params:
+        timestamps_granularity: word
+        diarize: true
+```
+
+Named-credential-backed deployments keep connection fields out of `deltallm_params`. Create the ElevenLabs named credential first, then reference it from each deployment:
+
+```yaml
+model_list:
+  - model_name: elevenlabs-tts
+    named_credential_id: cred-elevenlabs-prod
+    deltallm_params:
+      provider: elevenlabs
+      model: elevenlabs/eleven_multilingual_v2
+    model_info:
+      mode: audio_speech
+      default_params:
+        voice_id: 21m00Tcm4TlvDq8ikWAM
+
+  - model_name: elevenlabs-stt
+    named_credential_id: cred-elevenlabs-prod
+    deltallm_params:
+      provider: elevenlabs
+      model: elevenlabs/scribe_v2
+    model_info:
+      mode: audio_transcription
+```
+
+For TTS, request `voice` overrides `model_info.default_params.voice_id`. For STT, public `language` and `temperature` override matching provider defaults. Add pricing fields such as `input_cost_per_character` for TTS or `input_cost_per_second` for STT only when you want DeltaLLM spend estimates for those deployments.
 
 ## Access Groups and Routing Tags
 
@@ -349,6 +413,7 @@ For new deployments, set `deltallm_params.provider`. Provider prefixes in `delta
 | Perplexity | `perplexity/` | `perplexity/sonar` |
 | Gemini | `gemini/` | `gemini/gemini-2.0-flash` |
 | AWS Bedrock | `bedrock/` | `bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0` |
+| ElevenLabs | `elevenlabs/` | `elevenlabs/eleven_multilingual_v2` |
 | vLLM | `vllm/` | `vllm/meta-llama/Llama-3.1-8B-Instruct` |
 | LM Studio | `lmstudio/` | `lmstudio/qwen2.5-7b-instruct` |
 | Ollama | `ollama/` | `ollama/llama3.1` |
@@ -368,6 +433,7 @@ For new deployments, set `deltallm_params.provider`. Provider prefixes in `delta
 | Perplexity | Y | N | N | N | N | N |
 | Gemini | Y | N | N | N | N | N |
 | AWS Bedrock | Y | N | N | N | N | N |
+| ElevenLabs | N | N | N | Y | Y | N |
 | vLLM | Y | Y | Y | Y | Y | N |
 | LM Studio | Y | Y | N | N | N | N |
 | Ollama | Y | Y | N | N | N | N |

--- a/ui/src/components/ModelForm.tsx
+++ b/ui/src/components/ModelForm.tsx
@@ -44,13 +44,65 @@ function CollapsibleCard({ title, defaultOpen = false, children }: { title: stri
   );
 }
 
-function upstreamModelPlaceholder(mode: ModelMode): string {
+type DefaultParameterHint = {
+  description: string;
+  details?: string[];
+  keyPlaceholder: string;
+  valuePlaceholder: string;
+};
+
+const PROVIDER_MODEL_PLACEHOLDERS: Partial<Record<string, Partial<Record<ModelMode, string>>>> = {
+  elevenlabs: {
+    audio_speech: 'eleven_multilingual_v2',
+    audio_transcription: 'scribe_v2',
+  },
+};
+
+function normalizedProviderKey(provider: string | null | undefined): string {
+  return (provider || '').trim().toLowerCase();
+}
+
+function upstreamModelPlaceholder(mode: ModelMode, provider?: string): string {
+  const providerPlaceholder = PROVIDER_MODEL_PLACEHOLDERS[normalizedProviderKey(provider)]?.[mode];
+  if (providerPlaceholder) return providerPlaceholder;
   if (mode === 'image_generation') return 'gpt-image-1.5';
   if (mode === 'audio_speech') return 'gpt-4o-mini-tts';
   if (mode === 'audio_transcription') return 'gpt-4o-transcribe';
   if (mode === 'embedding') return 'text-embedding-3-large';
   if (mode === 'rerank') return 'rerank-english-v3.0';
   return 'gpt-5.4';
+}
+
+function defaultParameterHint(provider: string, mode: ModelMode): DefaultParameterHint {
+  const providerKey = normalizedProviderKey(provider);
+  if (providerKey === 'elevenlabs' && mode === 'audio_speech') {
+    return {
+      description: 'Default values injected into ElevenLabs TTS requests when callers omit them.',
+      details: [
+        'Use voice_id as the fallback voice when the public request does not include voice.',
+        'Use output_format for provider-native formats such as mp3_44100_128; public response_format still takes priority.',
+      ],
+      keyPlaceholder: 'Key (voice_id or output_format)',
+      valuePlaceholder: 'Value (voice ID or mp3_44100_128)',
+    };
+  }
+
+  if (providerKey === 'elevenlabs' && mode === 'audio_transcription') {
+    return {
+      description: 'Default values injected into ElevenLabs STT requests when callers omit them.',
+      details: [
+        'Common safe defaults include language_code, timestamps_granularity, diarize, num_speakers, and tag_audio_events.',
+      ],
+      keyPlaceholder: 'Key (e.g. timestamps_granularity)',
+      valuePlaceholder: 'Value (e.g. word)',
+    };
+  }
+
+  return {
+    description: 'Default values injected into provider requests when not specified by the caller (e.g. voice, response_format)',
+    keyPlaceholder: 'Key (e.g. voice)',
+    valuePlaceholder: 'Value (e.g. alloy)',
+  };
 }
 
 type MetadataAutofillField =
@@ -256,6 +308,7 @@ export default function ModelForm({
   const selectedModelOption = findProviderModelOption(modelOptions, form.model);
   const chatBatchingDisabled = form.chat_batching_mode === 'disabled';
   const chatBatchingSyncMicrobatch = form.chat_batching_mode === 'sync_microbatch';
+  const defaultParamHint = defaultParameterHint(form.provider, mode);
 
   const clearValidation = (field?: RequiredField) => {
     if (validationError) setValidationError(null);
@@ -540,7 +593,7 @@ export default function ModelForm({
                 list={modelSuggestionListId}
                 value={form.model}
                 onChange={(e) => updateModelValue(e.target.value)}
-                placeholder={upstreamModelPlaceholder(mode)}
+                placeholder={upstreamModelPlaceholder(mode, form.provider)}
                 className="min-w-0 flex-1 px-3 py-2 text-sm text-gray-900 focus:outline-none"
               />
             </div>
@@ -1048,7 +1101,12 @@ export default function ModelForm({
 
       <CollapsibleCard title="Default Parameters">
         <div className="space-y-3">
-          <p className="text-xs text-gray-400">Default values injected into provider requests when not specified by the caller (e.g. voice, response_format)</p>
+          <div className="space-y-1">
+            <p className="text-xs text-gray-400">{defaultParamHint.description}</p>
+            {defaultParamHint.details?.map((detail) => (
+              <p key={detail} className="text-xs text-gray-500">{detail}</p>
+            ))}
+          </div>
           {defaultParams.map((param, idx) => (
             <div key={idx} className="flex items-center gap-2">
               <input
@@ -1058,7 +1116,7 @@ export default function ModelForm({
                   updated[idx] = { ...updated[idx], key: e.target.value };
                   setDefaultParams(updated);
                 }}
-                placeholder="Key (e.g. voice)"
+                placeholder={defaultParamHint.keyPlaceholder}
                 className={`flex-1 ${inputClass}`}
               />
               <input
@@ -1068,7 +1126,7 @@ export default function ModelForm({
                   updated[idx] = { ...updated[idx], value: e.target.value };
                   setDefaultParams(updated);
                 }}
-                placeholder="Value (e.g. alloy)"
+                placeholder={defaultParamHint.valuePlaceholder}
                 className={`flex-1 ${inputClass}`}
               />
               <button


### PR DESCRIPTION
## Summary
- Add ElevenLabs-aware model placeholders in the Admin UI model form for TTS and STT deployments.
- Add ElevenLabs default-parameter guidance for `voice_id`, `output_format`, and STT options.
- Document ElevenLabs named credentials, Admin UI deployment workflows, config examples, public proxy behavior, and troubleshooting notes.
- Update the provider prefix and capability matrix documentation for ElevenLabs audio modes.

## Scope
Part of #129, PR 5: UI and docs polish.

## Validation
- `npm run build`
- `npx eslint src/components/ModelForm.tsx`
- `uv run --extra dev pytest tests/test_ui_provider_presets.py tests/test_named_credentials_api.py tests/test_elevenlabs_model_discovery.py tests/test_elevenlabs_tts.py tests/test_elevenlabs_stt.py -q`
- `uv run --with-requirements docs/requirements.txt mkdocs build`
- `git diff --check`

## Notes
- Full `npm run lint` is still blocked by existing repo-wide UI lint issues outside this PR.
- `mkdocs build --strict` is still blocked by existing internal-doc missing-link warnings outside this PR.