### PR TITLE
Expose batch capacity controls in model admin UI

### DIFF
--- a/docs/admin-ui/models.md
+++ b/docs/admin-ui/models.md
@@ -100,14 +100,22 @@ DeltaLLM maps public transcription fields such as `language` and `temperature` t
 For chat deployments, the model form includes **Batch Execution** controls in
 the Chat Settings section.
 
-- Leave **Mode** as **Default concurrent** for the standard behavior: one
-  upstream request per batch item, bounded by worker concurrency
-- Select **Concurrent** when you want to persist an explicit per-deployment
-  `max_in_flight` limit
-- Select **Sync microbatch** only for providers with a proven synchronous
-  microbatch API that returns one response and exact usage per input item
-- Select **Disabled** when the deployment should never use chat microbatch
-  grouping
+Most deployments should use the default behavior and leave numeric fields blank.
+Only set explicit limits when you know the provider or serving cluster capacity
+you want DeltaLLM to reserve for batch work.
+
+| Option | Stored as | What it does | Recommendation |
+|--------|-----------|--------------|----------------|
+| **Mode: Default concurrent** | No `deltallm_params.chat_batching` override | Sends one ordinary upstream request per batch item, bounded by the worker defaults. | Use this for most chat deployments, including vLLM and OpenAI-compatible providers with their own serving-side batching. |
+| **Mode: Concurrent** | `deltallm_params.chat_batching.mode: concurrent` | Keeps one upstream request per batch item, but persists deployment-specific chat batching settings such as **Max In-Flight**. | Use when this deployment needs a tighter or higher per-worker cap than the global worker setting. |
+| **Mode: Sync microbatch** | `deltallm_params.chat_batching.mode: sync_microbatch` | Groups compatible chat items into one synchronous upstream provider call when a matching executor is available. | Use only for provider adapters that are proven to return one result and exact usage per input item. Start with small batches such as `4` or `8`. |
+| **Mode: Disabled** | `deltallm_params.chat_batching.mode: disabled` | Prevents chat microbatch grouping for this deployment. | Use for providers or models where batch behavior is unknown, unsafe, or hard to bill correctly. |
+| **Max In-Flight** | `deltallm_params.chat_batching.max_in_flight` | Limits concurrent upstream chat requests for this deployment per worker replica. | Leave blank unless you need an explicit cap. Size it against provider limits, worker replica count, and serving capacity. |
+| **Upstream Max Size** | `deltallm_params.chat_batching.upstream_max_batch_size` | Maximum number of chat items in one sync microbatch. Required for **Sync microbatch** and must be at least `2`. | Set only with **Sync microbatch**. Start at `4` or `8`, then increase only after latency, response shape, and usage accounting look correct. |
+| **Max Total Input Tokens** | `deltallm_params.chat_batching.max_total_input_tokens` | Caps the combined input tokens in a sync microbatch chunk. | Set a conservative cap for sync microbatch providers so one large group does not exceed context or latency limits. Leave blank for concurrent modes. |
+| **Scheduler Max In-Flight** | `model_info.batch_capacity.max_in_flight` | Sets the batch scheduler capacity slots this model group can have in flight. This is separate from live request routing. | Leave blank to use scheduler defaults or inferred capacity. Set it when a model group needs a hard batch-specific cap. |
+| **Scheduler Max Claim Work Units** | `model_info.batch_capacity.max_claim_work_units` | Caps how much work the scheduler may claim for this model group at once. | Leave blank initially. Lower it when large jobs monopolize workers; raise it only after the model drains backlog without hurting latency. |
+| **Capacity Fraction** | `model_info.batch_capacity.capacity_fraction` | Fraction of router `max_in_flight` to use when scheduler capacity is inferred from chat batching limits. Must be greater than `0` and no more than `1`. | Leave blank unless you are sharing the deployment between live traffic and batch work. Use a conservative value such as `0.25` for shared capacity; reserve `1` for batch-dedicated capacity. |
 
 Blank numeric fields are treated as unset. For example, leaving **Max
 In-Flight** empty does not send `0`; it leaves that limit to the worker default.

--- a/src/config.py
+++ b/src/config.py
@@ -60,8 +60,8 @@ ChatBatchingMode = Literal["disabled", "concurrent", "sync_microbatch"]
 
 
 class BatchModelCapacityInfo(BaseModel):
-    max_in_flight: int | None = Field(default=None, ge=1)
-    max_claim_work_units: int | None = Field(default=None, ge=1)
+    max_in_flight: int | None = Field(default=None, ge=1, strict=True)
+    max_claim_work_units: int | None = Field(default=None, ge=1, strict=True)
     capacity_fraction: float | None = Field(default=None, gt=0.0, le=1.0)
 
 

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -334,6 +334,39 @@ def test_model_info_rejects_non_positive_upstream_max_batch_inputs(value: int):
         ModelInfo.model_validate({"upstream_max_batch_inputs": value})
 
 
