### PR TITLE
Add self-registration UI and documentation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -146,6 +146,52 @@ general_settings:
   #   - admin@example.com
   # sso_default_team_id: team-123
   # sso_state_ttl_seconds: 600
+  #
+  # Optional self-service developer sandbox onboarding for first-time SSO users.
+  # Defaults are applied only when the account is first provisioned; admins can
+  # edit the seeded org, team, memberships, budgets, and limits later.
+  #
+  # self_registration:
+  #   enabled: true
+  #   mode: sso_allowed_domain
+  #   allowed_domains:
+  #     - example.com
+  #   require_email_verification: true
+  #   require_admin_approval: false
+  #   default_org:
+  #     id: org-sandbox
+  #     name: Developer Sandbox
+  #     max_budget: 100
+  #     soft_budget: 80
+  #     rpm_limit: 300
+  #     tpm_limit: 500000
+  #     rph_limit: 2000
+  #     rpd_limit: 10000
+  #     tpd_limit: 5000000
+  #   default_team:
+  #     id: team-self-serve
+  #     alias: Self-Service Developers
+  #     role: team_developer
+  #     max_budget: 50
+  #     soft_budget: 40
+  #     rpm_limit: 150
+  #     tpm_limit: 250000
+  #     rph_limit: 1000
+  #     rpd_limit: 5000
+  #     tpd_limit: 2500000
+  #     self_service_keys_enabled: true
+  #     self_service_max_keys_per_user: 2
+  #     self_service_budget_ceiling: 5
+  #     self_service_require_expiry: true
+  #     self_service_max_expiry_days: 14
+  #   default_user:
+  #     max_budget: 10
+  #     soft_budget: 8
+  #     rpm_limit: 30
+  #     tpm_limit: 50000
+  #     rph_limit: 200
+  #     rpd_limit: 1000
+  #     tpd_limit: 500000
 
   # Optional JWT bearer authentication for proxy requests.
   #

--- a/docs/admin-ui/api-keys.md
+++ b/docs/admin-ui/api-keys.md
@@ -68,6 +68,8 @@ In restrict mode, a key can select direct callable targets and access groups tha
 
 Self-service keys follow the team's self-service policy and ownership rules. They still inherit the team asset boundary; admins can use the full key editor when a production integration needs explicit key-level narrowing.
 
+For self-registered sandbox users, the default team policy is the main guardrail for personal key creation. The key must stay within the sandbox team, the current user becomes the owner, and the requested key budget, expiry, and rate limits must satisfy the team's self-service policy. Runtime requests still pass through the normal organization, team, runtime user, and key-level budget and rate-limit checks.
+
 ## Important behavior
 
 - The raw key is shown once at creation time

--- a/docs/admin-ui/people-and-access.md
+++ b/docs/admin-ui/people-and-access.md
@@ -18,6 +18,8 @@ People & Access is the RBAC and onboarding control surface for platform accounts
 - The top list shows platform accounts and their current role
 - The invitation panel lets admins invite by email, resend pending invitations, and cancel them
 - Expanding an account reveals its organization and team memberships
+- Self-registered sandbox users are marked with a sandbox access badge
+- Runtime user budgets, rate limits, and self-service key policy are visible from the account details drawer
 - Modals let admins add accounts, attach memberships, or edit runtime user asset access without leaving the page
 
 ## Invitations
@@ -39,6 +41,22 @@ Organization and team detail pages deep-link back into this page for invitation 
 3. If the user has no auth method yet, they set a password during acceptance
 4. If the user is SSO-only, they can accept without creating a local password
 5. If the user already has MFA enabled, they accept access first and then complete a normal login flow
+
+## Self-Registered Sandbox Users
+
+If `general_settings.self_registration` is enabled for SSO, eligible first-time SSO users appear in People & Access after their first successful sign-in. Their account details show the seeded organization membership, team membership, runtime user limits, and the default team's self-service key policy.
+
+The badge is informational. Admins can still edit the account, add or remove memberships, adjust runtime user asset access, and update the seeded organization/team records from their detail pages.
+
+## Promoting a Sandbox User
+
+To move a developer from sandbox access to production access:
+
+1. Open the user in People & Access and confirm the account identity.
+2. Add the production organization or team membership with the correct role.
+3. Remove the sandbox team membership if the user should no longer create sandbox keys.
+4. Adjust runtime user limits or asset access if the production team requires different guardrails.
+5. Review API Keys and revoke any sandbox keys that should not remain active.
 
 ## Recommended model
 

--- a/docs/admin-ui/settings.md
+++ b/docs/admin-ui/settings.md
@@ -17,6 +17,8 @@ Settings control the global runtime behavior of the gateway.
 
 Use Settings for platform-wide defaults. Do not use it for per-group routing behavior; that belongs in [Route Groups](route-groups.md).
 
