### PR TITLE
Add self-registration sandbox provisioning foundation

### DIFF
--- a/src/bootstrap/auth.py
+++ b/src/bootstrap/auth.py
@@ -14,6 +14,7 @@ from src.services.invitation_service import InvitationService
 from src.services.key_service import KeyService
 from src.services.limit_counter import LimitCounter
 from src.services.platform_identity_service import PlatformIdentityService
+from src.services.self_registration_provisioning import SelfRegistrationProvisioningService
 from src.services.sso_state_store import SSOStateStore
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,10 @@ async def init_auth_runtime(app: Any, cfg: Any) -> AuthRuntime:
     await app.state.platform_identity_service.ensure_bootstrap_admin(
         email=cfg.general_settings.platform_bootstrap_admin_email,
         password=cfg.general_settings.platform_bootstrap_admin_password,
+    )
+    app.state.self_registration_provisioning_service = SelfRegistrationProvisioningService(
+        db_client=app.state.prisma_manager.client,
+        platform_identity_service=app.state.platform_identity_service,
     )
     app.state.limit_counter = LimitCounter(
         redis_client=app.state.redis,

--- a/src/config.py
+++ b/src/config.py
@@ -11,6 +11,7 @@ import yaml
 from pydantic import AliasChoices, BaseModel, Field, SecretStr, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from src.auth.roles import TeamRole, validate_team_role
 from src.governance.access_groups import normalize_access_group_list
 from src.batch.create.defaults import (
     DEFAULT_CREATE_SESSION_CLEANUP_INTERVAL_SECONDS,
@@ -57,6 +58,7 @@ RoutingStrategyName = Literal[
 
 
 ChatBatchingMode = Literal["disabled", "concurrent", "sync_microbatch"]
+SelfRegistrationMode = Literal["sso_allowed_domain", "request_access"]
 
 
 class BatchModelCapacityInfo(BaseModel):
@@ -247,6 +249,127 @@ class DeltaLLMSettings(BaseModel):
     turn_off_message_logging: bool = False
 
 
+class SelfRegistrationLimitDefaults(BaseModel):
+    max_budget: float | None = Field(default=None, gt=0)
+    soft_budget: float | None = Field(default=None, gt=0)
+    rpm_limit: int | None = Field(default=None, gt=0)
+    tpm_limit: int | None = Field(default=None, gt=0)
+    rph_limit: int | None = Field(default=None, gt=0)
+    rpd_limit: int | None = Field(default=None, gt=0)
+    tpd_limit: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def validate_soft_budget_ceiling(self) -> "SelfRegistrationLimitDefaults":
+        if (
+            self.max_budget is not None
+            and self.soft_budget is not None
+            and self.soft_budget > self.max_budget
+        ):
+            raise ValueError("soft_budget must be less than or equal to max_budget")
+        return self
+
+
+class SelfRegistrationDefaultOrg(SelfRegistrationLimitDefaults):
+    id: str | None = None
+    name: str | None = None
+
+    @field_validator("id", "name")
+    @classmethod
+    def normalize_optional_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+
+class SelfRegistrationDefaultTeam(SelfRegistrationLimitDefaults):
+    id: str | None = None
+    alias: str | None = None
+    role: str = TeamRole.DEVELOPER
+    self_service_keys_enabled: bool = True
+    self_service_max_keys_per_user: int | None = Field(default=None, gt=0)
+    self_service_budget_ceiling: float | None = Field(default=None, gt=0)
+    self_service_require_expiry: bool = True
+    self_service_max_expiry_days: int | None = Field(default=None, gt=0)
+
+    @field_validator("id", "alias")
+    @classmethod
+    def normalize_optional_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+    @field_validator("role")
+    @classmethod
+    def validate_role(cls, value: str) -> str:
+        return validate_team_role(value)
+
+
+class SelfRegistrationDefaultUser(SelfRegistrationLimitDefaults):
+    user_role: str = "internal_user"
+
+    @field_validator("user_role")
+    @classmethod
+    def normalize_user_role(cls, value: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("user_role cannot be blank")
+        return normalized
+
+
+class SelfRegistrationSettings(BaseModel):
+    enabled: bool = False
+    mode: SelfRegistrationMode = "sso_allowed_domain"
+    allowed_domains: list[str] = Field(default_factory=list)
+    require_email_verification: bool = True
+    require_admin_approval: bool = False
+    default_org: SelfRegistrationDefaultOrg = Field(default_factory=SelfRegistrationDefaultOrg)
+    default_team: SelfRegistrationDefaultTeam = Field(default_factory=SelfRegistrationDefaultTeam)
+    default_user: SelfRegistrationDefaultUser = Field(default_factory=SelfRegistrationDefaultUser)
+
+    @field_validator("allowed_domains", mode="before")
+    @classmethod
+    def normalize_allowed_domains_input(cls, value: object) -> list[object]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, list):
+            return value
+        raise ValueError("allowed_domains must be a list of domains")
+
+    @field_validator("allowed_domains")
+    @classmethod
+    def normalize_allowed_domains(cls, value: list[str]) -> list[str]:
+        normalized_domains: list[str] = []
+        seen: set[str] = set()
+        for raw_domain in value:
+            domain = str(raw_domain or "").strip().lower()
+            if not domain:
+                continue
+            if "@" in domain or "/" in domain or "\\" in domain or domain.startswith(".") or domain.endswith("."):
+                raise ValueError("allowed_domains entries must be bare email domains")
+            if domain not in seen:
+                normalized_domains.append(domain)
+                seen.add(domain)
+        return normalized_domains
+
+    @model_validator(mode="after")
+    def validate_enabled_defaults(self) -> "SelfRegistrationSettings":
+        if not self.enabled:
+            return self
+        if not self.default_org.id:
+            raise ValueError("self_registration.default_org.id is required when self-registration is enabled")
+        if not self.default_team.id:
+            raise ValueError("self_registration.default_team.id is required when self-registration is enabled")
+        if self.mode == "sso_allowed_domain" and not self.allowed_domains:
+            raise ValueError(
+                "self_registration.allowed_domains is required when mode is sso_allowed_domain"
+            )
+        return self
+
+
 def _validate_master_key_strength(value: str | None) -> str | None:
     if value is None:
         return None
@@ -307,6 +430,7 @@ class GeneralSettings(BaseModel):
     sso_admin_email_list: list[str] = Field(default_factory=list)
     sso_default_team_id: str | None = None
     sso_state_ttl_seconds: int = Field(default=600, ge=60, le=3600)
+    self_registration: SelfRegistrationSettings = Field(default_factory=SelfRegistrationSettings)
     enable_jwt_auth: bool = False
     jwt_public_key_url: str | None = None
     jwt_audience: str | None = None

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -4,6 +4,7 @@ from .key_service import KeyService
 from .limit_counter import LimitCounter
 from .model_deployments import load_model_registry, bootstrap_model_deployments_from_config
 from .platform_identity_service import PlatformIdentityService
+from .self_registration_provisioning import SelfRegistrationProvisioningService
 
 __all__ = [
     "AuditRetentionConfig",
@@ -12,6 +13,7 @@ __all__ = [
     "KeyService",
     "LimitCounter",
     "PlatformIdentityService",
+    "SelfRegistrationProvisioningService",
     "load_model_registry",
     "bootstrap_model_deployments_from_config",
 ]

--- a/src/services/self_registration_provisioning.py
+++ b/src/services/self_registration_provisioning.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+from src.auth.roles import OrganizationRole, PlatformRole
+from src.config import SelfRegistrationSettings
+from src.services.platform_identity_service import PlatformIdentityService
+
+
+_SELF_REGISTRATION_SOURCE = "self_registration"
+
+
+@dataclass(frozen=True)
+class SelfRegistrationProvisioningResult:
+    account_id: str
+    email: str
+    organization_id: str
+    team_id: str
+    user_id: str
+    team_role: str
+    account_is_active: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "account_id": self.account_id,
+            "email": self.email,
+            "organization_id": self.organization_id,
+            "team_id": self.team_id,
+            "user_id": self.user_id,
+            "team_role": self.team_role,
+            "account_is_active": self.account_is_active,
+        }
+
+
+class SelfRegistrationProvisioningService:
+    def __init__(
+        self,
+        *,
+        db_client: Any,
+        platform_identity_service: PlatformIdentityService,
+    ) -> None:
+        self.db = db_client
+        self.platform_identity_service = platform_identity_service
+
+    async def provision_from_defaults(
+        self,
+        *,
+        email: str,
+        settings: SelfRegistrationSettings,
+        is_active: bool = True,
+    ) -> SelfRegistrationProvisioningResult:
+        if not settings.enabled:
+            raise ValueError("self-registration is disabled")
+        if self.db is None:
+            raise RuntimeError("database is required for self-registration provisioning")
+
+        normalized_email = self.platform_identity_service.normalize_email(email)
+        if not normalized_email:
+            raise ValueError("email is required")
+
+        if hasattr(self.db, "tx"):
+            async with self.db.tx() as tx:
+                identity_service = self.platform_identity_service.with_db(tx)
+                return await self._provision_with_dependencies(
+                    db_client=tx,
+                    identity_service=identity_service,
+                    email=normalized_email,
+                    settings=settings,
+                    is_active=is_active,
+                )
+
+        return await self._provision_with_dependencies(
+            db_client=self.db,
+            identity_service=self.platform_identity_service,
+            email=normalized_email,
+            settings=settings,
+            is_active=is_active,
+        )
+
+    async def _provision_with_dependencies(
+        self,
+        *,
+        db_client: Any,
+        identity_service: PlatformIdentityService,
+        email: str,
+        settings: SelfRegistrationSettings,
+        is_active: bool,
+    ) -> SelfRegistrationProvisioningResult:
+        organization_id = str(settings.default_org.id or "").strip()
+        team_id = str(settings.default_team.id or "").strip()
+        if not organization_id or not team_id:
+            raise ValueError("default organization and team are required")
+
+        await self._ensure_team_can_belong_to_org(
+            db_client=db_client,
+            team_id=team_id,
+            organization_id=organization_id,
+        )
+        await self._insert_default_org(db_client, settings=settings)
+        await self._insert_default_team(db_client, settings=settings)
+
+        account = await identity_service.ensure_account(
+            email=email,
+            role=PlatformRole.ORG_USER,
+            is_active=is_active,
+        )
+        account_id = str(account.get("account_id") or "").strip()
+        if not account_id:
+            raise RuntimeError("failed to provision account")
+
+        await self._insert_org_membership(
+            db_client,
+            account_id=account_id,
+            organization_id=organization_id,
+        )
+        await self._insert_team_membership(
+            db_client,
+            account_id=account_id,
+            team_id=team_id,
+            role=settings.default_team.role,
+        )
+        user_id = await self._ensure_runtime_user(
+            db_client,
+            account_id=account_id,
+            email=email,
+            team_id=team_id,
+            settings=settings,
+        )
+
+        return SelfRegistrationProvisioningResult(
+            account_id=account_id,
+            email=str(account.get("email") or email),
+            organization_id=organization_id,
+            team_id=team_id,
+            user_id=user_id,
+            team_role=settings.default_team.role,
+            account_is_active=bool(account.get("is_active", is_active)),
+        )
+
+    async def _ensure_team_can_belong_to_org(
+        self,
+        *,
+        db_client: Any,
+        team_id: str,
+        organization_id: str,
+    ) -> None:
+        rows = await db_client.query_raw(
+            """
+            SELECT team_id, organization_id
+            FROM deltallm_teamtable
+            WHERE team_id = $1
+            LIMIT 1
+            """,
+            team_id,
+        )
+        if not rows:
+            return
+        existing_org_id = str(rows[0].get("organization_id") or "").strip()
+        if existing_org_id != organization_id:
+            raise ValueError("default team already belongs to a different organization")
+
+    async def _insert_default_org(self, db_client: Any, *, settings: SelfRegistrationSettings) -> None:
+        default_org = settings.default_org
+        await db_client.execute_raw(
+            """
+            INSERT INTO deltallm_organizationtable (
+                id,
+                organization_id,
+                organization_name,
+                max_budget,
+                soft_budget,
+                spend,
+                rpm_limit,
+                tpm_limit,
+                rph_limit,
+                rpd_limit,
+                tpd_limit,
+                metadata,
+                created_at,
+                updated_at
+            )
+            VALUES (gen_random_uuid(), $1, $2, $3, $4, 0, $5, $6, $7, $8, $9, $10::jsonb, NOW(), NOW())
+            ON CONFLICT (organization_id) DO NOTHING
+            """,
+            default_org.id,
+            default_org.name,
+            default_org.max_budget,
+            default_org.soft_budget,
+            default_org.rpm_limit,
+            default_org.tpm_limit,
+            default_org.rph_limit,
+            default_org.rpd_limit,
+            default_org.tpd_limit,
+            self._metadata_json("organization"),
+        )
+
+    async def _insert_default_team(self, db_client: Any, *, settings: SelfRegistrationSettings) -> None:
+        default_team = settings.default_team
+        await db_client.execute_raw(
+            """
+            INSERT INTO deltallm_teamtable (
+                team_id,
+                team_alias,
+                organization_id,
+                max_budget,
+                soft_budget,
+                spend,
+                rpm_limit,
+                tpm_limit,
+                rph_limit,
+                rpd_limit,
+                tpd_limit,
+                blocked,
+                metadata,
+                self_service_keys_enabled,
+                self_service_max_keys_per_user,
+                self_service_budget_ceiling,
+                self_service_require_expiry,
+                self_service_max_expiry_days,
+                created_at,
+                updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5, 0, $6, $7, $8, $9, $10, false, $11::jsonb, $12, $13, $14, $15, $16, NOW(), NOW())
+            ON CONFLICT (team_id) DO NOTHING
+            """,
+            default_team.id,
+            default_team.alias,
+            settings.default_org.id,
+            default_team.max_budget,
+            default_team.soft_budget,
+            default_team.rpm_limit,
+            default_team.tpm_limit,
+            default_team.rph_limit,
+            default_team.rpd_limit,
+            default_team.tpd_limit,
+            self._metadata_json("team"),
+            default_team.self_service_keys_enabled,
+            default_team.self_service_max_keys_per_user,
+            default_team.self_service_budget_ceiling,
+            default_team.self_service_require_expiry,
+            default_team.self_service_max_expiry_days,
+        )
+
+    async def _insert_org_membership(
+        self,
+        db_client: Any,
+        *,
+        account_id: str,
+        organization_id: str,
+    ) -> None:
+        await db_client.execute_raw(
+            """
+            INSERT INTO deltallm_organizationmembership (
+                membership_id, account_id, organization_id, role, created_at, updated_at
+            )
+            VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
+            ON CONFLICT (account_id, organization_id) DO NOTHING
+            """,
+            account_id,
+            organization_id,
+            OrganizationRole.MEMBER,
+        )
+
+    async def _insert_team_membership(
+        self,
+        db_client: Any,
+        *,
+        account_id: str,
+        team_id: str,
+        role: str,
+    ) -> None:
+        await db_client.execute_raw(
+            """
+            INSERT INTO deltallm_teammembership (
+                membership_id, account_id, team_id, role, created_at, updated_at
+            )
+            VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
+            ON CONFLICT (account_id, team_id) DO NOTHING
+            """,
+            account_id,
+            team_id,
+            role,
+        )
+
+    async def _ensure_runtime_user(
+        self,
+        db_client: Any,
+        *,
+        account_id: str,
+        email: str,
+        team_id: str,
+        settings: SelfRegistrationSettings,
+    ) -> str:
+        default_user = settings.default_user
+        await db_client.execute_raw(
+            """
+            INSERT INTO deltallm_usertable (
+                user_id,
+                user_email,
+                user_role,
+                max_budget,
+                soft_budget,
+                spend,
+                models,
+                rpm_limit,
+                tpm_limit,
+                rph_limit,
+                rpd_limit,
+                tpd_limit,
+                team_id,
+                metadata,
+                created_at,
+                updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5, 0, ARRAY[]::text[], $6, $7, $8, $9, $10, $11, $12::jsonb, NOW(), NOW())
+            ON CONFLICT DO NOTHING
+            """,
+            account_id,
+            email,
+            default_user.user_role,
+            default_user.max_budget,
+            default_user.soft_budget,
+            default_user.rpm_limit,
+            default_user.tpm_limit,
+            default_user.rph_limit,
+            default_user.rpd_limit,
+            default_user.tpd_limit,
+            team_id,
+            self._metadata_json("user"),
+        )
+        runtime_user = await self._get_runtime_user_by_account_or_email(
+            db_client,
+            account_id=account_id,
+            email=email,
+        )
+        if runtime_user is None:
+            raise RuntimeError("failed to provision runtime user")
+        user_id = str(runtime_user.get("user_id") or "").strip()
+        if not user_id:
+            raise RuntimeError("failed to provision runtime user")
+        return user_id
+
+    async def _get_runtime_user_by_account_or_email(
+        self,
+        db_client: Any,
+        *,
+        account_id: str,
+        email: str,
+    ) -> dict[str, Any] | None:
+        rows = await db_client.query_raw(
+            """
+            SELECT user_id, user_email, team_id
+            FROM deltallm_usertable
+            WHERE user_id = $1 OR lower(user_email) = lower($2)
+            ORDER BY CASE WHEN user_id = $1 THEN 0 ELSE 1 END
+            LIMIT 1
+            """,
+            account_id,
+            email,
+        )
+        return dict(rows[0]) if rows else None
+
+    def _metadata_json(self, entity_type: str) -> str:
+        return json.dumps(
+            {
+                "source": _SELF_REGISTRATION_SOURCE,
+                "self_registration_default": entity_type,
+            }
+        )

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -52,6 +52,154 @@ def test_batch_advisory_lock_mode_validation() -> None:
         )
 
 
+def test_self_registration_defaults_are_disabled() -> None:
+    settings = GeneralSettings()
+
+    assert settings.self_registration.enabled is False
+    assert settings.self_registration.allowed_domains == []
+    assert settings.self_registration.default_org.id is None
+    assert settings.self_registration.default_team.id is None
+    assert settings.self_registration.default_team.role == "team_developer"
+
+
+def test_self_registration_enabled_config_normalizes_values() -> None:
+    cfg = AppConfig.model_validate(
+        {
+            "general_settings": {
+                "self_registration": {
+                    "enabled": True,
+                    "mode": "sso_allowed_domain",
+                    "allowed_domains": ["Example.COM", "example.com", "Engineering.Internal"],
+                    "default_org": {
+                        "id": " org-sandbox ",
+                        "name": " Developer Sandbox ",
+                        "max_budget": 100,
+                        "soft_budget": 80,
+                        "rpm_limit": 300,
+                    },
+                    "default_team": {
+                        "id": " team-self-serve ",
+                        "alias": " Self Serve ",
+                        "role": "team_developer",
+                        "self_service_max_keys_per_user": 2,
+                        "self_service_budget_ceiling": 5,
+                        "self_service_require_expiry": True,
+                        "self_service_max_expiry_days": 14,
+                    },
+                    "default_user": {
+                        "max_budget": 10,
+                        "soft_budget": 8,
+                        "rpm_limit": 30,
+                        "tpm_limit": 50_000,
+                    },
+                }
+            }
+        }
+    )
+
+    registration = cfg.general_settings.self_registration
+    assert registration.enabled is True
+    assert registration.allowed_domains == ["example.com", "engineering.internal"]
+    assert registration.default_org.id == "org-sandbox"
+    assert registration.default_org.name == "Developer Sandbox"
+    assert registration.default_team.id == "team-self-serve"
+    assert registration.default_team.alias == "Self Serve"
+    assert registration.default_team.self_service_budget_ceiling == 5
+    assert registration.default_user.max_budget == 10
+
+
+def test_self_registration_enabled_requires_default_org_and_team() -> None:
+    with pytest.raises(ValueError, match="default_org.id"):
+        AppConfig.model_validate(
+            {
+                "general_settings": {
+                    "self_registration": {
+                        "enabled": True,
+                        "allowed_domains": ["example.com"],
+                        "default_team": {"id": "team-self-serve"},
+                    }
+                }
+            }
+        )
+
+    with pytest.raises(ValueError, match="default_team.id"):
+        AppConfig.model_validate(
+            {
+                "general_settings": {
+                    "self_registration": {
+                        "enabled": True,
+                        "allowed_domains": ["example.com"],
+                        "default_org": {"id": "org-sandbox"},
+                    }
+                }
+            }
+        )
+
+
+def test_self_registration_sso_allowed_domain_requires_domains() -> None:
+    with pytest.raises(ValueError, match="allowed_domains"):
+        AppConfig.model_validate(
+            {
+                "general_settings": {
+                    "self_registration": {
+                        "enabled": True,
+                        "mode": "sso_allowed_domain",
+                        "default_org": {"id": "org-sandbox"},
+                        "default_team": {"id": "team-self-serve"},
+                    }
+                }
+            }
+        )
+
+
+def test_self_registration_rejects_invalid_domains_and_limits() -> None:
+    with pytest.raises(ValueError, match="bare email domains"):
+        AppConfig.model_validate(
+            {
+                "general_settings": {
+                    "self_registration": {
+                        "enabled": True,
+                        "allowed_domains": ["@example.com"],
+                        "default_org": {"id": "org-sandbox"},
+                        "default_team": {"id": "team-self-serve"},
+                    }
+                }
+            }
+        )
+
+    with pytest.raises(ValueError, match="greater than 0"):
+        AppConfig.model_validate(
+            {
+                "general_settings": {
+                    "self_registration": {
+                        "enabled": True,
+                        "allowed_domains": ["example.com"],
+                        "default_org": {"id": "org-sandbox", "rpm_limit": 0},
+                        "default_team": {"id": "team-self-serve"},
+                    }
+                }
+            }
+        )
+
+    with pytest.raises(ValueError, match="soft_budget"):
+        AppConfig.model_validate(
+            {
+                "general_settings": {
+                    "self_registration": {
+                        "enabled": True,
+                        "allowed_domains": ["example.com"],
+                        "default_org": {
+                            "id": "org-sandbox",
+                            "max_budget": 10,
+                            "soft_budget": 12,
+                        },
+                        "default_team": {"id": "team-self-serve"},
+                    }
+                }
+            }
+        )
+
+
 def test_resolve_app_config_with_secrets_wraps_secret_resolution_errors():
     class BrokenResolver:
         def resolve_tree(self, value):

--- a/tests/services/test_self_registration_provisioning.py
+++ b/tests/services/test_self_registration_provisioning.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from src.config import AppConfig, SelfRegistrationSettings
+from src.services.platform_identity_service import PlatformIdentityService
+from src.services.self_registration_provisioning import SelfRegistrationProvisioningService
+
+
+def _enabled_settings() -> SelfRegistrationSettings:
+    cfg = AppConfig.model_validate(
+        {
+            "general_settings": {
+                "self_registration": {
+                    "enabled": True,
+                    "mode": "sso_allowed_domain",
+                    "allowed_domains": ["example.com"],
+                    "default_org": {
+                        "id": "org-sandbox",
+                        "name": "Developer Sandbox",
+                        "max_budget": 100,
+                        "soft_budget": 80,
+                        "rpm_limit": 300,
+                        "tpm_limit": 500_000,
+                        "rph_limit": 2_000,
+                        "rpd_limit": 10_000,
+                        "tpd_limit": 5_000_000,
+                    },
+                    "default_team": {
+                        "id": "team-self-serve",
+                        "alias": "Self Serve",
+                        "role": "team_developer",
+                        "max_budget": 50,
+                        "rpm_limit": 100,
+                        "tpm_limit": 200_000,
+                        "self_service_keys_enabled": True,
+                        "self_service_max_keys_per_user": 2,
+                        "self_service_budget_ceiling": 5,
+                        "self_service_require_expiry": True,
+                        "self_service_max_expiry_days": 14,
+                    },
+                    "default_user": {
+                        "max_budget": 10,
+                        "soft_budget": 8,
+                        "rpm_limit": 30,
+                        "tpm_limit": 50_000,
+                        "rph_limit": 200,
+                        "rpd_limit": 1_000,
+                        "tpd_limit": 500_000,
+                    },
+                }
+            }
+        }
+    )
+    return cfg.general_settings.self_registration
+
+
+class FakeSelfRegistrationDB:
+    def __init__(self) -> None:
+        self.accounts: dict[str, dict[str, Any]] = {}
+        self.organizations: dict[str, dict[str, Any]] = {}
+        self.teams: dict[str, dict[str, Any]] = {}
+        self.users: dict[str, dict[str, Any]] = {}
+        self.organization_memberships: dict[tuple[str, str], dict[str, Any]] = {}
+        self.team_memberships: dict[tuple[str, str], dict[str, Any]] = {}
+
+    async def query_raw(self, query: str, *params):  # noqa: ANN201
+        normalized = _normalize_sql(query)
+        if "from deltallm_teamtable" in normalized and "where team_id = $1" in normalized:
+            team = self.teams.get(str(params[0]))
+            return [dict(team)] if team else []
+        if "from deltallm_platformaccount" in normalized and "lower(email) = lower($1)" in normalized:
+            email = str(params[0]).strip().lower()
+            account = self._account_by_email(email)
+            return [dict(account)] if account else []
+        if "from deltallm_platformaccount" in normalized and "where account_id = $1" in normalized:
+            account = self.accounts.get(str(params[0]))
+            return [dict(account)] if account else []
+        if "from deltallm_usertable" in normalized and "where user_id = $1" in normalized:
+            account_id = str(params[0])
+            email = str(params[1]).strip().lower()
+            by_id = self.users.get(account_id)
+            if by_id is not None:
+                return [dict(by_id)]
+            by_email = next(
+                (
+                    user
+                    for user in self.users.values()
+                    if str(user.get("user_email") or "").lower() == email
+                ),
+                None,
+            )
+            return [dict(by_email)] if by_email else []
+        return []
+
+    async def execute_raw(self, query: str, *params):  # noqa: ANN201
+        normalized = _normalize_sql(query)
+        if "insert into deltallm_platformaccount" in normalized:
+            return self._insert_platform_account(*params)
+        if "insert into deltallm_organizationtable" in normalized:
+            return self._insert_organization(*params)
+        if "insert into deltallm_teamtable" in normalized:
+            return self._insert_team(*params)
+        if "insert into deltallm_organizationmembership" in normalized:
+            return self._insert_organization_membership(*params)
+        if "insert into deltallm_teammembership" in normalized:
+            return self._insert_team_membership(*params)
+        if "insert into deltallm_usertable" in normalized:
+            return self._insert_runtime_user(*params)
+        return 0
+
+    def add_account(
+        self,
+        *,
+        account_id: str,
+        email: str,
+        role: str = "org_user",
+        is_active: bool = True,
+    ) -> None:
+        self.accounts[account_id] = {
+            "account_id": account_id,
+            "email": email.strip().lower(),
+            "password_hash": None,
+            "role": role,
+            "is_active": is_active,
+            "force_password_change": False,
+            "mfa_enabled": False,
+            "created_at": None,
+            "updated_at": None,
+            "last_login_at": None,
+        }
+
+    def _account_by_email(self, email: str) -> dict[str, Any] | None:
+        return next(
+            (
+                account
+                for account in self.accounts.values()
+                if str(account.get("email") or "").lower() == email
+            ),
+            None,
+        )
+
+    def _insert_platform_account(self, email: str, role: str, is_active: bool) -> int:
+        normalized_email = email.strip().lower()
+        if self._account_by_email(normalized_email) is not None:
+            return 1
+        account_id = f"acct-{len(self.accounts) + 1}"
+        self.add_account(
+            account_id=account_id,
+            email=normalized_email,
+            role=role,
+            is_active=is_active,
+        )
+        return 1
+
+    def _insert_organization(
+        self,
+        organization_id: str,
+        organization_name: str | None,
+        max_budget: float | None,
+        soft_budget: float | None,
+        rpm_limit: int | None,
+        tpm_limit: int | None,
+        rph_limit: int | None,
+        rpd_limit: int | None,
+        tpd_limit: int | None,
+        metadata: str,
+    ) -> int:
+        if organization_id in self.organizations:
+            return 0
+        self.organizations[organization_id] = {
+            "organization_id": organization_id,
+            "organization_name": organization_name,
+            "max_budget": max_budget,
+            "soft_budget": soft_budget,
+            "spend": 0,
+            "rpm_limit": rpm_limit,
+            "tpm_limit": tpm_limit,
+            "rph_limit": rph_limit,
+            "rpd_limit": rpd_limit,
+            "tpd_limit": tpd_limit,
+            "metadata": json.loads(metadata),
+        }
+        return 1
+
+    def _insert_team(
+        self,
+        team_id: str,
+        team_alias: str | None,
+        organization_id: str,
+        max_budget: float | None,
+        soft_budget: float | None,
+        rpm_limit: int | None,
+        tpm_limit: int | None,
+        rph_limit: int | None,
+        rpd_limit: int | None,
+        tpd_limit: int | None,
+        metadata: str,
+        self_service_keys_enabled: bool,
+        self_service_max_keys_per_user: int | None,
+        self_service_budget_ceiling: float | None,
+        self_service_require_expiry: bool,
+        self_service_max_expiry_days: int | None,
+    ) -> int:
+        if team_id in self.teams:
+            return 0
+        self.teams[team_id] = {
+            "team_id": team_id,
+            "team_alias": team_alias,
+            "organization_id": organization_id,
+            "max_budget": max_budget,
+            "soft_budget": soft_budget,
+            "spend": 0,
+            "rpm_limit": rpm_limit,
+            "tpm_limit": tpm_limit,
+            "rph_limit": rph_limit,
+            "rpd_limit": rpd_limit,
+            "tpd_limit": tpd_limit,
+            "blocked": False,
+            "metadata": json.loads(metadata),
+            "self_service_keys_enabled": self_service_keys_enabled,
+            "self_service_max_keys_per_user": self_service_max_keys_per_user,
+            "self_service_budget_ceiling": self_service_budget_ceiling,
+            "self_service_require_expiry": self_service_require_expiry,
+            "self_service_max_expiry_days": self_service_max_expiry_days,
+        }
+        return 1
+
+    def _insert_organization_membership(
+        self,
+        account_id: str,
+        organization_id: str,
+        role: str,
+    ) -> int:
+        key = (account_id, organization_id)
+        self.organization_memberships.setdefault(
+            key,
+            {"account_id": account_id, "organization_id": organization_id, "role": role},
+        )
+        return 1
+
+    def _insert_team_membership(self, account_id: str, team_id: str, role: str) -> int:
+        key = (account_id, team_id)
+        self.team_memberships.setdefault(
+            key,
+            {"account_id": account_id, "team_id": team_id, "role": role},
+        )
+        return 1
+
+    def _insert_runtime_user(
+        self,
+        user_id: str,
+        user_email: str,
+        user_role: str,
+        max_budget: float | None,
+        soft_budget: float | None,
+        rpm_limit: int | None,
+        tpm_limit: int | None,
+        rph_limit: int | None,
+        rpd_limit: int | None,
+        tpd_limit: int | None,
+        team_id: str,
+        metadata: str,
+    ) -> int:
+        normalized_email = user_email.strip().lower()
+        if user_id in self.users:
+            return 0
+        if any(str(user.get("user_email") or "").lower() == normalized_email for user in self.users.values()):
+            return 0
+        self.users[user_id] = {
+            "user_id": user_id,
+            "user_email": normalized_email,
+            "user_role": user_role,
+            "max_budget": max_budget,
+            "soft_budget": soft_budget,
+            "spend": 0,
+            "rpm_limit": rpm_limit,
+            "tpm_limit": tpm_limit,
+            "rph_limit": rph_limit,
+            "rpd_limit": rpd_limit,
+            "tpd_limit": tpd_limit,
+            "team_id": team_id,
+            "metadata": json.loads(metadata),
+        }
+        return 1
+
+
+def _normalize_sql(query: str) -> str:
+    return " ".join(query.lower().split())
+
+
+def _service(db: FakeSelfRegistrationDB) -> SelfRegistrationProvisioningService:
+    return SelfRegistrationProvisioningService(
+        db_client=db,
+        platform_identity_service=PlatformIdentityService(db_client=db, salt="salt-key"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_provision_from_defaults_seeds_sandbox_records() -> None:
+    db = FakeSelfRegistrationDB()
+    service = _service(db)
+
+    result = await service.provision_from_defaults(
+        email=" Developer@Example.COM ",
+        settings=_enabled_settings(),
+    )
+
+    assert result.as_dict() == {
+        "account_id": "acct-1",
+        "email": "developer@example.com",
+        "organization_id": "org-sandbox",
+        "team_id": "team-self-serve",
+        "user_id": "acct-1",
+        "team_role": "team_developer",
+        "account_is_active": True,
+    }
+    assert db.organizations["org-sandbox"]["max_budget"] == 100
+    assert db.organizations["org-sandbox"]["soft_budget"] == 80
+    assert db.organizations["org-sandbox"]["rpm_limit"] == 300
+    assert db.organizations["org-sandbox"]["metadata"]["source"] == "self_registration"
+    assert db.teams["team-self-serve"]["organization_id"] == "org-sandbox"
+    assert db.teams["team-self-serve"]["max_budget"] == 50
+    assert db.teams["team-self-serve"]["self_service_keys_enabled"] is True
+    assert db.teams["team-self-serve"]["self_service_budget_ceiling"] == 5
+    assert db.organization_memberships[("acct-1", "org-sandbox")]["role"] == "org_member"
+    assert db.team_memberships[("acct-1", "team-self-serve")]["role"] == "team_developer"
+    assert db.users["acct-1"]["user_email"] == "developer@example.com"
+    assert db.users["acct-1"]["max_budget"] == 10
+    assert db.users["acct-1"]["team_id"] == "team-self-serve"
+
+
+@pytest.mark.asyncio
+async def test_provision_from_defaults_preserves_existing_admin_changes() -> None:
+    db = FakeSelfRegistrationDB()
+    db.add_account(
+        account_id="acct-existing",
+        email="existing@example.com",
+        role="platform_admin",
+        is_active=False,
+    )
+    db.organizations["org-sandbox"] = {
+        "organization_id": "org-sandbox",
+        "organization_name": "Admin Edited Org",
+        "max_budget": 999,
+        "soft_budget": 900,
+        "rpm_limit": 999,
+    }
+    db.teams["team-self-serve"] = {
+        "team_id": "team-self-serve",
+        "team_alias": "Admin Edited Team",
+        "organization_id": "org-sandbox",
+        "max_budget": 777,
+        "self_service_keys_enabled": False,
+        "self_service_budget_ceiling": 123,
+    }
+    db.users["acct-existing"] = {
+        "user_id": "acct-existing",
+        "user_email": "existing@example.com",
+        "max_budget": 500,
+        "team_id": "custom-team",
+    }
+    db.organization_memberships[("acct-existing", "org-sandbox")] = {
+        "account_id": "acct-existing",
+        "organization_id": "org-sandbox",
+        "role": "org_admin",
+    }
+    db.team_memberships[("acct-existing", "team-self-serve")] = {
+        "account_id": "acct-existing",
+        "team_id": "team-self-serve",
+        "role": "team_admin",
+    }
+
+    result = await _service(db).provision_from_defaults(
+        email="existing@example.com",
+        settings=_enabled_settings(),
+    )
+
+    assert result.account_id == "acct-existing"
+    assert result.account_is_active is False
+    assert db.accounts["acct-existing"]["role"] == "platform_admin"
+    assert db.organizations["org-sandbox"]["organization_name"] == "Admin Edited Org"
+    assert db.organizations["org-sandbox"]["max_budget"] == 999
+    assert db.teams["team-self-serve"]["team_alias"] == "Admin Edited Team"
+    assert db.teams["team-self-serve"]["self_service_keys_enabled"] is False
+    assert db.users["acct-existing"]["max_budget"] == 500
+    assert db.users["acct-existing"]["team_id"] == "custom-team"
+    assert db.organization_memberships[("acct-existing", "org-sandbox")]["role"] == "org_admin"
+    assert db.team_memberships[("acct-existing", "team-self-serve")]["role"] == "team_admin"
+
+
+@pytest.mark.asyncio
+async def test_provision_from_defaults_returns_existing_runtime_user_for_same_email() -> None:
+    db = FakeSelfRegistrationDB()
+    db.users["legacy-user"] = {
+        "user_id": "legacy-user",
+        "user_email": "developer@example.com",
+        "max_budget": 500,
+        "team_id": "legacy-team",
+    }
+
+    result = await _service(db).provision_from_defaults(
+        email="developer@example.com",
+        settings=_enabled_settings(),
+    )
+
+    assert result.account_id == "acct-1"
+    assert result.user_id == "legacy-user"
+    assert "acct-1" not in db.users
+    assert db.users["legacy-user"]["max_budget"] == 500
+    assert db.users["legacy-user"]["team_id"] == "legacy-team"
+
+
+@pytest.mark.asyncio
+async def test_provision_from_defaults_rejects_existing_team_in_wrong_org() -> None:
+    db = FakeSelfRegistrationDB()
+    db.teams["team-self-serve"] = {
+        "team_id": "team-self-serve",
+        "organization_id": "org-other",
+    }
+
+    with pytest.raises(ValueError, match="different organization"):
+        await _service(db).provision_from_defaults(
+            email="developer@example.com",
+            settings=_enabled_settings(),
+        )
+
+    assert db.organizations == {}
+    assert db.accounts == {}
+
+
+@pytest.mark.asyncio
+async def test_provision_from_defaults_rejects_disabled_settings() -> None:
+    db = FakeSelfRegistrationDB()
+    settings = AppConfig.model_validate({}).general_settings.self_registration
+
+    with pytest.raises(ValueError, match="disabled"):
+        await _service(db).provision_from_defaults(
+            email="developer@example.com",
+            settings=settings,
+        )
+
+    assert db.organizations == {}
+    assert db.accounts == {}


### PR DESCRIPTION
## Summary
- add typed `general_settings.self_registration` config models and validation
- add insert-only self-registration provisioning service for default org/team/user seeding
- register the provisioning service during auth bootstrap without changing login behavior
- add config and provisioning tests covering validation, seed behavior, admin-preserving inserts, and legacy runtime-user email conflicts

## Stack Target
This is PR 1 for issue #195 and targets the integration branch `feature/self-registration`. Follow-up self-registration PRs should merge into that branch first; the final integration PR will target `main`.

## Tests
- `uv run --extra dev pytest tests/config/test_settings.py tests/services/test_self_registration_provisioning.py -q`
- `uv run --extra dev pytest tests/test_ui_access_provisioning.py tests/services/test_platform_identity_service.py tests/bootstrap/test_auth_bootstrap.py -q`
- `uv run --extra dev ruff check src tests`

Refs #195