+def test_model_info_accepts_valid_batch_capacity():
+    info = ModelInfo.model_validate(
+        {
+            "batch_capacity": {
+                "max_in_flight": 4,
+                "max_claim_work_units": 200,
+                "capacity_fraction": 0.25,
+            }
+        }
+    )
+
+    assert info.batch_capacity is not None
+    assert info.batch_capacity.max_in_flight == 4
+    assert info.batch_capacity.max_claim_work_units == 200
+    assert info.batch_capacity.capacity_fraction == 0.25
+
+
+@pytest.mark.parametrize(
+    "batch_capacity",
+    [
+        {"max_in_flight": 0},
+        {"max_claim_work_units": 0},
+        {"capacity_fraction": 0},
+        {"capacity_fraction": 1.01},
+        {"max_in_flight": True},
+        {"max_claim_work_units": "4"},
+    ],
+)
+def test_model_info_rejects_invalid_batch_capacity(batch_capacity: dict[str, object]):
+    with pytest.raises(ValueError):
+        ModelInfo.model_validate({"batch_capacity": batch_capacity})
+
+
 def test_delta_llm_params_accepts_chat_batching_config():
     params = DeltaLLMParams.model_validate(
         {

--- a/tests/test_ui_models.py
+++ b/tests/test_ui_models.py
@@ -408,6 +408,70 @@ async def test_create_model_accepts_chat_batching_params(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_create_model_accepts_batch_capacity_metadata(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": "batch-capacity-model",
+            "deltallm_params": {
+                "provider": "vllm",
+                "model": "meta-llama/Llama-3.1-8B-Instruct",
+                "api_base": "https://vllm.example/v1",
+                "api_key": "provider-key",
+            },
+            "model_info": {
+                "mode": "chat",
+                "batch_capacity": {
+                    "max_in_flight": 4,
+                    "max_claim_work_units": 200,
+                    "capacity_fraction": 0.25,
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["model_info"]["batch_capacity"] == {
+        "max_in_flight": 4,
+        "max_claim_work_units": 200,
+        "capacity_fraction": 0.25,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_model_rejects_invalid_batch_capacity_metadata(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.post(
+        "/ui/api/models",
+        headers={"Authorization": "Bearer mk-test"},
+        json={
+            "model_name": "invalid-batch-capacity-model",
+            "deltallm_params": {
+                "provider": "vllm",
+                "model": "meta-llama/Llama-3.1-8B-Instruct",
+                "api_base": "https://vllm.example/v1",
+                "api_key": "provider-key",
+            },
+            "model_info": {
+                "mode": "chat",
+                "batch_capacity": {
+                    "max_in_flight": True,
+                    "max_claim_work_units": 200,
+                    "capacity_fraction": 0.25,
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    assert "batch_capacity" in response.text
+
+
+@pytest.mark.asyncio
 async def test_create_model_rejects_invalid_chat_batching_params(client, test_app):
     setattr(test_app.state.settings, "master_key", "mk-test")
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "autoprefixer": "^10.4.24",
+        "esbuild": "^0.27.3",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "npm run test:unit",
+    "test:unit": "esbuild tests/modelFormShared.test.ts --bundle --platform=node --format=esm --outfile=node_modules/.tmp/modelFormShared.test.mjs && node --test node_modules/.tmp/modelFormShared.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -24,6 +26,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "autoprefixer": "^10.4.24",
+    "esbuild": "^0.27.3",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/ui/src/components/ModelForm.tsx
+++ b/ui/src/components/ModelForm.tsx
@@ -191,6 +191,7 @@ function buildLiveDiscoveryRequestKey(payload: ProviderModelDiscoveryPayload): s
 interface ModelFormProps {
   initialValues?: ModelFormValues;
   initialDefaultParams?: { key: string; value: string }[];
+  initialModelInfo?: Record<string, unknown>;
   onSubmit: (payload: ModelPayload) => Promise<void>;
   onCancel: () => void;
   submitLabel?: string;
@@ -229,9 +230,19 @@ function validatePositiveInteger(value: string, label: string, minimum = 1): str
   return null;
 }
 
+function validateCapacityFraction(value: string): string | null {
+  if (!value.trim()) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 1) {
+    return 'Capacity Fraction must be greater than 0 and less than or equal to 1.';
+  }
+  return null;
+}
+
 export default function ModelForm({
   initialValues,
   initialDefaultParams,
+  initialModelInfo,
   onSubmit,
   onCancel,
   submitLabel = 'Create',
@@ -240,6 +251,7 @@ export default function ModelForm({
 }: ModelFormProps) {
   const [form, setForm] = useState<ModelFormValues>(initialValues || { ...EMPTY_FORM });
   const [defaultParams, setDefaultParams] = useState<{ key: string; value: string }[]>(initialDefaultParams || []);
+  const [initialModelInfoSnapshot] = useState<Record<string, unknown>>(() => ({ ...(initialModelInfo || {}) }));
   const [validationError, setValidationError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Partial<Record<RequiredField, string>>>({});
   const accessGroupInputRef = useRef<AccessGroupTokenInputHandle | null>(null);
@@ -308,6 +320,7 @@ export default function ModelForm({
   const selectedModelOption = findProviderModelOption(modelOptions, form.model);
   const chatBatchingDisabled = form.chat_batching_mode === 'disabled';
   const chatBatchingSyncMicrobatch = form.chat_batching_mode === 'sync_microbatch';
+  const supportsBatchCapacity = mode === 'chat' || mode === 'embedding';
   const defaultParamHint = defaultParameterHint(form.provider, mode);
 
   const clearValidation = (field?: RequiredField) => {
@@ -513,6 +526,17 @@ export default function ModelForm({
         }
       }
     }
+    if (supportsBatchCapacity) {
+      const batchCapacityErrors = [
+        validatePositiveInteger(form.batch_capacity_max_in_flight, 'Scheduler Max In-Flight'),
+        validatePositiveInteger(form.batch_capacity_max_claim_work_units, 'Scheduler Max Claim Work Units'),
+        validateCapacityFraction(form.batch_capacity_capacity_fraction),
+      ].filter(Boolean);
+      if (batchCapacityErrors.length > 0) {
+        setValidationError(batchCapacityErrors[0] || 'Fix the scheduler capacity settings before saving.');
+        return;
+      }
+    }
     setFieldErrors({});
     if (selectedProviderPreset && !selectedProviderPreset.supported_modes.includes(mode)) {
       const modeLabel = MODE_OPTIONS.find((m) => m.value === mode)?.label || mode;
@@ -535,9 +559,67 @@ export default function ModelForm({
         access_groups: accessGroupCommit?.value ?? form.access_groups,
       },
       defaultParams,
+      initialModelInfoSnapshot,
     );
     await onSubmit(payload);
   };
+
+  const batchCapacityFields = supportsBatchCapacity ? (
+    <div className="border-t border-gray-100 pt-4">
+      <h4 className="mb-3 text-sm font-medium text-gray-700">Scheduler Capacity</h4>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700">Scheduler Max In-Flight</label>
+          <input
+            type="number"
+            min="1"
+            step="1"
+            value={form.batch_capacity_max_in_flight}
+            onChange={(e) => {
+              setForm({ ...form, batch_capacity_max_in_flight: e.target.value });
+              clearValidation();
+            }}
+            placeholder="Optional, e.g. 4"
+            className={inputClass}
+          />
+          <p className="mt-1 text-xs text-gray-400">Slots this deployment contributes to batch scheduling.</p>
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700">Scheduler Max Claim Work Units</label>
+          <input
+            type="number"
+            min="1"
+            step="1"
+            value={form.batch_capacity_max_claim_work_units}
+            onChange={(e) => {
+              setForm({ ...form, batch_capacity_max_claim_work_units: e.target.value });
+              clearValidation();
+            }}
+            placeholder="Optional, e.g. 200"
+            className={inputClass}
+          />
+          <p className="mt-1 text-xs text-gray-400">Work-unit cap per scheduler claim.</p>
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700">Capacity Fraction</label>
+          <input
+            type="number"
+            min="0"
+            max="1"
+            step="any"
+            value={form.batch_capacity_capacity_fraction}
+            onChange={(e) => {
+              setForm({ ...form, batch_capacity_capacity_fraction: e.target.value });
+              clearValidation();
+            }}
+            placeholder="Optional, e.g. 0.25"
+            className={inputClass}
+          />
+          <p className="mt-1 text-xs text-gray-400">Only used when capacity is inferred from router limits.</p>
+        </div>
+      </div>
+    </div>
+  ) : null;
 
   return (
     <div className="space-y-6">
@@ -939,41 +1021,45 @@ export default function ModelForm({
                 </div>
               </div>
             </div>
+            {batchCapacityFields}
           </div>
         </CollapsibleCard>
       )}
 
       {mode === 'embedding' && (
         <CollapsibleCard title="Embedding Settings">
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Context Window</label>
-              <input type="number" value={form.max_context_window} onChange={(e) => setForm({ ...form, max_context_window: e.target.value })} placeholder="8192" className={inputClass} />
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Context Window</label>
+                <input type="number" value={form.max_context_window} onChange={(e) => setForm({ ...form, max_context_window: e.target.value })} placeholder="8192" className={inputClass} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Output Vector Size</label>
+                <input type="number" value={form.output_vector_size} onChange={(e) => setForm({ ...form, output_vector_size: e.target.value })} placeholder="1536" className={inputClass} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Batch Worker Upstream Max Inputs</label>
+                <input
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={form.upstream_max_batch_inputs}
+                  onChange={(e) => {
+                    setForm({ ...form, upstream_max_batch_inputs: e.target.value });
+                    clearValidation();
+                  }}
+                  placeholder="Optional, e.g. 8"
+                  className={inputClass}
+                />
+                <p className="text-xs text-gray-400 mt-1">
+                  Advanced. Only used for compatible async embedding batch jobs, not synchronous /v1/embeddings.
+                  Leave blank or use 1 to disable batch-worker micro-batching. Start small and increase only after
+                  validating provider behavior and throughput.
+                </p>
+              </div>
             </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Output Vector Size</label>
-              <input type="number" value={form.output_vector_size} onChange={(e) => setForm({ ...form, output_vector_size: e.target.value })} placeholder="1536" className={inputClass} />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Batch Worker Upstream Max Inputs</label>
-              <input
-                type="number"
-                min="1"
-                step="1"
-                value={form.upstream_max_batch_inputs}
-                onChange={(e) => {
-                  setForm({ ...form, upstream_max_batch_inputs: e.target.value });
-                  clearValidation();
-                }}
-                placeholder="Optional, e.g. 8"
-                className={inputClass}
-              />
-              <p className="text-xs text-gray-400 mt-1">
-                Advanced. Only used for compatible async embedding batch jobs, not synchronous /v1/embeddings.
-                Leave blank or use 1 to disable batch-worker micro-batching. Start small and increase only after
-                validating provider behavior and throughput.
-              </p>
-            </div>
+            {batchCapacityFields}
           </div>
         </CollapsibleCard>
       )}

--- a/ui/src/components/ModelForm.tsx
+++ b/ui/src/components/ModelForm.tsx
@@ -1,6 +1,6 @@
 import { useId, useRef, useState } from 'react';
 import Card from './Card';
-import { ChevronDown, Plus, X } from 'lucide-react';
+import { ChevronDown, ExternalLink, Plus, X } from 'lucide-react';
 import AccessGroupTokenInput, { type AccessGroupTokenInputHandle } from './AccessGroupTokenInput';
 import ProviderBadge from './ProviderBadge';
 import { useApi } from '../lib/hooks';
@@ -23,6 +23,7 @@ import {
 } from './modelFormShared';
 
 let collapsibleIdCounter = 0;
+const MODEL_BATCH_CONFIG_DOCS_URL = 'https://deltallm.readthedocs.io/en/latest/admin-ui/models/';
 
 function CollapsibleCard({ title, defaultOpen = false, children }: { title: string; defaultOpen?: boolean; children: React.ReactNode }) {
   const [open, setOpen] = useState(defaultOpen);
@@ -951,7 +952,18 @@ export default function ModelForm({
               </div>
             </div>
             <div className="border-t border-gray-100 pt-4">
-              <h4 className="text-sm font-medium text-gray-700 mb-3">Batch Execution</h4>
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <h4 className="text-sm font-medium text-gray-700">Batch Execution</h4>
+                <a
+                  href={MODEL_BATCH_CONFIG_DOCS_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                >
+                  Batch config docs
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                </a>
+              </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">Mode</label>

--- a/ui/src/components/ModelForm.tsx
+++ b/ui/src/components/ModelForm.tsx
@@ -23,7 +23,7 @@ import {
 } from './modelFormShared';
 
 let collapsibleIdCounter = 0;
-const MODEL_BATCH_CONFIG_DOCS_URL = 'https://deltallm.readthedocs.io/en/latest/admin-ui/models/';
+const MODEL_BATCH_CONFIG_DOCS_URL = 'https://deltallm.readthedocs.io/en/latest/admin-ui/models/#chat-batch-execution';
 
 function CollapsibleCard({ title, defaultOpen = false, children }: { title: string; defaultOpen?: boolean; children: React.ReactNode }) {
   const [open, setOpen] = useState(defaultOpen);

--- a/ui/src/components/modelFormShared.ts
+++ b/ui/src/components/modelFormShared.ts
@@ -71,6 +71,9 @@ export interface ModelFormValues {
   chat_batching_max_in_flight: string;
   chat_batching_upstream_max_batch_size: string;
   chat_batching_max_total_input_tokens: string;
+  batch_capacity_max_in_flight: string;
+  batch_capacity_max_claim_work_units: string;
+  batch_capacity_capacity_fraction: string;
   weight: string;
   priority: string;
   tags: string;
@@ -129,6 +132,9 @@ export const EMPTY_FORM: ModelFormValues = {
   chat_batching_max_in_flight: '',
   chat_batching_upstream_max_batch_size: '',
   chat_batching_max_total_input_tokens: '',
+  batch_capacity_max_in_flight: '',
+  batch_capacity_max_claim_work_units: '',
+  batch_capacity_capacity_fraction: '',
   weight: '',
   priority: '',
   tags: '',
@@ -164,6 +170,40 @@ function positiveIntOrUndef(val: string): number | undefined {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+function objectRecordOrEmpty(val: unknown): Record<string, unknown> {
+  return val && typeof val === 'object' && !Array.isArray(val)
+    ? (val as Record<string, unknown>)
+    : {};
+}
+
+const FORM_MANAGED_MODEL_INFO_FIELDS = [
+  'mode',
+  'priority',
+  'tags',
+  'access_groups',
+  'weight',
+  'input_cost_per_token',
+  'output_cost_per_token',
+  'input_cost_per_token_cache_hit',
+  'output_cost_per_token_cache_hit',
+  'batch_input_cost_per_token',
+  'batch_output_cost_per_token',
+  'batch_price_multiplier',
+  'input_cost_per_character',
+  'output_cost_per_character',
+  'input_cost_per_second',
+  'output_cost_per_second',
+  'input_cost_per_image',
+  'input_cost_per_audio_token',
+  'output_cost_per_audio_token',
+  'output_vector_size',
+  'max_tokens',
+  'max_input_tokens',
+  'max_output_tokens',
+  'upstream_max_batch_inputs',
+  'default_params',
+] as const;
+
 function buildChatBatchingPayload(form: ModelFormValues): Record<string, unknown> | null {
   if (form.chat_batching_mode === 'disabled') {
     return { mode: 'disabled' };
@@ -189,6 +229,25 @@ function buildChatBatchingPayload(form: ModelFormValues): Record<string, unknown
   return null;
 }
 
+function buildBatchCapacityPayload(form: ModelFormValues): Record<string, unknown> | undefined {
+  const payload: Record<string, unknown> = {};
+  const maxInFlight = positiveIntOrUndef(form.batch_capacity_max_in_flight);
+  const maxClaimWorkUnits = positiveIntOrUndef(form.batch_capacity_max_claim_work_units);
+  const capacityFraction = numOrUndef(form.batch_capacity_capacity_fraction);
+
+  if (maxInFlight !== undefined) {
+    payload.max_in_flight = maxInFlight;
+  }
+  if (maxClaimWorkUnits !== undefined) {
+    payload.max_claim_work_units = maxClaimWorkUnits;
+  }
+  if (capacityFraction !== undefined) {
+    payload.capacity_fraction = capacityFraction;
+  }
+
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
 function commaSeparatedListOrUndef(val: string): string[] | undefined {
   const items = val.split(',').map((item) => item.trim()).filter(Boolean);
   return items.length > 0 ? items : undefined;
@@ -207,6 +266,7 @@ function toModelMode(value: unknown): ModelMode {
 export function buildModelPayload(
   form: ModelFormValues,
   defaultParams: { key: string; value: string }[],
+  existingModelInfo: Record<string, unknown> = {},
 ): ModelPayload {
   const useNamedCredential = form.credential_source === 'named';
   const supportsCustomAuth = supportsCustomUpstreamAuthProvider(form.provider, form.model);
@@ -240,13 +300,16 @@ export function buildModelPayload(
     deltallm_params.chat_batching = null;
   }
 
-  const model_info: Record<string, unknown> = {
-    mode: form.mode,
-    priority: numOrUndef(form.priority),
-    tags: form.tags ? commaSeparatedListOrUndef(form.tags) : undefined,
-    access_groups: form.access_groups ? commaSeparatedListOrUndef(form.access_groups) : undefined,
-    weight: numOrUndef(form.weight),
-  };
+  const model_info: Record<string, unknown> = { ...existingModelInfo };
+  for (const field of FORM_MANAGED_MODEL_INFO_FIELDS) {
+    delete model_info[field];
+  }
+
+  model_info.mode = form.mode;
+  model_info.priority = numOrUndef(form.priority);
+  model_info.tags = form.tags ? commaSeparatedListOrUndef(form.tags) : undefined;
+  model_info.access_groups = form.access_groups ? commaSeparatedListOrUndef(form.access_groups) : undefined;
+  model_info.weight = numOrUndef(form.weight);
 
   if (form.mode === 'chat') {
     model_info.input_cost_per_token = numOrUndef(form.input_cost_per_token);
@@ -282,6 +345,13 @@ export function buildModelPayload(
     model_info.batch_price_multiplier = numOrUndef(form.batch_price_multiplier);
     model_info.batch_input_cost_per_token = numOrUndef(form.batch_input_cost_per_token);
     model_info.batch_output_cost_per_token = numOrUndef(form.batch_output_cost_per_token);
+
+    const batchCapacity = buildBatchCapacityPayload(form);
+    if (batchCapacity) {
+      model_info.batch_capacity = batchCapacity;
+    } else {
+      delete model_info.batch_capacity;
+    }
   }
 
   const defaultParamsPayload: Record<string, string | number | boolean> = {};
@@ -308,11 +378,10 @@ export function buildModelPayload(
 export function formFromModel(
   model: ModelDeploymentDetail,
 ): { form: ModelFormValues; defaultParams: { key: string; value: string }[] } {
-  const lp = (model.deltallm_params || {}) as Record<string, unknown>;
-  const mi = (model.model_info || {}) as Record<string, unknown>;
-  const chatBatching = (lp.chat_batching && typeof lp.chat_batching === 'object'
-    ? lp.chat_batching
-    : {}) as Record<string, unknown>;
+  const lp = objectRecordOrEmpty(model.deltallm_params);
+  const mi = objectRecordOrEmpty(model.model_info);
+  const chatBatching = objectRecordOrEmpty(lp.chat_batching);
+  const batchCapacity = objectRecordOrEmpty(mi.batch_capacity);
   const explicitProvider = strOrEmpty(lp.provider).trim();
   const inferredProvider = normalizeProvider(undefined, strOrEmpty(lp.model));
   const provider = explicitProvider || (inferredProvider !== 'unknown' ? inferredProvider : '');
@@ -349,6 +418,9 @@ export function formFromModel(
     chat_batching_max_in_flight: strOrEmpty(chatBatching.max_in_flight),
     chat_batching_upstream_max_batch_size: strOrEmpty(chatBatching.upstream_max_batch_size),
     chat_batching_max_total_input_tokens: strOrEmpty(chatBatching.max_total_input_tokens),
+    batch_capacity_max_in_flight: strOrEmpty(batchCapacity.max_in_flight),
+    batch_capacity_max_claim_work_units: strOrEmpty(batchCapacity.max_claim_work_units),
+    batch_capacity_capacity_fraction: strOrEmpty(batchCapacity.capacity_fraction),
     weight: strOrEmpty(mi.weight ?? lp.weight),
     priority: strOrEmpty(mi.priority),
     tags: Array.isArray(mi.tags) ? mi.tags.join(', ') : '',

--- a/ui/src/pages/ModelDetail.tsx
+++ b/ui/src/pages/ModelDetail.tsx
@@ -20,7 +20,7 @@ import {
 } from 'lucide-react';
 import { useApi } from '../lib/hooks';
 import { useAuth } from '../lib/auth';
-import { ApiError, models, type DeploymentHealth } from '../lib/api';
+import { ApiError, models, type DeploymentHealth, type ModelDeploymentDetail } from '../lib/api';
 import { modelEditPath } from '../lib/modelRoutes';
 import ModelUsageExamplesCard from '../components/ModelUsageExamplesCard';
 import { MODE_OPTIONS } from '../components/modelFormShared';
@@ -72,6 +72,13 @@ function formatCost(value: unknown): string | null {
   return `$${num.toFixed(6)}`;
 }
 
+function formatCapacityFraction(value: unknown): string | null {
+  if (value == null || value === '') return null;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  return num.toLocaleString(undefined, { maximumFractionDigits: 4 });
+}
+
 function formatUnixTimestamp(value: number | null | undefined): string | null {
   if (!value) return null;
   const date = new Date(value * 1000);
@@ -87,9 +94,16 @@ function timeSince(ts: number | null | undefined): string | null {
   return `${Math.floor(secs / 3600)}h ago`;
 }
 
-function modeSpecificItems(mode: string, model: any): Array<{ label: string; value: string | null }> {
+function modeSpecificItems(mode: string, model: ModelDeploymentDetail): Array<{ label: string; value: string | null }> {
   const lp = model.deltallm_params || {};
   const mi = model.model_info || {};
+  const batchCapacity = mi.batch_capacity && typeof mi.batch_capacity === 'object' ? mi.batch_capacity : {};
+  const schedulerCapacityItems = [
+    { label: 'Scheduler Max In-Flight', value: formatInteger(batchCapacity.max_in_flight) },
+    { label: 'Scheduler Max Claim Work Units', value: formatInteger(batchCapacity.max_claim_work_units) },
+    { label: 'Capacity Fraction', value: formatCapacityFraction(batchCapacity.capacity_fraction) },
+  ];
+
   switch (mode) {
     case 'chat':
       return [
@@ -98,12 +112,14 @@ function modeSpecificItems(mode: string, model: any): Array<{ label: string; val
         { label: 'Max Output Tokens', value: formatInteger(mi.max_output_tokens) },
         { label: 'Per Request Cap',   value: formatInteger(lp.max_tokens) },
         { label: 'Stream Timeout',    value: formatDurationSeconds(lp.stream_timeout) },
+        ...schedulerCapacityItems,
       ];
     case 'embedding':
       return [
         { label: 'Context Window', value: formatInteger(mi.max_tokens) },
         { label: 'Vector Size',    value: formatInteger(mi.output_vector_size) },
         { label: 'Batch Worker Upstream Max Inputs', value: formatInteger(mi.upstream_max_batch_inputs) || '—' },
+        ...schedulerCapacityItems,
       ];
     case 'image_generation':
       return [{ label: 'Cost / Image', value: formatCost(mi.input_cost_per_image) }];
@@ -137,7 +153,7 @@ function formatDefaultParamValue(value: unknown): string {
   return String(value);
 }
 
-function primaryCost(mode: string, mi: Record<string, any>): string | null {
+function primaryCost(mode: string, mi: Record<string, unknown>): string | null {
   if (mode === 'image_generation') return formatCost(mi.input_cost_per_image);
   if (mode === 'audio_speech') {
     return (
@@ -193,7 +209,7 @@ const EMPTY_DEPLOYMENT_HEALTH: DeploymentHealth = {
   last_success_at: null,
 };
 
-function OverviewTab({ model }: { model: any }) {
+function OverviewTab({ model }: { model: ModelDeploymentDetail }) {
   const lp = model.deltallm_params || {};
   const connectionSummary = model.connection_summary || {};
   const health: DeploymentHealth = model.health || EMPTY_DEPLOYMENT_HEALTH;
@@ -232,7 +248,7 @@ function OverviewTab({ model }: { model: any }) {
   );
 }
 
-function RuntimeTab({ model }: { model: any }) {
+function RuntimeTab({ model }: { model: ModelDeploymentDetail }) {
   const lp = model.deltallm_params || {};
   const mi = model.model_info || {};
   const mode = model.mode || mi.mode || 'chat';
@@ -282,7 +298,7 @@ function RuntimeTab({ model }: { model: any }) {
   );
 }
 
-function RoutingTab({ model }: { model: any }) {
+function RoutingTab({ model }: { model: ModelDeploymentDetail }) {
   const lp = model.deltallm_params || {};
   const mi = model.model_info || {};
   const rpmLimit = lp.rpm ?? mi.rpm_limit;
@@ -361,7 +377,7 @@ function RoutingTab({ model }: { model: any }) {
   );
 }
 
-function CostsTab({ model }: { model: any }) {
+function CostsTab({ model }: { model: ModelDeploymentDetail }) {
   const mi = model.model_info || {};
   const rows = [
     { label: 'Input Cost / Token',        value: formatCost(mi.input_cost_per_token),           hint: 'Standard request' },
@@ -485,8 +501,8 @@ export default function ModelDetail() {
     try {
       await models.delete(deploymentId!);
       navigate('/models');
-    } catch (err: any) {
-      alert(err?.message || 'Failed to delete model');
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : 'Failed to delete model');
     }
   };
 

--- a/ui/src/pages/ModelEdit.tsx
+++ b/ui/src/pages/ModelEdit.tsx
@@ -41,8 +41,8 @@ export default function ModelEdit() {
     try {
       await models.update(deploymentId!, payload);
       navigate(modelDetailPath(deploymentId!));
-    } catch (err: any) {
-      setError(err?.message || 'Failed to update model');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to update model');
     } finally {
       setSaving(false);
     }
@@ -57,6 +57,7 @@ export default function ModelEdit() {
       <ModelForm
         initialValues={initialValues}
         initialDefaultParams={initialDefaultParams}
+        initialModelInfo={model.model_info}
         onSubmit={handleSubmit}
         onCancel={() => navigate(modelDetailPath(deploymentId!))}
         submitLabel="Save Changes"

--- a/ui/tests/modelFormShared.test.ts
+++ b/ui/tests/modelFormShared.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ModelDeploymentDetail } from '../src/lib/api';
+import { EMPTY_FORM, buildModelPayload, formFromModel, type ModelFormValues } from '../src/components/modelFormShared';
+
+function chatForm(overrides: Partial<ModelFormValues> = {}): ModelFormValues {
+  return {
+    ...EMPTY_FORM,
+    mode: 'chat',
+    model_name: 'batch-capable-model',
+    provider: 'vllm',
+    model: 'meta-llama/Llama-3.1-8B-Instruct',
+    api_base: 'https://vllm.example/v1',
+    api_key: 'provider-key',
+    ...overrides,
+  };
+}
+
+test('formFromModel loads existing scheduler capacity values', () => {
+  const { form } = formFromModel({
+    deployment_id: 'dep-1',
+    model_name: 'batch-capable-model',
+    provider: 'vllm',
+    deltallm_params: {
+      provider: 'vllm',
+      model: 'meta-llama/Llama-3.1-8B-Instruct',
+      api_base: 'https://vllm.example/v1',
+    },
+    model_info: {
+      mode: 'embedding',
+      batch_capacity: {
+        max_in_flight: 4,
+        max_claim_work_units: 200,
+        capacity_fraction: 0.25,
+      },
+    },
+  } as ModelDeploymentDetail);
+
+  assert.equal(form.mode, 'embedding');
+  assert.equal(form.batch_capacity_max_in_flight, '4');
+  assert.equal(form.batch_capacity_max_claim_work_units, '200');
+  assert.equal(form.batch_capacity_capacity_fraction, '0.25');
+});
+
+test('buildModelPayload sets scheduler capacity and preserves unknown model_info fields', () => {
+  const payload = buildModelPayload(
+    chatForm({
+      batch_capacity_max_in_flight: '4',
+      batch_capacity_max_claim_work_units: '200',
+      batch_capacity_capacity_fraction: '0.25',
+      priority: '3',
+    }),
+    [],
+    {
+      provider_private_metadata: { region: 'iad' },
+      batch_capacity: {
+        max_in_flight: 99,
+      },
+      priority: 1,
+    },
+  );
+
+  assert.deepEqual(payload.model_info.batch_capacity, {
+    max_in_flight: 4,
+    max_claim_work_units: 200,
+    capacity_fraction: 0.25,
+  });
+  assert.deepEqual(payload.model_info.provider_private_metadata, { region: 'iad' });
+  assert.equal(payload.model_info.priority, 3);
+});
+
+test('buildModelPayload preserves existing scheduler capacity on unrelated saves', () => {
+  const existingModel: ModelDeploymentDetail = {
+    deployment_id: 'dep-1',
+    model_name: 'batch-capable-model',
+    provider: 'vllm',
+    deltallm_params: {
+      provider: 'vllm',
+      model: 'meta-llama/Llama-3.1-8B-Instruct',
+      api_base: 'https://vllm.example/v1',
+    },
+    model_info: {
+      mode: 'chat',
+      tags: ['batch'],
+      vendor_metadata: { owner: 'infra' },
+      batch_capacity: {
+        max_in_flight: 4,
+        max_claim_work_units: 200,
+        capacity_fraction: 0.25,
+      },
+    },
+  };
+  const { form, defaultParams } = formFromModel(existingModel);
+
+  const payload = buildModelPayload(
+    {
+      ...form,
+      tags: 'batch, production',
+    },
+    defaultParams,
+    existingModel.model_info,
+  );
+
+  assert.deepEqual(payload.model_info.batch_capacity, {
+    max_in_flight: 4,
+    max_claim_work_units: 200,
+    capacity_fraction: 0.25,
+  });
+  assert.deepEqual(payload.model_info.vendor_metadata, { owner: 'infra' });
+  assert.deepEqual(payload.model_info.tags, ['batch', 'production']);
+});
+
+test('buildModelPayload clears scheduler capacity when all scheduler fields are blank', () => {
+  const payload = buildModelPayload(
+    chatForm(),
+    [],
+    {
+      vendor_metadata: { owner: 'infra' },
+      batch_capacity: {
+        max_in_flight: 4,
+        max_claim_work_units: 200,
+        capacity_fraction: 0.25,
+      },
+    },
+  );
+
+  assert.equal('batch_capacity' in payload.model_info, false);
+  assert.deepEqual(payload.model_info.vendor_metadata, { owner: 'infra' });
+});


### PR DESCRIPTION
## Summary

Adds model admin UI support for scheduler batch capacity metadata from issue #184.

- Adds create/edit fields for model_info.batch_capacity.max_in_flight, max_claim_work_units, and capacity_fraction on chat and embedding deployments.
- Preserves unknown model_info fields while replacing form-managed fields, and allows clearing batch_capacity by blanking all scheduler capacity fields.
- Shows configured scheduler capacity values on the model detail runtime tab.
- Tightens backend validation for batch capacity metadata and adds targeted backend plus UI helper coverage.

## Impact

Admins can now configure deployment-level scheduler capacity without editing raw config or metadata. Existing custom model_info metadata is preserved during unrelated UI saves.

Fixes #184.

## Validation

- npm test
- npm run build
- npx eslint tests/modelFormShared.test.ts src/components/modelFormShared.ts src/components/ModelForm.tsx src/pages/ModelEdit.tsx src/pages/ModelDetail.tsx
- uv run ruff check src/config.py tests/config/test_settings.py tests/test_ui_models.py
- uv run --extra dev pytest tests/config/test_settings.py::test_model_info_accepts_valid_batch_capacity tests/config/test_settings.py::test_model_info_rejects_invalid_batch_capacity tests/test_ui_models.py::test_create_model_accepts_batch_capacity_metadata tests/test_ui_models.py::test_create_model_rejects_invalid_batch_capacity_metadata -q
- npm ci --dry-run --ignore-scripts