### PR TITLE
Add native ElevenLabs audio provider support

### DIFF
--- a/docs/admin-ui/models.md
+++ b/docs/admin-ui/models.md
@@ -43,6 +43,58 @@ For a simple first deployment:
 
 If you do not set a `deployment_id`, DeltaLLM creates one automatically.
 
+## ElevenLabs Audio Deployments
+
+ElevenLabs deployments use the same public DeltaLLM audio routes as other providers, but DeltaLLM calls the native ElevenLabs upstream APIs behind the scenes.
+
+For shared credentials and key rotation, create an ElevenLabs [Named Credential](named-credentials.md) with provider `elevenlabs`, the ElevenLabs API key, and the default API base `https://api.elevenlabs.io/v1`. Inline credentials also work for deployment-specific keys.
+
+### Text-to-Speech
+
+1. Open **AI Gateway > Models**
+2. Choose **Text-to-Speech**
+3. Set the public model name, for example `elevenlabs-tts`
+4. Choose provider **ElevenLabs**
+5. Set provider model to `eleven_multilingual_v2`, `eleven_v3`, or another ElevenLabs TTS model
+6. Select the ElevenLabs named credential, or choose **Inline Credentials** and enter the API key and API base
+7. Add default parameter `voice_id` when clients will not send a `voice` value
+8. Optionally add default parameter `output_format`, for example `mp3_44100_128`
+9. Save the deployment
+
+If the public request includes `voice`, that value is used as the ElevenLabs voice ID. If the public request omits `voice`, DeltaLLM uses `model_info.default_params.voice_id`. A TTS deployment without either value returns a request error instead of making an upstream call.
+
+### Speech-to-Text
+
+1. Open **AI Gateway > Models**
+2. Choose **Speech-to-Text**
+3. Set the public model name, for example `elevenlabs-stt`
+4. Choose provider **ElevenLabs**
+5. Set provider model to `scribe_v2` or `scribe_v1`
+6. Select the ElevenLabs named credential, or choose **Inline Credentials** and enter the API key and API base
+7. Optionally add safe default parameters such as `language_code`, `timestamps_granularity`, `diarize`, `num_speakers`, or `tag_audio_events`
+8. Save the deployment
+
+DeltaLLM maps public transcription fields such as `language` and `temperature` to the native ElevenLabs multipart fields. It does not send OpenAI-only fields such as `prompt` or `response_format` upstream to ElevenLabs.
+
+### ElevenLabs Default Parameters
+
+| Key | Mode | Use |
+|-----|------|-----|
+| `voice_id` | TTS | Fallback voice ID when the public request omits `voice` |
+| `output_format` | TTS | Native ElevenLabs output format such as `mp3_44100_128` |
+| `language_code` | STT | Default transcription language when the public request omits `language` |
+| `timestamps_granularity` | STT | Word or character timestamp granularity, when supported by the upstream model |
+| `diarize` | STT | Enables speaker diarization |
+| `num_speakers` | STT | Expected number of speakers for diarization |
+| `tag_audio_events` | STT | Controls audio-event tags in transcription results |
+
+### Troubleshooting
+
+- Missing voice ID: add `model_info.default_params.voice_id` or require clients to send `voice`
+- Auth failures: verify the named credential has `provider: elevenlabs`, a valid `api_key`, and no custom OpenAI auth fields
+- Output format errors: use public `response_format` values such as `mp3`, `opus`, `wav`, or `pcm`, or configure a valid ElevenLabs `output_format` default
+- STT duration billing: DeltaLLM derives billable duration from ElevenLabs timing metadata, then applies `input_cost_per_second` when configured
+
 ## Chat Batch Execution
 
 For chat deployments, the model form includes **Batch Execution** controls in

--- a/docs/admin-ui/named-credentials.md
+++ b/docs/admin-ui/named-credentials.md
@@ -9,7 +9,7 @@ Use them when you want to:
 - avoid repeating inline `api_key`, `api_base`, and similar connection fields in every model
 - convert repeated inline credentials into a reusable shared object
 
-This is especially useful for providers such as OpenAI-compatible gateways, Groq, Anthropic, Gemini, Azure OpenAI, and Bedrock.
+This is especially useful for providers such as OpenAI-compatible gateways, Groq, Anthropic, Gemini, Azure OpenAI, Bedrock, and ElevenLabs.
 
 ## What a Named Credential Contains
 
@@ -63,6 +63,16 @@ Validation rules:
 - reserved header names such as `Content-Type` are rejected
 
 If you leave both fields unset, DeltaLLM keeps the default upstream behavior: `Authorization: Bearer {api_key}`.
+
+## ElevenLabs Credentials
+
+For ElevenLabs, create a named credential with:
+
+- `provider: elevenlabs`
+- `connection_config.api_key`
+- `connection_config.api_base`, usually `https://api.elevenlabs.io/v1`
+
+Do not set `auth_header_name` or `auth_header_format` for ElevenLabs. ElevenLabs is a native provider in DeltaLLM, and upstream calls use `xi-api-key` automatically instead of OpenAI-compatible bearer auth.
 
 ## UI Workflow
 
@@ -155,6 +165,22 @@ Example response shape:
   "credentials_present": true,
   "usage_count": 0
 }
+```
+
+Example ElevenLabs credential:
+
+```bash
+curl http://localhost:4002/ui/api/named-credentials \
+  -H "Authorization: Bearer $DELTALLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "ElevenLabs production",
+    "provider": "elevenlabs",
+    "connection_config": {
+      "api_key": "elevenlabs-key",
+      "api_base": "https://api.elevenlabs.io/v1"
+    }
+  }'
 ```
 
 ### 2. Create deployments that reference it

--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -139,6 +139,8 @@ POST /v1/audio/speech
 
 This endpoint returns audio bytes, not JSON.
 
+Public speech requests remain OpenAI-compatible even when the selected deployment is ElevenLabs. For ElevenLabs, DeltaLLM maps `input` to native `text`, resolves the ElevenLabs voice ID from request `voice` or deployment `model_info.default_params.voice_id`, and calls `POST /v1/text-to-speech/{voice_id}` upstream with `xi-api-key`.
+
 ```bash
 curl http://localhost:8000/v1/audio/speech \
   -H "Authorization: Bearer YOUR_API_KEY" \
@@ -152,6 +154,21 @@ curl http://localhost:8000/v1/audio/speech \
   --output speech.mp3
 ```
 
+Example using an ElevenLabs-backed public model:
+
+```bash
+curl http://localhost:8000/v1/audio/speech \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "elevenlabs-tts",
+    "input": "Hello from ElevenLabs through DeltaLLM",
+    "voice": "21m00Tcm4TlvDq8ikWAM",
+    "response_format": "mp3"
+  }' \
+  --output elevenlabs-speech.mp3
+```
+
 ### Audio Transcription
 
 ```text
@@ -160,12 +177,25 @@ POST /v1/audio/transcriptions
 
 This endpoint accepts multipart form data.
 
+Public transcription requests remain OpenAI-compatible even when the selected deployment is ElevenLabs. For ElevenLabs, DeltaLLM sends the uploaded audio to native `POST /v1/speech-to-text`, maps public `language` to `language_code`, maps `temperature`, and reshapes the provider response back into the requested public response format.
+
 ```bash
 curl http://localhost:8000/v1/audio/transcriptions \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -F "file=@sample.wav" \
   -F "model=whisper-large" \
   -F "response_format=json"
+```
+
+Example using an ElevenLabs-backed public model:
+
+```bash
+curl http://localhost:8000/v1/audio/transcriptions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@sample.wav" \
+  -F "model=elevenlabs-stt" \
+  -F "language=en" \
+  -F "response_format=verbose_json"
 ```
 
 ### Rerank

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -64,9 +64,10 @@ After the initial seed, set `model_deployment_bootstrap_from_config` back to `fa
 | Field | Status | What it means |
 |-------|--------|---------------|
 | `model_name` | Required | Public model name clients send in API requests |
+| `named_credential_id` | Optional | Shared provider credential to merge into this deployment |
 | `deltallm_params.provider` | Recommended for new config; required by the admin UI/API | Authoritative provider identity for routing visibility, dashboards, spend, callbacks, and metrics |
 | `deltallm_params.model` | Required | Upstream model ID sent to the provider; provider prefixes remain supported as legacy/import fallback |
-| `deltallm_params.api_key` | Required | Provider API key |
+| `deltallm_params.api_key` | Required unless supplied by `named_credential_id` | Provider API key |
 | `deltallm_params.api_base` | Optional | Custom provider base URL |
 | `deltallm_params.auth_header_name` | Optional | Custom upstream auth header key for supported OpenAI-compatible providers |
 | `deltallm_params.auth_header_format` | Optional | Custom upstream auth header value template, must include `{api_key}` |
@@ -167,6 +168,69 @@ model_list:
     model_info:
       mode: audio_transcription
 ```
+
+## ElevenLabs Audio Examples
+
+ElevenLabs is a native audio provider. Public clients still call the OpenAI-compatible DeltaLLM routes, while DeltaLLM translates upstream calls to ElevenLabs native endpoints with `xi-api-key` auth.
+
+Text-to-speech deployment with inline credentials:
+
+```yaml
+model_list:
+  - model_name: elevenlabs-tts
+    deltallm_params:
+      provider: elevenlabs
+      model: elevenlabs/eleven_multilingual_v2
+      api_key: os.environ/ELEVENLABS_API_KEY
+      api_base: https://api.elevenlabs.io/v1
+    model_info:
+      mode: audio_speech
+      default_params:
+        voice_id: 21m00Tcm4TlvDq8ikWAM
+        output_format: mp3_44100_128
+```
+
+Speech-to-text deployment with inline credentials:
+
+```yaml
+model_list:
+  - model_name: elevenlabs-stt
+    deltallm_params:
+      provider: elevenlabs
+      model: elevenlabs/scribe_v2
+      api_key: os.environ/ELEVENLABS_API_KEY
+      api_base: https://api.elevenlabs.io/v1
+    model_info:
+      mode: audio_transcription
+      default_params:
+        timestamps_granularity: word
+        diarize: true
+```
+
+Named-credential-backed deployments keep connection fields out of `deltallm_params`. Create the ElevenLabs named credential first, then reference it from each deployment:
+
+```yaml
+model_list:
+  - model_name: elevenlabs-tts
+    named_credential_id: cred-elevenlabs-prod
+    deltallm_params:
+      provider: elevenlabs
+      model: elevenlabs/eleven_multilingual_v2
+    model_info:
+      mode: audio_speech
+      default_params:
+        voice_id: 21m00Tcm4TlvDq8ikWAM
+
+  - model_name: elevenlabs-stt
+    named_credential_id: cred-elevenlabs-prod
+    deltallm_params:
+      provider: elevenlabs
+      model: elevenlabs/scribe_v2
+    model_info:
+      mode: audio_transcription
+```
+
+For TTS, request `voice` overrides `model_info.default_params.voice_id`. For STT, public `language` and `temperature` override matching provider defaults. Add pricing fields such as `input_cost_per_character` for TTS or `input_cost_per_second` for STT only when you want DeltaLLM spend estimates for those deployments.
 
 ## Access Groups and Routing Tags
 
@@ -349,6 +413,7 @@ For new deployments, set `deltallm_params.provider`. Provider prefixes in `delta
 | Perplexity | `perplexity/` | `perplexity/sonar` |
 | Gemini | `gemini/` | `gemini/gemini-2.0-flash` |
 | AWS Bedrock | `bedrock/` | `bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0` |
+| ElevenLabs | `elevenlabs/` | `elevenlabs/eleven_multilingual_v2` |
 | vLLM | `vllm/` | `vllm/meta-llama/Llama-3.1-8B-Instruct` |
 | LM Studio | `lmstudio/` | `lmstudio/qwen2.5-7b-instruct` |
 | Ollama | `ollama/` | `ollama/llama3.1` |
@@ -368,6 +433,7 @@ For new deployments, set `deltallm_params.provider`. Provider prefixes in `delta
 | Perplexity | Y | N | N | N | N | N |
 | Gemini | Y | N | N | N | N | N |
 | AWS Bedrock | Y | N | N | N | N | N |
+| ElevenLabs | N | N | N | Y | Y | N |
 | vLLM | Y | Y | Y | Y | Y | N |
 | LM Studio | Y | Y | N | N | N | N |
 | Ollama | Y | Y | N | N | N | N |

--- a/src/audio/__init__.py
+++ b/src/audio/__init__.py
@@ -1,0 +1,1 @@
+"""Audio route helpers and provider runtimes."""

