### PR TITLE
Add tier schema foundation

### DIFF
--- a/prisma/migrations/20260617160000_tier_schema_foundation/migration.sql
+++ b/prisma/migrations/20260617160000_tier_schema_foundation/migration.sql
@@ -1,0 +1,223 @@
+CREATE TABLE "deltallm_tier" (
+  "tier_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "tier_key" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "enabled" BOOLEAN NOT NULL DEFAULT TRUE,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "deltallm_tier_pkey" PRIMARY KEY ("tier_id")
+);
+
+CREATE UNIQUE INDEX "deltallm_tier_tier_key_key"
+  ON "deltallm_tier"("tier_key");
+
+CREATE INDEX "deltallm_tier_enabled_idx"
+  ON "deltallm_tier"("enabled");
+
+CREATE TABLE "deltallm_tierversion" (
+  "tier_version_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "tier_id" TEXT NOT NULL,
+  "version_number" INTEGER NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'draft',
+  "published_at" TIMESTAMP(3),
+  "published_by_account_id" TEXT,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "deltallm_tierversion_pkey" PRIMARY KEY ("tier_version_id"),
+  CONSTRAINT "deltallm_tierversion_status_check"
+    CHECK ("status" IN ('draft', 'active', 'archived'))
+);
+
+CREATE UNIQUE INDEX "deltallm_tierversion_tier_version_key"
+  ON "deltallm_tierversion"("tier_id", "version_number");
+
+CREATE INDEX "deltallm_tierversion_tier_status_idx"
+  ON "deltallm_tierversion"("tier_id", "status");
+
+CREATE INDEX "deltallm_tierversion_status_idx"
+  ON "deltallm_tierversion"("status");
+
+CREATE INDEX "deltallm_tierversion_published_by_idx"
+  ON "deltallm_tierversion"("published_by_account_id");
+
+CREATE TABLE "deltallm_tiermodelpolicy" (
+  "tier_model_policy_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "tier_version_id" TEXT NOT NULL,
+  "callable_key" TEXT NOT NULL,
+  "enabled" BOOLEAN NOT NULL DEFAULT TRUE,
+  "access_mode" TEXT NOT NULL DEFAULT 'allow',
+  "rpm_limit" INTEGER,
+  "tpm_limit" INTEGER,
+  "rph_limit" INTEGER,
+  "rpd_limit" INTEGER,
+  "tpd_limit" INTEGER,
+  "max_parallel_requests" INTEGER,
+  "batch_rpm_limit" INTEGER,
+  "batch_tpm_limit" INTEGER,
+  "pricing" JSONB,
+  "capacity_pool_key" TEXT,
+  "priority" INTEGER NOT NULL DEFAULT 0,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "deltallm_tiermodelpolicy_pkey" PRIMARY KEY ("tier_model_policy_id"),
+  CONSTRAINT "deltallm_tiermodelpolicy_access_mode_check"
+    CHECK ("access_mode" IN ('allow', 'deny')),
+  CONSTRAINT "deltallm_tiermodelpolicy_rpm_limit_check"
+    CHECK ("rpm_limit" IS NULL OR "rpm_limit" > 0),
+  CONSTRAINT "deltallm_tiermodelpolicy_tpm_limit_check"
+    CHECK ("tpm_limit" IS NULL OR "tpm_limit" > 0),
+  CONSTRAINT "deltallm_tiermodelpolicy_rph_limit_check"
+    CHECK ("rph_limit" IS NULL OR "rph_limit" > 0),
+  CONSTRAINT "deltallm_tiermodelpolicy_rpd_limit_check"
+    CHECK ("rpd_limit" IS NULL OR "rpd_limit" > 0),
+  CONSTRAINT "deltallm_tiermodelpolicy_tpd_limit_check"
+    CHECK ("tpd_limit" IS NULL OR "tpd_limit" > 0),
+  CONSTRAINT "deltallm_tiermodelpolicy_max_parallel_check"
+    CHECK ("max_parallel_requests" IS NULL OR "max_parallel_requests" > 0),
+  CONSTRAINT "deltallm_tiermodelpolicy_batch_rpm_check"
+    CHECK ("batch_rpm_limit" IS NULL OR "batch_rpm_limit" > 0),
+  CONSTRAINT "deltallm_tiermodelpolicy_batch_tpm_check"
+    CHECK ("batch_tpm_limit" IS NULL OR "batch_tpm_limit" > 0)
+);
+
+CREATE UNIQUE INDEX "deltallm_tiermodelpolicy_version_callable_key"
+  ON "deltallm_tiermodelpolicy"("tier_version_id", "callable_key");
+
+CREATE INDEX "deltallm_tiermodelpolicy_callable_key_idx"
+  ON "deltallm_tiermodelpolicy"("callable_key");
+
+CREATE INDEX "deltallm_tiermodelpolicy_version_enabled_idx"
+  ON "deltallm_tiermodelpolicy"("tier_version_id", "enabled");
+
+CREATE INDEX "deltallm_tiermodelpolicy_capacity_pool_idx"
+  ON "deltallm_tiermodelpolicy"("capacity_pool_key");
+
+CREATE TABLE "deltallm_tiercapacitypool" (
+  "tier_capacity_pool_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "tier_version_id" TEXT NOT NULL,
+  "pool_key" TEXT NOT NULL,
+  "callable_key" TEXT NOT NULL,
+  "rpm_capacity" INTEGER,
+  "tpm_capacity" INTEGER,
+  "max_parallel_requests" INTEGER,
+  "strategy" TEXT NOT NULL DEFAULT 'hard_cap',
+  "saturation_threshold" DOUBLE PRECISION,
+  "burst_multiplier" DOUBLE PRECISION,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "deltallm_tiercapacitypool_pkey" PRIMARY KEY ("tier_capacity_pool_id"),
+  CONSTRAINT "deltallm_tiercapacitypool_strategy_check"
+    CHECK ("strategy" IN ('hard_cap', 'weighted_fair', 'reserved_burst')),
+  CONSTRAINT "deltallm_tiercapacitypool_rpm_capacity_check"
+    CHECK ("rpm_capacity" IS NULL OR "rpm_capacity" > 0),
+  CONSTRAINT "deltallm_tiercapacitypool_tpm_capacity_check"
+    CHECK ("tpm_capacity" IS NULL OR "tpm_capacity" > 0),
+  CONSTRAINT "deltallm_tiercapacitypool_max_parallel_check"
+    CHECK ("max_parallel_requests" IS NULL OR "max_parallel_requests" > 0),
+  CONSTRAINT "deltallm_tiercapacitypool_saturation_check"
+    CHECK ("saturation_threshold" IS NULL OR ("saturation_threshold" > 0 AND "saturation_threshold" <= 1)),
+  CONSTRAINT "deltallm_tiercapacitypool_burst_multiplier_check"
+    CHECK ("burst_multiplier" IS NULL OR "burst_multiplier" >= 1)
+);
+
+CREATE UNIQUE INDEX "deltallm_tiercapacitypool_version_pool_callable_key"
+  ON "deltallm_tiercapacitypool"("tier_version_id", "pool_key", "callable_key");
+
+CREATE INDEX "deltallm_tiercapacitypool_version_pool_idx"
+  ON "deltallm_tiercapacitypool"("tier_version_id", "pool_key");
+
+CREATE INDEX "deltallm_tiercapacitypool_callable_key_idx"
+  ON "deltallm_tiercapacitypool"("callable_key");
+
+CREATE TABLE "deltallm_organizationtierassignment" (
+  "assignment_id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "organization_id" TEXT NOT NULL,
+  "tier_id" TEXT NOT NULL,
+  "tier_version_id" TEXT,
+  "assignment_type" TEXT NOT NULL DEFAULT 'primary',
+  "enabled" BOOLEAN NOT NULL DEFAULT TRUE,
+  "weight" INTEGER NOT NULL DEFAULT 1,
+  "starts_at" TIMESTAMP(3),
+  "ends_at" TIMESTAMP(3),
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "deltallm_organizationtierassignment_pkey" PRIMARY KEY ("assignment_id"),
+  CONSTRAINT "deltallm_organizationtierassignment_type_check"
+    CHECK ("assignment_type" IN ('primary', 'addon', 'override')),
+  CONSTRAINT "deltallm_organizationtierassignment_weight_check"
+    CHECK ("weight" > 0),
+  CONSTRAINT "deltallm_organizationtierassignment_effective_window_check"
+    CHECK ("starts_at" IS NULL OR "ends_at" IS NULL OR "starts_at" < "ends_at")
+);
+
+CREATE INDEX "deltallm_orgtierassignment_org_enabled_idx"
+  ON "deltallm_organizationtierassignment"("organization_id", "enabled");
+
+CREATE INDEX "deltallm_orgtierassignment_org_type_enabled_idx"
+  ON "deltallm_organizationtierassignment"("organization_id", "assignment_type", "enabled");
+
+CREATE INDEX "deltallm_orgtierassignment_tier_enabled_idx"
+  ON "deltallm_organizationtierassignment"("tier_id", "enabled");
+
+CREATE INDEX "deltallm_orgtierassignment_tier_version_idx"
+  ON "deltallm_organizationtierassignment"("tier_version_id");
+
+ALTER TABLE "deltallm_tierversion"
+  ADD CONSTRAINT "deltallm_tierversion_tier_id_fkey"
+  FOREIGN KEY ("tier_id")
+  REFERENCES "deltallm_tier"("tier_id")
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;
+
+ALTER TABLE "deltallm_tierversion"
+  ADD CONSTRAINT "deltallm_tierversion_published_by_fkey"
+  FOREIGN KEY ("published_by_account_id")
+  REFERENCES "deltallm_platformaccount"("account_id")
+  ON DELETE SET NULL
+  ON UPDATE CASCADE;
+
+ALTER TABLE "deltallm_tiermodelpolicy"
+  ADD CONSTRAINT "deltallm_tiermodelpolicy_tier_version_id_fkey"
+  FOREIGN KEY ("tier_version_id")
+  REFERENCES "deltallm_tierversion"("tier_version_id")
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;
+
+ALTER TABLE "deltallm_tiercapacitypool"
+  ADD CONSTRAINT "deltallm_tiercapacitypool_tier_version_id_fkey"
+  FOREIGN KEY ("tier_version_id")
+  REFERENCES "deltallm_tierversion"("tier_version_id")
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;
+
+ALTER TABLE "deltallm_organizationtierassignment"
+  ADD CONSTRAINT "deltallm_orgtierassignment_organization_id_fkey"
+  FOREIGN KEY ("organization_id")
+  REFERENCES "deltallm_organizationtable"("organization_id")
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;
+
+ALTER TABLE "deltallm_organizationtierassignment"
+  ADD CONSTRAINT "deltallm_orgtierassignment_tier_id_fkey"
+  FOREIGN KEY ("tier_id")
+  REFERENCES "deltallm_tier"("tier_id")
+  ON DELETE RESTRICT
+  ON UPDATE CASCADE;
+
+ALTER TABLE "deltallm_organizationtierassignment"
+  ADD CONSTRAINT "deltallm_orgtierassignment_tier_version_id_fkey"
+  FOREIGN KEY ("tier_version_id")
+  REFERENCES "deltallm_tierversion"("tier_version_id")
+  ON DELETE SET NULL
+  ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -217,6 +217,8 @@ model DeltaLLM_OrganizationTable {
   created_at        DateTime @default(now())
   updated_at        DateTime @updatedAt
 
+  tier_assignments DeltaLLM_OrganizationTierAssignment[]
+
   @@map("deltallm_organizationtable")
 }
 
