### PR TITLE
Add runtime user blocked column migration

### DIFF
--- a/prisma/migrations/20260619123500_usertable_blocked_column/migration.sql
+++ b/prisma/migrations/20260619123500_usertable_blocked_column/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "deltallm_usertable"
+ADD COLUMN IF NOT EXISTS "blocked" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,6 +122,7 @@ model DeltaLLM_UserTable {
   budget_duration String?
   budget_reset_at DateTime?
   models          String[]
+  blocked         Boolean  @default(false)
   tpm_limit       Int?
   rpm_limit       Int?
   rph_limit       Int?


### PR DESCRIPTION
## Summary
- add the missing `blocked` field to the Prisma runtime user model
- add an idempotent migration for `deltallm_usertable.blocked`
- fixes `/ui/api/principals` failures when People & Access enriches runtime user details

## Why
Local live self-registration testing exposed a 500 from `/ui/api/principals` because the admin RBAC endpoint selects `u.blocked`, but clean databases did not have that column on `deltallm_usertable`.

## Validation
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/deltallm uv run prisma validate --schema=./prisma/schema.prisma`
- `uv run --extra dev pytest tests/test_ui_rbac_principals.py -q`
- `git diff --check`
- live Docker Compose verification: clean database applied the new migration; `/ui/api/principals` returned the self-registered account with runtime details; admin People & Access UI showed Runtime linked and Sandbox access badges