### PR TITLE
PR3: Enforce self-service sandbox key constraints

### DIFF
--- a/src/api/admin/endpoints/keys.py
+++ b/src/api/admin/endpoints/keys.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-import secrets
+import hashlib
 import logging
+import math
+import secrets
+from datetime import UTC, datetime, timedelta
 from time import perf_counter
 from typing import Any, Literal
 
@@ -22,6 +25,93 @@ from src.services.scoped_asset_access import apply_scope_asset_access, build_sco
 
 router = APIRouter(tags=["Admin Keys"])
 logger = logging.getLogger(__name__)
+_INT64_SIGN_BIT = 1 << 63
+_UINT64_MODULUS = 1 << 64
+_SELF_SERVICE_KEY_CREATE_LOCK_NAMESPACE = "self_service_key_create"
+_SELF_SERVICE_RATE_LIMIT_FIELDS = ("rpm_limit", "tpm_limit", "rph_limit", "rpd_limit", "tpd_limit")
+_ADMIN_KEY_LIST_PERMISSIONS = frozenset({Permission.KEY_UPDATE, Permission.KEY_REVOKE})
+_READ_KEY_LIST_PERMISSIONS = frozenset({Permission.KEY_READ})
+_OWNER_KEY_LIST_PERMISSIONS = frozenset({Permission.KEY_CREATE_SELF})
+
+
+def _normalize_lock_part(value: object) -> str:
+    normalized = str(value or "").strip() or "unknown"
+    return normalized.replace("\\", "\\\\").replace(":", "\\:")
+
+
+def _advisory_lock_key(namespace: str, *parts: object) -> int:
+    normalized_namespace = str(namespace or "").strip()
+    if not normalized_namespace:
+        raise ValueError("advisory lock namespace is required")
+    lock_name = ":".join([normalized_namespace, *(_normalize_lock_part(part) for part in parts)])
+    digest = hashlib.sha256(lock_name.encode("utf-8")).digest()
+    unsigned_value = int.from_bytes(digest[:8], byteorder="big", signed=False)
+    if unsigned_value >= _INT64_SIGN_BIT:
+        return unsigned_value - _UINT64_MODULUS
+    return unsigned_value
+
+
+async def _acquire_self_service_key_create_lock(db: Any, *, team_id: str, account_id: str) -> None:
+    await db.execute_raw(
+        "SELECT pg_advisory_xact_lock($1::bigint)",
+        _advisory_lock_key(_SELF_SERVICE_KEY_CREATE_LOCK_NAMESPACE, team_id, account_id),
+    )
+
+
+def _normalize_self_service_budget(max_budget: Any) -> float | None:
+    if max_budget is None:
+        return None
+    if isinstance(max_budget, bool):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be a valid number")
+    try:
+        budget_val = float(max_budget)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be a valid number")
+    if not math.isfinite(budget_val):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be a finite number")
+    return budget_val
+
+
+def _normalize_self_service_limit(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, float):
+        if not value.is_integer():
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+        parsed = int(value)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = int(stripped)
+        except ValueError:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+    else:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+
+    if parsed <= 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+    return parsed
+
+
+def _parse_self_service_expiry(expires: str | None) -> datetime | None:
+    if expires is None:
+        return None
+    raw = expires.strip()
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="expires must be a valid ISO 8601 datetime string")
+    try:
+        exp_dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="expires must be a valid ISO 8601 datetime string")
+    if exp_dt.tzinfo is None:
+        exp_dt = exp_dt.replace(tzinfo=UTC)
+    return exp_dt.astimezone(UTC)
 
 
 def _notification_record(row: dict[str, Any]) -> Any:
@@ -117,7 +207,7 @@ async def _validate_self_service_constraints(
     max_budget: Any,
     expires: str | None,
     **kwargs: Any,
-) -> None:
+) -> dict[str, Any]:
     if not policy.get("enabled"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -127,7 +217,13 @@ async def _validate_self_service_constraints(
     max_keys = policy.get("max_keys_per_user")
     if max_keys is not None:
         count_rows = await db.query_raw(
-            "SELECT COUNT(*) AS cnt FROM deltallm_verificationtoken WHERE team_id = $1 AND owner_account_id = $2",
+            """
+            SELECT COUNT(*) AS cnt
+            FROM deltallm_verificationtoken
+            WHERE team_id = $1
+              AND owner_account_id = $2
+              AND (expires IS NULL OR expires > NOW())
+            """,
             team_id,
             account_id,
         )
@@ -138,19 +234,15 @@ async def _validate_self_service_constraints(
                 detail=f"You have reached the maximum of {max_keys} self-service keys for this team",
             )
 
+    budget_val = _normalize_self_service_budget(max_budget)
+    if budget_val is not None and budget_val < 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be greater than or equal to 0")
     budget_ceiling = policy.get("budget_ceiling")
     if budget_ceiling is not None:
-        if max_budget is None:
+        if budget_val is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"A budget (max_budget) is required for self-service keys on this team (ceiling: ${budget_ceiling})",
-            )
-        try:
-            budget_val = float(max_budget)
-        except (TypeError, ValueError):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="max_budget must be a valid number",
             )
         if budget_val < 0 or budget_val > float(budget_ceiling):
             raise HTTPException(
@@ -158,27 +250,47 @@ async def _validate_self_service_constraints(
                 detail=f"Budget must be between $0 and ${budget_ceiling}",
             )
 
+    parsed_expiry = _parse_self_service_expiry(expires)
     require_expiry = policy.get("require_expiry", False)
     max_expiry_days = policy.get("max_expiry_days")
-    if require_expiry and not expires:
+    if require_expiry and parsed_expiry is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="An expiry date is required for self-service keys on this team",
         )
 
+    if parsed_expiry is not None:
+        now = datetime.now(tz=UTC)
+        if parsed_expiry <= now:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Expiry date must be in the future",
+            )
+        if max_expiry_days is not None:
+            max_allowed = now + timedelta(days=int(max_expiry_days))
+            if parsed_expiry > max_allowed:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Expiry date cannot be more than {max_expiry_days} days from now",
+                )
+
+    normalized_limits = {
+        limit_field: _normalize_self_service_limit(kwargs.get(limit_field), limit_field)
+        for limit_field in _SELF_SERVICE_RATE_LIMIT_FIELDS
+    }
     team_rows = await db.query_raw(
         "SELECT rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit FROM deltallm_teamtable WHERE team_id = $1 LIMIT 1",
         team_id,
     )
     if team_rows:
         team_limits = dict(team_rows[0])
-        for limit_field in ("rpm_limit", "tpm_limit", "rph_limit", "rpd_limit", "tpd_limit"):
+        for limit_field in _SELF_SERVICE_RATE_LIMIT_FIELDS:
             team_val = team_limits.get(limit_field)
             if team_val is not None:
-                from_payload = kwargs.get(limit_field)
+                from_payload = normalized_limits[limit_field]
                 if from_payload is not None:
                     try:
-                        if int(from_payload) > int(team_val):
+                        if from_payload > int(team_val):
                             raise HTTPException(
                                 status_code=status.HTTP_400_BAD_REQUEST,
                                 detail=f"{limit_field} ({from_payload}) cannot exceed team limit ({team_val})",
@@ -189,23 +301,55 @@ async def _validate_self_service_constraints(
                             detail=f"{limit_field} must be a valid integer",
                         )
 
-    if max_expiry_days is not None and expires:
-        from datetime import datetime, timedelta, timezone
-        try:
-            exp_dt = datetime.fromisoformat(expires.replace("Z", "+00:00"))
-            if exp_dt.tzinfo is None:
-                exp_dt = exp_dt.replace(tzinfo=timezone.utc)
-        except (ValueError, TypeError):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="expires must be a valid ISO 8601 datetime string",
-            )
-        max_allowed = datetime.now(timezone.utc) + timedelta(days=max_expiry_days)
-        if exp_dt > max_allowed:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Expiry date cannot be more than {max_expiry_days} days from now",
-            )
+    normalized_expiry = parsed_expiry.isoformat() if parsed_expiry is not None else None
+    return {"max_budget": budget_val, "expires": normalized_expiry, **normalized_limits}
+
+
+async def _resolve_required_self_service_runtime_user_id(
+    db: Any,
+    *,
+    team_id: str,
+    account_id: str,
+    email: str | None,
+) -> str:
+    normalized_email = str(email or "").strip() or None
+    rows = await db.query_raw(
+        """
+        SELECT user_id
+        FROM deltallm_usertable
+        WHERE user_id = $1
+          AND team_id = $2
+        LIMIT 1
+        """,
+        account_id,
+        team_id,
+    )
+    if not rows and normalized_email is not None:
+        rows = await db.query_raw(
+            """
+            SELECT user_id
+            FROM deltallm_usertable
+            WHERE lower(user_email) = lower($1)
+              AND team_id = $2
+            ORDER BY CASE WHEN user_id = $3 THEN 0 ELSE 1 END
+            LIMIT 1
+            """,
+            normalized_email,
+            team_id,
+            account_id,
+        )
+    if not rows:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Self-service key creation requires a runtime user in this team",
+        )
+    user_id = str(rows[0].get("user_id") or "").strip()
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Self-service key creation requires a runtime user in this team",
+        )
+    return user_id
 
 
 def _is_self_service_only(scope: Any) -> bool:
@@ -240,6 +384,46 @@ def _scope_has_permission(
     return False
 
 
+def _target_scope_permission_sets(
+    scope: Any,
+    *,
+    organization_id: str | None,
+    team_id: str | None,
+) -> list[set[str]]:
+    permission_sets: list[set[str]] = []
+    team_permissions = getattr(scope, "team_permissions_by_id", {}) or {}
+    if team_id:
+        permission_sets.append(set(team_permissions.get(team_id) or set()))
+
+    org_permissions = getattr(scope, "org_permissions_by_id", {}) or {}
+    if organization_id:
+        permission_sets.append(set(org_permissions.get(organization_id) or set()))
+    return permission_sets
+
+
+def _resolve_key_read_access_mode(
+    scope: Any,
+    *,
+    organization_id: str | None,
+    team_id: str | None,
+) -> Literal["admin", "self_service"]:
+    if scope.is_platform_admin:
+        return "admin"
+
+    owner_only_read = False
+    for permissions in _target_scope_permission_sets(scope, organization_id=organization_id, team_id=team_id):
+        if permissions.intersection(_ADMIN_KEY_LIST_PERMISSIONS):
+            return "admin"
+        if Permission.KEY_READ in permissions and Permission.KEY_CREATE_SELF not in permissions:
+            return "admin"
+        if Permission.KEY_READ in permissions and Permission.KEY_CREATE_SELF in permissions:
+            owner_only_read = True
+
+    if owner_only_read:
+        return "self_service"
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+
+
 def _resolve_key_access_mode(
     scope: Any,
     *,
@@ -265,6 +449,109 @@ def _resolve_key_access_mode(
         return "self_service"
 
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+
+
+def _scope_ids_with_any_permission(
+    permissions_by_id: dict[str, set[str]],
+    required_permissions: frozenset[str],
+) -> list[str]:
+    scope_ids: list[str] = []
+    for scope_id, permissions in permissions_by_id.items():
+        normalized_scope_id = str(scope_id or "").strip()
+        if normalized_scope_id and required_permissions.intersection(set(permissions or set())):
+            scope_ids.append(normalized_scope_id)
+    return scope_ids
+
+
+def _append_in_predicate(column: str, values: list[str], params: list[Any]) -> str | None:
+    normalized_values = [str(value or "").strip() for value in values if str(value or "").strip()]
+    if not normalized_values:
+        return None
+    start = len(params) + 1
+    params.extend(normalized_values)
+    placeholders = ", ".join(f"${idx}" for idx in range(start, start + len(normalized_values)))
+    return f"{column} IN ({placeholders})"
+
+
+def _ordered_unique_scope_ids(*groups: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for group in groups:
+        for scope_id in group:
+            if scope_id not in seen:
+                seen.add(scope_id)
+                ordered.append(scope_id)
+    return ordered
+
+
+def _append_key_list_scope_clause(scope: Any, clauses: list[str], params: list[Any], *, my_keys: bool) -> bool:
+    owner_account_id = str(getattr(scope, "account_id", "") or "").strip() or None
+    owner_param_index: int | None = None
+    if my_keys:
+        if owner_account_id is None:
+            return False
+        params.append(owner_account_id)
+        owner_param_index = len(params)
+        clauses.append(f"vt.owner_account_id = ${owner_param_index}")
+
+    if scope.is_platform_admin:
+        return True
+
+    org_permissions = getattr(scope, "org_permissions_by_id", {}) or {}
+    team_permissions = getattr(scope, "team_permissions_by_id", {}) or {}
+
+    admin_org_ids = _scope_ids_with_any_permission(org_permissions, _ADMIN_KEY_LIST_PERMISSIONS)
+    admin_team_ids = _scope_ids_with_any_permission(team_permissions, _ADMIN_KEY_LIST_PERMISSIONS)
+    admin_org_id_set = set(admin_org_ids)
+    admin_team_id_set = set(admin_team_ids)
+    owner_org_ids = [
+        scope_id
+        for scope_id in _scope_ids_with_any_permission(org_permissions, _OWNER_KEY_LIST_PERMISSIONS)
+        if scope_id not in admin_org_id_set
+    ]
+    owner_team_ids = [
+        scope_id
+        for scope_id in _scope_ids_with_any_permission(team_permissions, _OWNER_KEY_LIST_PERMISSIONS)
+        if scope_id not in admin_team_id_set
+    ]
+    owner_org_id_set = set(owner_org_ids)
+    owner_team_id_set = set(owner_team_ids)
+    read_org_ids = [
+        scope_id
+        for scope_id in _scope_ids_with_any_permission(org_permissions, _READ_KEY_LIST_PERMISSIONS)
+        if scope_id not in owner_org_id_set
+    ]
+    read_team_ids = [
+        scope_id
+        for scope_id in _scope_ids_with_any_permission(team_permissions, _READ_KEY_LIST_PERMISSIONS)
+        if scope_id not in owner_team_id_set
+    ]
+    full_org_ids = _ordered_unique_scope_ids(admin_org_ids, read_org_ids)
+    full_team_ids = _ordered_unique_scope_ids(admin_team_ids, read_team_ids)
+
+    scope_parts: list[str] = []
+    full_org_predicate = _append_in_predicate("t.organization_id", full_org_ids, params)
+    if full_org_predicate is not None:
+        scope_parts.append(full_org_predicate)
+    full_team_predicate = _append_in_predicate("vt.team_id", full_team_ids, params)
+    if full_team_predicate is not None:
+        scope_parts.append(full_team_predicate)
+
+    if owner_account_id is not None and (owner_org_ids or owner_team_ids):
+        if owner_param_index is None:
+            params.append(owner_account_id)
+            owner_param_index = len(params)
+        owner_org_predicate = _append_in_predicate("t.organization_id", owner_org_ids, params)
+        if owner_org_predicate is not None:
+            scope_parts.append(f"({owner_org_predicate} AND vt.owner_account_id = ${owner_param_index})")
+        owner_team_predicate = _append_in_predicate("vt.team_id", owner_team_ids, params)
+        if owner_team_predicate is not None:
+            scope_parts.append(f"({owner_team_predicate} AND vt.owner_account_id = ${owner_param_index})")
+
+    if not scope_parts:
+        return False
+    clauses.append(f"({' OR '.join(scope_parts)})")
+    return True
 
 
 def _key_response_payload(row: dict[str, Any]) -> dict[str, Any]:
@@ -374,6 +661,47 @@ async def _validate_owner_references(
     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="owner is required")
 
 
+async def _insert_key_row(
+    db: Any,
+    *,
+    token_hash: str,
+    key_name: str,
+    user_id: str | None,
+    team_id: str,
+    owner_account_id: str | None,
+    owner_service_account_id: str | None,
+    max_budget: Any,
+    rpm_limit: Any,
+    tpm_limit: Any,
+    rph_limit: Any,
+    rpd_limit: Any,
+    tpd_limit: Any,
+    expires: str | None,
+) -> None:
+    await db.execute_raw(
+        """
+        INSERT INTO deltallm_verificationtoken (
+            id, token, key_name, user_id, team_id, owner_account_id, owner_service_account_id,
+            spend, max_budget, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, expires, created_at, updated_at
+        )
+        VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, 0, $7, $8, $9, $10, $11, $12, $13::timestamp, NOW(), NOW())
+        """,
+        token_hash,
+        key_name,
+        user_id,
+        team_id,
+        owner_account_id,
+        owner_service_account_id,
+        max_budget,
+        rpm_limit,
+        tpm_limit,
+        rph_limit,
+        rpd_limit,
+        tpd_limit,
+        expires,
+    )
+
+
 @router.get("/ui/api/keys")
 async def list_keys(
     request: Request,
@@ -387,32 +715,12 @@ async def list_keys(
 ) -> dict[str, Any]:
     scope = get_auth_scope(request, authorization, x_master_key, any_permission=[Permission.KEY_READ, Permission.KEY_CREATE_SELF])
     db = db_or_503(request)
-    self_service_only = _is_self_service_only(scope)
 
     clauses: list[str] = []
     params: list[Any] = []
 
-    if self_service_only or my_keys:
-        if scope.account_id:
-            params.append(scope.account_id)
-            clauses.append(f"vt.owner_account_id = ${len(params)}")
-        else:
-            return {"data": [], "pagination": {"total": 0, "limit": limit, "offset": offset, "has_more": False}}
-
-    if not scope.is_platform_admin:
-        scope_parts: list[str] = []
-        if scope.org_ids:
-            ph = ", ".join(f"${len(params) + i + 1}" for i in range(len(scope.org_ids)))
-            params.extend(scope.org_ids)
-            scope_parts.append(f"t.organization_id IN ({ph})")
-        if scope.team_ids:
-            ph = ", ".join(f"${len(params) + i + 1}" for i in range(len(scope.team_ids)))
-            params.extend(scope.team_ids)
-            scope_parts.append(f"vt.team_id IN ({ph})")
-        if scope_parts:
-            clauses.append(f"({' OR '.join(scope_parts)})")
-        else:
-            return {"data": [], "pagination": {"total": 0, "limit": limit, "offset": offset, "has_more": False}}
+    if not _append_key_list_scope_clause(scope, clauses, params, my_keys=my_keys):
+        return {"data": [], "pagination": {"total": 0, "limit": limit, "offset": offset, "has_more": False}}
 
     if search:
         params.append(f"%{search}%")
@@ -516,26 +824,15 @@ async def create_key(
     )
     self_service_only = access_mode == "self_service"
 
+    account_email: str | None = None
     if self_service_only:
+        if not scope.account_id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Self-service key creation requires an account context")
         owner_account_id = scope.account_id
         owner_service_account_id = None
-        user_id = None
-
-        policy = await _get_self_service_policy(db, team_id)
-        await _validate_self_service_constraints(
-            db,
-            team_id=team_id,
-            account_id=scope.account_id,
-            policy=policy,
-            max_budget=max_budget,
-            expires=expires,
-            rpm_limit=rpm_limit,
-            tpm_limit=tpm_limit,
-            rph_limit=rph_limit,
-            rpd_limit=rpd_limit,
-            tpd_limit=tpd_limit,
-        )
-    if user_id:
+        ctx = get_platform_auth_context(request)
+        account_email = str(getattr(ctx, "email", "") or "").strip() or None
+    if user_id and not self_service_only:
         await _validate_runtime_user(db, user_id, team_id)
     if not self_service_only:
         owner_account_id, owner_service_account_id = await _validate_owner_references(
@@ -553,28 +850,76 @@ async def create_key(
     audit_action = AuditAction.ADMIN_KEY_SELF_CREATE if self_service_only else AuditAction.ADMIN_KEY_CREATE
 
     try:
-        await db.execute_raw(
-            """
-            INSERT INTO deltallm_verificationtoken (
-                id, token, key_name, user_id, team_id, owner_account_id, owner_service_account_id,
-                spend, max_budget, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, expires, created_at, updated_at
+        if self_service_only:
+            tx_factory = getattr(db, "tx", None)
+            if not callable(tx_factory):
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Database transactions are required for self-service key creation",
+                )
+
+            async with tx_factory() as tx:
+                await _acquire_self_service_key_create_lock(tx, team_id=team_id, account_id=scope.account_id)
+                policy = await _get_self_service_policy(tx, team_id)
+                normalized_self_service_values = await _validate_self_service_constraints(
+                    tx,
+                    team_id=team_id,
+                    account_id=scope.account_id,
+                    policy=policy,
+                    max_budget=max_budget,
+                    expires=expires,
+                    rpm_limit=rpm_limit,
+                    tpm_limit=tpm_limit,
+                    rph_limit=rph_limit,
+                    rpd_limit=rpd_limit,
+                    tpd_limit=tpd_limit,
+                )
+                user_id = await _resolve_required_self_service_runtime_user_id(
+                    tx,
+                    team_id=team_id,
+                    account_id=scope.account_id,
+                    email=account_email,
+                )
+                max_budget = normalized_self_service_values["max_budget"]
+                expires = normalized_self_service_values["expires"]
+                rpm_limit = normalized_self_service_values["rpm_limit"]
+                tpm_limit = normalized_self_service_values["tpm_limit"]
+                rph_limit = normalized_self_service_values["rph_limit"]
+                rpd_limit = normalized_self_service_values["rpd_limit"]
+                tpd_limit = normalized_self_service_values["tpd_limit"]
+                await _insert_key_row(
+                    tx,
+                    token_hash=token_hash,
+                    key_name=key_name,
+                    user_id=user_id,
+                    team_id=team_id,
+                    owner_account_id=owner_account_id,
+                    owner_service_account_id=owner_service_account_id,
+                    max_budget=max_budget,
+                    rpm_limit=rpm_limit,
+                    tpm_limit=tpm_limit,
+                    rph_limit=rph_limit,
+                    rpd_limit=rpd_limit,
+                    tpd_limit=tpd_limit,
+                    expires=expires,
+                )
+        else:
+            await _insert_key_row(
+                db,
+                token_hash=token_hash,
+                key_name=key_name,
+                user_id=user_id,
+                team_id=team_id,
+                owner_account_id=owner_account_id,
+                owner_service_account_id=owner_service_account_id,
+                max_budget=max_budget,
+                rpm_limit=rpm_limit,
+                tpm_limit=tpm_limit,
+                rph_limit=rph_limit,
+                rpd_limit=rpd_limit,
+                tpd_limit=tpd_limit,
+                expires=expires,
             )
-            VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, 0, $7, $8, $9, $10, $11, $12, $13::timestamp, NOW(), NOW())
-            """,
-            token_hash,
-            key_name,
-            user_id,
-            team_id,
-            owner_account_id,
-            owner_service_account_id,
-            max_budget,
-            rpm_limit,
-            tpm_limit,
-            rph_limit,
-            rpd_limit,
-            tpd_limit,
-            expires,
-        )
 
         response = {
             "token": token_hash,
@@ -810,13 +1155,16 @@ async def _require_key_access(
     row = await _get_key_scope_row(db, token_hash)
     organization_id = str(row.get("organization_id") or "").strip() or None
     team_id = str(row.get("team_id") or "").strip() or None
-    access_mode = _resolve_key_access_mode(
-        scope,
-        organization_id=organization_id,
-        team_id=team_id,
-        admin_permission=admin_permission,
-        allow_self_service=allow_self_service,
-    )
+    if admin_permission == Permission.KEY_READ:
+        access_mode = _resolve_key_read_access_mode(scope, organization_id=organization_id, team_id=team_id)
+    else:
+        access_mode = _resolve_key_access_mode(
+            scope,
+            organization_id=organization_id,
+            team_id=team_id,
+            admin_permission=admin_permission,
+            allow_self_service=allow_self_service,
+        )
 
     if access_mode == "self_service":
         owner_rows = await db.query_raw(

--- a/src/services/self_registration_provisioning.py
+++ b/src/services/self_registration_provisioning.py
@@ -183,6 +183,13 @@ class SelfRegistrationProvisioningService:
         if not account_id:
             raise RuntimeError("failed to provision account")
 
+        user_id = await self._ensure_runtime_user(
+            db_client,
+            account_id=account_id,
+            email=email,
+            team_id=team_id,
+            settings=settings,
+        )
         await self._insert_org_membership(
             db_client,
             account_id=account_id,
@@ -193,13 +200,6 @@ class SelfRegistrationProvisioningService:
             account_id=account_id,
             team_id=team_id,
             role=settings.default_team.role,
-        )
-        user_id = await self._ensure_runtime_user(
-            db_client,
-            account_id=account_id,
-            email=email,
-            team_id=team_id,
-            settings=settings,
         )
 
         return SelfRegistrationProvisioningResult(
@@ -413,6 +413,9 @@ class SelfRegistrationProvisioningService:
         user_id = str(runtime_user.get("user_id") or "").strip()
         if not user_id:
             raise RuntimeError("failed to provision runtime user")
+        runtime_team_id = str(runtime_user.get("team_id") or "").strip()
+        if runtime_team_id != team_id:
+            raise RuntimeError("self-registration runtime user belongs to a different team")
         return user_id
 
     async def _get_runtime_user_by_account_or_email(

--- a/tests/services/test_self_registration_provisioning.py
+++ b/tests/services/test_self_registration_provisioning.py
@@ -474,7 +474,7 @@ async def test_provision_from_defaults_preserves_existing_admin_changes() -> Non
         "user_id": "acct-existing",
         "user_email": "existing@example.com",
         "max_budget": 500,
-        "team_id": "custom-team",
+        "team_id": "team-self-serve",
     }
     db.organization_memberships[("acct-existing", "org-sandbox")] = {
         "account_id": "acct-existing",
@@ -500,19 +500,42 @@ async def test_provision_from_defaults_preserves_existing_admin_changes() -> Non
     assert db.teams["team-self-serve"]["team_alias"] == "Admin Edited Team"
     assert db.teams["team-self-serve"]["self_service_keys_enabled"] is False
     assert db.users["acct-existing"]["max_budget"] == 500
-    assert db.users["acct-existing"]["team_id"] == "custom-team"
+    assert db.users["acct-existing"]["team_id"] == "team-self-serve"
     assert db.organization_memberships[("acct-existing", "org-sandbox")]["role"] == "org_admin"
     assert db.team_memberships[("acct-existing", "team-self-serve")]["role"] == "team_admin"
 
 
 @pytest.mark.asyncio
-async def test_provision_from_defaults_returns_existing_runtime_user_for_same_email() -> None:
+async def test_provision_from_defaults_rejects_existing_runtime_user_outside_default_team() -> None:
     db = FakeSelfRegistrationDB()
     db.users["legacy-user"] = {
         "user_id": "legacy-user",
         "user_email": "developer@example.com",
         "max_budget": 500,
         "team_id": "legacy-team",
+    }
+
+    with pytest.raises(RuntimeError, match="runtime user belongs to a different team"):
+        await _service(db).provision_from_defaults(
+            email="developer@example.com",
+            settings=_enabled_settings(),
+        )
+
+    assert ("acct-1", "org-sandbox") not in db.organization_memberships
+    assert ("acct-1", "team-self-serve") not in db.team_memberships
+    assert "acct-1" not in db.users
+    assert db.users["legacy-user"]["max_budget"] == 500
+    assert db.users["legacy-user"]["team_id"] == "legacy-team"
+
+
+@pytest.mark.asyncio
+async def test_provision_from_defaults_returns_existing_runtime_user_in_default_team_for_same_email() -> None:
+    db = FakeSelfRegistrationDB()
+    db.users["legacy-user"] = {
+        "user_id": "legacy-user",
+        "user_email": "developer@example.com",
+        "max_budget": 500,
+        "team_id": "team-self-serve",
     }
 
     result = await _service(db).provision_from_defaults(
@@ -522,9 +545,10 @@ async def test_provision_from_defaults_returns_existing_runtime_user_for_same_em
 
     assert result.account_id == "acct-1"
     assert result.user_id == "legacy-user"
+    assert db.team_memberships[("acct-1", "team-self-serve")]["role"] == "team_developer"
     assert "acct-1" not in db.users
     assert db.users["legacy-user"]["max_budget"] == 500
-    assert db.users["legacy-user"]["team_id"] == "legacy-team"
+    assert db.users["legacy-user"]["team_id"] == "team-self-serve"
 
 
 @pytest.mark.asyncio

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -88,6 +88,38 @@ class OrgBudgetDB:
         return []
 
 
+class MultiEntityBudgetDB:
+    def __init__(self, *, exhausted_entity: str) -> None:
+        self.exhausted_entity = exhausted_entity
+
+    async def query_raw(self, query: str, *args):
+        normalized = " ".join(query.lower().split())
+        entity_type = None
+        if "from deltallm_verificationtoken" in normalized:
+            entity_type = "key"
+        elif "from deltallm_usertable" in normalized:
+            entity_type = "user"
+        elif "from deltallm_teamtable" in normalized:
+            entity_type = "team"
+        elif "from deltallm_organizationtable" in normalized:
+            entity_type = "org"
+        if entity_type is None:
+            return []
+
+        spend = 11.0 if entity_type == self.exhausted_entity else 1.0
+        return [
+            {
+                "entity_id": args[0],
+                "max_budget": 10.0,
+                "soft_budget": None,
+                "spend": spend,
+                "budget_duration": None,
+                "budget_reset_at": None,
+                "metadata": {},
+            }
+        ]
+
+
 class ResettingOrgBudgetDB:
     def __init__(self, *, update_count: int = 1, conflict_row: dict | None = None, metadata: dict | None = None) -> None:
         self.query_calls: list[tuple[str, tuple]] = []
@@ -244,6 +276,23 @@ async def test_spend_tracking_writes_normalized_event_and_team_model_counter():
     assert event_call[14] == "character"
     assert event_call[23] == 1200
     assert any("insert into deltallm_teammodelspend" in q.lower() for q, _ in db.calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exhausted_entity", ["key", "user", "team", "org"])
+async def test_sandbox_runtime_budget_enforcement_checks_all_scopes(exhausted_entity: str):
+    service = BudgetEnforcementService(db_client=MultiEntityBudgetDB(exhausted_entity=exhausted_entity))
+
+    with pytest.raises(BudgetExceeded) as exc_info:
+        await service.check_budgets(
+            api_key="key-sandbox",
+            user_id="acct-dev",
+            team_id="team-sandbox",
+            organization_id="org-sandbox",
+            model=None,
+        )
+
+    assert exc_info.value.entity_type == exhausted_entity
 
 
 @pytest.mark.asyncio

--- a/tests/test_key_service.py
+++ b/tests/test_key_service.py
@@ -127,3 +127,70 @@ async def test_validate_key_preserves_key_and_team_model_scopes() -> None:
 
     assert auth.models == ["gpt-4o-mini", "text-embedding-3-small"]
     assert auth.team_models == ["gpt-4o-mini", "text-embedding-3-small"]
+
+
+@pytest.mark.asyncio
+async def test_validate_key_preserves_sandbox_budget_and_rate_limit_scope_ids() -> None:
+    salt = "test-salt"
+    raw_key = "sk-sandbox"
+    token_hash = hashlib.sha256(f"{salt}:{raw_key}".encode("utf-8")).hexdigest()
+    repo = InMemoryRepo(
+        {
+            token_hash: KeyRecord(
+                token=token_hash,
+                user_id="acct-dev",
+                team_id="team-sandbox",
+                organization_id="org-sandbox",
+                max_budget=5.0,
+                rpm_limit=1,
+                tpm_limit=2,
+                key_rph_limit=3,
+                key_rpd_limit=4,
+                key_tpd_limit=5,
+                user_rpm_limit=6,
+                user_tpm_limit=7,
+                user_rph_limit=8,
+                user_rpd_limit=9,
+                user_tpd_limit=10,
+                team_rpm_limit=11,
+                team_tpm_limit=12,
+                team_rph_limit=13,
+                team_rpd_limit=14,
+                team_tpd_limit=15,
+                org_rpm_limit=16,
+                org_tpm_limit=17,
+                org_rph_limit=18,
+                org_rpd_limit=19,
+                org_tpd_limit=20,
+                expires=datetime.now(tz=UTC) + timedelta(hours=1),
+            )
+        }
+    )
+    service = KeyService(repository=repo, salt=salt)
+
+    auth = await service.validate_key(raw_key)
+
+    assert auth.user_id == "acct-dev"
+    assert auth.team_id == "team-sandbox"
+    assert auth.organization_id == "org-sandbox"
+    assert auth.max_budget == 5.0
+    assert auth.key_rpm_limit == 1
+    assert auth.key_tpm_limit == 2
+    assert auth.key_rph_limit == 3
+    assert auth.key_rpd_limit == 4
+    assert auth.key_tpd_limit == 5
+    assert auth.user_rpm_limit == 6
+    assert auth.user_tpm_limit == 7
+    assert auth.user_rph_limit == 8
+    assert auth.user_rpd_limit == 9
+    assert auth.user_tpd_limit == 10
+    assert auth.team_rpm_limit == 11
+    assert auth.team_tpm_limit == 12
+    assert auth.team_rph_limit == 13
+    assert auth.team_rpd_limit == 14
+    assert auth.team_tpd_limit == 15
+    assert auth.org_rpm_limit == 16
+    assert auth.org_tpm_limit == 17
+    assert auth.org_rph_limit == 18
+    assert auth.org_rpd_limit == 19
+    assert auth.org_tpd_limit == 20

--- a/tests/test_model_visibility.py
+++ b/tests/test_model_visibility.py
@@ -8,11 +8,13 @@ from src.config import AppConfig, GeneralSettings, Settings
 from src.db.callable_target_access_groups import CallableTargetAccessGroupBindingRecord
 from src.db.callable_targets import CallableTargetBindingRecord
 from src.db.callable_target_policies import CallableTargetScopePolicyRecord
+from src.models.errors import PermissionDeniedError
 from src.models.responses import UserAPIKeyAuth
 from src.services.callable_target_grants import CallableTargetGrantService
 from src.services.callable_targets import CallableTarget, DuplicateCallableTargetError, build_callable_target_catalog
 from src.services.model_deployments import build_model_registry_from_config
 from src.services.model_visibility import (
+    ensure_model_allowed,
     filter_visible_models,
     resolve_effective_model_allowlist,
     resolve_model_allowlist_resolution,
@@ -255,6 +257,59 @@ async def test_effective_model_allowlist_does_not_narrow_user_scope_when_policy_
     )
 
     assert resolution.effective_allowlist == {"gpt-4o-mini", "text-embedding-3-small"}
+
+
+@pytest.mark.asyncio
+async def test_sandbox_key_model_allowlist_stays_inside_default_org_and_team_boundary() -> None:
+    auth = UserAPIKeyAuth(
+        api_key="key-sandbox",
+        user_id="acct-dev",
+        team_id="team-sandbox",
+        organization_id="org-sandbox",
+    )
+    service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository(
+            [
+                CallableTargetBindingRecord(
+                    callable_target_binding_id="ctb-sandbox-org",
+                    callable_key="gpt-4o-mini",
+                    scope_type="organization",
+                    scope_id="org-sandbox",
+                    enabled=True,
+                ),
+                CallableTargetBindingRecord(
+                    callable_target_binding_id="ctb-prod-org",
+                    callable_key="prod-model",
+                    scope_type="organization",
+                    scope_id="org-production",
+                    enabled=True,
+                ),
+                CallableTargetBindingRecord(
+                    callable_target_binding_id="ctb-sandbox-team",
+                    callable_key="gpt-4o-mini",
+                    scope_type="team",
+                    scope_id="team-sandbox",
+                    enabled=True,
+                ),
+            ]
+        ),
+        policy_repository=_FakeCallableTargetScopePolicyRepository(
+            [
+                CallableTargetScopePolicyRecord(
+                    callable_target_scope_policy_id="ctp-sandbox-team",
+                    scope_type="team",
+                    scope_id="team-sandbox",
+                    mode="restrict",
+                )
+            ]
+        ),
+    )
+    await service.reload()
+
+    assert resolve_effective_model_allowlist(auth, callable_target_grant_service=service) == {"gpt-4o-mini"}
+    ensure_model_allowed(auth, "gpt-4o-mini", callable_target_grant_service=service)
+    with pytest.raises(PermissionDeniedError):
+        ensure_model_allowed(auth, "prod-model", callable_target_grant_service=service)
 
 
 @pytest.mark.asyncio
@@ -720,6 +775,44 @@ async def test_v1_models_uses_explicit_callable_target_grants_when_present(clien
 
     assert response.status_code == 200
     assert [item["id"] for item in response.json()["data"]] == ["text-embedding-3-small"]
+
+
+@pytest.mark.asyncio
+async def test_v1_models_for_self_registered_sandbox_key_stays_inside_sandbox_org(client, test_app) -> None:
+    record = next(iter(test_app.state._test_repo.records.values()))
+    record.user_id = "acct-dev"
+    record.team_id = "team-sandbox"
+    record.organization_id = "org-sandbox"
+    test_app.state.model_registry["prod-model"] = [
+        {"deltallm_params": {"model": "openai/prod-model", "api_key": "provider-key"}}
+    ]
+    test_app.state.callable_target_grant_service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository(
+            [
+                CallableTargetBindingRecord(
+                    callable_target_binding_id="ctb-sandbox-1",
+                    callable_key="gpt-4o-mini",
+                    scope_type="organization",
+                    scope_id="org-sandbox",
+                    enabled=True,
+                ),
+                CallableTargetBindingRecord(
+                    callable_target_binding_id="ctb-production-1",
+                    callable_key="prod-model",
+                    scope_type="organization",
+                    scope_id="org-production",
+                    enabled=True,
+                ),
+            ]
+        )
+    )
+    await test_app.state.callable_target_grant_service.reload()
+
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    response = await client.get("/v1/models", headers=headers)
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["data"]] == ["gpt-4o-mini"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_window_rate_limits.py
+++ b/tests/test_multi_window_rate_limits.py
@@ -6,6 +6,8 @@ import time
 import pytest
 
 from src.models.errors import RateLimitError
+from src.models.responses import UserAPIKeyAuth
+from src.rate_limit_policy import build_rate_limit_checks
 from src.services.limit_counter import LimitCounter, RateLimitCheck, RateLimitResult
 from tests.conftest import FakeRedis
 
@@ -37,6 +39,69 @@ class TestRateLimitCheckWindowSeconds:
     def test_day_window(self):
         check = RateLimitCheck(scope="key_rpd", entity_id="k1", limit=1000, window_seconds=86400)
         assert check.window_seconds == 86400
+
+
+def test_sandbox_runtime_rate_limit_checks_include_all_scopes_and_windows():
+    auth = UserAPIKeyAuth(
+        api_key="key-sandbox",
+        user_id="acct-dev",
+        team_id="team-sandbox",
+        organization_id="org-sandbox",
+        key_rpm_limit=1,
+        key_tpm_limit=2,
+        key_rph_limit=3,
+        key_rpd_limit=4,
+        key_tpd_limit=5,
+        user_rpm_limit=6,
+        user_tpm_limit=7,
+        user_rph_limit=8,
+        user_rpd_limit=9,
+        user_tpd_limit=10,
+        team_rpm_limit=11,
+        team_tpm_limit=12,
+        team_rph_limit=13,
+        team_rpd_limit=14,
+        team_tpd_limit=15,
+        org_rpm_limit=16,
+        org_tpm_limit=17,
+        org_rph_limit=18,
+        org_rpd_limit=19,
+        org_tpd_limit=20,
+    )
+
+    checks = build_rate_limit_checks(auth=auth, tokens=123, model="gpt-4o-mini")
+    by_scope = {check.scope: check for check in checks}
+
+    assert set(by_scope) == {
+        "org_rpm",
+        "team_rpm",
+        "user_rpm",
+        "key_rpm",
+        "org_tpm",
+        "team_tpm",
+        "user_tpm",
+        "key_tpm",
+        "org_rph",
+        "team_rph",
+        "user_rph",
+        "key_rph",
+        "org_rpd",
+        "team_rpd",
+        "user_rpd",
+        "key_rpd",
+        "org_tpd",
+        "team_tpd",
+        "user_tpd",
+        "key_tpd",
+    }
+    assert by_scope["org_rpm"].entity_id == "org-sandbox"
+    assert by_scope["team_rpm"].entity_id == "team-sandbox"
+    assert by_scope["user_rpm"].entity_id == "acct-dev"
+    assert by_scope["key_rpm"].entity_id == "key-sandbox"
+    assert by_scope["key_tpm"].amount == 123
+    assert by_scope["key_rph"].window_seconds == 3600
+    assert by_scope["key_rpd"].window_seconds == 86400
+    assert by_scope["key_tpd"].window_seconds == 86400
 
 
 class TestMultiWindowAtomicRedis:

--- a/tests/test_ui_self_service_keys.py
+++ b/tests/test_ui_self_service_keys.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+from datetime import UTC, datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
 
@@ -10,32 +12,165 @@ from src.auth.roles import OrganizationRole, Permission, TeamRole
 from src.models.platform_auth import PlatformAuthContext
 
 
+class _FakeKeyTransaction:
+    def __init__(self, db: "_FakeKeyDB") -> None:
+        self._db = db
+
+    async def __aenter__(self) -> "_FakeKeyDB":
+        self._db.events.append("tx_enter")
+        self._db._in_transaction = True
+        return self._db
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        self._db._in_transaction = False
+        self._db.events.append("tx_exit")
+
+
 class _FakeKeyDB:
     def __init__(
         self,
         keys: dict[str, dict[str, Any]],
         *,
         teams: dict[str, dict[str, Any]] | None = None,
+        users: dict[str, dict[str, Any]] | None = None,
         account_ids: set[str] | None = None,
     ) -> None:
         self.keys = dict(keys)
         self.teams = dict(teams or {})
+        self.users = dict(users or {})
         self.account_ids = set(account_ids or set())
+        self.advisory_locks: list[int] = []
+        self.events: list[str] = []
+        self.transactional_events: list[str] = []
+        self._in_transaction = False
+
+    def tx(self) -> _FakeKeyTransaction:
+        return _FakeKeyTransaction(self)
+
+    def _record_event(self, event: str) -> None:
+        self.events.append(event)
+        if self._in_transaction:
+            self.transactional_events.append(event)
+
+    def _param_value(self, params: tuple[Any, ...], placeholder: str) -> Any:
+        index = int(placeholder.removeprefix("$")) - 1
+        return params[index]
+
+    def _in_values(self, params: tuple[Any, ...], placeholders: str) -> set[str]:
+        return {str(self._param_value(params, placeholder) or "") for placeholder in re.findall(r"\$\d+", placeholders)}
+
+    def _list_key_rows(self, normalized_query: str, params: tuple[Any, ...]) -> list[tuple[str, dict[str, Any]]]:
+        owner_scoped_orgs: list[tuple[str, set[str]]] = []
+        owner_scoped_teams: list[tuple[str, set[str]]] = []
+
+        owner_org_pattern = r"\(t\.organization_id in \(([^)]*)\) and vt\.owner_account_id = \$(\d+)\)"
+        owner_team_pattern = r"\(vt\.team_id in \(([^)]*)\) and vt\.owner_account_id = \$(\d+)\)"
+        for placeholders, owner_index in re.findall(owner_org_pattern, normalized_query):
+            owner_scoped_orgs.append((str(params[int(owner_index) - 1] or ""), self._in_values(params, placeholders)))
+        for placeholders, owner_index in re.findall(owner_team_pattern, normalized_query):
+            owner_scoped_teams.append((str(params[int(owner_index) - 1] or ""), self._in_values(params, placeholders)))
+
+        full_scope_query = re.sub(owner_org_pattern, "", normalized_query)
+        full_scope_query = re.sub(owner_team_pattern, "", full_scope_query)
+        full_orgs: set[str] = set()
+        full_teams: set[str] = set()
+        for placeholders in re.findall(r"t\.organization_id in \(([^)]*)\)", full_scope_query):
+            full_orgs.update(self._in_values(params, placeholders))
+        for placeholders in re.findall(r"vt\.team_id in \(([^)]*)\)", full_scope_query):
+            full_teams.update(self._in_values(params, placeholders))
+
+        global_owner_match = re.search(r"where vt\.owner_account_id = \$(\d+)", normalized_query)
+        global_owner_id = str(params[int(global_owner_match.group(1)) - 1] or "") if global_owner_match else None
+        exact_team_match = re.search(r"(?:where| and) vt\.team_id = \$(\d+)", normalized_query)
+        exact_team_id = str(params[int(exact_team_match.group(1)) - 1] or "") if exact_team_match else None
+        search_match = re.search(r"\(vt\.key_name ilike \$(\d+) or vt\.token ilike \$\d+\)", normalized_query)
+        search_term = None
+        if search_match:
+            search_term = str(params[int(search_match.group(1)) - 1] or "").strip("%").lower()
+
+        has_scope_predicate = bool(full_orgs or full_teams or owner_scoped_orgs or owner_scoped_teams)
+
+        def _row_org(row: dict[str, Any]) -> str:
+            team = self.teams.get(str(row.get("team_id") or ""), {})
+            return str(row.get("organization_id") or team.get("organization_id") or "")
+
+        def _scope_matches(row: dict[str, Any]) -> bool:
+            if not has_scope_predicate:
+                return True
+            team_id = str(row.get("team_id") or "")
+            organization_id = _row_org(row)
+            owner_account_id = str(row.get("owner_account_id") or "")
+            if organization_id in full_orgs or team_id in full_teams:
+                return True
+            return any(
+                owner_account_id == owner_id and organization_id in org_ids
+                for owner_id, org_ids in owner_scoped_orgs
+            ) or any(
+                owner_account_id == owner_id and team_id in team_ids
+                for owner_id, team_ids in owner_scoped_teams
+            )
+
+        rows: list[tuple[str, dict[str, Any]]] = []
+        for token_hash, row in self.keys.items():
+            if global_owner_id is not None and str(row.get("owner_account_id") or "") != global_owner_id:
+                continue
+            if exact_team_id is not None and str(row.get("team_id") or "") != exact_team_id:
+                continue
+            if search_term and search_term not in str(row.get("key_name") or "").lower() and search_term not in token_hash.lower():
+                continue
+            if _scope_matches(row):
+                rows.append((token_hash, row))
+        return rows
 
     async def query_raw(self, query: str, *params):  # noqa: ANN201
         normalized = " ".join(query.lower().split())
         token_hash = str(params[0]) if params else ""
 
+        if "from deltallm_verificationtoken vt" in normalized and "left join deltallm_platformaccount" in normalized:
+            rows = self._list_key_rows(normalized, params)
+            if normalized.startswith("select count(*) as total"):
+                return [{"total": len(rows)}]
+            offset = int(params[-1]) if " offset $" in normalized and params else 0
+            limit = int(params[-2]) if " limit $" in normalized and len(params) >= 2 else len(rows)
+            response_rows: list[dict[str, Any]] = []
+            for token_hash, row in rows[offset : offset + limit]:
+                team = self.teams.get(str(row.get("team_id") or ""), {})
+                response_rows.append(
+                    {
+                        "token": token_hash,
+                        "key_name": row.get("key_name"),
+                        "user_id": row.get("user_id"),
+                        "team_id": row.get("team_id"),
+                        "team_alias": team.get("team_alias"),
+                        "owner_account_id": row.get("owner_account_id"),
+                        "owner_account_email": None,
+                        "owner_service_account_id": row.get("owner_service_account_id"),
+                        "owner_service_account_name": None,
+                        "spend": row.get("spend", 0),
+                        "max_budget": row.get("max_budget"),
+                        "rpm_limit": row.get("rpm_limit"),
+                        "tpm_limit": row.get("tpm_limit"),
+                        "rph_limit": row.get("rph_limit"),
+                        "rpd_limit": row.get("rpd_limit"),
+                        "tpd_limit": row.get("tpd_limit"),
+                        "expires": row.get("expires"),
+                        "created_at": row.get("created_at"),
+                        "updated_at": row.get("updated_at"),
+                    }
+                )
+            return response_rows
+
         if "from deltallm_verificationtoken vt" in normalized and "left join deltallm_usertable" in normalized:
             row = self.keys.get(token_hash)
             if row is None:
                 return []
+            team = self.teams.get(str(row.get("team_id") or ""), {})
             return [
                 {
                     "token": token_hash,
                     "user_id": row.get("user_id"),
                     "team_id": row.get("team_id"),
-                    "organization_id": row.get("organization_id"),
+                    "organization_id": row.get("organization_id") or team.get("organization_id"),
                 }
             ]
 
@@ -85,7 +220,28 @@ class _FakeKeyDB:
             row = self.teams.get(team_id)
             return [dict(row)] if row is not None else []
 
+        if normalized.startswith("select user_id from deltallm_usertable where user_id = $1 and team_id = $2"):
+            self._record_event("resolve_runtime_user")
+            account_id = str(params[0])
+            team_id = str(params[1])
+            row = self.users.get(account_id)
+            if row is not None and str(row.get("team_id") or "") == team_id:
+                return [{"user_id": row.get("user_id", account_id)}]
+            return []
+
+        if normalized.startswith("select user_id from deltallm_usertable where lower(user_email) = lower($1)"):
+            self._record_event("resolve_runtime_user")
+            email = str(params[0] or "").strip().lower()
+            team_id = str(params[1])
+            for fallback_id, candidate in self.users.items():
+                candidate_user_id = str(candidate.get("user_id") or fallback_id)
+                candidate_email = str(candidate.get("user_email") or "").strip().lower()
+                if str(candidate.get("team_id") or "") == team_id and candidate_email == email:
+                    return [{"user_id": candidate_user_id}]
+            return []
+
         if normalized.startswith("select count(*) as cnt from deltallm_verificationtoken where team_id = $1 and owner_account_id = $2"):
+            self._record_event("count_active_keys")
             team_id = str(params[0])
             owner_account_id = str(params[1])
             count = sum(
@@ -93,6 +249,7 @@ class _FakeKeyDB:
                 for row in self.keys.values()
                 if str(row.get("team_id") or "") == team_id
                 and str(row.get("owner_account_id") or "") == owner_account_id
+                and _is_active_key(row)
             )
             return [{"cnt": count}]
 
@@ -107,10 +264,15 @@ class _FakeKeyDB:
 
     async def execute_raw(self, query: str, *params):  # noqa: ANN201
         normalized = " ".join(query.lower().split())
+        if normalized.startswith("select pg_advisory_xact_lock"):
+            self._record_event("advisory_lock")
+            self.advisory_locks.append(int(params[0]))
+            return 1
         if normalized.startswith("delete from deltallm_verificationtoken where token = $1"):
             token_hash = str(params[0])
             return 1 if self.keys.pop(token_hash, None) is not None else 0
         if normalized.startswith("insert into deltallm_verificationtoken"):
+            self._record_event("insert_key")
             (
                 token_hash,
                 key_name,
@@ -156,10 +318,32 @@ class _FakeKeyDB:
         return 0
 
 
+class _FakeKeyDBWithoutTransactions(_FakeKeyDB):
+    tx = None
+
+
 def _set_auth_context(monkeypatch: pytest.MonkeyPatch, context: PlatformAuthContext | None) -> None:
     monkeypatch.setattr("src.middleware.platform_auth.get_platform_auth_context", lambda request: context)
     monkeypatch.setattr("src.middleware.admin.get_platform_auth_context", lambda request: context)
     monkeypatch.setattr("src.api.admin.endpoints.keys.get_platform_auth_context", lambda request: context)
+
+
+def _is_active_key(row: dict[str, Any]) -> bool:
+    expires = row.get("expires")
+    if expires is None:
+        return True
+    if isinstance(expires, datetime):
+        exp_dt = expires if expires.tzinfo else expires.replace(tzinfo=UTC)
+    elif isinstance(expires, str):
+        try:
+            exp_dt = datetime.fromisoformat(expires.replace("Z", "+00:00"))
+        except ValueError:
+            return True
+        if exp_dt.tzinfo is None:
+            exp_dt = exp_dt.replace(tzinfo=UTC)
+    else:
+        return True
+    return exp_dt.astimezone(UTC) > datetime.now(tz=UTC)
 
 
 def _make_context(
@@ -193,11 +377,57 @@ def _install_key_db(
     keys: dict[str, dict[str, Any]],
     *,
     teams: dict[str, dict[str, Any]] | None = None,
+    users: dict[str, dict[str, Any]] | None = None,
     account_ids: set[str] | None = None,
+    db_cls: type[_FakeKeyDB] = _FakeKeyDB,
 ) -> _FakeKeyDB:
-    fake_db = _FakeKeyDB(keys, teams=teams, account_ids=account_ids)
+    fake_db = db_cls(keys, teams=teams, users=users, account_ids=account_ids)
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     return fake_db
+
+
+def _self_service_team(**overrides: Any) -> dict[str, Any]:
+    team = {
+        "team_id": "team-sandbox",
+        "team_alias": "Sandbox",
+        "organization_id": "org-sandbox",
+        "self_service_keys_enabled": True,
+        "self_service_max_keys_per_user": 2,
+        "self_service_budget_ceiling": 5.0,
+        "self_service_require_expiry": True,
+        "self_service_max_expiry_days": 14,
+        "rpm_limit": 10,
+        "tpm_limit": 1000,
+        "rph_limit": 100,
+        "rpd_limit": 500,
+        "tpd_limit": 10000,
+    }
+    team.update(overrides)
+    return team
+
+
+def _list_tokens(response_body: dict[str, Any]) -> set[str]:
+    return {str(row.get("token") or "") for row in response_body.get("data", [])}
+
+
+def _install_key_asset_read_stubs(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_visibility(request: Any, **kwargs: Any) -> dict[str, Any]:
+        del request
+        call = {"kind": "visibility", **kwargs}
+        calls.append(call)
+        return call
+
+    async def fake_access(request: Any, **kwargs: Any) -> dict[str, Any]:
+        del request
+        call = {"kind": "access", **kwargs}
+        calls.append(call)
+        return call
+
+    monkeypatch.setattr("src.api.admin.endpoints.keys.build_asset_visibility_preview", fake_visibility)
+    monkeypatch.setattr("src.api.admin.endpoints.keys.build_scope_asset_access", fake_access)
+    return calls
 
 
 def test_get_auth_scope_tracks_effective_permissions_beyond_endpoint_permissions(monkeypatch: pytest.MonkeyPatch):
@@ -377,6 +607,368 @@ async def test_mixed_role_user_can_revoke_non_owned_key_in_admin_team(client, te
 
 
 @pytest.mark.asyncio
+async def test_mixed_role_user_lists_all_admin_team_keys_and_only_owned_developer_team_keys(
+    client,
+    test_app,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_key_db(
+        test_app,
+        {
+            "admin-owned": {
+                "key_name": "admin-owned",
+                "owner_account_id": "acct-mixed",
+                "team_id": "team-admin",
+            },
+            "admin-other": {
+                "key_name": "admin-other",
+                "owner_account_id": "acct-other",
+                "team_id": "team-admin",
+            },
+            "dev-owned": {
+                "key_name": "dev-owned",
+                "owner_account_id": "acct-mixed",
+                "team_id": "team-dev",
+            },
+            "dev-other": {
+                "key_name": "dev-other",
+                "owner_account_id": "acct-other",
+                "team_id": "team-dev",
+            },
+            "outside-owned": {
+                "key_name": "outside-owned",
+                "owner_account_id": "acct-mixed",
+                "team_id": "team-outside",
+            },
+        },
+        teams={
+            "team-admin": {"team_id": "team-admin", "team_alias": "Admin Team", "organization_id": "org-admin"},
+            "team-dev": {"team_id": "team-dev", "team_alias": "Developer Team", "organization_id": "org-dev"},
+            "team-outside": {"team_id": "team-outside", "team_alias": "Outside Team", "organization_id": "org-outside"},
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-mixed",
+            team_memberships=[
+                {"team_id": "team-admin", "role": TeamRole.ADMIN},
+                {"team_id": "team-dev", "role": TeamRole.DEVELOPER},
+            ],
+        ),
+    )
+
+    response = await client.get("/ui/api/keys")
+
+    assert response.status_code == 200
+    assert _list_tokens(response.json()) == {"admin-owned", "admin-other", "dev-owned"}
+
+
+@pytest.mark.asyncio
+async def test_mixed_role_my_keys_lists_only_owned_keys_in_authorized_scopes(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {
+            "admin-owned": {
+                "key_name": "admin-owned",
+                "owner_account_id": "acct-mixed",
+                "team_id": "team-admin",
+            },
+            "admin-other": {
+                "key_name": "admin-other",
+                "owner_account_id": "acct-other",
+                "team_id": "team-admin",
+            },
+            "dev-owned": {
+                "key_name": "dev-owned",
+                "owner_account_id": "acct-mixed",
+                "team_id": "team-dev",
+            },
+            "outside-owned": {
+                "key_name": "outside-owned",
+                "owner_account_id": "acct-mixed",
+                "team_id": "team-outside",
+            },
+        },
+        teams={
+            "team-admin": {"team_id": "team-admin", "team_alias": "Admin Team", "organization_id": "org-admin"},
+            "team-dev": {"team_id": "team-dev", "team_alias": "Developer Team", "organization_id": "org-dev"},
+            "team-outside": {"team_id": "team-outside", "team_alias": "Outside Team", "organization_id": "org-outside"},
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-mixed",
+            team_memberships=[
+                {"team_id": "team-admin", "role": TeamRole.ADMIN},
+                {"team_id": "team-dev", "role": TeamRole.DEVELOPER},
+            ],
+        ),
+    )
+
+    response = await client.get("/ui/api/keys?my_keys=true")
+
+    assert response.status_code == 200
+    assert _list_tokens(response.json()) == {"admin-owned", "dev-owned"}
+
+
+@pytest.mark.asyncio
+async def test_self_service_developer_lists_only_owned_team_keys(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {
+            "dev-owned": {
+                "key_name": "dev-owned",
+                "owner_account_id": "acct-dev",
+                "team_id": "team-dev",
+            },
+            "dev-other": {
+                "key_name": "dev-other",
+                "owner_account_id": "acct-other",
+                "team_id": "team-dev",
+            },
+            "outside-owned": {
+                "key_name": "outside-owned",
+                "owner_account_id": "acct-dev",
+                "team_id": "team-outside",
+            },
+        },
+        teams={
+            "team-dev": {"team_id": "team-dev", "team_alias": "Developer Team", "organization_id": "org-dev"},
+            "team-outside": {"team_id": "team-outside", "team_alias": "Outside Team", "organization_id": "org-outside"},
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-dev", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.get("/ui/api/keys")
+
+    assert response.status_code == 200
+    assert _list_tokens(response.json()) == {"dev-owned"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("org_role", [OrganizationRole.BILLING, OrganizationRole.AUDITOR])
+async def test_read_only_org_role_lists_scoped_keys(client, test_app, monkeypatch: pytest.MonkeyPatch, org_role: str):
+    _install_key_db(
+        test_app,
+        {
+            "org-key-owned": {
+                "key_name": "org-key-owned",
+                "owner_account_id": "acct-billing",
+                "team_id": "team-1",
+            },
+            "org-key-other": {
+                "key_name": "org-key-other",
+                "owner_account_id": "acct-other",
+                "team_id": "team-2",
+            },
+            "outside-key": {
+                "key_name": "outside-key",
+                "owner_account_id": "acct-other",
+                "team_id": "team-outside",
+            },
+        },
+        teams={
+            "team-1": {"team_id": "team-1", "team_alias": "Team One", "organization_id": "org-1"},
+            "team-2": {"team_id": "team-2", "team_alias": "Team Two", "organization_id": "org-1"},
+            "team-outside": {"team_id": "team-outside", "team_alias": "Outside Team", "organization_id": "org-2"},
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-billing",
+            org_memberships=[{"organization_id": "org-1", "role": org_role}],
+        ),
+    )
+
+    response = await client.get("/ui/api/keys")
+
+    assert response.status_code == 200
+    assert _list_tokens(response.json()) == {"org-key-owned", "org-key-other"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/ui/api/keys/dev-other/asset-visibility",
+        "/ui/api/keys/dev-other/asset-access",
+    ],
+)
+async def test_self_service_developer_cannot_read_non_owned_key_asset_metadata(
+    client,
+    test_app,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+):
+    calls = _install_key_asset_read_stubs(monkeypatch)
+    _install_key_db(
+        test_app,
+        {
+            "dev-other": {
+                "owner_account_id": "acct-other",
+                "team_id": "team-dev",
+                "organization_id": "org-dev",
+            }
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-dev", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.get(path)
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "You can only manage your own keys"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "kind"),
+    [
+        ("/ui/api/keys/dev-owned/asset-visibility", "visibility"),
+        ("/ui/api/keys/dev-owned/asset-access", "access"),
+    ],
+)
+async def test_self_service_developer_can_read_owned_key_asset_metadata(
+    client,
+    test_app,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    kind: str,
+):
+    _install_key_asset_read_stubs(monkeypatch)
+    _install_key_db(
+        test_app,
+        {
+            "dev-owned": {
+                "owner_account_id": "acct-dev",
+                "user_id": "acct-dev",
+                "team_id": "team-dev",
+                "organization_id": "org-dev",
+            }
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-dev", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.get(path)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["kind"] == kind
+    assert body["organization_id"] == "org-dev"
+    assert body["team_id"] == "team-dev"
+    assert body["api_key_id"] == "dev-owned"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("org_role", [OrganizationRole.BILLING, OrganizationRole.AUDITOR])
+@pytest.mark.parametrize(
+    ("path", "kind"),
+    [
+        ("/ui/api/keys/org-key-other/asset-visibility", "visibility"),
+        ("/ui/api/keys/org-key-other/asset-access", "access"),
+    ],
+)
+async def test_read_only_org_role_can_read_scoped_key_asset_metadata(
+    client,
+    test_app,
+    monkeypatch: pytest.MonkeyPatch,
+    org_role: str,
+    path: str,
+    kind: str,
+):
+    _install_key_asset_read_stubs(monkeypatch)
+    _install_key_db(
+        test_app,
+        {
+            "org-key-other": {
+                "owner_account_id": "acct-other",
+                "team_id": "team-1",
+                "organization_id": "org-1",
+            }
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-billing",
+            org_memberships=[{"organization_id": "org-1", "role": org_role}],
+        ),
+    )
+
+    response = await client.get(path)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["kind"] == kind
+    assert body["organization_id"] == "org-1"
+    assert body["team_id"] == "team-1"
+    assert body["api_key_id"] == "org-key-other"
+
+
+@pytest.mark.asyncio
+async def test_mixed_role_user_key_asset_read_is_full_in_admin_team_and_owner_only_in_developer_team(
+    client,
+    test_app,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_key_asset_read_stubs(monkeypatch)
+    _install_key_db(
+        test_app,
+        {
+            "admin-other": {
+                "owner_account_id": "acct-other",
+                "team_id": "team-admin",
+                "organization_id": "org-admin",
+            },
+            "dev-other": {
+                "owner_account_id": "acct-other",
+                "team_id": "team-dev",
+                "organization_id": "org-dev",
+            },
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-mixed",
+            team_memberships=[
+                {"team_id": "team-admin", "role": TeamRole.ADMIN},
+                {"team_id": "team-dev", "role": TeamRole.DEVELOPER},
+            ],
+        ),
+    )
+
+    admin_response = await client.get("/ui/api/keys/admin-other/asset-visibility")
+    developer_response = await client.get("/ui/api/keys/dev-other/asset-visibility")
+
+    assert admin_response.status_code == 200
+    assert admin_response.json()["api_key_id"] == "admin-other"
+    assert developer_response.status_code == 403
+    assert developer_response.json()["detail"] == "You can only manage your own keys"
+
+
+@pytest.mark.asyncio
 async def test_mixed_role_user_can_create_self_service_key_in_developer_team(client, test_app, monkeypatch: pytest.MonkeyPatch):
     _install_key_db(
         test_app,
@@ -397,6 +989,13 @@ async def test_mixed_role_user_can_create_self_service_key_in_developer_team(cli
                 "rpd_limit": None,
                 "tpd_limit": None,
             },
+        },
+        users={
+            "acct-mixed": {
+                "user_id": "acct-mixed",
+                "user_email": "acct-mixed@example.com",
+                "team_id": "team-dev",
+            }
         },
     )
     _set_auth_context(
@@ -424,3 +1023,426 @@ async def test_mixed_role_user_can_create_self_service_key_in_developer_team(cli
     assert body["owner_account_id"] == "acct-mixed"
     assert body["owner_service_account_id"] is None
     assert body["self_service"] is True
+    assert body["user_id"] == "acct-mixed"
+
+
+@pytest.mark.asyncio
+async def test_self_registered_user_self_service_key_binds_runtime_user(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    expires = (datetime.now(tz=UTC) + timedelta(days=7)).isoformat()
+    db = _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team()},
+        users={"acct-dev": {"user_id": "acct-dev", "team_id": "team-sandbox"}},
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "sandbox-key",
+            "team_id": "team-sandbox",
+            "user_id": "attacker-user",
+            "owner_service_account_id": "svc-1",
+            "max_budget": "5",
+            "rpm_limit": "3",
+            "tpm_limit": 500,
+            "rph_limit": 30.0,
+            "rpd_limit": 100,
+            "tpd_limit": 1000,
+            "expires": expires,
+        },
+    )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["user_id"] == "acct-dev"
+    assert body["owner_account_id"] == "acct-dev"
+    assert body["owner_service_account_id"] is None
+    assert body["max_budget"] == 5.0
+    assert body["rpm_limit"] == 3
+    assert db.keys[body["token"]]["user_id"] == "acct-dev"
+    assert db.events.index("advisory_lock") < db.events.index("count_active_keys")
+    assert db.events.index("count_active_keys") < db.events.index("insert_key")
+    assert {"advisory_lock", "count_active_keys", "resolve_runtime_user", "insert_key"}.issubset(
+        db.transactional_events
+    )
+    assert len(db.advisory_locks) == 1
+
+
+@pytest.mark.asyncio
+async def test_self_service_key_creation_resolves_runtime_user_by_email(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    expires = (datetime.now(tz=UTC) + timedelta(days=7)).isoformat()
+    db = _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team()},
+        users={
+            "runtime-user-1": {
+                "user_id": "runtime-user-1",
+                "user_email": "ACCT-DEV@example.com",
+                "team_id": "team-sandbox",
+            }
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "sandbox-key",
+            "team_id": "team-sandbox",
+            "max_budget": 1,
+            "expires": expires,
+        },
+    )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["user_id"] == "runtime-user-1"
+    assert db.keys[body["token"]]["user_id"] == "runtime-user-1"
+
+
+@pytest.mark.asyncio
+async def test_self_service_key_creation_stores_normalized_utc_expiry(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    utc_expiry = datetime.now(tz=UTC).replace(microsecond=0) + timedelta(days=7)
+    offset_expiry = utc_expiry.astimezone(timezone(timedelta(hours=3)))
+    expected_expiry = offset_expiry.astimezone(UTC).isoformat()
+    db = _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team()},
+        users={"acct-dev": {"user_id": "acct-dev", "user_email": "acct-dev@example.com", "team_id": "team-sandbox"}},
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "normalized-expiry-key",
+            "team_id": "team-sandbox",
+            "max_budget": 1,
+            "expires": offset_expiry.isoformat(),
+        },
+    )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["expires"] == expected_expiry
+    assert db.keys[body["token"]]["expires"] == expected_expiry
+
+
+@pytest.mark.asyncio
+async def test_self_service_key_creation_requires_runtime_user(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team()},
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "sandbox-key",
+            "team_id": "team-sandbox",
+            "max_budget": 1,
+            "expires": (datetime.now(tz=UTC) + timedelta(days=1)).isoformat(),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Self-service key creation requires a runtime user in this team"
+
+
+@pytest.mark.asyncio
+async def test_self_service_key_creation_requires_transaction_support(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team()},
+        users={"acct-dev": {"user_id": "acct-dev", "user_email": "acct-dev@example.com", "team_id": "team-sandbox"}},
+        db_cls=_FakeKeyDBWithoutTransactions,
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "sandbox-key",
+            "team_id": "team-sandbox",
+            "max_budget": 1,
+            "expires": (datetime.now(tz=UTC) + timedelta(days=1)).isoformat(),
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Database transactions are required for self-service key creation"
+
+
+@pytest.mark.asyncio
+async def test_self_service_key_creation_enforces_max_active_keys(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {
+            "existing-key": {
+                "owner_account_id": "acct-dev",
+                "team_id": "team-sandbox",
+                "organization_id": "org-sandbox",
+                "expires": datetime.now(tz=UTC) + timedelta(days=1),
+            }
+        },
+        teams={"team-sandbox": _self_service_team(self_service_max_keys_per_user=1)},
+        users={"acct-dev": {"user_id": "acct-dev", "team_id": "team-sandbox"}},
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "second-key",
+            "team_id": "team-sandbox",
+            "max_budget": 1,
+            "expires": (datetime.now(tz=UTC) + timedelta(days=1)).isoformat(),
+        },
+    )
+
+    assert response.status_code == 403
+    assert "maximum of 1 self-service keys" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_self_service_key_creation_enforces_budget_ceiling(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team(self_service_budget_ceiling=5.0)},
+        users={"acct-dev": {"user_id": "acct-dev", "team_id": "team-sandbox"}},
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "expensive-key",
+            "team_id": "team-sandbox",
+            "max_budget": 6,
+            "expires": (datetime.now(tz=UTC) + timedelta(days=1)).isoformat(),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Budget must be between $0 and $5.0"
+
+
+@pytest.mark.asyncio
+async def test_self_service_key_creation_requires_budget_when_ceiling_configured(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team(self_service_budget_ceiling=5.0)},
+        users={"acct-dev": {"user_id": "acct-dev", "team_id": "team-sandbox"}},
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "missing-budget",
+            "team_id": "team-sandbox",
+            "expires": (datetime.now(tz=UTC) + timedelta(days=1)).isoformat(),
+        },
+    )
+
+    assert response.status_code == 400
+    assert "A budget (max_budget) is required" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_self_service_key_creation_rejects_negative_budget_without_ceiling(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team(self_service_budget_ceiling=None)},
+        users={"acct-dev": {"user_id": "acct-dev", "team_id": "team-sandbox"}},
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "negative-budget",
+            "team_id": "team-sandbox",
+            "max_budget": -1,
+            "expires": (datetime.now(tz=UTC) + timedelta(days=1)).isoformat(),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "max_budget must be greater than or equal to 0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("expires", "expected_detail"),
+    [
+        (None, "An expiry date is required for self-service keys on this team"),
+        ("not-a-date", "expires must be a valid ISO 8601 datetime string"),
+        (
+            lambda: (datetime.now(tz=UTC) - timedelta(minutes=1)).isoformat(),
+            "Expiry date must be in the future",
+        ),
+        (
+            lambda: (datetime.now(tz=UTC) + timedelta(days=15)).isoformat(),
+            "Expiry date cannot be more than 14 days from now",
+        ),
+    ],
+)
+async def test_self_service_key_creation_enforces_expiry_policy(
+    client,
+    test_app,
+    monkeypatch: pytest.MonkeyPatch,
+    expires: str | None,
+    expected_detail: str,
+):
+    _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team()},
+        users={"acct-dev": {"user_id": "acct-dev", "team_id": "team-sandbox"}},
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+    expires_value = expires() if callable(expires) else expires
+    payload = {
+        "key_name": "expiry-policy-key",
+        "team_id": "team-sandbox",
+        "max_budget": 1,
+    }
+    if expires_value is not None:
+        payload["expires"] = expires_value
+
+    response = await client.post("/ui/api/keys", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == expected_detail
+
+
+@pytest.mark.asyncio
+async def test_self_service_key_creation_rejects_limits_above_team_limits(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {},
+        teams={"team-sandbox": _self_service_team(rpm_limit=10)},
+        users={"acct-dev": {"user_id": "acct-dev", "team_id": "team-sandbox"}},
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.post(
+        "/ui/api/keys",
+        json={
+            "key_name": "limit-policy-key",
+            "team_id": "team-sandbox",
+            "max_budget": 1,
+            "rpm_limit": 11,
+            "expires": (datetime.now(tz=UTC) + timedelta(days=1)).isoformat(),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "rpm_limit (11) cannot exceed team limit (10)"
+
+
+@pytest.mark.asyncio
+async def test_self_service_user_cannot_update_key_asset_access(client, test_app, monkeypatch: pytest.MonkeyPatch):
+    _install_key_db(
+        test_app,
+        {
+            "key-team-1": {
+                "owner_account_id": "acct-dev",
+                "user_id": "acct-dev",
+                "team_id": "team-sandbox",
+                "organization_id": "org-sandbox",
+            }
+        },
+    )
+    _set_auth_context(
+        monkeypatch,
+        _make_context(
+            account_id="acct-dev",
+            team_memberships=[{"team_id": "team-sandbox", "role": TeamRole.DEVELOPER}],
+        ),
+    )
+
+    response = await client.put(
+        "/ui/api/keys/key-team-1/asset-access",
+        json={"mode": "restrict", "selected_callable_keys": ["prod-model"]},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Insufficient permissions"


### PR DESCRIPTION
## Summary
- enforce owner-only listing and direct key reads for self-service developers while preserving full scoped reads for admins and read-only org roles
- require self-service key creation to run inside a transaction with a stable advisory lock and normalized budgets, limits, and expiry values
- bind self-service keys to a runtime user in the team and fail self-registration closed when a same-email runtime user belongs to a different team
- add regressions for sandbox budgets, rate limits, model visibility, key creation, key listing, direct asset reads, and provisioning conflicts

## Verification
- uv run --extra dev ruff check src/api/admin/endpoints/keys.py src/services/self_registration_provisioning.py tests/test_ui_self_service_keys.py tests/services/test_self_registration_provisioning.py
- uv run --extra dev pytest tests/test_ui_self_service_keys.py tests/services/test_self_registration_provisioning.py -q
- uv run --extra dev pytest tests/test_ui_asset_access.py tests/test_ui_scope_asset_visibility.py tests/test_auth.py tests/test_ui_authorization.py -q
- uv run --extra dev pytest tests/test_key_service.py tests/test_billing.py tests/test_multi_window_rate_limits.py tests/test_model_visibility.py tests/test_ui_key_notifications.py tests/test_ui_rate_limits.py tests/test_ui_authorization.py -q
- uv run --extra dev pytest tests/test_text_endpoints.py -q
- git diff --check

Part of #195