+Authentication and onboarding controls such as SSO, invitations, and self-registration sandbox defaults are configured in `general_settings`, not from this page. See [General Settings](../configuration/general.md#self-registration-settings) and [Authentication & SSO](../features/authentication.md#self-service-sandbox-registration) for the self-registration sandbox flow.
+
 ## Good operating pattern
 
 - Keep global defaults conservative

--- a/docs/admin-ui/teams.md
+++ b/docs/admin-ui/teams.md
@@ -35,6 +35,8 @@ All limits are optional. Only configured limits are enforced. Team limits act as
 
 Teams can allow their developers to create their own API keys without admin involvement. New teams start with self-service enabled by default in the create form, and you can review or tighten the policy later in the Team Detail page under the **Self-Service Keys** card (visible to team admins and above).
 
+When SSO self-registration is enabled, the configured `self_registration.default_team` is created automatically the first time an eligible user is provisioned. Its self-service key policy is seeded from config once, then remains editable from the Team Detail page.
+
 ### Policy fields
 
 | Field | Description |
@@ -46,6 +48,8 @@ Teams can allow their developers to create their own API keys without admin invo
 | Max expiry days | Longest allowed key lifetime in days |
 
 When a developer creates a key through self-service, the backend enforces all of these constraints and rejects requests that violate any of them. See [API Keys: Self-Service Key Creation](api-keys.md#self-service-key-creation) for the full list of enforced constraints.
+
+For sandbox teams, keep the policy intentionally narrow: low key count, small key budget ceiling, required expiry, and a short maximum lifetime. These limits are enforced in addition to organization, team, runtime user, and key-level budgets and rate limits.
 
 ### Enabling self-service
 

--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -97,6 +97,47 @@ general_settings:
   sso_admin_email_list: []
   sso_default_team_id: null
   sso_state_ttl_seconds: 600
+  self_registration:
+    enabled: false
+    mode: sso_allowed_domain
+    allowed_domains: []
+    require_email_verification: true
+    require_admin_approval: false
+    default_org:
+      id: null
+      name: null
+      max_budget: null
+      soft_budget: null
+      rpm_limit: null
+      tpm_limit: null
+      rph_limit: null
+      rpd_limit: null
+      tpd_limit: null
+    default_team:
+      id: null
+      alias: null
+      role: team_developer
+      max_budget: null
+      soft_budget: null
+      rpm_limit: null
+      tpm_limit: null
+      rph_limit: null
+      rpd_limit: null
+      tpd_limit: null
+      self_service_keys_enabled: true
+      self_service_max_keys_per_user: null
+      self_service_budget_ceiling: null
+      self_service_require_expiry: true
+      self_service_max_expiry_days: null
+    default_user:
+      user_role: internal_user
+      max_budget: null
+      soft_budget: null
+      rpm_limit: null
+      tpm_limit: null
+      rph_limit: null
+      rpd_limit: null
+      tpd_limit: null
   embeddings_batch_enabled: false
   embeddings_batch_worker_enabled: true
   embeddings_batch_completion_outbox_worker_enabled: true
@@ -275,6 +316,71 @@ If `email_enabled: true`, `email_base_url` must be an absolute `http://` or `htt
 | `sso_state_ttl_seconds` | `600` | TTL for Redis-backed SSO callback state |
 
 SSO callback state is stored in Redis. If SSO is enabled but Redis is unavailable, DeltaLLM keeps SSO disabled instead of exposing a broken login flow.
+
+## Self-Registration Settings
+
+`self_registration` enables constrained self-service onboarding for first-time SSO users. It is intended for developer sandbox access, not unrestricted public signup.
+
+```yaml
+general_settings:
+  enable_sso: true
+  self_registration:
+    enabled: true
+    mode: sso_allowed_domain
+    allowed_domains:
+      - example.com
+    require_email_verification: true
+    require_admin_approval: false
+    default_org:
+      id: org-sandbox
+      name: Developer Sandbox
+      max_budget: 100
+      soft_budget: 80
+      rpm_limit: 300
+      tpm_limit: 500000
+      rph_limit: 2000
+      rpd_limit: 10000
+      tpd_limit: 5000000
+    default_team:
+      id: team-self-serve
+      alias: Self-Service Developers
+      role: team_developer
+      max_budget: 50
+      soft_budget: 40
+      rpm_limit: 150
+      tpm_limit: 250000
+      rph_limit: 1000
+      rpd_limit: 5000
+      tpd_limit: 2500000
+      self_service_keys_enabled: true
+      self_service_max_keys_per_user: 2
+      self_service_budget_ceiling: 5
+      self_service_require_expiry: true
+      self_service_max_expiry_days: 14
+    default_user:
+      max_budget: 10
+      soft_budget: 8
+      rpm_limit: 30
+      tpm_limit: 50000
+      rph_limit: 200
+      rpd_limit: 1000
+      tpd_limit: 500000
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `self_registration.enabled` | `false` | Enable first-time SSO provisioning into the configured sandbox org/team |
+| `self_registration.mode` | `sso_allowed_domain` | Current supported production path for automatic provisioning |
+| `self_registration.allowed_domains` | `[]` | Bare email domains eligible for first-time SSO provisioning |
+| `self_registration.require_email_verification` | `true` | Require the identity provider to report a verified email before provisioning |
+| `self_registration.require_admin_approval` | `false` | Reserved approval gate. When true, automatic sandbox provisioning is blocked |
+| `self_registration.default_org.*` | — | Organization ID, display name, budgets, and rate limits to seed |
+| `self_registration.default_team.*` | — | Team ID, alias, role, budgets, rate limits, and self-service key policy to seed |
+| `self_registration.default_user.*` | — | Runtime user profile type, budget, and rate limits to seed |
+
+When enabled, `default_org.id`, `default_team.id`, and at least one `allowed_domains` entry are required for `sso_allowed_domain`.
+
+The config values seed records only during provisioning. DeltaLLM does not continuously reconcile those records, so platform admins can later edit the organization, team, memberships, asset access, budgets, and limits through the Admin UI or API without config reloads reverting those changes.
 
 ## Governance Notification Settings
 

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -188,6 +188,45 @@ general_settings:
 !!! note
     SSO callback state is stored in Redis. If Redis is unavailable, DeltaLLM keeps SSO disabled instead of advertising a broken login flow.
 
+### Self-Service Sandbox Registration
+
+When SSO is enabled, DeltaLLM can provision first-time users from approved email domains into a constrained developer sandbox. This is not public signup: users must authenticate through the configured identity provider, pass the allowed-domain check, and land in the configured default organization and team.
+
+```yaml
+general_settings:
+  enable_sso: true
+  self_registration:
+    enabled: true
+    mode: sso_allowed_domain
+    allowed_domains:
+      - example.com
+    require_email_verification: true
+    default_org:
+      id: org-sandbox
+      max_budget: 100
+      rpm_limit: 300
+    default_team:
+      id: team-self-serve
+      role: team_developer
+      self_service_keys_enabled: true
+      self_service_max_keys_per_user: 2
+      self_service_budget_ceiling: 5
+      self_service_require_expiry: true
+      self_service_max_expiry_days: 14
+    default_user:
+      max_budget: 10
+      rpm_limit: 30
+```
+
+Provisioning creates or links:
+
+- a platform account with `org_user`
+- an organization membership in the default organization
+- a team membership in the default team
+- a runtime user row with the configured budget and rate limits
+
+The default organization, team, and runtime user values are applied once at provisioning time. Admin edits are not overwritten by config reloads.
+
 ### Auto-Assign Platform Admins
 
 Add emails to `sso_admin_email_list` to grant `platform_admin` on first SSO login.

--- a/prisma/migrations/20260619120000_usertable_lower_email_lookup/migration.sql
+++ b/prisma/migrations/20260619120000_usertable_lower_email_lookup/migration.sql
@@ -1,0 +1,6 @@
+-- Supports the case-insensitive legacy runtime-user email fallback in the admin principals API.
+-- Rebuild concurrently so K8s rollouts do not block user-table writes and retries recover invalid indexes.
+DROP INDEX CONCURRENTLY IF EXISTS "deltallm_usertable_lower_user_email_idx";
+CREATE INDEX CONCURRENTLY "deltallm_usertable_lower_user_email_idx"
+ON "deltallm_usertable" (lower("user_email"))
+WHERE "user_email" IS NOT NULL;

--- a/src/api/admin/endpoints/rbac.py
+++ b/src/api/admin/endpoints/rbac.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from time import perf_counter
 from typing import Any
 
@@ -12,6 +13,131 @@ from src.middleware.admin import require_admin_permission
 from src.services.access_provisioning_service import AccessProvisioningService
 
 router = APIRouter(tags=["Admin RBAC"])
+
+_SELF_REGISTRATION_SOURCE = "self_registration"
+_ACCOUNT_SELF_REGISTRATION_METADATA_KEY = "self_registration"
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _is_self_registration_default(metadata: Any, entity_type: str) -> bool:
+    metadata_obj = _json_object(metadata)
+    return (
+        metadata_obj.get("source") == _SELF_REGISTRATION_SOURCE
+        and metadata_obj.get("self_registration_default") == entity_type
+    )
+
+
+def _self_registration_account_metadata(metadata: Any) -> dict[str, Any]:
+    metadata_obj = _json_object(metadata)
+    registration = metadata_obj.get(_ACCOUNT_SELF_REGISTRATION_METADATA_KEY)
+    if not isinstance(registration, dict):
+        return {}
+    if registration.get("source") != _SELF_REGISTRATION_SOURCE or registration.get("registered") is not True:
+        return {}
+    return registration
+
+
+def _empty_self_registration_payload(account_metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    registration = account_metadata or {}
+    return {
+        "is_self_registered": bool(registration),
+        "seeded_user": False,
+        "seeded_team": False,
+        "seeded_organization": False,
+        "sandbox_team_id": registration.get("default_team_id"),
+        "sandbox_organization_id": registration.get("default_organization_id"),
+    }
+
+
+def _merge_account_self_registration(
+    runtime_payload: dict[str, Any] | None,
+    account_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(runtime_payload, dict):
+        return _empty_self_registration_payload(account_metadata)
+
+    return {
+        **runtime_payload,
+        "is_self_registered": bool(account_metadata) or bool(runtime_payload.get("is_self_registered")),
+        "sandbox_team_id": runtime_payload.get("sandbox_team_id") or account_metadata.get("default_team_id"),
+        "sandbox_organization_id": runtime_payload.get("sandbox_organization_id")
+        or account_metadata.get("default_organization_id"),
+    }
+
+
+def _self_service_policy_payload(row: dict[str, Any]) -> dict[str, Any] | None:
+    team_id = str(row.get("team_id") or "").strip()
+    if not team_id:
+        return None
+    return {
+        "team_id": team_id,
+        "team_alias": row.get("team_alias"),
+        "self_service_keys_enabled": bool(row.get("self_service_keys_enabled")),
+        "self_service_max_keys_per_user": row.get("self_service_max_keys_per_user"),
+        "self_service_budget_ceiling": row.get("self_service_budget_ceiling"),
+        "self_service_require_expiry": bool(row.get("self_service_require_expiry")),
+        "self_service_max_expiry_days": row.get("self_service_max_expiry_days"),
+    }
+
+
+def _runtime_user_context(row: dict[str, Any]) -> dict[str, Any]:
+    item = to_json_value(dict(row))
+    if not isinstance(item, dict):
+        return {}
+
+    user_default = _is_self_registration_default(item.pop("user_metadata", None), "user")
+    team_default = _is_self_registration_default(item.pop("team_metadata", None), "team")
+    organization_default = _is_self_registration_default(
+        item.pop("organization_metadata", None),
+        "organization",
+    )
+
+    runtime_user = {
+        "user_id": item.get("user_id"),
+        "user_email": item.get("user_email"),
+        "team_id": item.get("team_id"),
+        "team_alias": item.get("team_alias"),
+        "organization_id": item.get("organization_id"),
+        "organization_name": item.get("organization_name"),
+        "max_budget": item.get("max_budget"),
+        "soft_budget": item.get("soft_budget"),
+        "spend": item.get("spend"),
+        "rpm_limit": item.get("rpm_limit"),
+        "tpm_limit": item.get("tpm_limit"),
+        "rph_limit": item.get("rph_limit"),
+        "rpd_limit": item.get("rpd_limit"),
+        "tpd_limit": item.get("tpd_limit"),
+        "blocked": bool(item.get("blocked")),
+        "created_at": item.get("created_at"),
+        "updated_at": item.get("updated_at"),
+        "self_registration_default": user_default,
+    }
+
+    return {
+        "runtime_user": runtime_user,
+        "self_registration": {
+            "is_self_registered": user_default,
+            "seeded_user": user_default,
+            "seeded_team": team_default,
+            "seeded_organization": organization_default,
+            "sandbox_team_id": item.get("team_id") if team_default else None,
+            "sandbox_organization_id": item.get("organization_id") if organization_default else None,
+        },
+        "self_service_policy": _self_service_policy_payload(item),
+    }
+
 
 @router.get("/ui/api/rbac/accounts", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
 async def list_rbac_accounts(request: Request) -> list[dict[str, Any]]:
@@ -50,7 +176,8 @@ async def list_principals(
     page_params = [*params, limit, offset]
     account_rows = await db.query_raw(
         f"""
-        SELECT account_id, email, role, is_active, force_password_change, mfa_enabled, created_at, updated_at, last_login_at
+        SELECT account_id, email, role, is_active, force_password_change, mfa_enabled,
+               metadata AS account_metadata, created_at, updated_at, last_login_at
         FROM deltallm_platformaccount
         {where_sql}
         ORDER BY created_at DESC
@@ -68,30 +195,89 @@ async def list_principals(
     account_ph = ", ".join(f"${i + 1}" for i in range(len(account_ids)))
     org_rows = await db.query_raw(
         f"""
-        SELECT membership_id, account_id, organization_id, role, created_at, updated_at
-        FROM deltallm_organizationmembership
-        WHERE account_id IN ({account_ph})
-        ORDER BY created_at DESC
+        SELECT om.membership_id, om.account_id, om.organization_id, om.role, om.created_at, om.updated_at,
+               o.organization_name, o.metadata AS organization_metadata
+        FROM deltallm_organizationmembership om
+        LEFT JOIN deltallm_organizationtable o
+          ON o.organization_id = om.organization_id
+        WHERE om.account_id IN ({account_ph})
+        ORDER BY om.created_at DESC
         """,
         *account_ids,
     )
     team_rows = await db.query_raw(
         f"""
-        SELECT membership_id, account_id, team_id, role, created_at, updated_at
-        FROM deltallm_teammembership
-        WHERE account_id IN ({account_ph})
-        ORDER BY created_at DESC
+        SELECT tm.membership_id, tm.account_id, tm.team_id, tm.role, tm.created_at, tm.updated_at,
+               t.team_alias, t.organization_id, t.metadata AS team_metadata,
+               t.self_service_keys_enabled, t.self_service_max_keys_per_user,
+               t.self_service_budget_ceiling, t.self_service_require_expiry,
+               t.self_service_max_expiry_days
+        FROM deltallm_teammembership tm
+        LEFT JOIN deltallm_teamtable t
+          ON t.team_id = tm.team_id
+        WHERE tm.account_id IN ({account_ph})
+        ORDER BY tm.created_at DESC
         """,
         *account_ids,
     )
+
+    runtime_params: list[Any] = []
+    runtime_account_values: list[str] = []
+    for row in account_rows:
+        account_id = str(row.get("account_id") or "").strip()
+        if not account_id:
+            continue
+        placeholder_index = len(runtime_params) + 1
+        runtime_params.extend([account_id, str(row.get("email") or "").strip().lower()])
+        runtime_account_values.append(f"(${placeholder_index}::text, ${placeholder_index + 1}::text)")
+
     runtime_user_rows = await db.query_raw(
         f"""
-        SELECT pa.account_id, u.user_id
-        FROM deltallm_platformaccount pa
-        JOIN deltallm_usertable u ON lower(u.user_email) = lower(pa.email)
-        WHERE pa.account_id IN ({account_ph})
+        WITH page_accounts(account_id, account_email) AS (
+            VALUES {", ".join(runtime_account_values)}
+        ),
+        matched_runtime_users AS (
+            SELECT p.account_id AS matched_account_id, 0 AS match_rank, u.user_id
+            FROM page_accounts p
+            JOIN deltallm_usertable u
+              ON u.user_id = p.account_id
+            UNION ALL
+            SELECT p.account_id AS matched_account_id, 1 AS match_rank, u.user_id
+            FROM page_accounts p
+            JOIN deltallm_usertable u
+              ON u.user_email = p.account_email
+            WHERE p.account_email <> ''
+            UNION ALL
+            SELECT p.account_id AS matched_account_id, 2 AS match_rank, u.user_id
+            FROM page_accounts p
+            JOIN deltallm_usertable u
+              ON lower(u.user_email) = p.account_email
+            WHERE p.account_email <> ''
+              AND u.user_email IS DISTINCT FROM p.account_email
+        ),
+        ranked_runtime_users AS (
+            SELECT DISTINCT ON (matched_account_id)
+                   matched_account_id, user_id
+            FROM matched_runtime_users
+            ORDER BY matched_account_id, match_rank, user_id
+        )
+        SELECT r.matched_account_id, u.user_id, u.user_email, u.team_id, u.max_budget, u.soft_budget, u.spend,
+               u.rpm_limit, u.tpm_limit, u.rph_limit, u.rpd_limit, u.tpd_limit,
+               u.blocked, u.metadata AS user_metadata, u.created_at, u.updated_at,
+               t.organization_id, t.team_alias,
+               t.self_service_keys_enabled, t.self_service_max_keys_per_user,
+               t.self_service_budget_ceiling, t.self_service_require_expiry,
+               t.self_service_max_expiry_days, t.metadata AS team_metadata,
+               o.organization_name, o.metadata AS organization_metadata
+        FROM ranked_runtime_users r
+        JOIN deltallm_usertable u
+          ON u.user_id = r.user_id
+        LEFT JOIN deltallm_teamtable t
+          ON t.team_id = u.team_id
+        LEFT JOIN deltallm_organizationtable o
+          ON o.organization_id = t.organization_id
         """,
-        *account_ids,
+        *runtime_params,
     )
 
     org_by_account: dict[str, list[dict[str, Any]]] = {}
@@ -99,6 +285,10 @@ async def list_principals(
         item = to_json_value(dict(row))
         if not isinstance(item, dict):
             continue
+        item["self_registration_default"] = _is_self_registration_default(
+            item.pop("organization_metadata", None),
+            "organization",
+        )
         account_id = str(item.get("account_id") or "")
         if not account_id:
             continue
@@ -109,21 +299,22 @@ async def list_principals(
         item = to_json_value(dict(row))
         if not isinstance(item, dict):
             continue
+        item["self_registration_default"] = _is_self_registration_default(
+            item.pop("team_metadata", None),
+            "team",
+        )
         account_id = str(item.get("account_id") or "")
         if not account_id:
             continue
         team_by_account.setdefault(account_id, []).append(item)
 
-    runtime_user_by_account: dict[str, str] = {}
+    runtime_context_by_account: dict[str, dict[str, Any]] = {}
     for row in runtime_user_rows:
-        item = to_json_value(dict(row))
-        if not isinstance(item, dict):
+        item = dict(row)
+        account_id = str(item.pop("matched_account_id", "") or "").strip()
+        if not account_id:
             continue
-        account_id = str(item.get("account_id") or "")
-        runtime_user_id = str(item.get("user_id") or "")
-        if not account_id or not runtime_user_id:
-            continue
-        runtime_user_by_account[account_id] = runtime_user_id
+        runtime_context_by_account[account_id] = _runtime_user_context(item)
 
     principals: list[dict[str, Any]] = []
     for row in account_rows:
@@ -132,13 +323,30 @@ async def list_principals(
             continue
 
         account_id = str(base.get("account_id") or "")
+        account_metadata_value = base.pop("account_metadata", None)
+        if account_metadata_value is None:
+            account_metadata_value = base.pop("metadata", None)
+        else:
+            base.pop("metadata", None)
+        account_metadata = _self_registration_account_metadata(account_metadata_value)
         org_memberships = org_by_account.get(account_id, [])
         team_memberships = team_by_account.get(account_id, [])
+        runtime_context = runtime_context_by_account.get(account_id, {})
+        runtime_user = runtime_context.get("runtime_user") if runtime_context else None
+        self_registration = _merge_account_self_registration(
+            runtime_context.get("self_registration") if runtime_context else None,
+            account_metadata,
+        )
 
         principals.append(
             {
                 **base,
-                "runtime_user_id": runtime_user_by_account.get(account_id),
+                "runtime_user_id": runtime_user.get("user_id") if isinstance(runtime_user, dict) else None,
+                "runtime_user": runtime_user,
+                "self_registration": self_registration,
+                "self_service_policy": runtime_context.get("self_service_policy")
+                if runtime_context
+                else None,
                 "organization_memberships": org_memberships,
                 "team_memberships": team_memberships,
             }

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -122,6 +122,22 @@ def _is_self_registration_enabled(settings: Any) -> bool:
     return bool(settings is not None and getattr(settings, "enabled", False))
 
 
+def _self_registration_sso_config(general_settings: Any, *, sso_enabled: bool) -> dict[str, Any]:
+    settings = getattr(general_settings, "self_registration", None)
+    enabled = bool(sso_enabled and _is_self_registration_enabled(settings))
+    mode = str(getattr(settings, "mode", "") or "").strip() if enabled else None
+    sandbox_access_enabled = bool(
+        enabled
+        and mode == "sso_allowed_domain"
+        and not getattr(settings, "require_admin_approval", False)
+    )
+    return {
+        "enabled": enabled,
+        "mode": mode,
+        "sandbox_access_enabled": sandbox_access_enabled,
+    }
+
+
 def _is_allowed_self_registration_domain(settings: Any, *, email: str) -> bool:
     domain = _normalized_email_domain(email)
     if domain is None:
@@ -1050,12 +1066,20 @@ async def reset_password(request: Request, payload: ResetPasswordRequest) -> dic
 
 @router.get("/sso-config")
 async def sso_config(request: Request):
+    app_config = getattr(request.app.state, "app_config", None)
+    general_settings = getattr(app_config, "general_settings", None)
     handler = getattr(request.app.state, "sso_auth_handler", None)
     if handler is None:
-        return {"sso_enabled": False}
-    app_config = getattr(request.app.state, "app_config", None)
-    provider = str(getattr(getattr(app_config, "general_settings", None), "sso_provider", "oidc"))
-    return {"sso_enabled": True, "provider": provider}
+        return {
+            "sso_enabled": False,
+            "self_registration": _self_registration_sso_config(general_settings, sso_enabled=False),
+        }
+    provider = str(getattr(general_settings, "sso_provider", "oidc"))
+    return {
+        "sso_enabled": True,
+        "provider": provider,
+        "self_registration": _self_registration_sso_config(general_settings, sso_enabled=True),
+    }
 
 
 @router.get("/login")

--- a/src/services/self_registration_provisioning.py
+++ b/src/services/self_registration_provisioning.py
@@ -10,6 +10,7 @@ from src.services.platform_identity_service import PlatformIdentityService
 
 
 _SELF_REGISTRATION_SOURCE = "self_registration"
+_ACCOUNT_METADATA_KEY = "self_registration"
 
 
 @dataclass(frozen=True)
@@ -201,6 +202,12 @@ class SelfRegistrationProvisioningService:
             team_id=team_id,
             role=settings.default_team.role,
         )
+        await self._mark_account_self_registered(
+            db_client,
+            account_id=account_id,
+            organization_id=organization_id,
+            team_id=team_id,
+        )
 
         return SelfRegistrationProvisioningResult(
             account_id=account_id,
@@ -355,6 +362,48 @@ class SelfRegistrationProvisioningService:
             account_id,
             team_id,
             role,
+        )
+
+    async def _mark_account_self_registered(
+        self,
+        db_client: Any,
+        *,
+        account_id: str,
+        organization_id: str,
+        team_id: str,
+    ) -> None:
+        await db_client.execute_raw(
+            """
+            UPDATE deltallm_platformaccount
+            SET metadata = NULLIF(
+                    CASE
+                        WHEN jsonb_typeof(metadata) = 'object'
+                        THEN metadata
+                        ELSE '{}'::jsonb
+                    END
+                    || jsonb_build_object(
+                        $2,
+                        CASE
+                            WHEN jsonb_typeof(metadata -> $2) = 'object'
+                            THEN metadata -> $2
+                            ELSE '{}'::jsonb
+                        END || $3::jsonb
+                    ),
+                    '{}'::jsonb
+                ),
+                updated_at = NOW()
+            WHERE account_id = $1
+            """,
+            account_id,
+            _ACCOUNT_METADATA_KEY,
+            json.dumps(
+                {
+                    "source": _SELF_REGISTRATION_SOURCE,
+                    "registered": True,
+                    "default_organization_id": organization_id,
+                    "default_team_id": team_id,
+                }
+            ),
         )
 
     async def _ensure_runtime_user(

--- a/tests/services/test_self_registration_provisioning.py
+++ b/tests/services/test_self_registration_provisioning.py
@@ -60,6 +60,15 @@ def _enabled_settings() -> SelfRegistrationSettings:
     return cfg.general_settings.self_registration
 
 
+def _expected_account_self_registration_metadata() -> dict[str, Any]:
+    return {
+        "source": "self_registration",
+        "registered": True,
+        "default_organization_id": "org-sandbox",
+        "default_team_id": "team-self-serve",
+    }
+
+
 class FakeSelfRegistrationDB:
     def __init__(self) -> None:
         self.accounts: dict[str, dict[str, Any]] = {}
@@ -112,6 +121,8 @@ class FakeSelfRegistrationDB:
             return self._insert_team_membership(*params)
         if "insert into deltallm_usertable" in normalized:
             return self._insert_runtime_user(*params)
+        if "update deltallm_platformaccount" in normalized and "set metadata" in normalized:
+            return self._update_platform_account_metadata(*params)
         return 0
 
     def add_account(
@@ -121,6 +132,7 @@ class FakeSelfRegistrationDB:
         email: str,
         role: str = "org_user",
         is_active: bool = True,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         self.accounts[account_id] = {
             "account_id": account_id,
@@ -130,6 +142,7 @@ class FakeSelfRegistrationDB:
             "is_active": is_active,
             "force_password_change": False,
             "mfa_enabled": False,
+            "metadata": copy.deepcopy(metadata),
             "created_at": None,
             "updated_at": None,
             "last_login_at": None,
@@ -289,6 +302,18 @@ class FakeSelfRegistrationDB:
         }
         return 1
 
+    def _update_platform_account_metadata(self, account_id: str, metadata_key: str, metadata: str) -> int:
+        account = self.accounts.get(account_id)
+        if account is None:
+            return 0
+
+        account_metadata = account.get("metadata") if isinstance(account.get("metadata"), dict) else {}
+        current_value = account_metadata.get(metadata_key)
+        current_obj = dict(current_value) if isinstance(current_value, dict) else {}
+        account_metadata[metadata_key] = {**current_obj, **json.loads(metadata)}
+        account["metadata"] = account_metadata
+        return 1
+
 
 class TransactionalFakeSelfRegistrationDB(FakeSelfRegistrationDB):
     def tx(self) -> "_FakeTransaction":
@@ -444,6 +469,7 @@ async def test_provision_from_defaults_seeds_sandbox_records() -> None:
     assert db.users["acct-1"]["user_email"] == "developer@example.com"
     assert db.users["acct-1"]["max_budget"] == 10
     assert db.users["acct-1"]["team_id"] == "team-self-serve"
+    assert db.accounts["acct-1"]["metadata"]["self_registration"] == _expected_account_self_registration_metadata()
 
 
 @pytest.mark.asyncio
@@ -454,6 +480,7 @@ async def test_provision_from_defaults_preserves_existing_admin_changes() -> Non
         email="existing@example.com",
         role="platform_admin",
         is_active=False,
+        metadata={"external_id": "idp-user-1"},
     )
     db.organizations["org-sandbox"] = {
         "organization_id": "org-sandbox",
@@ -503,6 +530,11 @@ async def test_provision_from_defaults_preserves_existing_admin_changes() -> Non
     assert db.users["acct-existing"]["team_id"] == "team-self-serve"
     assert db.organization_memberships[("acct-existing", "org-sandbox")]["role"] == "org_admin"
     assert db.team_memberships[("acct-existing", "team-self-serve")]["role"] == "team_admin"
+    assert db.accounts["acct-existing"]["metadata"]["external_id"] == "idp-user-1"
+    assert (
+        db.accounts["acct-existing"]["metadata"]["self_registration"]
+        == _expected_account_self_registration_metadata()
+    )
 
 
 @pytest.mark.asyncio
@@ -526,6 +558,7 @@ async def test_provision_from_defaults_rejects_existing_runtime_user_outside_def
     assert "acct-1" not in db.users
     assert db.users["legacy-user"]["max_budget"] == 500
     assert db.users["legacy-user"]["team_id"] == "legacy-team"
+    assert "self_registration" not in (db.accounts["acct-1"].get("metadata") or {})
 
 
 @pytest.mark.asyncio
@@ -549,6 +582,7 @@ async def test_provision_from_defaults_returns_existing_runtime_user_in_default_
     assert "acct-1" not in db.users
     assert db.users["legacy-user"]["max_budget"] == 500
     assert db.users["legacy-user"]["team_id"] == "team-self-serve"
+    assert db.accounts["acct-1"]["metadata"]["self_registration"] == _expected_account_self_registration_metadata()
 
 
 @pytest.mark.asyncio

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -914,7 +914,36 @@ async def test_sso_config_reports_disabled_when_handler_is_unavailable(client, t
     response = await client.get("/auth/sso-config")
 
     assert response.status_code == 200
-    assert response.json() == {"sso_enabled": False}
+    assert response.json() == {
+        "sso_enabled": False,
+        "self_registration": {
+            "enabled": False,
+            "mode": None,
+            "sandbox_access_enabled": False,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_sso_config_reports_self_registration_sandbox_status(client, test_app):
+    test_app.state.sso_auth_handler = object()
+    test_app.state.app_config = _self_registration_app_config(
+        enabled=True,
+        allowed_domains=["example.com"],
+    )
+
+    response = await client.get("/auth/sso-config")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "sso_enabled": True,
+        "provider": "oidc",
+        "self_registration": {
+            "enabled": True,
+            "mode": "sso_allowed_domain",
+            "sandbox_access_enabled": True,
+        },
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_rbac_principals.py
+++ b/tests/test_ui_rbac_principals.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
+
+
+def _account_self_registration_metadata() -> dict:
+    return {
+        "self_registration": {
+            "source": "self_registration",
+            "registered": True,
+            "default_organization_id": "org-1",
+            "default_team_id": "team-1",
+        }
+    }
 
 
 class FakeDB:
@@ -43,10 +55,52 @@ class FakeDB:
         }
         self.sessions: list[dict] = [{"account_id": "acct-1"}]
         self.identities: list[dict] = [{"account_id": "acct-1"}]
+        self.organizations: dict[str, dict] = {
+            "org-1": {
+                "organization_id": "org-1",
+                "organization_name": "Sandbox Org",
+                "metadata": {
+                    "source": "self_registration",
+                    "self_registration_default": "organization",
+                },
+            }
+        }
+        self.teams: dict[str, dict] = {
+            "team-1": {
+                "team_id": "team-1",
+                "team_alias": "Sandbox Team",
+                "organization_id": "org-1",
+                "self_service_keys_enabled": True,
+                "self_service_max_keys_per_user": 2,
+                "self_service_budget_ceiling": 5.0,
+                "self_service_require_expiry": True,
+                "self_service_max_expiry_days": 14,
+                "metadata": {
+                    "source": "self_registration",
+                    "self_registration_default": "team",
+                },
+            }
+        }
         self.runtime_users: dict[str, dict] = {
             "user-1": {
                 "user_id": "user-1",
                 "user_email": "alice@example.com",
+                "team_id": "team-1",
+                "max_budget": 10.0,
+                "soft_budget": 8.0,
+                "spend": 1.5,
+                "rpm_limit": 30,
+                "tpm_limit": 50000,
+                "rph_limit": 200,
+                "rpd_limit": 1000,
+                "tpd_limit": 500000,
+                "blocked": False,
+                "metadata": {
+                    "source": "self_registration",
+                    "self_registration_default": "user",
+                },
+                "created_at": now,
+                "updated_at": now,
             }
         }
 
@@ -63,9 +117,8 @@ class FakeDB:
                     return [row]
             return []
         if "FROM deltallm_teamtable WHERE team_id = $1" in query:
-            if str(params[0]) == "team-1":
-                return [{"team_id": "team-1", "organization_id": "org-1"}]
-            return []
+            row = self.teams.get(str(params[0]))
+            return [row] if row else []
         if "FROM deltallm_organizationmembership" in query and "WHERE account_id = $1 AND organization_id = $2" in query:
             account_id = str(params[0])
             organization_id = str(params[1])
@@ -73,27 +126,97 @@ class FakeDB:
                 if row["account_id"] == account_id and row["organization_id"] == organization_id:
                     return [row]
             return []
-        if "FROM deltallm_platformaccount pa" in query and "JOIN deltallm_usertable u ON lower(u.user_email) = lower(pa.email)" in query:
-            results = []
-            for account_id in params:
-                account = self.accounts.get(str(account_id))
-                if not account:
-                    continue
-                email = str(account.get("email") or "").lower()
-                for user in self.runtime_users.values():
-                    if str(user.get("user_email") or "").lower() == email:
-                        results.append({"account_id": str(account_id), "user_id": user["user_id"]})
-            return results
+        if "matched_runtime_users AS" in query:
+            return self._runtime_user_rows_for_principals(params)
         if "FROM deltallm_platformaccount" in query:
-            return list(self.accounts.values())
+            rows = []
+            for account in self.accounts.values():
+                row = dict(account)
+                if "metadata AS account_metadata" in query:
+                    row["account_metadata"] = row.pop("metadata", None)
+                rows.append(row)
+            return rows
         if "FROM deltallm_organizationmembership" in query and "WHERE membership_id = $1" in query:
             row = self.org_memberships.get(str(params[0]))
             return [row] if row else []
         if "FROM deltallm_organizationmembership" in query:
-            return list(self.org_memberships.values())
+            rows = []
+            for membership in self.org_memberships.values():
+                organization = self.organizations.get(str(membership.get("organization_id") or ""), {})
+                rows.append(
+                    {
+                        **membership,
+                        "organization_name": organization.get("organization_name"),
+                        "organization_metadata": organization.get("metadata"),
+                    }
+                )
+            return rows
         if "FROM deltallm_teammembership" in query:
-            return list(self.team_memberships.values())
+            rows = []
+            for membership in self.team_memberships.values():
+                team = self.teams.get(str(membership.get("team_id") or ""), {})
+                rows.append(
+                    {
+                        **membership,
+                        "team_alias": team.get("team_alias"),
+                        "organization_id": team.get("organization_id"),
+                        "self_service_keys_enabled": team.get("self_service_keys_enabled"),
+                        "self_service_max_keys_per_user": team.get("self_service_max_keys_per_user"),
+                        "self_service_budget_ceiling": team.get("self_service_budget_ceiling"),
+                        "self_service_require_expiry": team.get("self_service_require_expiry"),
+                        "self_service_max_expiry_days": team.get("self_service_max_expiry_days"),
+                        "team_metadata": team.get("metadata"),
+                    }
+                )
+            return rows
         return []
+
+    def _runtime_user_rows_for_principals(self, params: tuple[object, ...]) -> list[dict]:
+        results = []
+        for account_id, account_email in zip(params[::2], params[1::2], strict=False):
+            matched_user = self._matched_runtime_user(str(account_id), str(account_email))
+            if matched_user is None:
+                continue
+            team = self.teams.get(str(matched_user.get("team_id") or ""), {})
+            organization = self.organizations.get(str(team.get("organization_id") or ""), {})
+            results.append(
+                {
+                    **matched_user,
+                    "matched_account_id": str(account_id),
+                    "organization_id": team.get("organization_id"),
+                    "team_alias": team.get("team_alias"),
+                    "self_service_keys_enabled": team.get("self_service_keys_enabled"),
+                    "self_service_max_keys_per_user": team.get("self_service_max_keys_per_user"),
+                    "self_service_budget_ceiling": team.get("self_service_budget_ceiling"),
+                    "self_service_require_expiry": team.get("self_service_require_expiry"),
+                    "self_service_max_expiry_days": team.get("self_service_max_expiry_days"),
+                    "team_metadata": team.get("metadata"),
+                    "organization_name": organization.get("organization_name"),
+                    "organization_metadata": organization.get("metadata"),
+                    "user_metadata": matched_user.get("metadata"),
+                }
+            )
+        return results
+
+    def _matched_runtime_user(self, account_id: str, account_email: str) -> dict | None:
+        by_id = self.runtime_users.get(account_id)
+        if by_id is not None:
+            return by_id
+
+        for user in self.runtime_users.values():
+            if str(user.get("user_email") or "") == account_email:
+                return user
+
+        account_email_lower = account_email.lower()
+        lower_matches = [
+            user
+            for user in self.runtime_users.values()
+            if str(user.get("user_email") or "").lower() == account_email_lower
+            and str(user.get("user_email") or "") != account_email
+        ]
+        if not lower_matches:
+            return None
+        return sorted(lower_matches, key=lambda user: str(user.get("user_id") or ""))[0]
 
     async def execute_raw(self, query: str, *params):
         if "DELETE FROM deltallm_teammembership WHERE membership_id = $1" in query:
@@ -157,8 +280,127 @@ async def test_list_principals_returns_account_with_memberships(client, test_app
     assert payload["pagination"]["total"] == 1
     assert principals[0]["email"] == "alice@example.com"
     assert principals[0]["runtime_user_id"] == "user-1"
+    assert principals[0]["runtime_user"]["max_budget"] == 10.0
+    assert principals[0]["runtime_user"]["rpm_limit"] == 30
+    assert principals[0]["runtime_user"]["organization_name"] == "Sandbox Org"
+    assert principals[0]["self_registration"] == {
+        "is_self_registered": True,
+        "seeded_user": True,
+        "seeded_team": True,
+        "seeded_organization": True,
+        "sandbox_team_id": "team-1",
+        "sandbox_organization_id": "org-1",
+    }
+    assert principals[0]["self_service_policy"] == {
+        "team_id": "team-1",
+        "team_alias": "Sandbox Team",
+        "self_service_keys_enabled": True,
+        "self_service_max_keys_per_user": 2,
+        "self_service_budget_ceiling": 5.0,
+        "self_service_require_expiry": True,
+        "self_service_max_expiry_days": 14,
+    }
     assert len(principals[0]["organization_memberships"]) == 1
     assert len(principals[0]["team_memberships"]) == 1
+    assert principals[0]["organization_memberships"][0]["self_registration_default"] is True
+    assert principals[0]["team_memberships"][0]["self_registration_default"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_principals_uses_account_marker_for_reused_runtime_user(client, test_app):
+    fake_db = FakeDB()
+    fake_db.accounts["acct-1"]["metadata"] = _account_self_registration_metadata()
+    fake_db.runtime_users["legacy-user"] = {
+        **fake_db.runtime_users.pop("user-1"),
+        "user_id": "legacy-user",
+        "metadata": None,
+    }
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.get("/ui/api/principals", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    principal = response.json()["data"][0]
+    assert principal["runtime_user_id"] == "legacy-user"
+    assert "metadata" not in principal
+    assert "account_metadata" not in principal
+    assert principal["self_registration"] == {
+        "is_self_registered": True,
+        "seeded_user": False,
+        "seeded_team": True,
+        "seeded_organization": True,
+        "sandbox_team_id": "team-1",
+        "sandbox_organization_id": "org-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_principals_matches_runtime_user_email_case_insensitively(client, test_app):
+    fake_db = FakeDB()
+    fake_db.runtime_users["user-1"]["user_email"] = "Alice@Example.COM"
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.get("/ui/api/principals", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    principal = response.json()["data"][0]
+    assert principal["runtime_user_id"] == "user-1"
+    assert principal["runtime_user"]["user_email"] == "Alice@Example.COM"
+
+
+@pytest.mark.asyncio
+async def test_list_principals_prefers_runtime_user_id_over_email_match(client, test_app):
+    fake_db = FakeDB()
+    fake_db.runtime_users["acct-1"] = {
+        **fake_db.runtime_users["user-1"],
+        "user_id": "acct-1",
+        "user_email": "other@example.com",
+    }
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.get("/ui/api/principals", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    principal = response.json()["data"][0]
+    assert principal["runtime_user_id"] == "acct-1"
+    assert principal["runtime_user"]["user_email"] == "other@example.com"
+
+
+@pytest.mark.asyncio
+async def test_list_principals_prefers_exact_email_over_lowercase_fallback(client, test_app):
+    fake_db = FakeDB()
+    fake_db.runtime_users["legacy-user"] = {
+        **fake_db.runtime_users["user-1"],
+        "user_id": "legacy-user",
+        "user_email": "Alice@Example.COM",
+    }
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.get("/ui/api/principals", headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 200
+    principal = response.json()["data"][0]
+    assert principal["runtime_user_id"] == "user-1"
+    assert principal["runtime_user"]["user_email"] == "alice@example.com"
+
+
+def test_lower_runtime_email_lookup_migration_exists() -> None:
+    migration = (
+        Path(__file__).resolve().parents[1]
+        / "prisma/migrations/20260619120000_usertable_lower_email_lookup/migration.sql"
+    )
+    sql = migration.read_text(encoding="utf-8")
+
+    assert 'DROP INDEX CONCURRENTLY IF EXISTS "deltallm_usertable_lower_user_email_idx"' in sql
+    assert 'CREATE INDEX CONCURRENTLY "deltallm_usertable_lower_user_email_idx"' in sql
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS" not in sql
+    assert '"deltallm_usertable_lower_user_email_idx"' in sql
+    assert 'ON "deltallm_usertable" (lower("user_email"))' in sql
+    assert 'WHERE "user_email" IS NOT NULL' in sql
 
 
 @pytest.mark.asyncio

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1243,7 +1243,9 @@ export interface OrgMembership {
   membership_id: string;
   account_id: string;
   organization_id: string;
+  organization_name?: string | null;
   role: string;
+  self_registration_default?: boolean;
   created_at?: string;
   updated_at?: string;
 }
@@ -1252,13 +1254,54 @@ export interface TeamMembership {
   membership_id: string;
   account_id: string;
   team_id: string;
+  team_alias?: string | null;
+  organization_id?: string | null;
   role: string;
+  self_service_keys_enabled?: boolean;
+  self_service_max_keys_per_user?: number | null;
+  self_service_budget_ceiling?: number | null;
+  self_service_require_expiry?: boolean;
+  self_service_max_expiry_days?: number | null;
+  self_registration_default?: boolean;
   created_at?: string;
   updated_at?: string;
 }
 
+export interface RuntimeUserProfile {
+  user_id: string;
+  user_email?: string | null;
+  team_id?: string | null;
+  team_alias?: string | null;
+  organization_id?: string | null;
+  organization_name?: string | null;
+  max_budget?: number | null;
+  soft_budget?: number | null;
+  spend?: number | null;
+  rpm_limit?: number | null;
+  tpm_limit?: number | null;
+  rph_limit?: number | null;
+  rpd_limit?: number | null;
+  tpd_limit?: number | null;
+  blocked?: boolean;
+  created_at?: string | null;
+  updated_at?: string | null;
+  self_registration_default?: boolean;
+}
+
+export interface PrincipalSelfRegistration {
+  is_self_registered: boolean;
+  seeded_user: boolean;
+  seeded_team: boolean;
+  seeded_organization: boolean;
+  sandbox_team_id?: string | null;
+  sandbox_organization_id?: string | null;
+}
+
 export interface Principal extends RBACAccount {
   runtime_user_id?: string | null;
+  runtime_user?: RuntimeUserProfile | null;
+  self_registration?: PrincipalSelfRegistration | null;
+  self_service_policy?: (SelfServicePolicy & { team_id?: string | null; team_alias?: string | null }) | null;
   organization_memberships: OrgMembership[];
   team_memberships: TeamMembership[];
 }
@@ -1355,6 +1398,18 @@ export const invitations = {
     apiFetch<{ cancelled: boolean; invitation_id: string }>(`/ui/api/invitations/${encodeURIComponent(invitationId)}/cancel`, { method: 'POST' }),
 };
 
+export interface SelfRegistrationPublicConfig {
+  enabled: boolean;
+  mode: string | null;
+  sandbox_access_enabled: boolean;
+}
+
+export interface AuthSsoConfig {
+  sso_enabled: boolean;
+  provider?: string;
+  self_registration?: SelfRegistrationPublicConfig;
+}
+
 export const auth = {
   me: () => apiFetch<any>('/auth/me', { headers: new Headers({ 'Content-Type': 'application/json' }) }),
   internalLogin: (payload: { email: string; password: string; mfa_code?: string }) =>
@@ -1371,7 +1426,7 @@ export const auth = {
     apiFetch<any>(`/auth/internal/reset-password/${encodeURIComponent(token)}`),
   resetPassword: (token: string, new_password: string) =>
     apiFetch<{ changed: boolean }>('/auth/internal/reset-password', { method: 'POST', json: { token, new_password } }),
-  ssoConfig: () => apiFetch<{ sso_enabled: boolean; provider?: string }>('/auth/sso-config'),
+  ssoConfig: () => apiFetch<AuthSsoConfig>('/auth/sso-config'),
   ssoLogin: (state: string) => apiFetch<{ authorize_url: string }>(`/auth/login?state=${encodeURIComponent(state)}`),
   mfaEnrollStart: () => apiFetch<{ secret: string; otpauth_url: string }>('/auth/mfa/enroll/start', { method: 'POST' }),
   mfaEnrollConfirm: (code: string) => apiFetch<{ mfa_enabled: boolean }>('/auth/mfa/enroll/confirm', { method: 'POST', json: { code } }),

--- a/ui/src/lib/selfRegistration.ts
+++ b/ui/src/lib/selfRegistration.ts
@@ -1,0 +1,19 @@
+import type { AuthSsoConfig, Principal } from './api';
+
+export function hasSandboxSelfRegistration(config: AuthSsoConfig | null | undefined): boolean {
+  return Boolean(config?.sso_enabled && config.self_registration?.sandbox_access_enabled);
+}
+
+export function isSelfRegisteredPrincipal(principal: Principal | null | undefined): boolean {
+  return Boolean(principal?.self_registration?.is_self_registered);
+}
+
+export function formatOptionalLimit(value: number | null | undefined): string {
+  if (value == null) return 'No limit';
+  return Number(value).toLocaleString();
+}
+
+export function formatOptionalBudget(value: number | null | undefined): string {
+  if (value == null) return 'No limit';
+  return `$${Number(value).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 import type { FormEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../lib/auth';
-import { auth as authApi } from '../lib/api';
+import { auth as authApi, type AuthSsoConfig } from '../lib/api';
+import { hasSandboxSelfRegistration } from '../lib/selfRegistration';
 import { Zap, Mail, KeyRound, Globe } from 'lucide-react';
 
 type Tab = 'credentials' | 'master_key' | 'sso';
@@ -13,6 +14,10 @@ const SSO_PROVIDER_LABELS: Record<string, string> = {
   okta: 'Okta',
   oidc: 'SSO',
 };
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
 
 export default function Login() {
   const { loginWithCredentials, loginWithMasterKey, isLoading } = useAuth();
@@ -30,16 +35,19 @@ export default function Login() {
 
   const [ssoEnabled, setSsoEnabled] = useState(false);
   const [ssoProvider, setSsoProvider] = useState('oidc');
+  const [sandboxSelfRegistration, setSandboxSelfRegistration] = useState(false);
   const [ssoLoading, setSsoLoading] = useState(true);
 
   useEffect(() => {
     authApi.ssoConfig()
-      .then((cfg: { sso_enabled: boolean; provider?: string }) => {
+      .then((cfg: AuthSsoConfig) => {
         setSsoEnabled(cfg.sso_enabled);
+        setSandboxSelfRegistration(hasSandboxSelfRegistration(cfg));
         if (cfg.provider) setSsoProvider(cfg.provider);
       })
       .catch(() => {
         setSsoEnabled(false);
+        setSandboxSelfRegistration(false);
       })
       .finally(() => setSsoLoading(false));
   }, []);
@@ -62,8 +70,8 @@ export default function Login() {
     setError('');
     try {
       await loginWithCredentials(email.trim(), password.trim(), mfaCode.trim() || undefined);
-    } catch (err: any) {
-      const msg = err?.message || 'Login failed';
+    } catch (err: unknown) {
+      const msg = errorMessage(err, 'Login failed');
       if (msg.toLowerCase().includes('mfa') || msg.toLowerCase().includes('invalid credentials')) {
         if (!showMfa) setShowMfa(true);
       }
@@ -83,8 +91,8 @@ export default function Login() {
     setError('');
     try {
       await loginWithMasterKey(masterKey.trim());
-    } catch (err: any) {
-      setError(err?.message || 'Invalid master key');
+    } catch (err: unknown) {
+      setError(errorMessage(err, 'Invalid master key'));
     } finally {
       setLoading(false);
     }
@@ -97,8 +105,8 @@ export default function Login() {
       const state = crypto.randomUUID();
       const { authorize_url } = await authApi.ssoLogin(state);
       window.location.href = authorize_url;
-    } catch (err: any) {
-      setError(err?.message || 'Failed to start SSO login');
+    } catch (err: unknown) {
+      setError(errorMessage(err, 'Failed to start SSO login'));
       setLoading(false);
     }
   };
@@ -205,8 +213,15 @@ export default function Login() {
             {tab === 'sso' && (
               <div className="space-y-4">
                 <p className="text-sm text-gray-600 text-center">
-                  Sign in with your organization's {providerLabel} identity provider.
+                  {sandboxSelfRegistration
+                    ? `Sign in with your organization's ${providerLabel} identity provider for managed sandbox access.`
+                    : `Sign in with your organization's ${providerLabel} identity provider.`}
                 </p>
+                {sandboxSelfRegistration ? (
+                  <div className="rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-blue-700">
+                    Eligible first-time users are placed in an admin-managed developer sandbox with limited budgets, rate limits, and self-service key policy.
+                  </div>
+                ) : null}
                 <button
                   onClick={handleSsoLogin}
                   disabled={loading}

--- a/ui/src/pages/RBACAccounts.tsx
+++ b/ui/src/pages/RBACAccounts.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { invitations, organizations, rbac, teams, users, type Invitation, type Principal, type PrincipalSummary, type ScopedAssetAccess } from '../lib/api';
-import { Plus, UserCog, ShieldCheck, Search, Building2, UsersRound, Trash2, Mail } from 'lucide-react';
+import { Plus, UserCog, ShieldCheck, Search, Building2, UsersRound, Trash2, Mail, KeyRound, Gauge } from 'lucide-react';
+import { formatOptionalBudget, formatOptionalLimit, isSelfRegisteredPrincipal } from '../lib/selfRegistration';
 import Modal from '../components/Modal';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
 import { ContentCard, IndexShell } from '../components/admin/shells';
@@ -60,6 +61,85 @@ function MembershipCountBadge({ count, label }: { count: number; label: string }
       <span>{count}</span>
       <span>{label}</span>
     </span>
+  );
+}
+
+function SandboxAccessBadge() {
+  return (
+    <span className="inline-flex items-center rounded-full bg-cyan-50 px-2 py-0.5 text-xs font-medium text-cyan-700">
+      Sandbox access
+    </span>
+  );
+}
+
+function LimitStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white px-3 py-2">
+      <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">{label}</p>
+      <p className="mt-1 text-sm font-semibold text-gray-900">{value}</p>
+    </div>
+  );
+}
+
+function RuntimeAccessSummary({ account }: { account: Principal }) {
+  const runtime = account.runtime_user;
+  if (!runtime) return null;
+
+  const sandbox = isSelfRegisteredPrincipal(account);
+  const policy = account.self_service_policy;
+  const runtimeTeam = runtime.team_alias || runtime.team_id || 'No team';
+  const runtimeOrg = runtime.organization_name || runtime.organization_id || 'No organization';
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h4 className="flex items-center gap-1.5 text-sm font-medium text-gray-800">
+            <Gauge className="h-4 w-4 text-blue-600" />
+            {sandbox ? 'Sandbox Runtime Limits' : 'Runtime Limits'}
+          </h4>
+          <p className="mt-1 text-xs text-gray-500">
+            {runtimeOrg} · {runtimeTeam}
+          </p>
+        </div>
+        {sandbox ? <SandboxAccessBadge /> : null}
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-4">
+        <LimitStat label="Budget" value={formatOptionalBudget(runtime.max_budget)} />
+        <LimitStat label="Soft alert" value={formatOptionalBudget(runtime.soft_budget)} />
+        <LimitStat label="Spend" value={formatOptionalBudget(runtime.spend)} />
+        <LimitStat label="RPM" value={formatOptionalLimit(runtime.rpm_limit)} />
+        <LimitStat label="TPM" value={formatOptionalLimit(runtime.tpm_limit)} />
+        <LimitStat label="RPH" value={formatOptionalLimit(runtime.rph_limit)} />
+        <LimitStat label="RPD" value={formatOptionalLimit(runtime.rpd_limit)} />
+        <LimitStat label="TPD" value={formatOptionalLimit(runtime.tpd_limit)} />
+      </div>
+
+      {policy ? (
+        <div className="mt-4 rounded-lg border border-gray-200 bg-white px-3 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h5 className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <KeyRound className="h-3.5 w-3.5" />
+              Self-Service Keys
+            </h5>
+            <span
+              className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                policy.self_service_keys_enabled ? 'bg-emerald-50 text-emerald-700' : 'bg-gray-100 text-gray-600'
+              }`}
+            >
+              {policy.self_service_keys_enabled ? 'Enabled' : 'Disabled'}
+            </span>
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-gray-600 md:grid-cols-4">
+            <span>Max keys: {formatOptionalLimit(policy.self_service_max_keys_per_user)}</span>
+            <span>Key budget: {formatOptionalBudget(policy.self_service_budget_ceiling)}</span>
+            <span>Expiry: {policy.self_service_require_expiry ? 'Required' : 'Optional'}</span>
+            <span>Max days: {formatOptionalLimit(policy.self_service_max_expiry_days)}</span>
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -682,6 +762,7 @@ export default function RBACAccounts() {
                                       Runtime linked
                                     </span>
                                   ) : null}
+                                  {isSelfRegisteredPrincipal(acct) ? <SandboxAccessBadge /> : null}
                                 </div>
                               </div>
                             </div>
@@ -827,6 +908,7 @@ export default function RBACAccounts() {
                     Runtime user linked
                   </span>
                 ) : null}
+                {isSelfRegisteredPrincipal(selectedAccount) ? <SandboxAccessBadge /> : null}
               </div>
               <div className="mt-3 grid grid-cols-1 gap-2 text-xs text-gray-500 sm:grid-cols-2">
                 <span>ID: {selectedAccount.account_id}</span>
@@ -835,6 +917,8 @@ export default function RBACAccounts() {
                 {selectedAccount.runtime_user_id ? <span>Runtime user: {selectedAccount.runtime_user_id}</span> : null}
               </div>
             </div>
+
+            <RuntimeAccessSummary account={selectedAccount} />
 
             <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
               <div>
@@ -859,10 +943,11 @@ export default function RBACAccounts() {
                     {selectedAccount.organization_memberships.map((membership) => (
                       <div key={membership.membership_id} className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-3 py-2.5">
                         <div className="min-w-0">
-                          <p className="truncate text-sm font-medium text-gray-900">{getOrgName(membership.organization_id)}</p>
+                          <p className="truncate text-sm font-medium text-gray-900">{membership.organization_name || getOrgName(membership.organization_id)}</p>
                           <p className="mt-0.5 text-[11px] text-gray-400">{membership.organization_id}</p>
                         </div>
                         <div className="flex items-center gap-2 pl-3">
+                          {membership.self_registration_default ? <SandboxAccessBadge /> : null}
                           <RoleBadge role={membership.role} />
                           <button
                             onClick={() => deleteOrgMembership(membership.membership_id)}
@@ -900,10 +985,11 @@ export default function RBACAccounts() {
                     {selectedAccount.team_memberships.map((membership) => (
                       <div key={membership.membership_id} className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-3 py-2.5">
                         <div className="min-w-0">
-                          <p className="truncate text-sm font-medium text-gray-900">{getTeamName(membership.team_id)}</p>
+                          <p className="truncate text-sm font-medium text-gray-900">{membership.team_alias || getTeamName(membership.team_id)}</p>
                           <p className="mt-0.5 text-[11px] text-gray-400">{membership.team_id}</p>
                         </div>
                         <div className="flex items-center gap-2 pl-3">
+                          {membership.self_registration_default ? <SandboxAccessBadge /> : null}
                           <RoleBadge role={membership.role} />
                           <button
                             onClick={() => deleteTeamMembership(membership.membership_id)}

--- a/ui/tests/modelFormShared.test.ts
+++ b/ui/tests/modelFormShared.test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import type { ModelDeploymentDetail } from '../src/lib/api';
+import type { AuthSsoConfig, ModelDeploymentDetail, Principal } from '../src/lib/api';
 import { EMPTY_FORM, buildModelPayload, formFromModel, type ModelFormValues } from '../src/components/modelFormShared';
+import {
+  formatOptionalBudget,
+  formatOptionalLimit,
+  hasSandboxSelfRegistration,
+  isSelfRegisteredPrincipal,
+} from '../src/lib/selfRegistration';
 
 function chatForm(overrides: Partial<ModelFormValues> = {}): ModelFormValues {
   return {
@@ -126,4 +132,39 @@ test('buildModelPayload clears scheduler capacity when all scheduler fields are 
 
   assert.equal('batch_capacity' in payload.model_info, false);
   assert.deepEqual(payload.model_info.vendor_metadata, { owner: 'infra' });
+});
+
+test('self-registration helpers require enabled SSO sandbox access', () => {
+  const enabled: AuthSsoConfig = {
+    sso_enabled: true,
+    provider: 'oidc',
+    self_registration: {
+      enabled: true,
+      mode: 'sso_allowed_domain',
+      sandbox_access_enabled: true,
+    },
+  };
+
+  assert.equal(hasSandboxSelfRegistration(enabled), true);
+  assert.equal(hasSandboxSelfRegistration({ ...enabled, sso_enabled: false }), false);
+  assert.equal(
+    hasSandboxSelfRegistration({
+      ...enabled,
+      self_registration: { ...enabled.self_registration!, sandbox_access_enabled: false },
+    }),
+    false,
+  );
+});
+
+test('self-registration helpers identify principals and format optional limits', () => {
+  const principal = {
+    self_registration: { is_self_registered: true },
+  } as Principal;
+
+  assert.equal(isSelfRegisteredPrincipal(principal), true);
+  assert.equal(isSelfRegisteredPrincipal(null), false);
+  assert.equal(formatOptionalLimit(50000), '50,000');
+  assert.equal(formatOptionalLimit(null), 'No limit');
+  assert.equal(formatOptionalBudget(5), '$5');
+  assert.equal(formatOptionalBudget(null), 'No limit');
 });


### PR DESCRIPTION
## Summary

- expose self-registration sandbox state in login and People & Access UI
- mark self-registered accounts, seeded memberships, runtime limits, and self-service key policy
- document the self-registration config and sandbox operating model
- add account-level self-registration metadata for reused runtime users
- add a retry-safe concurrent functional index for legacy runtime-user email fallback

## Verification

- `uv run --extra dev ruff check src/api/admin/endpoints/rbac.py tests/test_ui_rbac_principals.py tests/services/test_self_registration_provisioning.py`
- `uv run --extra dev pytest tests/test_ui_rbac_principals.py tests/test_auth.py tests/services/test_self_registration_provisioning.py -q`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/deltallm' uv run prisma validate --schema=prisma/schema.prisma`
- `npm run build`
- `npm run test:unit`
- `git diff --check`
- `git diff --cached --check`

Part of #195.