@@ -305,6 +307,7 @@ model DeltaLLM_PlatformAccount {
   sent_invitations    DeltaLLM_PlatformInvitation[] @relation("platform_invitation_inviter")
   email_tokens        DeltaLLM_EmailToken[] @relation("email_token_account")
   created_email_tokens DeltaLLM_EmailToken[] @relation("email_token_creator")
+  published_tier_versions DeltaLLM_TierVersion[] @relation("tier_version_publisher")
 
   @@map("deltallm_platformaccount")
 }
@@ -500,6 +503,125 @@ model DeltaLLM_Config {
   updated_at   DateTime @default(now())
 
   @@map("deltallm_config")
+}
+
+model DeltaLLM_Tier {
+  tier_id     String   @id @default(uuid())
+  tier_key    String   @unique(map: "deltallm_tier_tier_key_key")
+  name        String
+  description String?
+  enabled     Boolean  @default(true)
+  metadata    Json?
+  created_at  DateTime @default(now())
+  updated_at  DateTime @updatedAt
+
+  versions    DeltaLLM_TierVersion[]
+  assignments DeltaLLM_OrganizationTierAssignment[]
+
+  @@index([enabled], map: "deltallm_tier_enabled_idx")
+  @@map("deltallm_tier")
+}
+
+model DeltaLLM_TierVersion {
+  tier_version_id        String    @id @default(uuid())
+  tier_id                String
+  version_number         Int
+  status                 String    @default("draft")
+  published_at           DateTime?
+  published_by_account_id String?
+  metadata               Json?
+  created_at             DateTime  @default(now())
+  updated_at             DateTime  @updatedAt
+
+  tier          DeltaLLM_Tier @relation(fields: [tier_id], references: [tier_id], onDelete: Cascade)
+  published_by  DeltaLLM_PlatformAccount? @relation("tier_version_publisher", fields: [published_by_account_id], references: [account_id], onDelete: SetNull)
+  model_policies DeltaLLM_TierModelPolicy[]
+  capacity_pools DeltaLLM_TierCapacityPool[]
+  assignments    DeltaLLM_OrganizationTierAssignment[]
+
+  @@unique([tier_id, version_number], map: "deltallm_tierversion_tier_version_key")
+  @@index([tier_id, status], map: "deltallm_tierversion_tier_status_idx")
+  @@index([status], map: "deltallm_tierversion_status_idx")
+  @@index([published_by_account_id], map: "deltallm_tierversion_published_by_idx")
+  @@map("deltallm_tierversion")
+}
+
+model DeltaLLM_TierModelPolicy {
+  tier_model_policy_id String   @id @default(uuid())
+  tier_version_id      String
+  callable_key         String
+  enabled              Boolean  @default(true)
+  access_mode          String   @default("allow")
+  rpm_limit            Int?
+  tpm_limit            Int?
+  rph_limit            Int?
+  rpd_limit            Int?
+  tpd_limit            Int?
+  max_parallel_requests Int?
+  batch_rpm_limit      Int?
+  batch_tpm_limit      Int?
+  pricing              Json?
+  capacity_pool_key    String?
+  priority             Int      @default(0)
+  metadata             Json?
+  created_at           DateTime @default(now())
+  updated_at           DateTime @updatedAt
+
+  tier_version DeltaLLM_TierVersion @relation(fields: [tier_version_id], references: [tier_version_id], onDelete: Cascade)
+
+  @@unique([tier_version_id, callable_key], map: "deltallm_tiermodelpolicy_version_callable_key")
+  @@index([callable_key], map: "deltallm_tiermodelpolicy_callable_key_idx")
+  @@index([tier_version_id, enabled], map: "deltallm_tiermodelpolicy_version_enabled_idx")
+  @@index([capacity_pool_key], map: "deltallm_tiermodelpolicy_capacity_pool_idx")
+  @@map("deltallm_tiermodelpolicy")
+}
+
+model DeltaLLM_TierCapacityPool {
+  tier_capacity_pool_id String   @id @default(uuid())
+  tier_version_id       String
+  pool_key              String
+  callable_key          String
+  rpm_capacity          Int?
+  tpm_capacity          Int?
+  max_parallel_requests Int?
+  strategy              String   @default("hard_cap")
+  saturation_threshold  Float?
+  burst_multiplier      Float?
+  metadata              Json?
+  created_at            DateTime @default(now())
+  updated_at            DateTime @updatedAt
+
+  tier_version DeltaLLM_TierVersion @relation(fields: [tier_version_id], references: [tier_version_id], onDelete: Cascade)
+
+  @@unique([tier_version_id, pool_key, callable_key], map: "deltallm_tiercapacitypool_version_pool_callable_key")
+  @@index([tier_version_id, pool_key], map: "deltallm_tiercapacitypool_version_pool_idx")
+  @@index([callable_key], map: "deltallm_tiercapacitypool_callable_key_idx")
+  @@map("deltallm_tiercapacitypool")
+}
+
+model DeltaLLM_OrganizationTierAssignment {
+  assignment_id   String   @id @default(uuid())
+  organization_id String
+  tier_id         String
+  tier_version_id String?
+  assignment_type String   @default("primary")
+  enabled         Boolean  @default(true)
+  weight          Int      @default(1)
+  starts_at       DateTime?
+  ends_at         DateTime?
+  metadata        Json?
+  created_at      DateTime @default(now())
+  updated_at      DateTime @updatedAt
+
+  organization DeltaLLM_OrganizationTable @relation(fields: [organization_id], references: [organization_id], onDelete: Cascade)
+  tier         DeltaLLM_Tier @relation(fields: [tier_id], references: [tier_id], onDelete: Restrict)
+  tier_version DeltaLLM_TierVersion? @relation(fields: [tier_version_id], references: [tier_version_id], onDelete: SetNull)
+
+  @@index([organization_id, enabled], map: "deltallm_orgtierassignment_org_enabled_idx")
+  @@index([organization_id, assignment_type, enabled], map: "deltallm_orgtierassignment_org_type_enabled_idx")
+  @@index([tier_id, enabled], map: "deltallm_orgtierassignment_tier_enabled_idx")
+  @@index([tier_version_id], map: "deltallm_orgtierassignment_tier_version_idx")
+  @@map("deltallm_organizationtierassignment")
 }
 
 model DeltaLLM_NamedCredential {


### PR DESCRIPTION
## Summary

Adds the storage foundation for organization model tiers without changing runtime behavior.

This PR introduces first-class schema objects for:

- Tiers
- Tier versions
- Per-model tier policy
- Tier capacity pools
- Organization tier assignments

It also adds the matching raw SQL migration with indexes, foreign keys, and database-level check constraints for status/type/strategy values and positive capacity/limit fields.

## Scope

This is PR 1 for issue #197 and intentionally does not add repositories, admin APIs, runtime policy resolution, billing integration, rate-limit enforcement, or UI changes.

## Validation

- `env UV_CACHE_DIR=.uv-cache DATABASE_URL=postgresql://postgres:postgres@localhost:5432/deltallm_test uv run prisma validate --schema=./prisma/schema.prisma`
- `env UV_CACHE_DIR=.uv-cache DATABASE_URL=postgresql://postgres:postgres@localhost:5432/deltallm_test uv run prisma generate --schema=./prisma/schema.prisma`
- `git diff --check`

## Not Run

- `uv run prisma migrate deploy --schema=./prisma/schema.prisma`

Local migration deploy could not be completed because no Postgres server was reachable at `localhost:5432`, and Docker was not running locally to start the compose `db` service.