--- a/src/audio/elevenlabs_stt.py
+++ b/src/audio/elevenlabs_stt.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from time import perf_counter
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import Request
+
+from src.audio.transcription_formats import render_srt, render_vtt
+from src.providers.resolution import resolve_upstream_model
+from src.router.router import Deployment
+from src.upstream_http import build_upstream_request_timeout_for_request
+
+ELEVENLABS_STT_FORM_DEFAULT_KEYS = {
+    "tag_audio_events",
+    "num_speakers",
+    "timestamps_granularity",
+    "diarize",
+    "diarization_threshold",
+    "file_format",
+    "seed",
+    "use_multi_channel",
+    "no_verbatim",
+}
+ELEVENLABS_STT_QUERY_DEFAULT_KEYS = {"enable_logging"}
+
+
+async def execute_elevenlabs_stt(
+    *,
+    request: Request,
+    file_content: bytes,
+    filename: str,
+    content_type: str,
+    model: str,
+    language: str | None,
+    response_format: str | None,
+    temperature: float | None,
+    deployment: Deployment,
+    api_base: str,
+    api_key: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    defaults = _model_default_params(deployment.model_info)
+    upstream_model = resolve_upstream_model(deployment.deltallm_params, fallback_model=model) or model
+    form_data = _build_elevenlabs_stt_form_data(
+        model_id=upstream_model,
+        language=language,
+        temperature=temperature,
+        default_params=defaults,
+    )
+    endpoint = f"{api_base}/speech-to-text"
+    query = _build_elevenlabs_stt_query(default_params=defaults)
+    if query:
+        endpoint = f"{endpoint}?{query}"
+
+    upstream_start = perf_counter()
+    response = await request.app.state.http_client.post(
+        endpoint,
+        headers={"xi-api-key": api_key},
+        files={"file": (filename, file_content, content_type)},
+        data=form_data,
+        timeout=build_upstream_request_timeout_for_request(request, timeout_seconds),
+    )
+    if response.status_code >= 400:
+        raise httpx.HTTPStatusError(
+            _format_elevenlabs_stt_error(response),
+            request=httpx.Request("POST", endpoint),
+            response=response,
+        )
+
+    try:
+        parsed_response = response.json()
+    except ValueError as exc:
+        error_request = httpx.Request("POST", endpoint)
+        error_response = httpx.Response(
+            502,
+            text="Upstream ElevenLabs STT call returned invalid JSON",
+            request=error_request,
+        )
+        raise httpx.HTTPStatusError(
+            "Upstream ElevenLabs STT call returned invalid JSON",
+            request=error_request,
+            response=error_response,
+        ) from exc
+
+    data, billing_payload = _reshape_elevenlabs_transcription_response(
+        requested_response_format=response_format,
+        response_payload=parsed_response,
+    )
+    data["_billing_payload"] = billing_payload
+    data["_api_latency_ms"] = (perf_counter() - upstream_start) * 1000
+    data["_api_base"] = api_base
+    data["_deployment_model"] = deployment.deltallm_params.get("model")
+    data["_model_info"] = deployment.model_info
+    return data
+
+
+def _model_default_params(model_info: dict[str, Any] | None) -> dict[str, Any]:
+    defaults = (model_info or {}).get("default_params")
+    return dict(defaults) if isinstance(defaults, Mapping) else {}
+
+
+def _build_elevenlabs_stt_form_data(
+    *,
+    model_id: str,
+    language: str | None,
+    temperature: float | None,
+    default_params: Mapping[str, Any],
+) -> dict[str, str]:
+    form_data: dict[str, Any] = {"model_id": model_id}
+    for key in ELEVENLABS_STT_FORM_DEFAULT_KEYS:
+        if key in default_params and default_params[key] is not None:
+            form_data[key] = default_params[key]
+
+    if language:
+        form_data["language_code"] = language
+    elif default_params.get("language_code"):
+        form_data["language_code"] = default_params["language_code"]
+
+    if temperature is not None:
+        form_data["temperature"] = temperature
+    elif default_params.get("temperature") is not None:
+        form_data["temperature"] = default_params["temperature"]
+
+    return {
+        key: _stringify_elevenlabs_form_value(value)
+        for key, value in form_data.items()
+        if value is not None
+    }
+
+
+def _build_elevenlabs_stt_query(*, default_params: Mapping[str, Any]) -> str:
+    query_params: dict[str, str] = {}
+    for key in ELEVENLABS_STT_QUERY_DEFAULT_KEYS:
+        value = default_params.get(key)
+        if value is None:
+            continue
+        query_params[key] = _stringify_elevenlabs_form_value(value)
+    return urlencode(query_params)
+
+
+def _stringify_elevenlabs_form_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _reshape_elevenlabs_transcription_response(
+    *,
+    requested_response_format: str | None,
+    response_payload: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    normalized_payload = _normalize_elevenlabs_transcript_payload(response_payload)
+    duration_seconds = _extract_elevenlabs_duration_seconds(response_payload)
+    normalized_payload["duration"] = duration_seconds or 0.0
+
+    billing_payload = dict(normalized_payload)
+    if duration_seconds is not None and duration_seconds > 0:
+        billing_payload["_billing_duration_seconds"] = duration_seconds
+        billable_duration_seconds = _extract_elevenlabs_billable_duration_seconds(
+            response_payload=response_payload,
+            duration_seconds=duration_seconds,
+        )
+        if billable_duration_seconds > duration_seconds:
+            billing_payload["_billing_billable_duration_seconds"] = billable_duration_seconds
+
+    normalized_format = (requested_response_format or "json").strip().lower() or "json"
+    transcript_text = str(normalized_payload.get("text") or "")
+    if normalized_format == "json":
+        return {"text": transcript_text}, billing_payload
+    if normalized_format == "text":
+        return {"text": transcript_text}, billing_payload
+    if normalized_format == "srt":
+        return {"text": render_srt(normalized_payload)}, billing_payload
+    if normalized_format == "vtt":
+        return {"text": render_vtt(normalized_payload)}, billing_payload
+    return normalized_payload, billing_payload
+
+
+def _normalize_elevenlabs_transcript_payload(response_payload: dict[str, Any]) -> dict[str, Any]:
+    transcripts = response_payload.get("transcripts")
+    transcript_payloads = (
+        [item for item in transcripts if isinstance(item, Mapping)]
+        if isinstance(transcripts, list)
+        else [response_payload]
+    )
+
+    text_parts: list[str] = []
+    all_words: list[dict[str, Any]] = []
+    segments: list[dict[str, Any]] = []
+    language: str | None = None
+    language_probability: Any = None
+
+    for index, transcript in enumerate(transcript_payloads):
+        transcript_text = str(transcript.get("text") or "").strip()
+        if transcript_text:
+            text_parts.append(transcript_text)
+
+        if language is None and transcript.get("language_code"):
+            language = str(transcript.get("language_code"))
+        if language_probability is None and transcript.get("language_probability") is not None:
+            language_probability = transcript.get("language_probability")
+
+        channel_index = transcript.get("channel_index")
+        if channel_index is None and isinstance(transcripts, list):
+            channel_index = index
+        words = _normalize_elevenlabs_words(transcript.get("words"), channel_index=channel_index)
+        all_words.extend(words)
+        segments.extend(_elevenlabs_words_to_segments(words))
+
+    if not text_parts and all_words:
+        text_parts.append(_join_elevenlabs_tokens(str(word.get("text") or word.get("word") or "") for word in all_words))
+
+    normalized: dict[str, Any] = {"text": "\n".join(text_parts)}
+    if language:
+        normalized["language"] = language
+    if language_probability is not None:
+        normalized["language_probability"] = language_probability
+    if response_payload.get("transcription_id") is not None:
+        normalized["transcription_id"] = response_payload["transcription_id"]
+    if all_words:
+        normalized["words"] = all_words
+    normalized["segments"] = segments
+    if isinstance(transcripts, list):
+        normalized["transcripts"] = transcripts
+    if response_payload.get("entities") is not None:
+        normalized["entities"] = response_payload["entities"]
+    if response_payload.get("additional_formats") is not None:
+        normalized["additional_formats"] = response_payload["additional_formats"]
+    return normalized
+
+
+def _normalize_elevenlabs_words(words: Any, *, channel_index: Any = None) -> list[dict[str, Any]]:
+    if not isinstance(words, list):
+        return []
+
+    normalized_words: list[dict[str, Any]] = []
+    for word in words:
+        if not isinstance(word, Mapping):
+            continue
+        text = str(word.get("text") or word.get("word") or "")
+        normalized: dict[str, Any] = {"text": text, "word": text}
+        start = _float_or_none(word.get("start"))
+        end = _float_or_none(word.get("end"))
+        if start is not None:
+            normalized["start"] = start
+        if end is not None:
+            normalized["end"] = end
+        for key in ("type", "speaker_id", "logprob"):
+            if word.get(key) is not None:
+                normalized[key] = word[key]
+        if channel_index is not None:
+            normalized["channel_index"] = channel_index
+        if word.get("characters") is not None:
+            normalized["characters"] = word["characters"]
+        normalized_words.append(normalized)
+    return normalized_words
+
+
+def _elevenlabs_words_to_segments(words: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    segments: list[dict[str, Any]] = []
+    current_words: list[str] = []
+    current_start: float | None = None
+    current_end: float | None = None
+    current_speaker: Any = None
+    current_channel: Any = None
+
+    def flush_segment() -> None:
+        nonlocal current_words, current_start, current_end, current_speaker, current_channel
+        if not current_words or current_start is None or current_end is None:
+            current_words = []
+            current_start = None
+            current_end = None
+            current_speaker = None
+            current_channel = None
+            return
+        segment: dict[str, Any] = {
+            "start": current_start,
+            "end": current_end,
+            "text": _join_elevenlabs_tokens(current_words),
+        }
+        if current_speaker is not None:
+            segment["speaker"] = current_speaker
+        if current_channel is not None:
+            segment["channel_index"] = current_channel
+        segments.append(segment)
+        current_words = []
+        current_start = None
+        current_end = None
+        current_speaker = None
+        current_channel = None
+
+    for word in words:
+        text = str(word.get("text") or word.get("word") or "").strip()
+        start = _float_or_none(word.get("start"))
+        end = _float_or_none(word.get("end"))
+        if not text or start is None or end is None:
+            continue
+
+        speaker = word.get("speaker_id")
+        channel = word.get("channel_index")
+        should_flush = bool(current_words) and (
+            speaker != current_speaker
+            or channel != current_channel
+            or (current_start is not None and start - current_start >= 5.0)
+        )
+        if should_flush:
+            flush_segment()
+
+        if not current_words:
+            current_start = start
+            current_speaker = speaker
+            current_channel = channel
+        current_words.append(text)
+        current_end = max(end, current_end or end)
+        if text.endswith((".", "!", "?")):
+            flush_segment()
+
+    flush_segment()
+    return segments
+
+
+def _extract_elevenlabs_duration_seconds(response_payload: dict[str, Any]) -> float | None:
+    duration_seconds = _float_or_none(response_payload.get("duration_seconds"))
+    if duration_seconds is not None and duration_seconds > 0:
+        return duration_seconds
+
+    transcripts = response_payload.get("transcripts")
+    if isinstance(transcripts, list):
+        transcript_duration = max(
+            (
+                duration
+                for item in transcripts
+                if isinstance(item, Mapping)
+                for duration in [_float_or_none(item.get("duration_seconds"))]
+                if duration is not None
+            ),
+            default=None,
+        )
+        if transcript_duration is not None and transcript_duration > 0:
+            return transcript_duration
+
+    top_level_word_end = _max_elevenlabs_word_end(response_payload.get("words"))
+    if top_level_word_end is not None and top_level_word_end > 0:
+        return top_level_word_end
+
+    if isinstance(transcripts, list):
+        transcript_word_end = max(
+            (
+                word_end
+                for item in transcripts
+                if isinstance(item, Mapping)
+                for word_end in [_max_elevenlabs_word_end(item.get("words"))]
+                if word_end is not None
+            ),
+            default=None,
+        )
+        if transcript_word_end is not None and transcript_word_end > 0:
+            return transcript_word_end
+
+    return None
+
+
+def _extract_elevenlabs_billable_duration_seconds(
+    *,
+    response_payload: dict[str, Any],
+    duration_seconds: float,
+) -> float:
+    transcripts = response_payload.get("transcripts")
+    if not isinstance(transcripts, list):
+        return duration_seconds
+    channel_count = sum(1 for item in transcripts if isinstance(item, Mapping))
+    if channel_count <= 1:
+        return duration_seconds
+    return duration_seconds * channel_count
+
+
+def _max_elevenlabs_word_end(words: Any) -> float | None:
+    if not isinstance(words, list):
+        return None
+    return max(
+        (
+            end
+            for word in words
+            if isinstance(word, Mapping)
+            for end in [_float_or_none(word.get("end"))]
+            if end is not None
+        ),
+        default=None,
+    )
+
+
+def _join_elevenlabs_tokens(tokens: Any) -> str:
+    text = ""
+    for token in tokens:
+        value = str(token or "").strip()
+        if not value:
+            continue
+        if not text:
+            text = value
+        elif value in {".", ",", "!", "?", ";", ":", "%", ")", "]", "}"}:
+            text = f"{text}{value}"
+        elif text.endswith(("(", "[", "{")):
+            text = f"{text}{value}"
+        else:
+            text = f"{text} {value}"
+    return text
+
+
+def _format_elevenlabs_stt_error(response: httpx.Response) -> str:
+    upstream_msg = response.text
+    try:
+        upstream_body = response.json()
+    except Exception:
+        upstream_body = None
+
+    if isinstance(upstream_body, Mapping):
+        detail = upstream_body.get("detail")
+        if isinstance(detail, Mapping):
+            upstream_msg = str(detail.get("message") or detail.get("detail") or upstream_msg)
+        elif detail:
+            upstream_msg = str(detail)
+        else:
+            upstream_msg = str(upstream_body.get("message") or upstream_msg)
+
+    return f"Upstream ElevenLabs STT call failed with status {response.status_code}: {upstream_msg}"
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/audio/transcription_formats.py
+++ b/src/audio/transcription_formats.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def render_srt(response_payload: dict[str, Any]) -> str:
+    segments = response_payload.get("segments")
+    if not isinstance(segments, list) or not segments:
+        return str(response_payload.get("text") or "")
+
+    lines: list[str] = []
+    for index, segment in enumerate(segments, start=1):
+        if not isinstance(segment, dict):
+            continue
+        text = str(segment.get("text") or "").strip()
+        if not text:
+            continue
+        start = _format_timestamp(segment.get("start"), decimal_separator=",")
+        end = _format_timestamp(segment.get("end"), decimal_separator=",")
+        lines.extend([str(index), f"{start} --> {end}", text, ""])
+    return "\n".join(lines).strip()
+
+
+def render_vtt(response_payload: dict[str, Any]) -> str:
+    segments = response_payload.get("segments")
+    if not isinstance(segments, list) or not segments:
+        transcript_text = str(response_payload.get("text") or "")
+        return f"WEBVTT\n\n{transcript_text}".strip()
+
+    lines = ["WEBVTT", ""]
+    for segment in segments:
+        if not isinstance(segment, dict):
+            continue
+        text = str(segment.get("text") or "").strip()
+        if not text:
+            continue
+        start = _format_timestamp(segment.get("start"), decimal_separator=".")
+        end = _format_timestamp(segment.get("end"), decimal_separator=".")
+        lines.extend([f"{start} --> {end}", text, ""])
+    return "\n".join(lines).strip()
+
+
+def _format_timestamp(value: Any, *, decimal_separator: str) -> str:
+    total_seconds = max(0.0, float(value or 0))
+    hours = int(total_seconds // 3600)
+    minutes = int((total_seconds % 3600) // 60)
+    seconds = int(total_seconds % 60)
+    milliseconds = int(round((total_seconds - int(total_seconds)) * 1000))
+
+    if milliseconds == 1000:
+        milliseconds = 0
+        seconds += 1
+    if seconds == 60:
+        seconds = 0
+        minutes += 1
+    if minutes == 60:
+        minutes = 0
+        hours += 1
+
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}{decimal_separator}{milliseconds:03d}"

--- a/src/billing/audio_usage.py
+++ b/src/billing/audio_usage.py
@@ -17,9 +17,15 @@ def normalize_transcription_usage(
         usage.update(_extract_token_usage(provider_usage))
 
     duration_seconds = _extract_duration_seconds(response_payload, provider_usage)
+    provider_billable_duration_seconds = _extract_billable_duration_seconds(response_payload)
+    if duration_seconds is None:
+        duration_seconds = provider_billable_duration_seconds
     if duration_seconds is not None and duration_seconds > 0:
         usage["duration_seconds"] = duration_seconds
-        billable_duration_seconds = _apply_stt_provider_billing_rules(duration_seconds, provider)
+        billable_duration_seconds = max(
+            _apply_stt_provider_billing_rules(duration_seconds, provider),
+            provider_billable_duration_seconds or 0.0,
+        )
         if billable_duration_seconds != duration_seconds:
             usage["billable_duration_seconds"] = billable_duration_seconds
     return usage
@@ -150,6 +156,10 @@ def _extract_duration_seconds(
             return duration_seconds
 
     return None
+
+
+def _extract_billable_duration_seconds(response_payload: Mapping[str, Any]) -> float | None:
+    return _first_float(response_payload.get("_billing_billable_duration_seconds"))
 
 
 def _first_int(*values: Any) -> int | None:

--- a/src/billing/audio_usage.py
+++ b/src/billing/audio_usage.py
@@ -32,9 +32,13 @@ def normalize_speech_usage(
     provider: str | None = None,
 ) -> dict[str, Any]:
     usage: dict[str, Any] = {"input_characters": len(request_text)}
+    if isinstance(response_payload, Mapping):
+        usage.update(_extract_speech_character_usage(response_payload))
+
     provider_usage = response_payload.get("usage") if isinstance(response_payload, Mapping) else None
     if isinstance(provider_usage, Mapping):
         usage.update(_extract_speech_token_usage(provider_usage))
+        usage.update(_extract_speech_character_usage(provider_usage))
 
     duration_seconds = (
         _extract_duration_seconds(response_payload, provider_usage)
@@ -96,6 +100,22 @@ def _extract_speech_token_usage(provider_usage: Mapping[str, Any]) -> dict[str, 
     return usage
 
 
+def _extract_speech_character_usage(payload: Mapping[str, Any]) -> dict[str, int]:
+    usage: dict[str, int] = {}
+    input_characters = _first_int(
+        payload.get("input_characters"),
+        payload.get("characters"),
+        payload.get("character_count"),
+    )
+    if input_characters is not None:
+        usage["input_characters"] = input_characters
+
+    output_characters = _first_int(payload.get("output_characters"))
+    if output_characters is not None:
+        usage["output_characters"] = output_characters
+    return usage
+
+
 def _extract_duration_seconds(
     response_payload: Mapping[str, Any],
     provider_usage: Mapping[str, Any] | None,
@@ -129,6 +149,17 @@ def _extract_duration_seconds(
         if duration_seconds is not None:
             return duration_seconds
 
+    return None
+
+
+def _first_int(*values: Any) -> int | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            continue
     return None
 
 

--- a/src/providers/catalogs/elevenlabs.models.json
+++ b/src/providers/catalogs/elevenlabs.models.json
@@ -1,0 +1,66 @@
+{
+  "provider": "elevenlabs",
+  "last_verified_at": "2026-06-13",
+  "source_type": "mixed",
+  "sources": [
+    {
+      "label": "ElevenLabs models",
+      "url": "https://elevenlabs.io/docs/models"
+    },
+    {
+      "label": "ElevenLabs list models API",
+      "url": "https://elevenlabs.io/docs/api-reference/models/list"
+    },
+    {
+      "label": "ElevenLabs API pricing",
+      "url": "https://elevenlabs.io/pricing/api"
+    }
+  ],
+  "models": [
+    {
+      "id": "eleven_v3",
+      "label": "Eleven v3",
+      "status": "active",
+      "supported_modes": ["audio_speech"],
+      "metadata": {
+        "input_cost_per_character": 0.0001
+      }
+    },
+    {
+      "id": "eleven_multilingual_v2",
+      "label": "Eleven Multilingual v2",
+      "status": "active",
+      "supported_modes": ["audio_speech"],
+      "metadata": {
+        "input_cost_per_character": 0.0001
+      }
+    },
+    {
+      "id": "eleven_flash_v2_5",
+      "label": "Eleven Flash v2.5",
+      "status": "active",
+      "supported_modes": ["audio_speech"],
+      "metadata": {
+        "input_cost_per_character": 0.00005
+      }
+    },
+    {
+      "id": "scribe_v2",
+      "label": "Scribe v2",
+      "status": "active",
+      "supported_modes": ["audio_transcription"],
+      "metadata": {
+        "input_cost_per_second": 0.0000611111111111
+      }
+    },
+    {
+      "id": "scribe_v1",
+      "label": "Scribe v1",
+      "status": "deprecated",
+      "supported_modes": ["audio_transcription"],
+      "metadata": {
+        "input_cost_per_second": 0.0000611111111111
+      }
+    }
+  ]
+}

--- a/src/providers/healthcheck.py
+++ b/src/providers/healthcheck.py
@@ -119,6 +119,32 @@ async def probe_provider_health(
         except httpx.HTTPError as exc:
             return HealthProbeResult(healthy=False, error=f"Gemini health check failed: {exc}")
 
+    if provider == "elevenlabs":
+        api_key = str(params.get("api_key") or "").strip()
+        if not api_key:
+            return HealthProbeResult(healthy=False, error="Provider API key is missing")
+        api_base = str(params.get("api_base") or "https://api.elevenlabs.io/v1").rstrip("/")
+        try:
+            response = await http_client.get(
+                f"{api_base}/models",
+                headers={"xi-api-key": api_key},
+                timeout=request_timeout,
+            )
+            if response.status_code >= 400:
+                return HealthProbeResult(
+                    healthy=False,
+                    error=_status_error("ElevenLabs health check", response.status_code),
+                    status_code=response.status_code,
+                )
+            return HealthProbeResult(healthy=True, status_code=response.status_code)
+        except httpx.PoolTimeout:
+            error = GatewayCapacityError()
+            return HealthProbeResult(healthy=False, error=error.message, affects_deployment_health=False)
+        except httpx.TimeoutException:
+            return HealthProbeResult(healthy=False, error="ElevenLabs health check timed out")
+        except httpx.HTTPError as exc:
+            return HealthProbeResult(healthy=False, error=f"ElevenLabs health check failed: {exc}")
+
     if provider == "bedrock":
         if not str(params.get("aws_access_key_id") or "").strip():
             return HealthProbeResult(healthy=False, error="AWS access key is missing")

--- a/src/providers/model_discovery.py
+++ b/src/providers/model_discovery.py
@@ -10,6 +10,8 @@ from src.providers.resolution import PROVIDER_PRESETS, is_openai_compatible_prov
 from src.upstream_auth import build_openai_compatible_auth_headers
 from src.upstream_http import build_upstream_request_timeout
 
+_ELEVENLABS_BATCH_TRANSCRIPTION_MODELS = frozenset({"scribe_v1", "scribe_v2"})
+
 
 def _normalized_provider(provider: str | None) -> str:
     return canonical_catalog_provider(provider)
@@ -31,6 +33,23 @@ def _default_api_base(provider: str, *, default_openai_base_url: str) -> str | N
     return api_base or None
 
 
+def _provider_model_option(
+    *,
+    model_id: str,
+    label: str,
+    provider: str,
+    supported_modes: list[ModelMode] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": model_id,
+        "label": label,
+        "provider": provider,
+        "source": "provider_api",
+        "supported_modes": list(supported_modes or []),
+        "known_metadata": catalog_model_metadata(provider, model_id),
+    }
+
+
 def _extract_openai_style_models(payload: Any, *, provider: str) -> list[dict[str, Any]]:
     items = payload.get("data") if isinstance(payload, dict) else None
     if not isinstance(items, list):
@@ -43,15 +62,13 @@ def _extract_openai_style_models(payload: Any, *, provider: str) -> list[dict[st
         model_id = str(item.get("id") or item.get("name") or "").strip()
         if not model_id:
             continue
+        label = str(item.get("display_name") or item.get("name") or model_id).strip() or model_id
         models.append(
-            {
-                "id": model_id,
-                "label": str(item.get("display_name") or item.get("name") or model_id).strip() or model_id,
-                "provider": provider,
-                "source": "provider_api",
-                "supported_modes": [],
-                "known_metadata": catalog_model_metadata(provider, model_id),
-            }
+            _provider_model_option(
+                model_id=model_id,
+                label=label,
+                provider=provider,
+            )
         )
     return models
 
@@ -70,14 +87,11 @@ def _extract_anthropic_models(payload: Any, *, provider: str) -> list[dict[str, 
             continue
         label = str(item.get("display_name") or item.get("name") or model_id).strip() or model_id
         models.append(
-            {
-                "id": model_id,
-                "label": label,
-                "provider": provider,
-                "source": "provider_api",
-                "supported_modes": [],
-                "known_metadata": catalog_model_metadata(provider, model_id),
-            }
+            _provider_model_option(
+                model_id=model_id,
+                label=label,
+                provider=provider,
+            )
         )
     return models
 
@@ -97,14 +111,64 @@ def _extract_gemini_models(payload: Any, *, provider: str) -> list[dict[str, Any
             continue
         label = str(item.get("displayName") or model_id).strip() or model_id
         models.append(
-            {
-                "id": model_id,
-                "label": label,
-                "provider": provider,
-                "source": "provider_api",
-                "supported_modes": [],
-                "known_metadata": catalog_model_metadata(provider, model_id),
-            }
+            _provider_model_option(
+                model_id=model_id,
+                label=label,
+                provider=provider,
+            )
+        )
+    return models
+
+
+def _elevenlabs_model_items(payload: Any) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return []
+    for key in ("models", "data"):
+        items = payload.get(key)
+        if isinstance(items, list):
+            return items
+    return []
+
+
+def _truthy_provider_flag(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
+def _extract_elevenlabs_supported_modes(item: dict[str, Any], *, model_id: str) -> list[ModelMode]:
+    modes: list[ModelMode] = []
+    normalized_id = model_id.strip().lower()
+    if _truthy_provider_flag(item.get("can_do_text_to_speech")):
+        modes.append("audio_speech")
+    if normalized_id in _ELEVENLABS_BATCH_TRANSCRIPTION_MODELS:
+        modes.append("audio_transcription")
+    return modes
+
+
+def _extract_elevenlabs_models(payload: Any, *, provider: str) -> list[dict[str, Any]]:
+    models: list[dict[str, Any]] = []
+    for item in _elevenlabs_model_items(payload):
+        if not isinstance(item, dict):
+            continue
+        model_id = str(item.get("model_id") or item.get("id") or item.get("name") or "").strip()
+        if not model_id:
+            continue
+        supported_modes = _extract_elevenlabs_supported_modes(item, model_id=model_id)
+        if not supported_modes:
+            continue
+        label = str(item.get("name") or item.get("display_name") or model_id).strip() or model_id
+        models.append(
+            _provider_model_option(
+                model_id=model_id,
+                label=label,
+                provider=provider,
+                supported_modes=supported_modes,
+            )
         )
     return models
 
@@ -185,6 +249,17 @@ async def _discover_live_models(
         )
         return _extract_gemini_models(payload, provider=response_provider)
 
+    if provider == "elevenlabs":
+        if not api_key:
+            return []
+        payload = await _load_json(
+            http_client,
+            url=f"{str(api_base or '').rstrip('/')}/models",
+            headers={"xi-api-key": api_key},
+            general_settings=general_settings,
+        )
+        return _extract_elevenlabs_models(payload, provider=response_provider)
+
     if not is_openai_compatible_provider(provider):
         return []
     if not api_key or not api_base:
@@ -207,6 +282,8 @@ async def _discover_live_models(
 def _merge_model_options(
     catalog_options: list[dict[str, Any]],
     live_options: list[dict[str, Any]],
+    *,
+    mode: ModelMode | None = None,
 ) -> list[dict[str, Any]]:
     merged: dict[tuple[str, str], dict[str, Any]] = {}
 
@@ -215,6 +292,9 @@ def _merge_model_options(
         model_id = str(option.get("id") or "").strip()
         if not provider or not model_id:
             continue
+        option_modes = list(option.get("supported_modes") or [])
+        if mode is not None and option_modes and mode not in option_modes:
+            continue
 
         key = (provider, model_id.lower())
         existing = merged.get(key)
@@ -222,7 +302,7 @@ def _merge_model_options(
             merged[key] = {
                 **option,
                 "known_metadata": dict(option.get("known_metadata") or {}) or None,
-                "supported_modes": list(option.get("supported_modes") or []),
+                "supported_modes": option_modes,
             }
             continue
 
@@ -297,6 +377,6 @@ async def discover_provider_models(
         warnings.append(str(exc))
 
     return {
-        "data": _merge_model_options(catalog_options, live_options),
+        "data": _merge_model_options(catalog_options, live_options, mode=mode),
         "warnings": warnings,
     }

--- a/src/providers/resolution.py
+++ b/src/providers/resolution.py
@@ -35,6 +35,7 @@ PROVIDER_MODEL_PREFIXES_TO_STRIP: dict[str, tuple[str, ...]] = {
     "azure_openai": ("azure/", "azure_openai/"),
     "gemini": ("gemini/",),
     "bedrock": ("bedrock/",),
+    "elevenlabs": ("elevenlabs/",),
 }
 
 PROVIDER_CAPABILITIES: dict[str, set[ModelMode]] = {
@@ -50,6 +51,7 @@ PROVIDER_CAPABILITIES: dict[str, set[ModelMode]] = {
     "perplexity": {"chat"},
     "gemini": {"chat", "audio_speech"},
     "bedrock": {"chat"},
+    "elevenlabs": {"audio_speech", "audio_transcription"},
     "vllm": {"chat", "embedding", "image_generation", "audio_speech", "audio_transcription"},
     "lmstudio": {"chat", "embedding"},
     "ollama": {"chat", "embedding"},
@@ -67,6 +69,7 @@ PROVIDER_PRESETS: dict[str, dict[str, str | None]] = {
     "perplexity": {"provider": "perplexity", "api_base": "https://api.perplexity.ai", "compat": "openai"},
     "gemini": {"provider": "gemini", "api_base": "https://generativelanguage.googleapis.com/v1beta", "compat": "native"},
     "bedrock": {"provider": "bedrock", "api_base": "https://bedrock-runtime.{region}.amazonaws.com", "compat": "native"},
+    "elevenlabs": {"provider": "elevenlabs", "api_base": "https://api.elevenlabs.io/v1", "compat": "native"},
     "vllm": {"provider": "vllm", "api_base": None, "compat": "openai"},
     "lmstudio": {"provider": "lmstudio", "api_base": None, "compat": "openai"},
     "ollama": {"provider": "ollama", "api_base": None, "compat": "openai"},

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import base64
 import json
 import wave
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from io import BytesIO
 from time import perf_counter
 from typing import Any
+from urllib.parse import quote, urlencode
 
 import httpx
 from fastapi import APIRouter, Depends, Request
@@ -60,6 +62,30 @@ AUDIO_CONTENT_TYPES = {
 
 SSE_USAGE_PROVIDERS = {"openai", "azure", "azure_openai"}
 GEMINI_SUPPORTED_RESPONSE_FORMATS = {"wav", "pcm"}
+ELEVENLABS_DEFAULT_OUTPUT_FORMAT = "mp3_44100_128"
+ELEVENLABS_RESPONSE_FORMAT_MAP = {
+    "mp3": "mp3_44100_128",
+    "opus": "opus_48000_128",
+    "wav": "wav_44100",
+    "pcm": "pcm_24000",
+}
+ELEVENLABS_REQUEST_DEFAULT_KEYS = {
+    "language_code",
+    "voice_settings",
+    "pronunciation_dictionary_locators",
+    "seed",
+    "previous_text",
+    "next_text",
+    "previous_request_ids",
+    "next_request_ids",
+    "apply_text_normalization",
+    "apply_language_text_normalization",
+    "use_pvc_as_ivc",
+}
+ELEVENLABS_QUERY_DEFAULT_KEYS = {
+    "enable_logging",
+    "optimize_streaming_latency",
+}
 
 
 async def _execute_tts(
@@ -76,6 +102,14 @@ async def _execute_tts(
     provider = resolve_provider(params)
     if provider == "gemini":
         return await _execute_gemini_tts(
+            request=request,
+            payload=payload,
+            deployment=deployment,
+            api_base=api_base,
+            api_key=str(api_key),
+        )
+    if provider == "elevenlabs":
+        return await _execute_elevenlabs_tts(
             request=request,
             payload=payload,
             deployment=deployment,
@@ -467,6 +501,60 @@ async def _execute_gemini_tts(
     }
 
 
+async def _execute_elevenlabs_tts(
+    *,
+    request: Request,
+    payload: AudioSpeechRequest,
+    deployment: Deployment,
+    api_base: str,
+    api_key: str,
+) -> dict[str, Any]:
+    defaults = _model_default_params(deployment.model_info)
+    voice_id = _resolve_elevenlabs_voice_id(payload=payload, default_params=defaults)
+    provider_output_format = _resolve_elevenlabs_output_format(
+        payload=payload, default_params=defaults
+    )
+    response_format = _elevenlabs_response_format(provider_output_format)
+    upstream_payload = _build_elevenlabs_tts_payload(
+        payload=payload,
+        default_params=defaults,
+        upstream_model=resolve_upstream_model(deployment.deltallm_params),
+    )
+    endpoint = f"{api_base}/text-to-speech/{quote(voice_id, safe='')}"
+    query = _build_elevenlabs_tts_query(
+        provider_output_format=provider_output_format, default_params=defaults
+    )
+    if query:
+        endpoint = f"{endpoint}?{query}"
+
+    upstream_start = perf_counter()
+    response = await request.app.state.http_client.post(
+        endpoint,
+        headers={"xi-api-key": api_key, "Content-Type": "application/json"},
+        json=upstream_payload,
+        timeout=build_upstream_request_timeout_for_request(
+            request,
+            configured_timeout_seconds(deployment.deltallm_params.get("timeout")),
+        ),
+    )
+    if response.status_code >= 400:
+        raise httpx.HTTPStatusError(
+            _format_elevenlabs_tts_error(response),
+            request=httpx.Request("POST", endpoint),
+            response=response,
+        )
+
+    return {
+        "_audio_bytes": response.content,
+        "_billing_payload": _extract_elevenlabs_billing_payload(response),
+        "_api_latency_ms": (perf_counter() - upstream_start) * 1000,
+        "_api_base": api_base,
+        "_deployment_model": deployment.deltallm_params.get("model"),
+        "_model_info": deployment.model_info,
+        "_response_format": response_format,
+    }
+
+
 def _should_force_tts_sse(*, model_info: dict[str, Any] | None, provider: str) -> bool:
     normalized_provider = (provider or "").strip().lower()
     if normalized_provider not in SSE_USAGE_PROVIDERS:
@@ -489,6 +577,142 @@ def _should_force_tts_sse(*, model_info: dict[str, Any] | None, provider: str) -
         for field in ("input_cost_per_character", "output_cost_per_character")
     )
     return has_token_or_second_pricing and not has_character_pricing
+
+
+def _model_default_params(model_info: dict[str, Any] | None) -> dict[str, Any]:
+    defaults = (model_info or {}).get("default_params")
+    return dict(defaults) if isinstance(defaults, Mapping) else {}
+
+
+def _resolve_elevenlabs_voice_id(
+    *,
+    payload: AudioSpeechRequest,
+    default_params: Mapping[str, Any],
+) -> str:
+    if "voice" in payload.model_fields_set:
+        voice_id = str(payload.voice or "").strip()
+    else:
+        voice_id = str(default_params.get("voice_id") or "").strip()
+
+    if not voice_id:
+        raise InvalidRequestError(
+            message="ElevenLabs TTS requires a request voice or model_info.default_params.voice_id"
+        )
+    return voice_id
+
+
+def _resolve_elevenlabs_output_format(
+    *,
+    payload: AudioSpeechRequest,
+    default_params: Mapping[str, Any],
+) -> str:
+    default_output_format = str(default_params.get("output_format") or "").strip().lower()
+    if "response_format" not in payload.model_fields_set:
+        return (
+            ELEVENLABS_RESPONSE_FORMAT_MAP.get(default_output_format)
+            or default_output_format
+            or ELEVENLABS_DEFAULT_OUTPUT_FORMAT
+        )
+
+    requested_format = str(payload.response_format or "mp3").strip().lower()
+    mapped_format = ELEVENLABS_RESPONSE_FORMAT_MAP.get(requested_format)
+    if mapped_format:
+        return mapped_format
+
+    raise InvalidRequestError(
+        message=(
+            "ElevenLabs TTS supports 'mp3', 'opus', 'wav', and 'pcm' response_format values. "
+            "Configure model_info.default_params.output_format for provider-specific formats."
+        )
+    )
+
+
+def _build_elevenlabs_tts_payload(
+    *,
+    payload: AudioSpeechRequest,
+    default_params: Mapping[str, Any],
+    upstream_model: str | None,
+) -> dict[str, Any]:
+    upstream_payload: dict[str, Any] = {"text": payload.input}
+    if upstream_model:
+        upstream_payload["model_id"] = upstream_model
+
+    for key in ELEVENLABS_REQUEST_DEFAULT_KEYS:
+        if key in default_params:
+            upstream_payload[key] = default_params[key]
+
+    if "speed" in payload.model_fields_set and payload.speed is not None:
+        voice_settings = upstream_payload.get("voice_settings")
+        if not isinstance(voice_settings, Mapping):
+            voice_settings = {}
+        upstream_payload["voice_settings"] = {**dict(voice_settings), "speed": payload.speed}
+
+    return upstream_payload
+
+
+def _build_elevenlabs_tts_query(
+    *,
+    provider_output_format: str,
+    default_params: Mapping[str, Any],
+) -> str:
+    query_params: dict[str, str] = {"output_format": provider_output_format}
+    for key in ELEVENLABS_QUERY_DEFAULT_KEYS:
+        if key not in default_params:
+            continue
+        value = default_params[key]
+        if value is None:
+            continue
+        query_params[key] = _elevenlabs_query_value(value)
+    return urlencode(query_params)
+
+
+def _elevenlabs_query_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _elevenlabs_response_format(provider_output_format: str) -> str:
+    normalized = provider_output_format.strip().lower()
+    if normalized.startswith("mp3_"):
+        return "mp3"
+    if normalized.startswith("opus_"):
+        return "opus"
+    if normalized.startswith("wav_"):
+        return "wav"
+    if normalized.startswith(("pcm_", "ulaw_", "alaw_")):
+        return "pcm"
+    return "mp3"
+
+
+def _extract_elevenlabs_billing_payload(response: httpx.Response) -> dict[str, Any] | None:
+    character_count = _first_int(
+        response.headers.get("x-character-count"),
+        response.headers.get("x-characters-count"),
+        response.headers.get("character-count"),
+    )
+    if character_count is None:
+        return None
+    return {"input_characters": character_count}
+
+
+def _format_elevenlabs_tts_error(response: httpx.Response) -> str:
+    upstream_msg = response.text
+    try:
+        upstream_body = response.json()
+    except Exception:
+        upstream_body = None
+
+    if isinstance(upstream_body, Mapping):
+        detail = upstream_body.get("detail")
+        if isinstance(detail, Mapping):
+            upstream_msg = str(detail.get("message") or detail.get("detail") or upstream_msg)
+        elif detail:
+            upstream_msg = str(detail)
+        else:
+            upstream_msg = str(upstream_body.get("message") or upstream_msg)
+
+    return f"Upstream ElevenLabs TTS call failed with status {response.status_code}: {upstream_msg}"
 
 
 def _resolve_gemini_response_format(payload: AudioSpeechRequest) -> str:
@@ -637,6 +861,17 @@ def _extract_sse_audio_and_usage(payload: bytes) -> tuple[bytes, dict[str, Any] 
     if duration_seconds is not None and duration_seconds > 0:
         billing_payload["duration"] = duration_seconds
     return b"".join(audio_chunks), billing_payload or None
+
+
+def _first_int(*values: Any) -> int | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 def _parse_sse_events(payload: bytes) -> list[dict[str, Any]]:

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -8,6 +8,8 @@ import httpx
 from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 from fastapi.responses import JSONResponse
 
+from src.audio.elevenlabs_stt import execute_elevenlabs_stt
+from src.audio.transcription_formats import render_srt, render_vtt
 from src.billing.audio_usage import billing_metadata, normalize_transcription_usage
 from src.billing.cost import compute_billing_result
 from src.callbacks import CallbackManager, build_standard_logging_payload
@@ -73,6 +75,22 @@ async def _execute_stt(
 
     api_base = params.get("api_base", request.app.state.settings.openai_base_url).rstrip("/")
     api_provider = resolve_provider(params)
+    if api_provider == "elevenlabs":
+        return await execute_elevenlabs_stt(
+            request=request,
+            file_content=file_content,
+            filename=filename,
+            content_type=content_type,
+            model=model,
+            language=language,
+            response_format=response_format,
+            temperature=temperature,
+            deployment=deployment,
+            api_base=api_base,
+            api_key=str(api_key),
+            timeout_seconds=_transcription_timeout_seconds(params),
+        )
+
     headers = build_openai_compatible_auth_headers(
         provider=api_provider,
         api_key=str(api_key),
@@ -486,64 +504,7 @@ def _reshape_transcription_response(
     if normalized_format == "text":
         return {"text": transcript_text}
     if normalized_format == "srt":
-        return {"text": _render_srt(response_payload)}
+        return {"text": render_srt(response_payload)}
     if normalized_format == "vtt":
-        return {"text": _render_vtt(response_payload)}
+        return {"text": render_vtt(response_payload)}
     return response_payload
-
-
-def _render_srt(response_payload: dict[str, Any]) -> str:
-    segments = response_payload.get("segments")
-    if not isinstance(segments, list) or not segments:
-        return str(response_payload.get("text") or "")
-
-    lines: list[str] = []
-    for index, segment in enumerate(segments, start=1):
-        if not isinstance(segment, dict):
-            continue
-        text = str(segment.get("text") or "").strip()
-        if not text:
-            continue
-        start = _format_timestamp(segment.get("start"), decimal_separator=",")
-        end = _format_timestamp(segment.get("end"), decimal_separator=",")
-        lines.extend([str(index), f"{start} --> {end}", text, ""])
-    return "\n".join(lines).strip()
-
-
-def _render_vtt(response_payload: dict[str, Any]) -> str:
-    segments = response_payload.get("segments")
-    if not isinstance(segments, list) or not segments:
-        transcript_text = str(response_payload.get("text") or "")
-        return f"WEBVTT\n\n{transcript_text}".strip()
-
-    lines = ["WEBVTT", ""]
-    for segment in segments:
-        if not isinstance(segment, dict):
-            continue
-        text = str(segment.get("text") or "").strip()
-        if not text:
-            continue
-        start = _format_timestamp(segment.get("start"), decimal_separator=".")
-        end = _format_timestamp(segment.get("end"), decimal_separator=".")
-        lines.extend([f"{start} --> {end}", text, ""])
-    return "\n".join(lines).strip()
-
-
-def _format_timestamp(value: Any, *, decimal_separator: str) -> str:
-    total_seconds = max(0.0, float(value or 0))
-    hours = int(total_seconds // 3600)
-    minutes = int((total_seconds % 3600) // 60)
-    seconds = int(total_seconds % 60)
-    milliseconds = int(round((total_seconds - int(total_seconds)) * 1000))
-
-    if milliseconds == 1000:
-        milliseconds = 0
-        seconds += 1
-    if seconds == 60:
-        seconds = 0
-        minutes += 1
-    if minutes == 60:
-        minutes = 0
-        hours += 1
-
-    return f"{hours:02d}:{minutes:02d}:{seconds:02d}{decimal_separator}{milliseconds:03d}"

--- a/src/services/named_credentials.py
+++ b/src/services/named_credentials.py
@@ -191,6 +191,8 @@ def _allowed_fields_for_provider(provider: str) -> set[str]:
         return _API_KEY_PROVIDER_FIELDS
     if provider == "gemini":
         return _API_KEY_PROVIDER_FIELDS
+    if provider == "elevenlabs":
+        return _API_KEY_PROVIDER_FIELDS
     if supports_custom_openai_compatible_auth(provider):
         return _CUSTOM_AUTH_PROVIDER_FIELDS
     if is_openai_compatible_provider(provider):

--- a/tests/test_elevenlabs_model_discovery.py
+++ b/tests/test_elevenlabs_model_discovery.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.db.named_credentials import NamedCredentialRecord
+
+
+class _FakeNamedCredentialRepository:
+    def __init__(self, records: list[NamedCredentialRecord]) -> None:
+        self.records = {record.credential_id: record for record in records}
+
+    async def get_by_id(self, credential_id: str) -> NamedCredentialRecord | None:
+        return self.records.get(credential_id)
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_returns_tts_catalog_without_credentials(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_speech"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+    models = {item["id"]: item for item in payload["data"]}
+    assert set(models) == {"eleven_v3", "eleven_multilingual_v2", "eleven_flash_v2_5"}
+    assert models["eleven_flash_v2_5"]["known_metadata"]["input_cost_per_character"] == 0.00005
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_returns_stt_catalog_without_credentials(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_transcription"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+    models = {item["id"]: item for item in payload["data"]}
+    assert set(models) == {"scribe_v2", "scribe_v1"}
+    assert models["scribe_v2"]["known_metadata"]["input_cost_per_second"] == 0.0000611111111111
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_uses_xi_api_key_and_merges_live_catalog(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    captured: dict[str, object] = {}
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "model_id": "eleven_multilingual_v2",
+                    "name": "Eleven Multilingual v2",
+                    "can_do_text_to_speech": True,
+                },
+                {
+                    "model_id": "eleven_turbo_v2_5",
+                    "name": "Eleven Turbo v2.5",
+                    "can_do_text_to_speech": True,
+                },
+                {
+                    "model_id": "eleven_music_v1",
+                    "name": "Eleven Music v1",
+                    "can_do_text_to_speech": False,
+                },
+            ],
+        )
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_speech", "api_key": "provider-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+    assert captured["url"] == "https://api.elevenlabs.io/v1/models"
+    assert captured["headers"] == {"xi-api-key": "provider-key"}
+    assert "Authorization" not in captured["headers"]
+    models = {item["id"]: item for item in payload["data"]}
+    assert models["eleven_multilingual_v2"]["source"] == "catalog+provider_api"
+    assert models["eleven_multilingual_v2"]["supported_modes"] == ["audio_speech"]
+    assert models["eleven_multilingual_v2"]["known_metadata"]["input_cost_per_character"] == 0.0001
+    assert models["eleven_turbo_v2_5"]["source"] == "provider_api"
+    assert models["eleven_turbo_v2_5"]["known_metadata"] is None
+    assert models["eleven_turbo_v2_5"]["supported_modes"] == ["audio_speech"]
+    assert "eleven_music_v1" not in models
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_supports_named_credentials(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.named_credential_repository = _FakeNamedCredentialRepository(
+        [
+            NamedCredentialRecord(
+                credential_id="cred-1",
+                name="ElevenLabs prod",
+                provider="elevenlabs",
+                connection_config={
+                    "api_key": "credential-key",
+                    "api_base": "https://elevenlabs-proxy.example/v1",
+                },
+            )
+        ]
+    )
+    captured: dict[str, object] = {}
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        captured["url"] = url
+        captured["headers"] = headers
+        del timeout
+        return httpx.Response(
+            200,
+            json={"models": [{"model_id": "eleven_v3", "name": "Eleven v3", "can_do_text_to_speech": True}]},
+        )
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_speech", "named_credential_id": "cred-1"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["warnings"] == []
+    assert captured["url"] == "https://elevenlabs-proxy.example/v1/models"
+    assert captured["headers"] == {"xi-api-key": "credential-key"}
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_filters_live_results_to_supported_batch_stt(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        del url, headers, timeout
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "model_id": "eleven_turbo_v2_5",
+                    "name": "Eleven Turbo v2.5",
+                    "can_do_text_to_speech": True,
+                },
+                {
+                    "model_id": "scribe_v2",
+                    "name": "Scribe v2",
+                    "can_do_text_to_speech": False,
+                },
+                {
+                    "model_id": "scribe_v2_realtime",
+                    "name": "Scribe v2 Realtime",
+                    "can_do_text_to_speech": False,
+                },
+                {
+                    "model_id": "eleven_music_v1",
+                    "name": "Eleven Music v1",
+                },
+            ],
+        )
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_transcription", "api_key": "provider-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+    models = {item["id"]: item for item in payload["data"]}
+    assert "eleven_turbo_v2_5" not in models
+    assert "scribe_v2_realtime" not in models
+    assert "eleven_music_v1" not in models
+    assert models["scribe_v2"]["source"] == "catalog+provider_api"
+    assert models["scribe_v2"]["supported_modes"] == ["audio_transcription"]
+    assert models["scribe_v2"]["known_metadata"]["input_cost_per_second"] == 0.0000611111111111
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_keeps_catalog_on_live_failure(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        del url, headers, timeout
+        return httpx.Response(503, json={"detail": "unavailable"})
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_transcription", "api_key": "provider-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"]
+    assert {item["id"] for item in payload["data"]} == {"scribe_v2", "scribe_v1"}
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_model_discovery_keeps_catalog_on_invalid_live_json(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    async def get(url: str, headers: dict[str, str] | None = None, timeout=None):  # noqa: ANN001, ANN201
+        del url, headers, timeout
+        return httpx.Response(200, content=b"not-json")
+
+    test_app.state.http_client.get = get
+
+    response = await client.post(
+        "/ui/api/provider-models/discover",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"provider": "elevenlabs", "mode": "audio_speech", "api_key": "provider-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert any("invalid JSON" in warning for warning in payload["warnings"])
+    assert {"eleven_v3", "eleven_multilingual_v2", "eleven_flash_v2_5"}.issubset(
+        {item["id"] for item in payload["data"]}
+    )

--- a/tests/test_elevenlabs_stt.py
+++ b/tests/test_elevenlabs_stt.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import asyncio
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from src.billing.audio_usage import normalize_transcription_usage
+
+
+class _SpendRecorder:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def log_spend(self, **kwargs):  # noqa: ANN003, ANN201
+        self.events.append({"status": "success", **kwargs})
+
+    async def log_request_failure(self, **kwargs):  # noqa: ANN003, ANN201
+        self.events.append({"status": "error", **kwargs})
+
+
+def _configure_elevenlabs_stt_deployment(
+    test_app,  # noqa: ANN001
+    *,
+    default_params: dict | None = None,
+    model_info: dict | None = None,
+) -> None:
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = "elevenlabs"
+    deployment.deltallm_params["model"] = "elevenlabs/scribe_v2"
+    deployment.deltallm_params["api_base"] = "https://api.elevenlabs.io/v1"
+    deployment.deltallm_params["api_key"] = "elevenlabs-key"
+    deployment.model_info = {
+        "input_cost_per_second": 0.5,
+        "default_params": dict(default_params or {}),
+        **dict(model_info or {}),
+    }
+
+
+def test_normalize_transcription_usage_accepts_provider_billable_duration() -> None:
+    usage = normalize_transcription_usage(
+        response_payload={
+            "_billing_duration_seconds": 3.0,
+            "_billing_billable_duration_seconds": 6.0,
+        },
+        file_size_bytes=16,
+        provider="elevenlabs",
+    )
+
+    assert usage["duration_seconds"] == 3.0
+    assert usage["billable_duration_seconds"] == 6.0
+
+
+def test_normalize_transcription_usage_ignores_public_billable_duration() -> None:
+    usage = normalize_transcription_usage(
+        response_payload={
+            "duration": 3.0,
+            "billable_duration_seconds": 999.0,
+        },
+        file_size_bytes=16,
+        provider="elevenlabs",
+    )
+
+    assert usage["duration_seconds"] == 3.0
+    assert "billable_duration_seconds" not in usage
+
+
+@pytest.mark.asyncio
+async def test_audio_transcription_elevenlabs_native_multipart_defaults_and_billing(
+    client,
+    test_app,
+):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    _configure_elevenlabs_stt_deployment(
+        test_app,
+        default_params={
+            "language_code": "en",
+            "tag_audio_events": True,
+            "num_speakers": 2,
+            "timestamps_granularity": "word",
+            "diarize": False,
+            "diarization_threshold": 0.55,
+            "file_format": "pcm_s16le_16",
+            "seed": 7,
+            "use_multi_channel": False,
+            "no_verbatim": True,
+            "enable_logging": False,
+            "additional_formats": [{"format": "srt"}],
+            "webhook": True,
+            "entity_detection": True,
+            "keyterms": ["should", "not", "forward"],
+        },
+    )
+    captured: dict[str, object] = {}
+
+    async def post(  # noqa: ANN201
+        url: str,
+        headers: dict[str, str],
+        files: dict,
+        data: dict,
+        timeout: httpx.Timeout,
+    ):
+        del timeout
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["files"] = files
+        captured["data"] = data
+        return httpx.Response(
+            200,
+            json={
+                "language_code": "en",
+                "language_probability": 0.98,
+                "text": "Hello world.",
+                "words": [
+                    {"text": "Hello", "start": 0.0, "end": 0.4, "type": "word", "speaker_id": "speaker_0"},
+                    {"text": "world.", "start": 0.5, "end": 1.2, "type": "word", "speaker_id": "speaker_0"},
+                ],
+                "transcription_id": "tr_123",
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/transcriptions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        data={
+            "model": "gpt-4o-mini",
+            "language": "fr",
+            "prompt": "do not forward",
+            "response_format": "verbose_json",
+            "temperature": "0.2",
+        },
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["text"] == "Hello world."
+    assert body["language"] == "en"
+    assert body["language_probability"] == 0.98
+    assert body["duration"] == 1.2
+    assert body["segments"] == [
+        {
+            "start": 0.0,
+            "end": 1.2,
+            "text": "Hello world.",
+            "speaker": "speaker_0",
+        }
+    ]
+    assert "_billing_payload" not in body
+    assert "_billing_duration_seconds" not in body
+
+    parsed_url = urlparse(str(captured["url"]))
+    assert parsed_url.path == "/v1/speech-to-text"
+    assert parse_qs(parsed_url.query) == {"enable_logging": ["false"]}
+
+    headers = captured["headers"]
+    assert headers == {"xi-api-key": "elevenlabs-key"}
+
+    upstream_files = captured["files"]
+    assert upstream_files["file"] == ("sample.wav", b"RIFFDATA", "audio/wav")
+
+    upstream_data = captured["data"]
+    assert upstream_data == {
+        "model_id": "scribe_v2",
+        "language_code": "fr",
+        "temperature": "0.2",
+        "tag_audio_events": "true",
+        "num_speakers": "2",
+        "timestamps_granularity": "word",
+        "diarize": "false",
+        "diarization_threshold": "0.55",
+        "file_format": "pcm_s16le_16",
+        "seed": "7",
+        "use_multi_channel": "false",
+        "no_verbatim": "true",
+    }
+    for field in ("model", "language", "prompt", "response_format", "additional_formats", "webhook", "entity_detection", "keyterms"):
+        assert field not in upstream_data
+
+    assert "x-deltallm-route-deployment" in response.headers
+
+    await asyncio.sleep(0.05)
+    last_spend = test_app.state.spend_tracking_service.events[-1]
+    billing = (last_spend.get("metadata") or {}).get("billing") or {}
+    assert billing["billing_unit"] == "second"
+    assert billing["cost"] == 0.6
+    assert billing["usage_snapshot"]["duration_seconds"] == 1.2
+
+    route_deployment = response.headers["x-deltallm-route-deployment"]
+    route_usage = await test_app.state.router_state_backend.get_usage(route_deployment)
+    assert route_usage["audio_seconds_pm"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response_format", "expected_text"),
+    [
+        ("json", "Hello world."),
+        ("text", "Hello world."),
+        ("srt", "1\n00:00:00,000 --> 00:00:01,200\nHello world."),
+        ("vtt", "WEBVTT\n\n00:00:00.000 --> 00:00:01.200\nHello world."),
+    ],
+)
+async def test_audio_transcription_elevenlabs_response_formats(
+    client,
+    test_app,
+    response_format: str,
+    expected_text: str,
+):
+    _configure_elevenlabs_stt_deployment(test_app)
+
+    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+        del headers, files, data, timeout
+        return httpx.Response(
+            200,
+            json={
+                "text": "Hello world.",
+                "words": [
+                    {"text": "Hello", "start": 0.0, "end": 0.4, "type": "word"},
+                    {"text": "world.", "start": 0.5, "end": 1.2, "type": "word"},
+                ],
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/transcriptions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        data={"model": "gpt-4o-mini", "response_format": response_format},
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": expected_text}
+
+
+@pytest.mark.asyncio
+async def test_audio_transcription_elevenlabs_multichannel_uses_billable_channel_duration(
+    client,
+    test_app,
+):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    _configure_elevenlabs_stt_deployment(
+        test_app,
+        default_params={"use_multi_channel": True},
+        model_info={"input_cost_per_second": 0.2},
+    )
+
+    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+        del headers, files, data, timeout
+        return httpx.Response(
+            200,
+            json={
+                "duration_seconds": 3.0,
+                "transcription_id": "tr_multi",
+                "transcripts": [
+                    {
+                        "text": "Left channel.",
+                        "language_code": "en",
+                        "words": [{"text": "Left channel.", "start": 0.0, "end": 3.0}],
+                    },
+                    {
+                        "text": "Right channel.",
+                        "language_code": "en",
+                        "words": [{"text": "Right channel.", "start": 0.0, "end": 3.0}],
+                    },
+                ],
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/transcriptions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        data={"model": "gpt-4o-mini", "response_format": "json"},
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": "Left channel.\nRight channel."}
+
+    await asyncio.sleep(0.05)
+    last_spend = test_app.state.spend_tracking_service.events[-1]
+    billing = (last_spend.get("metadata") or {}).get("billing") or {}
+    assert billing["cost"] == 1.2
+    assert billing["usage_snapshot"]["duration_seconds"] == 3.0
+    assert billing["usage_snapshot"]["billable_duration_seconds"] == 6.0
+
+    route_deployment = response.headers["x-deltallm-route-deployment"]
+    route_usage = await test_app.state.router_state_backend.get_usage(route_deployment)
+    assert route_usage["audio_seconds_pm"] == 6
+
+
+@pytest.mark.asyncio
+async def test_audio_transcription_elevenlabs_surfaces_upstream_errors(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    _configure_elevenlabs_stt_deployment(test_app)
+
+    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+        del headers, files, data, timeout
+        return httpx.Response(
+            422,
+            json={"detail": {"message": "bad audio"}},
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/transcriptions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        data={"model": "gpt-4o-mini"},
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+
+    assert response.status_code == 400
+    assert "bad audio" in response.text
+
+    await asyncio.sleep(0.05)
+    last_event = test_app.state.spend_tracking_service.events[-1]
+    assert last_event["status"] == "error"
+    assert last_event["call_type"] == "audio_transcription"
+
+
+@pytest.mark.asyncio
+async def test_audio_transcription_elevenlabs_invalid_json_logs_upstream_502(
+    client,
+    test_app,
+):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    _configure_elevenlabs_stt_deployment(test_app)
+
+    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+        del headers, files, data, timeout
+        return httpx.Response(
+            200,
+            content=b"not-json",
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/transcriptions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        data={"model": "gpt-4o-mini"},
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+
+    assert response.status_code == 503
+    assert "invalid JSON" in response.text
+
+    await asyncio.sleep(0.05)
+    last_event = test_app.state.spend_tracking_service.events[-1]
+    assert last_event["status"] == "error"
+    assert last_event["call_type"] == "audio_transcription"
+    assert last_event["http_status_code"] == 503
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "api_base", "upstream_model"),
+    [
+        ("groq", "https://api.groq.com/openai/v1", "whisper-large-v3"),
+        ("vllm", "https://vllm.example/v1", "vllm/custom-stt"),
+    ],
+)
+async def test_audio_transcription_openai_compatible_providers_keep_existing_path(
+    client,
+    test_app,
+    provider: str,
+    api_base: str,
+    upstream_model: str,
+):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = provider
+    deployment.deltallm_params["model"] = upstream_model
+    deployment.deltallm_params["api_base"] = api_base
+    deployment.deltallm_params["api_key"] = "provider-key"
+    captured: dict[str, object] = {}
+
+    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+        del timeout
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["files"] = files
+        captured["data"] = data
+        return httpx.Response(200, json={"text": "hello"}, request=httpx.Request("POST", url))
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/transcriptions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        data={"model": "gpt-4o-mini", "language": "en", "response_format": "json"},
+        files={"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": "hello"}
+    assert captured["url"] == f"{api_base}/audio/transcriptions"
+    assert captured["headers"] == {"Authorization": "Bearer provider-key"}
+    assert "xi-api-key" not in captured["headers"]
+    assert captured["files"]["file"] == ("sample.wav", b"RIFFDATA", "audio/wav")
+    assert captured["data"]["model"] == upstream_model
+    assert captured["data"]["language"] == "en"
+    assert captured["data"]["response_format"] == "json"
+    assert captured["data"]["temperature"] == "0.0"

--- a/tests/test_elevenlabs_tts.py
+++ b/tests/test_elevenlabs_tts.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import asyncio
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from src.billing.audio_usage import normalize_speech_usage
+
+
+class _SpendRecorder:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def log_spend(self, **kwargs):  # noqa: ANN003, ANN201
+        self.events.append({"status": "success", **kwargs})
+
+    async def log_request_failure(self, **kwargs):  # noqa: ANN003, ANN201
+        self.events.append({"status": "error", **kwargs})
+
+
+def _configure_elevenlabs_deployment(test_app, *, default_params: dict | None = None) -> None:  # noqa: ANN001
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = "elevenlabs"
+    deployment.deltallm_params["model"] = "elevenlabs/eleven_multilingual_v2"
+    deployment.deltallm_params["api_base"] = "https://api.elevenlabs.io/v1"
+    deployment.deltallm_params["api_key"] = "elevenlabs-key"
+    deployment.model_info = {
+        "input_cost_per_character": 0.01,
+        "default_params": dict(default_params or {}),
+    }
+
+
+def test_normalize_speech_usage_prefers_provider_character_count() -> None:
+    usage = normalize_speech_usage(
+        request_text="short",
+        response_payload={"input_characters": 123},
+        provider="elevenlabs",
+    )
+
+    assert usage["input_characters"] == 123
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "api_base", "upstream_model"),
+    [
+        ("groq", "https://api.groq.com/openai/v1", "openai/playai-tts"),
+        ("vllm", "https://vllm.example/v1", "vllm/custom-tts"),
+    ],
+)
+async def test_audio_speech_openai_compatible_tts_providers_stay_on_audio_speech_path(
+    client,
+    test_app,
+    provider: str,
+    api_base: str,
+    upstream_model: str,
+):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = provider
+    deployment.deltallm_params["model"] = upstream_model
+    deployment.deltallm_params["api_base"] = api_base
+    deployment.deltallm_params["api_key"] = "provider-key"
+    captured: dict[str, object] = {}
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del timeout
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        return httpx.Response(200, content=b"audio-bytes", request=httpx.Request("POST", url))
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "voice": "alloy",
+            "response_format": "mp3",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"audio-bytes"
+    assert captured["url"] == f"{api_base}/audio/speech"
+    assert captured["headers"] == {
+        "Authorization": "Bearer provider-key",
+        "Content-Type": "application/json",
+    }
+    assert "xi-api-key" not in captured["headers"]
+    assert captured["json"]["model"] == upstream_model
+    assert captured["json"]["input"] == "hello world"
+    assert captured["json"]["voice"] == "alloy"
+    assert captured["json"]["response_format"] == "mp3"
+    assert "stream_format" not in captured["json"]
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_uses_elevenlabs_native_endpoint_defaults_and_billing(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    _configure_elevenlabs_deployment(
+        test_app,
+        default_params={
+            "voice_id": "voice-default",
+            "output_format": "opus_48000_128",
+            "voice_settings": {"stability": 0.4},
+            "language_code": "en",
+            "enable_logging": False,
+            "optimize_streaming_latency": 2,
+            "available_voices": ["should-not-forward"],
+        },
+    )
+    captured: dict[str, object] = {}
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del timeout
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        return httpx.Response(
+            200,
+            content=b"eleven-audio",
+            headers={"x-character-count": "123"},
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "input": "hello world"},
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"eleven-audio"
+    assert response.headers["content-type"].startswith("audio/opus")
+
+    parsed_url = urlparse(str(captured["url"]))
+    assert parsed_url.path == "/v1/text-to-speech/voice-default"
+    query = parse_qs(parsed_url.query)
+    assert query["output_format"] == ["opus_48000_128"]
+    assert query["enable_logging"] == ["false"]
+    assert query["optimize_streaming_latency"] == ["2"]
+
+    headers = captured["headers"]
+    assert headers["xi-api-key"] == "elevenlabs-key"
+    assert "Authorization" not in headers
+
+    upstream_json = captured["json"]
+    assert upstream_json == {
+        "text": "hello world",
+        "model_id": "eleven_multilingual_v2",
+        "voice_settings": {"stability": 0.4},
+        "language_code": "en",
+    }
+
+    await asyncio.sleep(0.05)
+    last_spend = test_app.state.spend_tracking_service.events[-1]
+    billing = (last_spend.get("metadata") or {}).get("billing") or {}
+    assert billing["billing_unit"] == "character"
+    assert billing["cost"] == 1.23
+    assert billing["usage_snapshot"]["input_characters"] == 123
+
+    route_deployment = response.headers["x-deltallm-route-deployment"]
+    route_usage = await test_app.state.router_state_backend.get_usage(route_deployment)
+    assert route_usage["char_pm"] == 123
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_elevenlabs_explicit_voice_format_and_speed_override(client, test_app):
+    _configure_elevenlabs_deployment(
+        test_app,
+        default_params={
+            "voice_id": "voice-default",
+            "voice_settings": {"stability": 0.7, "similarity_boost": 0.9},
+        },
+    )
+    captured: dict[str, object] = {}
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del headers, timeout
+        captured["url"] = url
+        captured["json"] = json
+        return httpx.Response(200, content=b"wav-audio", request=httpx.Request("POST", url))
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "voice": "voice/request id",
+            "response_format": "wav",
+            "speed": 1.2,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("audio/wav")
+
+    parsed_url = urlparse(str(captured["url"]))
+    assert parsed_url.path == "/v1/text-to-speech/voice%2Frequest%20id"
+    assert parse_qs(parsed_url.query)["output_format"] == ["wav_44100"]
+    assert captured["json"]["voice_settings"] == {
+        "stability": 0.7,
+        "similarity_boost": 0.9,
+        "speed": 1.2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_elevenlabs_requires_voice_or_deployment_default(client, test_app):
+    _configure_elevenlabs_deployment(test_app)
+    called = False
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        nonlocal called
+        del url, headers, json, timeout
+        called = True
+        return httpx.Response(200, content=b"audio")
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "input": "hello world"},
+    )
+
+    assert response.status_code == 400
+    assert "requires a request voice or model_info.default_params.voice_id" in response.text
+    assert called is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response_format", ["aac", "flac"])
+async def test_audio_speech_elevenlabs_rejects_unsupported_openai_formats(
+    client,
+    test_app,
+    response_format: str,
+):
+    _configure_elevenlabs_deployment(test_app, default_params={"voice_id": "voice-default"})
+    called = False
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        nonlocal called
+        del url, headers, json, timeout
+        called = True
+        return httpx.Response(200, content=b"audio")
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "response_format": response_format,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "supports 'mp3', 'opus', 'wav', and 'pcm'" in response.text
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_elevenlabs_surfaces_upstream_errors(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    _configure_elevenlabs_deployment(test_app, default_params={"voice_id": "voice-default"})
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        return httpx.Response(
+            422,
+            json={"detail": {"message": "bad voice"}},
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "input": "hello world"},
+    )
+
+    assert response.status_code == 400
+    assert "bad voice" in response.text
+
+    await asyncio.sleep(0.05)
+    last_event = test_app.state.spend_tracking_service.events[-1]
+    assert last_event["status"] == "error"
+    assert last_event["call_type"] == "audio_speech"

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -767,6 +767,74 @@ async def test_provider_health_check_defaults_unresolved_provider_to_openai():
 
 
 @pytest.mark.asyncio
+async def test_provider_health_check_supports_elevenlabs_with_default_base_url():
+    captured: dict[str, object] = {}
+
+    class FakeHTTPClient:
+        async def get(self, url, headers=None, timeout=None):  # noqa: ANN001, ANN201
+            captured["url"] = url
+            captured["headers"] = dict(headers or {})
+            captured["timeout"] = timeout
+            return httpx.Response(200, json={"models": []}, request=httpx.Request("GET", url))
+
+    result = await probe_provider_health(
+        FakeHTTPClient(),  # type: ignore[arg-type]
+        {"provider": "elevenlabs", "model": "elevenlabs/eleven_multilingual_v2", "api_key": "provider-key"},
+        default_openai_base_url="https://api.openai.com/v1",
+    )
+
+    assert result.healthy is True
+    assert result.status_code == 200
+    assert captured["url"] == "https://api.elevenlabs.io/v1/models"
+    assert captured["headers"] == {"xi-api-key": "provider-key"}
+    timeout = captured["timeout"]
+    assert getattr(timeout, "read") == 10.0
+
+
+@pytest.mark.asyncio
+async def test_provider_health_check_supports_elevenlabs_custom_base_url():
+    captured: dict[str, object] = {}
+
+    class FakeHTTPClient:
+        async def get(self, url, headers=None, timeout=None):  # noqa: ANN001, ANN201
+            captured["url"] = url
+            captured["headers"] = dict(headers or {})
+            del timeout
+            return httpx.Response(200, json={"models": []}, request=httpx.Request("GET", url))
+
+    result = await probe_provider_health(
+        FakeHTTPClient(),  # type: ignore[arg-type]
+        {
+            "provider": "elevenlabs",
+            "model": "elevenlabs/eleven_multilingual_v2",
+            "api_key": "provider-key",
+            "api_base": "https://elevenlabs-proxy.example/v1/",
+        },
+        default_openai_base_url="https://api.openai.com/v1",
+    )
+
+    assert result.healthy is True
+    assert captured["url"] == "https://elevenlabs-proxy.example/v1/models"
+    assert captured["headers"] == {"xi-api-key": "provider-key"}
+
+
+@pytest.mark.asyncio
+async def test_provider_health_check_marks_elevenlabs_missing_api_key_unhealthy():
+    class FakeHTTPClient:
+        async def get(self, url, headers=None, timeout=None):  # noqa: ANN001, ANN201
+            raise AssertionError("health check must not call upstream without an API key")
+
+    result = await probe_provider_health(
+        FakeHTTPClient(),  # type: ignore[arg-type]
+        {"provider": "elevenlabs", "model": "elevenlabs/eleven_multilingual_v2"},
+        default_openai_base_url="https://api.openai.com/v1",
+    )
+
+    assert result.healthy is False
+    assert result.error == "Provider API key is missing"
+
+
+@pytest.mark.asyncio
 async def test_background_health_checker_ignores_non_health_affecting_result():
     state = RedisStateBackend(redis=None)
     deployment = _deployment("dep-a")

--- a/tests/test_named_credentials_api.py
+++ b/tests/test_named_credentials_api.py
@@ -222,6 +222,41 @@ async def test_named_credentials_create_accepts_custom_auth_header_fields(client
 
 
 @pytest.mark.asyncio
+async def test_named_credentials_create_accepts_elevenlabs_api_key_config(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    repository = _FakeNamedCredentialRepository()
+    test_app.state.named_credential_repository = repository
+
+    response = await client.post(
+        "/ui/api/named-credentials",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "name": "ElevenLabs Shared",
+            "provider": "elevenlabs",
+            "connection_config": {
+                "api_key": "elevenlabs-key",
+                "api_base": "https://api.elevenlabs.io/v1",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["provider"] == "elevenlabs"
+    assert payload["connection_config"]["api_key"] == "***REDACTED***"
+    assert payload["connection_config"]["api_base"] == "https://api.elevenlabs.io/v1"
+    assert payload["credentials_present"] is True
+
+    list_response = await client.get(
+        "/ui/api/named-credentials?provider=elevenlabs",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+    assert list_response.status_code == 200
+    listed = list_response.json()["data"]
+    assert [item["name"] for item in listed] == ["ElevenLabs Shared"]
+
+
+@pytest.mark.asyncio
 async def test_named_credentials_update_reloads_runtime_when_in_use_and_delete_blocks(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
     repository = _FakeNamedCredentialRepository()
@@ -316,6 +351,23 @@ async def test_named_credentials_validate_provider_specific_fields(client, test_
     )
     assert invalid_azure_custom_auth.status_code == 400
     assert "unsupported fields" in invalid_azure_custom_auth.text
+
+    invalid_elevenlabs_custom_auth = await client.post(
+        "/ui/api/named-credentials",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "name": "ElevenLabs Prod",
+            "provider": "elevenlabs",
+            "connection_config": {
+                "api_key": "provider-key",
+                "api_base": "https://api.elevenlabs.io/v1",
+                "auth_header_name": "Authorization",
+                "auth_header_format": "Bearer {api_key}",
+            },
+        },
+    )
+    assert invalid_elevenlabs_custom_auth.status_code == 400
+    assert "unsupported fields" in invalid_elevenlabs_custom_auth.text
 
     invalid_auth_format = await client.post(
         "/ui/api/named-credentials",

--- a/tests/test_provider_model_catalog_loader.py
+++ b/tests/test_provider_model_catalog_loader.py
@@ -19,7 +19,7 @@ from src.providers.model_catalog_loader import (
 def test_provider_catalog_loader_returns_expected_providers() -> None:
     catalogs = reload_provider_catalogs()
 
-    assert {"openai", "anthropic", "groq", "gemini"}.issubset(catalogs.keys())
+    assert {"openai", "anthropic", "groq", "gemini", "elevenlabs"}.issubset(catalogs.keys())
     assert get_provider_catalog("openai") is not None
 
 
@@ -28,6 +28,8 @@ def test_provider_catalog_summary_includes_provenance() -> None:
 
     assert summary["openai"]["last_verified_at"] == "2026-04-01"
     assert summary["openai"]["model_count"] >= 10
+    assert summary["elevenlabs"]["last_verified_at"] == "2026-06-13"
+    assert summary["elevenlabs"]["model_count"] == 5
 
 
 def test_catalog_model_metadata_supports_aliases() -> None:
@@ -43,11 +45,39 @@ def test_catalog_models_for_provider_filters_by_mode() -> None:
     assert models == {"gemini-embedding-001"}
 
 
+def test_catalog_models_for_elevenlabs_filters_audio_modes() -> None:
+    speech_models = {item["id"] for item in catalog_models_for_provider("elevenlabs", mode="audio_speech")}
+    transcription_models = {
+        item["id"] for item in catalog_models_for_provider("elevenlabs", mode="audio_transcription")
+    }
+
+    assert speech_models == {"eleven_v3", "eleven_multilingual_v2", "eleven_flash_v2_5"}
+    assert transcription_models == {"scribe_v2", "scribe_v1"}
+
+
 def test_catalog_provider_sources_returns_official_urls() -> None:
     sources = catalog_provider_sources("openai")
 
     assert sources
     assert any(source["url"].startswith("https://developers.openai.com/") for source in sources)
+
+
+def test_elevenlabs_catalog_exposes_official_sources_and_metadata() -> None:
+    catalog = get_provider_catalog("elevenlabs")
+    assert catalog is not None
+
+    sources = catalog_provider_sources("elevenlabs")
+    speech_metadata = catalog_model_metadata("elevenlabs", "eleven_flash_v2_5")
+    transcription_metadata = catalog_model_metadata("elevenlabs", "scribe_v2")
+    model_statuses = {model.id: model.status for model in catalog.models}
+
+    assert any(source["url"].startswith("https://elevenlabs.io/docs/") for source in sources)
+    assert any(source["url"].startswith("https://elevenlabs.io/pricing/") for source in sources)
+    assert model_statuses["scribe_v1"] == "deprecated"
+    assert speech_metadata is not None
+    assert speech_metadata["input_cost_per_character"] == 0.00005
+    assert transcription_metadata is not None
+    assert transcription_metadata["input_cost_per_second"] == 0.0000611111111111
 
 
 def test_canonical_catalog_provider_maps_azure_alias() -> None:

--- a/tests/test_provider_presets_smoke.py
+++ b/tests/test_provider_presets_smoke.py
@@ -5,6 +5,7 @@ from typing import Any
 import httpx
 import pytest
 
+from src.db.callable_targets import CallableTargetBindingRecord
 from src.providers.anthropic import AnthropicAdapter
 from src.providers.resolution import provider_presets, provider_supports_mode
 
@@ -102,6 +103,26 @@ def _install_mock_provider_post(test_app) -> None:  # noqa: ANN001
     test_app.state.anthropic_adapter = AnthropicAdapter(test_app.state.http_client)  # type: ignore[arg-type]
 
 
+async def _grant_smoke_model(test_app, model_name: str) -> None:  # noqa: ANN001
+    key_record = next(iter(test_app.state._test_repo.records.values()))
+    key_record.models = sorted({*(key_record.models or []), model_name})
+
+    grant_service = test_app.state.callable_target_grant_service
+    repository = getattr(grant_service, "repository", None)
+    bindings = getattr(repository, "bindings", None)
+    if isinstance(bindings, list):
+        bindings.append(
+            CallableTargetBindingRecord(
+                callable_target_binding_id=f"ctb-smoke-{model_name}",
+                callable_key=model_name,
+                scope_type="organization",
+                scope_id=key_record.organization_id or "org-default",
+                enabled=True,
+            )
+        )
+        await grant_service.reload()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("preset", provider_presets(), ids=lambda x: str(x["provider"]))
 async def test_provider_presets_chat_smoke(client, test_app, preset: dict[str, Any]):
@@ -125,7 +146,14 @@ async def test_provider_presets_chat_smoke(client, test_app, preset: dict[str, A
         headers={"Authorization": "Bearer mk-test"},
         json=_deployment_payload(model_name=model_name, provider=provider, mode="chat", upstream_model=upstream_model),
     )
+
+    if not provider_supports_mode(provider, "chat"):
+        assert create_response.status_code == 400
+        assert "does not support mode" in create_response.text
+        return
+
     assert create_response.status_code == 200, create_response.text
+    await _grant_smoke_model(test_app, model_name)
 
     response = await client.post(
         "/v1/chat/completions",
@@ -156,6 +184,7 @@ async def test_provider_presets_embedding_smoke_with_capability_gate(client, tes
 
     if provider_supports_mode(provider, "embedding"):
         assert create_response.status_code == 200, create_response.text
+        await _grant_smoke_model(test_app, model_name)
         response = await client.post(
             "/v1/embeddings",
             headers={"Authorization": f"Bearer {test_app.state._test_key}"},

--- a/tests/test_provider_resolution.py
+++ b/tests/test_provider_resolution.py
@@ -27,6 +27,15 @@ def test_provider_supports_mode_unknown_is_permissive() -> None:
     assert provider_supports_mode("custom-gateway", "chat") is True
 
 
+def test_elevenlabs_supports_audio_modes_only() -> None:
+    assert provider_supports_mode("elevenlabs", "audio_speech") is True
+    assert provider_supports_mode("elevenlabs", "audio_transcription") is True
+    assert provider_supports_mode("elevenlabs", "chat") is False
+    assert provider_supports_mode("elevenlabs", "embedding") is False
+    assert provider_supports_mode("elevenlabs", "image_generation") is False
+    assert provider_supports_mode("elevenlabs", "rerank") is False
+
+
 def test_resolve_upstream_model_preserves_slash_prefixed_ids_for_groq() -> None:
     params = {"provider": "groq", "model": "openai/gpt-oss-120b"}
     assert resolve_upstream_model(params) == "openai/gpt-oss-120b"
@@ -42,10 +51,16 @@ def test_resolve_upstream_model_strips_anthropic_prefix_for_anthropic() -> None:
     assert resolve_upstream_model(params) == "claude-sonnet-4-20250514"
 
 
+def test_resolve_upstream_model_strips_elevenlabs_prefix_for_elevenlabs() -> None:
+    params = {"provider": "elevenlabs", "model": "elevenlabs/eleven_multilingual_v2"}
+    assert resolve_upstream_model(params) == "eleven_multilingual_v2"
+
+
 def test_openai_compatible_registry_contains_common_gateways() -> None:
     assert is_openai_compatible_provider("openrouter") is True
     assert is_openai_compatible_provider("groq") is True
     assert is_openai_compatible_provider("anthropic") is False
+    assert is_openai_compatible_provider("elevenlabs") is False
 
 
 def test_model_validation_rejects_unsupported_provider_mode_combo() -> None:

--- a/tests/test_ui_provider_presets.py
+++ b/tests/test_ui_provider_presets.py
@@ -15,6 +15,78 @@ async def test_provider_presets_endpoint_returns_known_presets(client, test_app)
     assert "openai" in providers
     assert "openrouter" in providers
     assert "anthropic" in providers
+    assert "elevenlabs" in providers
+
+
+@pytest.mark.asyncio
+async def test_provider_presets_endpoint_returns_elevenlabs_as_native_audio_provider(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.get("/ui/api/provider-presets", headers={"Authorization": "Bearer mk-test"})
+    assert response.status_code == 200
+    payload = response.json()
+    presets = {item["provider"]: item for item in payload["data"]}
+
+    elevenlabs = presets["elevenlabs"]
+    assert elevenlabs["api_base"] == "https://api.elevenlabs.io/v1"
+    assert elevenlabs["compat"] == "native"
+    assert set(elevenlabs["supported_modes"]) == {"audio_speech", "audio_transcription"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "upstream_model"),
+    [
+        ("audio_speech", "elevenlabs/eleven_multilingual_v2"),
+        ("audio_transcription", "elevenlabs/scribe_v2"),
+    ],
+)
+async def test_create_model_accepts_elevenlabs_audio_modes(client, test_app, mode, upstream_model):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": f"elevenlabs-{mode}",
+            "deltallm_params": {
+                "provider": "elevenlabs",
+                "model": upstream_model,
+                "api_base": "https://api.elevenlabs.io/v1",
+                "api_key": "provider-key",
+            },
+            "model_info": {"mode": mode},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["provider"] == "elevenlabs"
+    assert payload["mode"] == mode
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["chat", "embedding", "image_generation", "rerank"])
+async def test_create_model_rejects_elevenlabs_unsupported_modes(client, test_app, mode):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": f"bad-elevenlabs-{mode}",
+            "deltallm_params": {
+                "provider": "elevenlabs",
+                "model": "elevenlabs/eleven_multilingual_v2",
+                "api_base": "https://api.elevenlabs.io/v1",
+                "api_key": "provider-key",
+            },
+            "model_info": {"mode": mode},
+        },
+    )
+
+    assert response.status_code == 400
+    assert "does not support mode" in response.text
 
 
 @pytest.mark.asyncio

--- a/ui/src/assets/provider-logos/elevenlabs.svg
+++ b/ui/src/assets/provider-logos/elevenlabs.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>ElevenLabs</title><path d="M4.6035 0v24h4.9317V0zm9.8613 0v24h4.9317V0z"/></svg>

--- a/ui/src/components/ModelForm.tsx
+++ b/ui/src/components/ModelForm.tsx
@@ -44,13 +44,65 @@ function CollapsibleCard({ title, defaultOpen = false, children }: { title: stri
   );
 }
 
-function upstreamModelPlaceholder(mode: ModelMode): string {
+type DefaultParameterHint = {
+  description: string;
+  details?: string[];
+  keyPlaceholder: string;
+  valuePlaceholder: string;
+};
+
+const PROVIDER_MODEL_PLACEHOLDERS: Partial<Record<string, Partial<Record<ModelMode, string>>>> = {
+  elevenlabs: {
+    audio_speech: 'eleven_multilingual_v2',
+    audio_transcription: 'scribe_v2',
+  },
+};
+
+function normalizedProviderKey(provider: string | null | undefined): string {
+  return (provider || '').trim().toLowerCase();
+}
+
+function upstreamModelPlaceholder(mode: ModelMode, provider?: string): string {
+  const providerPlaceholder = PROVIDER_MODEL_PLACEHOLDERS[normalizedProviderKey(provider)]?.[mode];
+  if (providerPlaceholder) return providerPlaceholder;
   if (mode === 'image_generation') return 'gpt-image-1.5';
   if (mode === 'audio_speech') return 'gpt-4o-mini-tts';
   if (mode === 'audio_transcription') return 'gpt-4o-transcribe';
   if (mode === 'embedding') return 'text-embedding-3-large';
   if (mode === 'rerank') return 'rerank-english-v3.0';
   return 'gpt-5.4';
+}
+
+function defaultParameterHint(provider: string, mode: ModelMode): DefaultParameterHint {
+  const providerKey = normalizedProviderKey(provider);
+  if (providerKey === 'elevenlabs' && mode === 'audio_speech') {
+    return {
+      description: 'Default values injected into ElevenLabs TTS requests when callers omit them.',
+      details: [
+        'Use voice_id as the fallback voice when the public request does not include voice.',
+        'Use output_format for provider-native formats such as mp3_44100_128; public response_format still takes priority.',
+      ],
+      keyPlaceholder: 'Key (voice_id or output_format)',
+      valuePlaceholder: 'Value (voice ID or mp3_44100_128)',
+    };
+  }
+
+  if (providerKey === 'elevenlabs' && mode === 'audio_transcription') {
+    return {
+      description: 'Default values injected into ElevenLabs STT requests when callers omit them.',
+      details: [
+        'Common safe defaults include language_code, timestamps_granularity, diarize, num_speakers, and tag_audio_events.',
+      ],
+      keyPlaceholder: 'Key (e.g. timestamps_granularity)',
+      valuePlaceholder: 'Value (e.g. word)',
+    };
+  }
+
+  return {
+    description: 'Default values injected into provider requests when not specified by the caller (e.g. voice, response_format)',
+    keyPlaceholder: 'Key (e.g. voice)',
+    valuePlaceholder: 'Value (e.g. alloy)',
+  };
 }
 
 type MetadataAutofillField =
@@ -256,6 +308,7 @@ export default function ModelForm({
   const selectedModelOption = findProviderModelOption(modelOptions, form.model);
   const chatBatchingDisabled = form.chat_batching_mode === 'disabled';
   const chatBatchingSyncMicrobatch = form.chat_batching_mode === 'sync_microbatch';
+  const defaultParamHint = defaultParameterHint(form.provider, mode);
 
   const clearValidation = (field?: RequiredField) => {
     if (validationError) setValidationError(null);
@@ -540,7 +593,7 @@ export default function ModelForm({
                 list={modelSuggestionListId}
                 value={form.model}
                 onChange={(e) => updateModelValue(e.target.value)}
-                placeholder={upstreamModelPlaceholder(mode)}
+                placeholder={upstreamModelPlaceholder(mode, form.provider)}
                 className="min-w-0 flex-1 px-3 py-2 text-sm text-gray-900 focus:outline-none"
               />
             </div>
@@ -1048,7 +1101,12 @@ export default function ModelForm({
 
       <CollapsibleCard title="Default Parameters">
         <div className="space-y-3">
-          <p className="text-xs text-gray-400">Default values injected into provider requests when not specified by the caller (e.g. voice, response_format)</p>
+          <div className="space-y-1">
+            <p className="text-xs text-gray-400">{defaultParamHint.description}</p>
+            {defaultParamHint.details?.map((detail) => (
+              <p key={detail} className="text-xs text-gray-500">{detail}</p>
+            ))}
+          </div>
           {defaultParams.map((param, idx) => (
             <div key={idx} className="flex items-center gap-2">
               <input
@@ -1058,7 +1116,7 @@ export default function ModelForm({
                   updated[idx] = { ...updated[idx], key: e.target.value };
                   setDefaultParams(updated);
                 }}
-                placeholder="Key (e.g. voice)"
+                placeholder={defaultParamHint.keyPlaceholder}
                 className={`flex-1 ${inputClass}`}
               />
               <input
@@ -1068,7 +1126,7 @@ export default function ModelForm({
                   updated[idx] = { ...updated[idx], value: e.target.value };
                   setDefaultParams(updated);
                 }}
-                placeholder="Value (e.g. alloy)"
+                placeholder={defaultParamHint.valuePlaceholder}
                 className={`flex-1 ${inputClass}`}
               />
               <button

--- a/ui/src/components/ProviderBadge.tsx
+++ b/ui/src/components/ProviderBadge.tsx
@@ -11,8 +11,9 @@ import {
   Sparkles,
   SquareCode,
   Triangle,
+  Volume2,
 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 import { PROVIDER_LOGOS } from '../lib/providerLogos';
 import { normalizeProvider, providerDisplayName } from '../lib/providers';
 
@@ -35,6 +36,7 @@ const PROVIDER_STYLES: Record<string, ProviderStyle> = {
   perplexity: { Icon: Search, logoUrl: PROVIDER_LOGOS.perplexity, tone: 'bg-rose-50 text-rose-700 border-rose-100' },
   gemini: { Icon: Sparkles, logoUrl: PROVIDER_LOGOS.gemini, tone: 'bg-blue-50 text-blue-700 border-blue-100' },
   bedrock: { Icon: Triangle, tone: 'bg-stone-100 text-stone-700 border-stone-200' },
+  elevenlabs: { Icon: Volume2, logoUrl: PROVIDER_LOGOS.elevenlabs, tone: 'bg-neutral-100 text-neutral-800 border-neutral-200' },
   vllm: { Icon: Bot, logoUrl: PROVIDER_LOGOS.vllm, tone: 'bg-lime-50 text-lime-700 border-lime-100' },
   lmstudio: { Icon: Bot, tone: 'bg-slate-100 text-slate-700 border-slate-200' },
   ollama: { Icon: Bot, logoUrl: PROVIDER_LOGOS.ollama, tone: 'bg-teal-50 text-teal-700 border-teal-100' },
@@ -50,14 +52,11 @@ interface ProviderBadgeProps {
 export default function ProviderBadge({ provider, model, compact = false }: ProviderBadgeProps) {
   const key = normalizeProvider(provider, model);
   const style = PROVIDER_STYLES[key] || PROVIDER_STYLES.unknown;
-  const [logoFailed, setLogoFailed] = useState(false);
+  const [failedLogoKey, setFailedLogoKey] = useState<string | null>(null);
   const label = providerDisplayName(key);
   const FallbackIcon = style.Icon || Bot;
-  const shouldShowLogo = useMemo(() => Boolean(style.logoUrl && !logoFailed), [style.logoUrl, logoFailed]);
-
-  useEffect(() => {
-    setLogoFailed(false);
-  }, [key, style.logoUrl]);
+  const logoFailureKey = style.logoUrl ? `${key}:${style.logoUrl}` : null;
+  const shouldShowLogo = Boolean(style.logoUrl && failedLogoKey !== logoFailureKey);
 
   return (
     <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${style.tone}`}>
@@ -66,7 +65,7 @@ export default function ProviderBadge({ provider, model, compact = false }: Prov
           src={style.logoUrl}
           alt={`${label} logo`}
           className="h-3.5 w-3.5 rounded-sm object-contain"
-          onError={() => setLogoFailed(true)}
+          onError={() => setFailedLogoKey(logoFailureKey)}
           loading="lazy"
         />
       ) : (

--- a/ui/src/lib/providerLogos.ts
+++ b/ui/src/lib/providerLogos.ts
@@ -1,4 +1,5 @@
 import anthropicLogo from '../assets/provider-logos/anthropic.svg';
+import elevenlabsLogo from '../assets/provider-logos/elevenlabs.svg';
 import fireworksLogo from '../assets/provider-logos/fireworks.svg';
 import geminiLogo from '../assets/provider-logos/gemini.svg';
 import groqLogo from '../assets/provider-logos/groq.svg';
@@ -16,6 +17,7 @@ export const PROVIDER_LOGOS: Record<string, string> = {
   fireworks: fireworksLogo,
   perplexity: perplexityLogo,
   gemini: geminiLogo,
+  elevenlabs: elevenlabsLogo,
   vllm: vllmLogo,
   ollama: ollamaLogo,
 };

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -11,6 +11,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   perplexity: 'Perplexity',
   gemini: 'Google Gemini',
   bedrock: 'AWS Bedrock',
+  elevenlabs: 'ElevenLabs',
   vllm: 'vLLM',
   lmstudio: 'LM Studio',
   ollama: 'Ollama',


### PR DESCRIPTION
## Summary
- Add native ElevenLabs provider support for `/v1/audio/speech` and `/v1/audio/transcriptions`.
- Add low-latency TTS and STT runtime integrations using named credentials and provider resolution.
- Add ElevenLabs model catalog discovery, health/discovery wiring, and Admin UI provider model suggestions.
- Document ElevenLabs named credentials, model configuration, proxy behavior, and troubleshooting.

## Included PRs
- #185 - Provider foundation
- #186 - TTS runtime
- #187 - STT runtime
- #188 - Catalog and discovery
- #189 - UI and docs polish

## Validation
- Compared `feature/elevenlabs-audio-support` against `main`: 5 commits ahead, 0 behind.
- Stacked PRs include mocked provider runtime coverage for TTS/STT, discovery/catalog coverage, provider preset tests, named credential checks, and UI/docs validation.
- No live ElevenLabs credentials are required for the automated coverage.

Closes #129