### PR TITLE
Add tier policy snapshot service

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -91,6 +91,13 @@ general_settings:
   cache_backend: memory
   cache_ttl: 3600
   cache_max_size: 10000
+  # Organization tier policy compiles into an in-memory snapshot. Enforcement is staged.
+  tier_policy_mode: disabled
+  tier_policy_missing_service_mode: fail_open
+  tier_policy_refresh_interval_seconds: 300
+  tier_policy_refresh_jitter_seconds: 1
+  tier_policy_transition_grace_seconds: 0.05
+  tier_policy_refresh_retry_delay_seconds: 5
 
   # Governance notifications are opt-in and disabled by default.
   governance_notifications_enabled: false

--- a/src/api/admin/endpoints/organization_tier_assignments.py
+++ b/src/api/admin/endpoints/organization_tier_assignments.py
@@ -22,6 +22,7 @@ from src.services.tier_admin_errors import (
 )
 from src.services.tier_assignment_admin import TierAssignmentAdminService
 from src.services.tier_assignment_admin_serialization import serialize_tier_assignment
+from src.services.tier_policy_invalidation import reload_tier_policy
 
 router = APIRouter(tags=["Admin Organization Tier Assignments"])
 _PLATFORM_ADMIN_DEPENDENCY = [Depends(require_admin_permission(Permission.PLATFORM_ADMIN))]
@@ -60,6 +61,10 @@ def _http_error(exc: TierAdminError) -> HTTPException:
 
 def _payload(model: Any) -> dict[str, Any]:
     return model.model_dump(mode="python", exclude_unset=True)
+
+
+async def _reload_tier_policy_for_audit(request: Request) -> dict[str, Any]:
+    return (await reload_tier_policy(request)).to_dict()
 
 
 @router.get(
@@ -102,6 +107,7 @@ async def create_organization_tier_assignment(
     created = result.assignment
     response = serialize_tier_assignment(created)
     cache_invalidation_payload = result.cache_invalidation.to_dict()
+    tier_policy_invalidation = await _reload_tier_policy_for_audit(request)
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -110,10 +116,17 @@ async def create_organization_tier_assignment(
         resource_type="organization_tier_assignment",
         resource_id=created.assignment_id,
         request_payload={"organization_id": organization_id, **request_payload},
-        response_payload={**response, "cache_invalidation": cache_invalidation_payload},
+        response_payload={
+            **response,
+            "cache_invalidation": cache_invalidation_payload,
+            "tier_policy_invalidation": tier_policy_invalidation,
+        },
         before=None,
         after=response,
-        metadata={"cache_invalidation": cache_invalidation_payload},
+        metadata={
+            "cache_invalidation": cache_invalidation_payload,
+            "tier_policy_invalidation": tier_policy_invalidation,
+        },
     )
     return response
 
@@ -144,6 +157,7 @@ async def update_organization_tier_assignment(
     updated = result.assignment
     response = serialize_tier_assignment(updated)
     cache_invalidation_payload = result.cache_invalidation.to_dict()
+    tier_policy_invalidation = await _reload_tier_policy_for_audit(request)
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -152,10 +166,17 @@ async def update_organization_tier_assignment(
         resource_type="organization_tier_assignment",
         resource_id=assignment_id,
         request_payload={"organization_id": organization_id, **request_payload},
-        response_payload={**response, "cache_invalidation": cache_invalidation_payload},
+        response_payload={
+            **response,
+            "cache_invalidation": cache_invalidation_payload,
+            "tier_policy_invalidation": tier_policy_invalidation,
+        },
         before=before,
         after=response,
-        metadata={"cache_invalidation": cache_invalidation_payload},
+        metadata={
+            "cache_invalidation": cache_invalidation_payload,
+            "tier_policy_invalidation": tier_policy_invalidation,
+        },
     )
     return response
 
@@ -182,6 +203,7 @@ async def delete_organization_tier_assignment(
     before = serialize_tier_assignment(result.before)
     response = result.response
     cache_invalidation_payload = result.cache_invalidation.to_dict()
+    tier_policy_invalidation = await _reload_tier_policy_for_audit(request)
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -189,9 +211,16 @@ async def delete_organization_tier_assignment(
         organization_id=response["organization_id"],
         resource_type="organization_tier_assignment",
         resource_id=assignment_id,
-        response_payload={**response, "cache_invalidation": cache_invalidation_payload},
+        response_payload={
+            **response,
+            "cache_invalidation": cache_invalidation_payload,
+            "tier_policy_invalidation": tier_policy_invalidation,
+        },
         before=before,
         after=response,
-        metadata={"cache_invalidation": cache_invalidation_payload},
+        metadata={
+            "cache_invalidation": cache_invalidation_payload,
+            "tier_policy_invalidation": tier_policy_invalidation,
+        },
     )
     return response

--- a/src/api/admin/endpoints/tiers.py
+++ b/src/api/admin/endpoints/tiers.py
@@ -16,6 +16,7 @@ from src.api.admin.endpoints.tier_schemas import (
 from src.audit.actions import AuditAction
 from src.auth.roles import Permission
 from src.middleware.admin import require_admin_permission
+from src.services.tier_policy_invalidation import reload_tier_policy
 from src.middleware.platform_auth import get_platform_auth_context
 from src.services.tier_admin import (
     TierAdminConflictError,
@@ -62,6 +63,10 @@ def _payload(model: Any) -> dict[str, Any]:
 def _actor_account_id(request: Request) -> str | None:
     context = get_platform_auth_context(request)
     return str(context.account_id) if context is not None and context.account_id else None
+
+
+async def _reload_tier_policy_for_audit(request: Request) -> dict[str, Any]:
+    return (await reload_tier_policy(request)).to_dict()
 
 
 @router.get("/ui/api/tiers", dependencies=_PLATFORM_ADMIN_DEPENDENCY)
@@ -131,6 +136,7 @@ async def update_tier(
         raise _http_error(exc) from exc
 
     response = serialize_tier(updated)
+    tier_policy_invalidation = await _reload_tier_policy_for_audit(request)
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -138,9 +144,10 @@ async def update_tier(
         resource_type="tier",
         resource_id=tier_id,
         request_payload=request_payload,
-        response_payload=response,
+        response_payload={**response, "tier_policy_invalidation": tier_policy_invalidation},
         before=before,
         after=response,
+        metadata={"tier_policy_invalidation": tier_policy_invalidation},
     )
     return response
 
@@ -155,15 +162,17 @@ async def delete_tier(request: Request, tier_id: str) -> dict[str, Any]:
     except TierAdminError as exc:
         raise _http_error(exc) from exc
 
+    tier_policy_invalidation = await _reload_tier_policy_for_audit(request)
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
         action=AuditAction.ADMIN_TIER_DELETE,
         resource_type="tier",
         resource_id=tier_id,
-        response_payload=response,
+        response_payload={**response, "tier_policy_invalidation": tier_policy_invalidation},
         before=before,
         after=response,
+        metadata={"tier_policy_invalidation": tier_policy_invalidation},
     )
     return response
 
@@ -237,6 +246,7 @@ async def replace_tier_model_policies(
         raise _http_error(exc) from exc
 
     response = {"data": [serialize_model_policy(record) for record in records]}
+    tier_policy_invalidation = await _reload_tier_policy_for_audit(request)
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -247,9 +257,13 @@ async def replace_tier_model_policies(
             "tier_id": tier_id,
             "policy_count": len(policies_payload),
         },
-        response_payload={"policy_count": len(response["data"])},
+        response_payload={
+            "policy_count": len(response["data"]),
+            "tier_policy_invalidation": tier_policy_invalidation,
+        },
         before={"policy_count": len(before_detail["model_policies"]) if before_detail else 0},
         after={"policy_count": len(response["data"])},
+        metadata={"tier_policy_invalidation": tier_policy_invalidation},
     )
     return response
 
@@ -280,6 +294,7 @@ async def replace_tier_capacity_pools(
         raise _http_error(exc) from exc
 
     response = {"data": [serialize_capacity_pool(record) for record in records]}
+    tier_policy_invalidation = await _reload_tier_policy_for_audit(request)
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -287,9 +302,13 @@ async def replace_tier_capacity_pools(
         resource_type="tier_capacity_pool_set",
         resource_id=tier_version_id,
         request_payload={"tier_id": tier_id, "pool_count": len(pools_payload)},
-        response_payload={"pool_count": len(response["data"])},
+        response_payload={
+            "pool_count": len(response["data"]),
+            "tier_policy_invalidation": tier_policy_invalidation,
+        },
         before={"pool_count": len(before_detail["capacity_pools"]) if before_detail else 0},
         after={"pool_count": len(response["data"])},
+        metadata={"tier_policy_invalidation": tier_policy_invalidation},
     )
     return response
 
@@ -318,6 +337,7 @@ async def publish_tier_version(
         raise _http_error(exc) from exc
 
     response = serialize_tier_version(published)
+    tier_policy_invalidation = await _reload_tier_policy_for_audit(request)
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -325,9 +345,10 @@ async def publish_tier_version(
         resource_type="tier_version",
         resource_id=tier_version_id,
         request_payload={"tier_id": tier_id},
-        response_payload=response,
+        response_payload={**response, "tier_policy_invalidation": tier_policy_invalidation},
         before=before,
         after=response,
+        metadata={"tier_policy_invalidation": tier_policy_invalidation},
     )
     return response
 
@@ -352,6 +373,7 @@ async def archive_tier_version(
         raise _http_error(exc) from exc
 
     response = serialize_tier_version(archived)
+    tier_policy_invalidation = await _reload_tier_policy_for_audit(request)
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -359,8 +381,9 @@ async def archive_tier_version(
         resource_type="tier_version",
         resource_id=tier_version_id,
         request_payload={"tier_id": tier_id},
-        response_payload=response,
+        response_payload={**response, "tier_policy_invalidation": tier_policy_invalidation},
         before=before,
         after=response,
+        metadata={"tier_policy_invalidation": tier_policy_invalidation},
     )
     return response

--- a/src/bootstrap/runtime_services.py
+++ b/src/bootstrap/runtime_services.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import Any
 
 from src.bootstrap.status import BootstrapStatus
-from src.billing import AlertConfig, AlertService, BudgetEnforcementService, SpendLedgerService, SpendTrackingService
+from src.billing import (
+    AlertConfig,
+    AlertService,
+    BudgetEnforcementService,
+    SpendLedgerService,
+    SpendTrackingService,
+)
 from src.callbacks import CallbackManager
 from src.guardrails.middleware import GuardrailMiddleware
 from src.guardrails.registry import GuardrailRegistry
@@ -27,13 +34,41 @@ from src.services.governance_invalidation import GovernanceInvalidationService
 from src.services.key_notifications import KeyNotificationService
 from src.services.notification_recipients import NotificationRecipientResolver
 from src.services.prompt_registry import PromptRegistryService
+from src.services.tier_policy_service import TierPolicyService
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class RuntimeServicesRuntime:
     callback_manager: CallbackManager
     governance_invalidation_service: GovernanceInvalidationService
+    tier_policy_service: Any | None = None
     statuses: tuple[BootstrapStatus, ...] = ()
+
+
+_MISSING = object()
+
+
+def _runtime_setting(
+    general_settings: Any,
+    settings: Any,
+    field_name: str,
+    default: Any,
+) -> Any:
+    value = _explicit_general_setting(general_settings, field_name)
+    if value is not _MISSING:
+        return value
+    return getattr(settings, field_name, default)
+
+
+def _explicit_general_setting(general_settings: Any, field_name: str) -> Any:
+    if general_settings is None:
+        return _MISSING
+    fields_set = getattr(general_settings, "model_fields_set", None)
+    if fields_set is not None and field_name not in fields_set:
+        return _MISSING
+    return getattr(general_settings, field_name, _MISSING)
 
 
 async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
@@ -44,6 +79,74 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
         callable_target_catalog_getter=lambda: getattr(app.state, "callable_target_catalog", None),
     )
     await app.state.callable_target_grant_service.reload()
+    general_settings = getattr(cfg, "general_settings", None)
+    settings = getattr(app.state, "settings", None)
+    tier_policy_mode = str(
+        _runtime_setting(general_settings, settings, "tier_policy_mode", "disabled")
+        or "disabled"
+    )
+    tier_policy_missing_service_mode = str(
+        _runtime_setting(
+            general_settings,
+            settings,
+            "tier_policy_missing_service_mode",
+            "fail_open",
+        )
+        or "fail_open"
+    )
+    app.state.tier_policy_service = TierPolicyService(
+        repository=getattr(app.state, "tier_repository", None),
+        mode=tier_policy_mode,
+        missing_service_mode=tier_policy_missing_service_mode,
+        refresh_interval_seconds=_runtime_setting(
+            general_settings,
+            settings,
+            "tier_policy_refresh_interval_seconds",
+            300.0,
+        ),
+        refresh_jitter_seconds=_runtime_setting(
+            general_settings,
+            settings,
+            "tier_policy_refresh_jitter_seconds",
+            1.0,
+        ),
+        transition_grace_seconds=_runtime_setting(
+            general_settings,
+            settings,
+            "tier_policy_transition_grace_seconds",
+            0.05,
+        ),
+        refresh_retry_delay_seconds=_runtime_setting(
+            general_settings,
+            settings,
+            "tier_policy_refresh_retry_delay_seconds",
+            5.0,
+        ),
+    )
+    resolved_tier_policy_mode = str(
+        getattr(app.state.tier_policy_service, "mode", tier_policy_mode) or "disabled"
+    )
+    resolved_tier_policy_missing_service_mode = str(
+        getattr(
+            app.state.tier_policy_service,
+            "missing_service_mode",
+            tier_policy_missing_service_mode,
+        )
+        or "fail_open"
+    )
+    tier_policy_status = "disabled"
+    if resolved_tier_policy_mode != "disabled":
+        try:
+            await app.state.tier_policy_service.reload()
+        except Exception:
+            if resolved_tier_policy_missing_service_mode != "fail_open":
+                raise
+            tier_policy_status = "degraded"
+            logger.exception(
+                "tier policy startup reload failed; continuing because fail_open is configured"
+            )
+        else:
+            tier_policy_status = "ready"
     app.state.prompt_registry_service = PromptRegistryService(
         repository=app.state.prompt_registry_repository,
         route_group_repository=app.state.route_group_repository,
@@ -77,6 +180,9 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
     app.state.governance_invalidation_service = GovernanceInvalidationService(
         redis_client=app.state.redis,
         callable_target_grant_service=app.state.callable_target_grant_service,
+        tier_policy_service=(
+            app.state.tier_policy_service if resolved_tier_policy_mode != "disabled" else None
+        ),
         mcp_registry_service=app.state.mcp_registry_service,
         mcp_governance_service=app.state.mcp_governance_service,
     )
@@ -101,15 +207,18 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
     app.state.callback_manager = callback_manager
     app.state.turn_off_message_logging = cfg.deltallm_settings.turn_off_message_logging
 
-    general_settings = getattr(cfg, "general_settings", None)
-    app.state.notification_recipient_resolver = NotificationRecipientResolver(app.state.prisma_manager.client)
+    app.state.notification_recipient_resolver = NotificationRecipientResolver(
+        app.state.prisma_manager.client
+    )
     budget_alert_ttl = int(getattr(general_settings, "budget_alert_ttl_seconds", 3600) or 3600)
 
     channels: list[NotificationChannel] = []
     email_outbox_service = getattr(app.state, "email_outbox_service", None)
     if email_outbox_service is not None:
         channels.append(EmailChannel(outbox_service=email_outbox_service))
-    if getattr(general_settings, "slack_alerting_enabled", False) and getattr(general_settings, "slack_webhook_url", None):
+    if getattr(general_settings, "slack_alerting_enabled", False) and getattr(
+        general_settings, "slack_webhook_url", None
+    ):
         channels.append(
             SlackChannel(
                 webhook_url=general_settings.slack_webhook_url,
@@ -145,11 +254,18 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
         alert_service=app.state.alert_service,
     )
 
+    if resolved_tier_policy_mode != "disabled":
+        start_tier_policy_service = getattr(app.state.tier_policy_service, "start", None)
+        if callable(start_tier_policy_service):
+            await start_tier_policy_service()
+
     return RuntimeServicesRuntime(
         callback_manager=callback_manager,
         governance_invalidation_service=app.state.governance_invalidation_service,
+        tier_policy_service=app.state.tier_policy_service,
         statuses=(
             BootstrapStatus("callable_target_grants", "ready"),
+            BootstrapStatus("tier_policy", tier_policy_status),
             BootstrapStatus("prompt_registry", "ready"),
             BootstrapStatus("mcp_runtime", "ready"),
             BootstrapStatus("guardrails", "ready"),
@@ -160,6 +276,9 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
 
 
 async def shutdown_runtime_services(runtime: RuntimeServicesRuntime) -> None:
+    tier_policy_service = runtime.tier_policy_service
+    if tier_policy_service is not None and callable(getattr(tier_policy_service, "close", None)):
+        await tier_policy_service.close()
     await runtime.governance_invalidation_service.close()
     await runtime.callback_manager.shutdown()
     await close_shared_client()

--- a/src/config.py
+++ b/src/config.py
@@ -494,6 +494,12 @@ class GeneralSettings(BaseModel):
     embeddings_batch_gc_interval_seconds: float = 86400.0
     embeddings_batch_gc_scan_limit: int = 200
     callable_target_scope_policy_mode: Literal["legacy", "shadow", "enforce"] = "enforce"
+    tier_policy_mode: Literal["disabled", "shadow", "enforce"] = "disabled"
+    tier_policy_missing_service_mode: Literal["fail_open", "fail_closed"] = "fail_open"
+    tier_policy_refresh_interval_seconds: float = Field(default=300.0, gt=0.0)
+    tier_policy_refresh_jitter_seconds: float = Field(default=1.0, ge=0.0)
+    tier_policy_transition_grace_seconds: float = Field(default=0.05, ge=0.0)
+    tier_policy_refresh_retry_delay_seconds: float = Field(default=5.0, gt=0.0)
     audit_enabled: bool = True
     audit_retention_worker_enabled: bool = True
     audit_retention_interval_seconds: float = 86400.0
@@ -612,6 +618,12 @@ class Settings(BaseSettings):
     redis_degraded_mode: Literal["fail_open", "fail_closed"] = "fail_open"
     salt_key: str | None = None
     callable_target_scope_policy_mode: Literal["legacy", "shadow", "enforce"] = "enforce"
+    tier_policy_mode: Literal["disabled", "shadow", "enforce"] = "disabled"
+    tier_policy_missing_service_mode: Literal["fail_open", "fail_closed"] = "fail_open"
+    tier_policy_refresh_interval_seconds: float = Field(default=300.0, gt=0.0)
+    tier_policy_refresh_jitter_seconds: float = Field(default=1.0, ge=0.0)
+    tier_policy_transition_grace_seconds: float = Field(default=0.05, ge=0.0)
+    tier_policy_refresh_retry_delay_seconds: float = Field(default=5.0, gt=0.0)
 
     @field_validator("master_key")
     @classmethod

--- a/src/db/tier_policy_repository.py
+++ b/src/db/tier_policy_repository.py
@@ -1,18 +1,178 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from src.db.tier_records import (
     TierCapacityPoolRecord,
     TierModelPolicyRecord,
+    TierPolicyAssignmentRecord,
+    TierPolicyLoadResult,
     json_param,
+    parse_datetime,
     to_capacity_pool_record,
     to_model_policy_record,
+    to_tier_policy_assignment_record,
 )
+
+
+class TierPolicyRepositoryUnavailableError(RuntimeError):
+    pass
 
 
 class TierPolicyRepositoryMixin:
     prisma: Any | None
+
+    def _require_tier_policy_prisma(self) -> Any:
+        if self.prisma is None:
+            raise TierPolicyRepositoryUnavailableError("tier policy repository database unavailable")
+        return self.prisma
+
+    async def load_active_tier_policy_inputs(
+        self,
+        *,
+        reference_time: datetime | None = None,
+    ) -> TierPolicyLoadResult:
+        self._require_tier_policy_prisma()
+        assignments = await self.list_active_tier_policy_assignments(
+            reference_time=reference_time,
+        )
+        version_ids = [
+            assignment.effective_tier_version_id
+            for assignment in assignments
+            if assignment.effective_tier_version_id
+        ]
+        model_policies = await self.list_model_policies_for_tier_versions(version_ids)
+        capacity_pools = await self.list_capacity_pools_for_tier_versions(version_ids)
+        next_transition_at = await self.get_next_tier_policy_assignment_transition(
+            reference_time=reference_time,
+        )
+        return TierPolicyLoadResult(
+            assignments=tuple(assignments),
+            model_policies=tuple(model_policies),
+            capacity_pools=tuple(capacity_pools),
+            next_transition_at=next_transition_at,
+        )
+
+    async def list_active_tier_policy_assignments(
+        self,
+        *,
+        reference_time: datetime | None = None,
+    ) -> list[TierPolicyAssignmentRecord]:
+        if self.prisma is None:
+            return []
+
+        rows = await self.prisma.query_raw(
+            """
+            SELECT
+                a.assignment_id,
+                a.organization_id,
+                a.tier_id,
+                a.tier_version_id,
+                resolved_version.tier_version_id AS effective_tier_version_id,
+                a.assignment_type,
+                a.enabled,
+                a.weight,
+                a.starts_at,
+                a.ends_at,
+                a.metadata,
+                a.created_at,
+                a.updated_at,
+                t.tier_key,
+                t.name AS tier_name,
+                resolved_version.version_number AS tier_version_number,
+                resolved_version.status AS tier_version_status
+            FROM deltallm_organizationtierassignment a
+            JOIN deltallm_tier t ON t.tier_id = a.tier_id
+            JOIN LATERAL (
+                SELECT v.tier_version_id, v.version_number, v.status
+                FROM deltallm_tierversion v
+                WHERE v.tier_id = a.tier_id
+                  AND v.status = 'active'
+                  AND (
+                      a.tier_version_id IS NULL
+                      OR v.tier_version_id = a.tier_version_id
+                  )
+                ORDER BY v.version_number DESC, v.tier_version_id ASC
+                LIMIT 1
+            ) AS resolved_version ON TRUE
+            WHERE a.enabled = TRUE
+              AND t.enabled = TRUE
+              AND (a.starts_at IS NULL OR a.starts_at <= $1::timestamp)
+              AND (a.ends_at IS NULL OR a.ends_at > $1::timestamp)
+            ORDER BY
+                a.organization_id ASC,
+                CASE a.assignment_type
+                    WHEN 'override' THEN 3
+                    WHEN 'addon' THEN 2
+                    ELSE 1
+                END DESC,
+                a.weight DESC,
+                a.created_at ASC,
+                a.assignment_id ASC
+            """,
+            _timestamp_param(reference_time),
+        )
+        return [to_tier_policy_assignment_record(row) for row in rows]
+
+    async def get_next_tier_policy_assignment_transition(
+        self,
+        *,
+        reference_time: datetime | None = None,
+    ) -> datetime | None:
+        prisma = self._require_tier_policy_prisma()
+        rows = await prisma.query_raw(
+            """
+            SELECT MIN(transition_at) AS next_transition_at
+            FROM (
+                SELECT a.starts_at AS transition_at
+                FROM deltallm_organizationtierassignment a
+                JOIN deltallm_tier t ON t.tier_id = a.tier_id
+                JOIN LATERAL (
+                    SELECT v.tier_version_id
+                    FROM deltallm_tierversion v
+                    WHERE v.tier_id = a.tier_id
+                      AND v.status = 'active'
+                      AND (
+                          a.tier_version_id IS NULL
+                          OR v.tier_version_id = a.tier_version_id
+                      )
+                    ORDER BY v.version_number DESC, v.tier_version_id ASC
+                    LIMIT 1
+                ) AS resolved_version ON TRUE
+                WHERE a.enabled = TRUE
+                  AND t.enabled = TRUE
+                  AND a.starts_at IS NOT NULL
+                  AND a.starts_at > $1::timestamp
+
+                UNION ALL
+
+                SELECT a.ends_at AS transition_at
+                FROM deltallm_organizationtierassignment a
+                JOIN deltallm_tier t ON t.tier_id = a.tier_id
+                JOIN LATERAL (
+                    SELECT v.tier_version_id
+                    FROM deltallm_tierversion v
+                    WHERE v.tier_id = a.tier_id
+                      AND v.status = 'active'
+                      AND (
+                          a.tier_version_id IS NULL
+                          OR v.tier_version_id = a.tier_version_id
+                      )
+                    ORDER BY v.version_number DESC, v.tier_version_id ASC
+                    LIMIT 1
+                ) AS resolved_version ON TRUE
+                WHERE a.enabled = TRUE
+                  AND t.enabled = TRUE
+                  AND a.ends_at IS NOT NULL
+                  AND a.ends_at > $1::timestamp
+            ) transitions
+            """,
+            _timestamp_param(reference_time),
+        )
+        if not rows:
+            return None
+        return parse_datetime(rows[0].get("next_transition_at"))
 
     async def list_model_policies(self, tier_version_id: str) -> list[TierModelPolicyRecord]:
         if self.prisma is None:
@@ -45,6 +205,47 @@ class TierPolicyRepositoryMixin:
             ORDER BY priority DESC, callable_key ASC
             """,
             tier_version_id,
+        )
+        return [to_model_policy_record(row) for row in rows]
+
+    async def list_model_policies_for_tier_versions(
+        self,
+        tier_version_ids: list[str],
+    ) -> list[TierModelPolicyRecord]:
+        if self.prisma is None:
+            return []
+
+        version_ids = _unique_non_empty(tier_version_ids)
+        if not version_ids:
+            return []
+
+        rows = await self.prisma.query_raw(
+            f"""
+            SELECT
+                tier_model_policy_id,
+                tier_version_id,
+                callable_key,
+                enabled,
+                access_mode,
+                rpm_limit,
+                tpm_limit,
+                rph_limit,
+                rpd_limit,
+                tpd_limit,
+                max_parallel_requests,
+                batch_rpm_limit,
+                batch_tpm_limit,
+                pricing,
+                capacity_pool_key,
+                priority,
+                metadata,
+                created_at,
+                updated_at
+            FROM deltallm_tiermodelpolicy
+            WHERE tier_version_id IN ({_placeholders(len(version_ids))})
+            ORDER BY tier_version_id ASC, priority DESC, callable_key ASC
+            """,
+            *version_ids,
         )
         return [to_model_policy_record(row) for row in rows]
 
@@ -188,6 +389,41 @@ class TierPolicyRepositoryMixin:
             ORDER BY pool_key ASC, callable_key ASC
             """,
             tier_version_id,
+        )
+        return [to_capacity_pool_record(row) for row in rows]
+
+    async def list_capacity_pools_for_tier_versions(
+        self,
+        tier_version_ids: list[str],
+    ) -> list[TierCapacityPoolRecord]:
+        if self.prisma is None:
+            return []
+
+        version_ids = _unique_non_empty(tier_version_ids)
+        if not version_ids:
+            return []
+
+        rows = await self.prisma.query_raw(
+            f"""
+            SELECT
+                tier_capacity_pool_id,
+                tier_version_id,
+                pool_key,
+                callable_key,
+                rpm_capacity,
+                tpm_capacity,
+                max_parallel_requests,
+                strategy,
+                saturation_threshold,
+                burst_multiplier,
+                metadata,
+                created_at,
+                updated_at
+            FROM deltallm_tiercapacitypool
+            WHERE tier_version_id IN ({_placeholders(len(version_ids))})
+            ORDER BY tier_version_id ASC, pool_key ASC, callable_key ASC
+            """,
+            *version_ids,
         )
         return [to_capacity_pool_record(row) for row in rows]
 
@@ -345,3 +581,26 @@ def _ensure_unique_capacity_pool_refs(pools: list[TierCapacityPoolRecord]) -> No
         if ref in seen:
             raise ValueError("capacity pools must have unique pool_key and callable_key pairs")
         seen.add(ref)
+
+
+def _timestamp_param(value: datetime | None) -> datetime:
+    normalized = value or datetime.now(tz=UTC)
+    if normalized.tzinfo is not None:
+        return normalized.astimezone(UTC).replace(tzinfo=None)
+    return normalized
+
+
+def _unique_non_empty(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for value in values:
+        item = str(value or "").strip()
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        normalized.append(item)
+    return normalized
+
+
+def _placeholders(count: int) -> str:
+    return ", ".join(f"${index}" for index in range(1, count + 1))

--- a/src/db/tier_records.py
+++ b/src/db/tier_records.py
@@ -132,6 +132,35 @@ class OrganizationTierAssignmentRecord:
     updated_at: datetime | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class TierPolicyAssignmentRecord:
+    assignment_id: str
+    organization_id: str
+    tier_id: str
+    tier_version_id: str | None
+    effective_tier_version_id: str
+    assignment_type: str = "primary"
+    enabled: bool = True
+    weight: int = 1
+    starts_at: datetime | None = None
+    ends_at: datetime | None = None
+    metadata: dict[str, Any] | None = None
+    tier_key: str | None = None
+    tier_name: str | None = None
+    tier_version_number: int | None = None
+    tier_version_status: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TierPolicyLoadResult:
+    assignments: tuple[TierPolicyAssignmentRecord, ...]
+    model_policies: tuple[TierModelPolicyRecord, ...]
+    capacity_pools: tuple[TierCapacityPoolRecord, ...]
+    next_transition_at: datetime | None = None
+
+
 def tier_version_select_sql() -> str:
     return """
         SELECT
@@ -285,6 +314,34 @@ def to_assignment_record(row: dict[str, Any]) -> OrganizationTierAssignmentRecor
         tier_version_id=str(row.get("tier_version_id"))
         if row.get("tier_version_id") is not None
         else None,
+        assignment_type=str(row.get("assignment_type") or "primary"),
+        enabled=bool(row.get("enabled", True)),
+        weight=int(row.get("weight") or 1),
+        starts_at=parse_datetime(row.get("starts_at")),
+        ends_at=parse_datetime(row.get("ends_at")),
+        metadata=parse_json_object(row.get("metadata"))
+        if row.get("metadata") is not None
+        else None,
+        tier_key=str(row.get("tier_key")) if row.get("tier_key") is not None else None,
+        tier_name=str(row.get("tier_name")) if row.get("tier_name") is not None else None,
+        tier_version_number=int_or_none(row.get("tier_version_number")),
+        tier_version_status=str(row.get("tier_version_status"))
+        if row.get("tier_version_status") is not None
+        else None,
+        created_at=parse_datetime(row.get("created_at")),
+        updated_at=parse_datetime(row.get("updated_at")),
+    )
+
+
+def to_tier_policy_assignment_record(row: dict[str, Any]) -> TierPolicyAssignmentRecord:
+    return TierPolicyAssignmentRecord(
+        assignment_id=str(row.get("assignment_id") or ""),
+        organization_id=str(row.get("organization_id") or ""),
+        tier_id=str(row.get("tier_id") or ""),
+        tier_version_id=str(row.get("tier_version_id"))
+        if row.get("tier_version_id") is not None
+        else None,
+        effective_tier_version_id=str(row.get("effective_tier_version_id") or ""),
         assignment_type=str(row.get("assignment_type") or "primary"),
         enabled=bool(row.get("enabled", True)),
         weight=int(row.get("weight") or 1),

--- a/src/db/tiers.py
+++ b/src/db/tiers.py
@@ -4,11 +4,16 @@ from typing import Any
 
 from src.db.tier_assignment_repository import TierAssignmentRepositoryMixin
 from src.db.tier_catalog_repository import TierCatalogRepositoryMixin
-from src.db.tier_policy_repository import TierPolicyRepositoryMixin
+from src.db.tier_policy_repository import (
+    TierPolicyRepositoryMixin,
+    TierPolicyRepositoryUnavailableError,
+)
 from src.db.tier_records import (
     OrganizationTierAssignmentRecord,
     TierCapacityPoolRecord,
     TierModelPolicyRecord,
+    TierPolicyAssignmentRecord,
+    TierPolicyLoadResult,
     TierRecord,
     TierVersionRecord,
 )
@@ -42,6 +47,9 @@ __all__ = [
     "OrganizationTierAssignmentRecord",
     "TierCapacityPoolRecord",
     "TierModelPolicyRecord",
+    "TierPolicyAssignmentRecord",
+    "TierPolicyLoadResult",
+    "TierPolicyRepositoryUnavailableError",
     "TierRecord",
     "TierRepository",
     "TierVersionRecord",

--- a/src/services/governance_invalidation.py
+++ b/src/services/governance_invalidation.py
@@ -10,7 +10,15 @@ from uuid import uuid4
 logger = logging.getLogger(__name__)
 
 GOVERNANCE_INVALIDATION_CHANNEL = "governance_invalidation"
-_ALLOWED_TARGETS = frozenset({"callable_target", "mcp"})
+_ALLOWED_TARGETS = frozenset({"callable_target", "mcp", "tier_policy"})
+
+
+class GovernanceInvalidationApplyError(RuntimeError):
+    def __init__(self, failed_targets: tuple[str, ...]) -> None:
+        self.failed_targets = failed_targets
+        super().__init__(
+            "failed applying governance invalidation for targets: " + ", ".join(failed_targets)
+        )
 
 
 class GovernanceInvalidationService:
@@ -19,22 +27,30 @@ class GovernanceInvalidationService:
         *,
         redis_client: Any | None,
         callable_target_grant_service: Any | None = None,
+        tier_policy_service: Any | None = None,
         mcp_registry_service: Any | None = None,
         mcp_governance_service: Any | None = None,
         channel_name: str = GOVERNANCE_INVALIDATION_CHANNEL,
         remote_apply_delay_seconds: float = 0.05,
+        remote_retry_delay_seconds: float = 1.0,
     ) -> None:
         self.redis = redis_client
         self.callable_target_grant_service = callable_target_grant_service
+        self.tier_policy_service = tier_policy_service
         self.mcp_registry_service = mcp_registry_service
         self.mcp_governance_service = mcp_governance_service
         self.channel_name = channel_name
         self.remote_apply_delay_seconds = max(float(remote_apply_delay_seconds), 0.0)
+        self.remote_retry_delay_seconds = max(
+            float(remote_retry_delay_seconds),
+            self.remote_apply_delay_seconds,
+        )
         self.instance_id = uuid4().hex
         self._pubsub_task: asyncio.Task[None] | None = None
         self._remote_apply_task: asyncio.Task[None] | None = None
         self._stopping = False
         self._apply_lock = asyncio.Lock()
+        self._remote_targets_lock = asyncio.Lock()
         self._ready = asyncio.Event()
         self._remote_targets: set[str] = set()
 
@@ -46,14 +62,13 @@ class GovernanceInvalidationService:
 
     async def close(self) -> None:
         self._stopping = True
-        if self._pubsub_task is None:
-            return
-        self._pubsub_task.cancel()
-        try:
-            await self._pubsub_task
-        except asyncio.CancelledError:
-            pass
-        self._pubsub_task = None
+        if self._pubsub_task is not None:
+            self._pubsub_task.cancel()
+            try:
+                await self._pubsub_task
+            except asyncio.CancelledError:
+                pass
+            self._pubsub_task = None
         if self._remote_apply_task is not None:
             self._remote_apply_task.cancel()
             try:
@@ -67,12 +82,15 @@ class GovernanceInvalidationService:
         if not normalized_targets:
             return
         async with self._apply_lock:
-            await self._apply_targets(normalized_targets)
+            failed_targets = await self._apply_targets(normalized_targets)
+        if failed_targets:
+            await self._queue_remote_targets(failed_targets, retry=True)
+            raise GovernanceInvalidationApplyError(failed_targets)
 
-    async def notify(self, *targets: str) -> None:
+    async def notify(self, *targets: str) -> bool:
         normalized_targets = self._normalize_targets(targets)
         if not normalized_targets or self.redis is None:
-            return
+            return False
         payload = json.dumps(
             {
                 "type": "governance_invalidation",
@@ -85,6 +103,8 @@ class GovernanceInvalidationService:
             await self.redis.publish(self.channel_name, payload)
         except Exception as exc:
             logger.warning("failed publishing governance invalidation: %s", exc)
+            return False
+        return True
 
     async def _listen(self) -> None:
         if self.redis is None:
@@ -115,7 +135,7 @@ class GovernanceInvalidationService:
                 targets = self._normalize_targets(data.get("targets") or [])
                 if not targets:
                     continue
-                self._queue_remote_targets(targets)
+                await self._queue_remote_targets(targets)
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -129,33 +149,89 @@ class GovernanceInvalidationService:
                 pass
             await pubsub.close()
 
-    def _queue_remote_targets(self, targets: tuple[str, ...]) -> None:
-        self._remote_targets.update(targets)
+    async def _queue_remote_targets(self, targets: tuple[str, ...], *, retry: bool = False) -> None:
+        async with self._remote_targets_lock:
+            self._remote_targets.update(targets)
         if self._remote_apply_task is None or self._remote_apply_task.done():
-            self._remote_apply_task = asyncio.create_task(self._flush_remote_targets())
+            self._remote_apply_task = asyncio.create_task(self._flush_remote_targets(retry=retry))
 
-    async def _flush_remote_targets(self) -> None:
-        if self.remote_apply_delay_seconds > 0:
-            await asyncio.sleep(self.remote_apply_delay_seconds)
-        targets = tuple(sorted(self._remote_targets))
-        self._remote_targets.clear()
-        if not targets:
-            return
-        async with self._apply_lock:
-            await self._apply_targets(targets)
+    async def _flush_remote_targets(self, *, retry: bool = False) -> None:
+        targets: tuple[str, ...] = ()
+        failed_targets: tuple[str, ...] = ()
+        delay_seconds = (
+            self.remote_retry_delay_seconds if retry else self.remote_apply_delay_seconds
+        )
+        if delay_seconds > 0:
+            await asyncio.sleep(delay_seconds)
+        try:
+            async with self._remote_targets_lock:
+                targets = tuple(sorted(self._remote_targets))
+                self._remote_targets.difference_update(targets)
+            if not targets:
+                return
 
-    async def _apply_targets(self, targets: tuple[str, ...]) -> None:
+            async with self._apply_lock:
+                failed_targets = await self._apply_targets(targets)
+            if failed_targets:
+                async with self._remote_targets_lock:
+                    self._remote_targets.update(failed_targets)
+                logger.warning(
+                    "remote governance invalidation targets failed and will be retried: %s",
+                    ", ".join(failed_targets),
+                )
+        except asyncio.CancelledError:
+            if targets:
+                async with self._remote_targets_lock:
+                    self._remote_targets.update(targets)
+            raise
+        finally:
+            if not self._stopping:
+                async with self._remote_targets_lock:
+                    has_pending_targets = bool(self._remote_targets)
+                if has_pending_targets:
+                    self._remote_apply_task = asyncio.create_task(
+                        self._flush_remote_targets(retry=bool(failed_targets))
+                    )
+
+    async def _apply_targets(self, targets: tuple[str, ...]) -> tuple[str, ...]:
+        failed_targets: list[str] = []
         if "callable_target" in targets:
             service = self.callable_target_grant_service
             if service is not None and callable(getattr(service, "reload", None)):
-                await service.reload()
+                try:
+                    await service.reload()
+                except Exception as exc:
+                    failed_targets.append("callable_target")
+                    logger.warning("failed applying callable target invalidation: %s", exc)
+        if "tier_policy" in targets:
+            service = self.tier_policy_service
+            if _service_mode(service) == "disabled":
+                service = None
+            if service is not None and callable(getattr(service, "reload", None)):
+                try:
+                    await service.reload()
+                except Exception as exc:
+                    failed_targets.append("tier_policy")
+                    logger.warning("failed applying tier policy invalidation: %s", exc)
         if "mcp" in targets:
+            target_failed = False
             registry = self.mcp_registry_service
             if registry is not None and callable(getattr(registry, "invalidate_all", None)):
-                await registry.invalidate_all()
+                try:
+                    await registry.invalidate_all()
+                except Exception as exc:
+                    target_failed = True
+                    logger.warning("failed applying MCP registry invalidation: %s", exc)
             governance = self.mcp_governance_service
             if governance is not None and callable(getattr(governance, "reload", None)):
-                await governance.reload()
+                try:
+                    await governance.reload()
+                except Exception as exc:
+                    target_failed = True
+                    logger.warning("failed applying MCP governance invalidation: %s", exc)
+            if target_failed:
+                failed_targets.append("mcp")
+        return tuple(failed_targets)
 
     @staticmethod
     def _normalize_targets(targets: Iterable[str]) -> tuple[str, ...]:
@@ -168,3 +244,10 @@ class GovernanceInvalidationService:
             seen.add(target)
             normalized.append(target)
         return tuple(normalized)
+
+
+def _service_mode(service: Any | None) -> str | None:
+    if service is None:
+        return None
+    mode = str(getattr(service, "mode", "") or "").strip().lower()
+    return mode or None

--- a/src/services/tier_policy_builders.py
+++ b/src/services/tier_policy_builders.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from src.db.tiers import (
+    TierCapacityPoolRecord,
+    TierModelPolicyRecord,
+    TierPolicyAssignmentRecord,
+)
+from src.services.tier_policy_models import (
+    CompiledTierCapacityPoolPolicy,
+    CompiledTierModelPolicy,
+    CompiledTierPricingPolicy,
+    CompiledTierRateLimitDescriptor,
+    TierPolicyLimits,
+    TierPolicySource,
+)
+
+_BATCH_PRICING_PREFIX = "batch_"
+_CAPACITY_STRATEGY_RANK = {"hard_cap": 1, "weighted_fair": 2, "reserved_burst": 3}
+
+
+def compile_model_policy(
+    assignment: TierPolicyAssignmentRecord,
+    policy: TierModelPolicyRecord,
+) -> CompiledTierModelPolicy:
+    return CompiledTierModelPolicy(
+        organization_id=assignment.organization_id,
+        callable_key=policy.callable_key,
+        access_mode=str(policy.access_mode or "allow").strip().lower(),
+        source=TierPolicySource(
+            assignment_id=assignment.assignment_id,
+            organization_id=assignment.organization_id,
+            tier_id=assignment.tier_id,
+            tier_key=assignment.tier_key,
+            tier_version_id=assignment.effective_tier_version_id,
+            tier_version_number=assignment.tier_version_number,
+            assignment_type=str(assignment.assignment_type or "primary").strip().lower(),
+            assignment_weight=int(assignment.weight or 1),
+            model_policy_id=policy.tier_model_policy_id,
+            model_policy_priority=int(policy.priority or 0),
+        ),
+        limits=TierPolicyLimits(
+            rpm_limit=policy.rpm_limit,
+            tpm_limit=policy.tpm_limit,
+            rph_limit=policy.rph_limit,
+            rpd_limit=policy.rpd_limit,
+            tpd_limit=policy.tpd_limit,
+            max_parallel_requests=policy.max_parallel_requests,
+            batch_rpm_limit=policy.batch_rpm_limit,
+            batch_tpm_limit=policy.batch_tpm_limit,
+        ),
+        pricing=_freeze_pricing(policy.pricing),
+        capacity_pool_key=policy.capacity_pool_key,
+        metadata=_freeze_metadata(policy.metadata),
+    )
+
+
+def compile_pricing_policies(
+    policy: CompiledTierModelPolicy,
+) -> dict[tuple[str, str, str], CompiledTierPricingPolicy]:
+    if not policy.pricing:
+        return {}
+
+    compiled: dict[tuple[str, str, str], CompiledTierPricingPolicy] = {}
+    sync_pricing = {
+        key: value
+        for key, value in policy.pricing.items()
+        if not key.startswith(_BATCH_PRICING_PREFIX)
+    }
+    if sync_pricing:
+        compiled[(policy.organization_id, policy.callable_key, "sync")] = (
+            CompiledTierPricingPolicy(
+                organization_id=policy.organization_id,
+                callable_key=policy.callable_key,
+                mode="sync",
+                pricing=MappingProxyType(sync_pricing),
+                source=policy.source,
+            )
+        )
+    if any(key.startswith(_BATCH_PRICING_PREFIX) for key in policy.pricing):
+        compiled[(policy.organization_id, policy.callable_key, "batch")] = (
+            CompiledTierPricingPolicy(
+                organization_id=policy.organization_id,
+                callable_key=policy.callable_key,
+                mode="batch",
+                pricing=policy.pricing,
+                source=policy.source,
+            )
+        )
+    return compiled
+
+
+def compile_rate_limit_descriptors(
+    policy: CompiledTierModelPolicy,
+) -> tuple[CompiledTierRateLimitDescriptor, ...]:
+    entity_id = f"{policy.organization_id}:{policy.callable_key}"
+    limits = policy.limits
+    descriptors = [
+        _descriptor("tier_org_model_rpm", entity_id, limits.rpm_limit, "requests", 60),
+        _descriptor("tier_org_model_tpm", entity_id, limits.tpm_limit, "tokens", 60),
+        _descriptor("tier_org_model_rph", entity_id, limits.rph_limit, "requests", 3600),
+        _descriptor("tier_org_model_rpd", entity_id, limits.rpd_limit, "requests", 86400),
+        _descriptor("tier_org_model_tpd", entity_id, limits.tpd_limit, "tokens", 86400),
+        _descriptor(
+            "tier_org_model_parallel",
+            entity_id,
+            limits.max_parallel_requests,
+            "concurrency",
+            0,
+        ),
+        _descriptor(
+            "tier_org_model_batch_rpm",
+            entity_id,
+            limits.batch_rpm_limit,
+            "requests",
+            60,
+            mode="batch",
+        ),
+        _descriptor(
+            "tier_org_model_batch_tpm",
+            entity_id,
+            limits.batch_tpm_limit,
+            "tokens",
+            60,
+            mode="batch",
+        ),
+    ]
+    return tuple(descriptor for descriptor in descriptors if descriptor is not None)
+
+
+def compile_capacity_pools(
+    pools: Sequence[TierCapacityPoolRecord],
+) -> dict[tuple[str, str], CompiledTierCapacityPoolPolicy]:
+    compiled: dict[tuple[str, str], CompiledTierCapacityPoolPolicy] = {}
+    for pool in sorted(
+        pools,
+        key=lambda item: (
+            item.pool_key,
+            item.callable_key,
+            item.tier_version_id,
+            item.tier_capacity_pool_id,
+        ),
+    ):
+        key = (pool.pool_key, pool.callable_key)
+        next_policy = CompiledTierCapacityPoolPolicy(
+            pool_key=pool.pool_key,
+            callable_key=pool.callable_key,
+            rpm_capacity=pool.rpm_capacity,
+            tpm_capacity=pool.tpm_capacity,
+            max_parallel_requests=pool.max_parallel_requests,
+            strategy=str(pool.strategy or "hard_cap").strip().lower(),
+            saturation_threshold=pool.saturation_threshold,
+            burst_multiplier=pool.burst_multiplier,
+            source_tier_version_ids=(pool.tier_version_id,),
+            source_pool_ids=(pool.tier_capacity_pool_id,),
+            metadata=_freeze_metadata(pool.metadata),
+        )
+        existing = compiled.get(key)
+        compiled[key] = (
+            next_policy if existing is None else _merge_capacity_pool(existing, next_policy)
+        )
+    return compiled
+
+
+def _descriptor(
+    scope: str,
+    entity_id: str,
+    limit: int | None,
+    amount_kind: str,
+    window_seconds: int,
+    *,
+    mode: str = "sync",
+) -> CompiledTierRateLimitDescriptor | None:
+    if limit is None or limit <= 0:
+        return None
+    return CompiledTierRateLimitDescriptor(
+        scope=scope,
+        entity_id=entity_id,
+        limit=int(limit),
+        amount_kind=amount_kind,
+        window_seconds=window_seconds,
+        mode=mode,
+    )
+
+
+def _merge_capacity_pool(
+    left: CompiledTierCapacityPoolPolicy,
+    right: CompiledTierCapacityPoolPolicy,
+) -> CompiledTierCapacityPoolPolicy:
+    strategy = min(
+        (left.strategy, right.strategy),
+        key=lambda item: _CAPACITY_STRATEGY_RANK.get(item, 99),
+    )
+    return CompiledTierCapacityPoolPolicy(
+        pool_key=left.pool_key,
+        callable_key=left.callable_key,
+        rpm_capacity=_min_optional_int(left.rpm_capacity, right.rpm_capacity),
+        tpm_capacity=_min_optional_int(left.tpm_capacity, right.tpm_capacity),
+        max_parallel_requests=_min_optional_int(
+            left.max_parallel_requests,
+            right.max_parallel_requests,
+        ),
+        strategy=strategy,
+        saturation_threshold=_min_optional_float(
+            left.saturation_threshold,
+            right.saturation_threshold,
+        ),
+        burst_multiplier=_min_optional_float(left.burst_multiplier, right.burst_multiplier),
+        source_tier_version_ids=tuple(
+            sorted(set(left.source_tier_version_ids) | set(right.source_tier_version_ids))
+        ),
+        source_pool_ids=tuple(sorted(set(left.source_pool_ids) | set(right.source_pool_ids))),
+        metadata=left.metadata or right.metadata,
+    )
+
+
+def _freeze_pricing(pricing: Mapping[str, Any] | None) -> Mapping[str, float]:
+    if not pricing:
+        return MappingProxyType({})
+    return MappingProxyType({str(key): float(value) for key, value in pricing.items()})
+
+
+def _freeze_metadata(metadata: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
+    if not metadata:
+        return None
+    return MappingProxyType({str(key): _freeze_json_value(value) for key, value in metadata.items()})
+
+
+def _freeze_json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {str(key): _freeze_json_value(nested) for key, nested in value.items()}
+        )
+    if isinstance(value, list):
+        return tuple(_freeze_json_value(item) for item in value)
+    return value
+
+
+def _min_optional_int(left: int | None, right: int | None) -> int | None:
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return min(left, right)
+
+
+def _min_optional_float(left: float | None, right: float | None) -> float | None:
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return min(left, right)
+

--- a/src/services/tier_policy_compiler.py
+++ b/src/services/tier_policy_compiler.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from dataclasses import fields, is_dataclass
+from datetime import UTC, datetime
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from src.db.tiers import (
+    TierCapacityPoolRecord,
+    TierModelPolicyRecord,
+    TierPolicyAssignmentRecord,
+    TierPolicyLoadResult,
+)
+from src.services.tier_policy_builders import (
+    compile_capacity_pools,
+    compile_model_policy,
+    compile_pricing_policies,
+    compile_rate_limit_descriptors,
+)
+from src.services.tier_policy_models import (
+    CompiledTierModelPolicy,
+    CompiledTierPricingPolicy,
+    CompiledTierRateLimitDescriptor,
+    TierPolicySnapshot,
+)
+
+_ASSIGNMENT_RANK = {"primary": 1, "addon": 2, "override": 3}
+
+
+def compile_tier_policy_snapshot(
+    inputs: TierPolicyLoadResult,
+    *,
+    generated_at: datetime | None = None,
+    reference_time: datetime | None = None,
+) -> TierPolicySnapshot:
+    now = _utc(reference_time or generated_at or datetime.now(tz=UTC))
+    generated_at = _utc(generated_at or now)
+    next_transition_at = _next_transition_at(
+        inputs.assignments,
+        now,
+        provided=inputs.next_transition_at,
+    )
+
+    assignments = tuple(
+        assignment
+        for assignment in inputs.assignments
+        if _assignment_is_active(assignment, now)
+    )
+    active_version_ids = {
+        assignment.effective_tier_version_id
+        for assignment in assignments
+        if assignment.effective_tier_version_id
+    }
+    model_policies = tuple(
+        policy
+        for policy in inputs.model_policies
+        if policy.tier_version_id in active_version_ids and policy.enabled and policy.callable_key
+    )
+    capacity_pools = tuple(
+        pool
+        for pool in inputs.capacity_pools
+        if pool.tier_version_id in active_version_ids and pool.pool_key and pool.callable_key
+    )
+
+    policies_by_version: dict[str, list[TierModelPolicyRecord]] = defaultdict(list)
+    for policy in model_policies:
+        policies_by_version[policy.tier_version_id].append(policy)
+
+    org_tier_keys: dict[str, set[str]] = defaultdict(set)
+    explicit_orgs: set[str] = set()
+    allow_candidates: dict[tuple[str, str], CompiledTierModelPolicy] = {}
+    deny_candidates: dict[tuple[str, str], CompiledTierModelPolicy] = {}
+
+    for assignment in assignments:
+        organization_id = assignment.organization_id
+        if not organization_id:
+            continue
+        explicit_orgs.add(organization_id)
+        if assignment.tier_key:
+            org_tier_keys[organization_id].add(assignment.tier_key)
+
+        for policy in policies_by_version.get(assignment.effective_tier_version_id, ()):
+            compiled = compile_model_policy(assignment, policy)
+            key = (compiled.organization_id, compiled.callable_key)
+            if compiled.access_mode == "deny":
+                _set_if_better(deny_candidates, key, compiled)
+            else:
+                _set_if_better(allow_candidates, key, compiled)
+
+    org_model_policy: dict[tuple[str, str], CompiledTierModelPolicy] = {}
+    org_allowed_callable_keys: dict[str, set[str]] = {
+        organization_id: set() for organization_id in explicit_orgs
+    }
+    pricing_policies: dict[tuple[str, str, str], CompiledTierPricingPolicy] = {}
+    rate_limit_descriptors: dict[tuple[str, str], tuple[CompiledTierRateLimitDescriptor, ...]] = {}
+
+    for key in sorted(set(allow_candidates) | set(deny_candidates)):
+        deny_policy = deny_candidates.get(key)
+        if deny_policy is not None:
+            org_model_policy[key] = deny_policy
+            continue
+
+        allow_policy = allow_candidates[key]
+        org_model_policy[key] = allow_policy
+        org_allowed_callable_keys.setdefault(allow_policy.organization_id, set()).add(
+            allow_policy.callable_key
+        )
+        pricing_policies.update(compile_pricing_policies(allow_policy))
+        descriptors = compile_rate_limit_descriptors(allow_policy)
+        if descriptors:
+            rate_limit_descriptors[key] = descriptors
+
+    capacity_pool_policy = compile_capacity_pools(capacity_pools)
+
+    return TierPolicySnapshot(
+        etag=_snapshot_etag(assignments, model_policies, capacity_pools),
+        generated_at=generated_at,
+        next_transition_at=next_transition_at,
+        org_allowed_callable_keys=MappingProxyType(
+            {
+                org_id: frozenset(callable_keys)
+                for org_id, callable_keys in org_allowed_callable_keys.items()
+            }
+        ),
+        org_model_policy=MappingProxyType(org_model_policy),
+        pricing_policies=MappingProxyType(pricing_policies),
+        rate_limit_descriptors=MappingProxyType(rate_limit_descriptors),
+        capacity_pool_policy=MappingProxyType(capacity_pool_policy),
+        org_tier_keys=MappingProxyType(
+            {
+                org_id: tuple(sorted(tier_keys))
+                for org_id, tier_keys in org_tier_keys.items()
+            }
+        ),
+        org_has_explicit_tier_policy=frozenset(explicit_orgs),
+        assignment_count=len(assignments),
+        model_policy_count=len(model_policies),
+        capacity_pool_count=len(capacity_pools),
+    )
+
+
+def _set_if_better(
+    candidates: dict[tuple[str, str], CompiledTierModelPolicy],
+    key: tuple[str, str],
+    policy: CompiledTierModelPolicy,
+) -> None:
+    existing = candidates.get(key)
+    if existing is None or _policy_rank(policy) > _policy_rank(existing):
+        candidates[key] = policy
+
+
+def _policy_rank(policy: CompiledTierModelPolicy) -> tuple[int, int, int, int, str, str]:
+    source = policy.source
+    return (
+        _ASSIGNMENT_RANK.get(source.assignment_type, 0),
+        int(source.assignment_weight or 0),
+        int(source.model_policy_priority or 0),
+        int(source.tier_version_number or 0),
+        source.assignment_id,
+        source.model_policy_id or "",
+    )
+
+
+def _assignment_is_active(assignment: TierPolicyAssignmentRecord, now: datetime) -> bool:
+    if not assignment.enabled or not assignment.organization_id or not assignment.effective_tier_version_id:
+        return False
+    if str(assignment.tier_version_status or "").strip().lower() != "active":
+        return False
+    starts_at = _utc_or_none(assignment.starts_at)
+    ends_at = _utc_or_none(assignment.ends_at)
+    if starts_at is not None and starts_at > now:
+        return False
+    return not (ends_at is not None and ends_at <= now)
+
+
+def _next_transition_at(
+    assignments: Sequence[TierPolicyAssignmentRecord],
+    now: datetime,
+    *,
+    provided: datetime | None,
+) -> datetime | None:
+    candidates: list[datetime] = []
+    provided_at = _utc_or_none(provided)
+    if provided_at is not None and provided_at >= now:
+        candidates.append(provided_at)
+
+    for assignment in assignments:
+        if not assignment.enabled or not assignment.organization_id or not assignment.effective_tier_version_id:
+            continue
+        if str(assignment.tier_version_status or "").strip().lower() != "active":
+            continue
+
+        starts_at = _utc_or_none(assignment.starts_at)
+        ends_at = _utc_or_none(assignment.ends_at)
+        if starts_at is not None and starts_at > now:
+            candidates.append(starts_at)
+            continue
+        if ends_at is not None and ends_at > now:
+            candidates.append(ends_at)
+
+    return min(candidates) if candidates else None
+
+
+def _snapshot_etag(
+    assignments: Sequence[TierPolicyAssignmentRecord],
+    policies: Sequence[TierModelPolicyRecord],
+    pools: Sequence[TierCapacityPoolRecord],
+) -> str:
+    payload = {
+        "assignments": [_record_dict(item) for item in assignments],
+        "model_policies": [_record_dict(item) for item in policies],
+        "capacity_pools": [_record_dict(item) for item in pools],
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:24]
+
+
+def _record_dict(record: Any) -> dict[str, Any]:
+    if is_dataclass(record):
+        return {
+            field.name: _etag_value(getattr(record, field.name))
+            for field in fields(record)
+        }
+    payload: dict[str, Any] = {}
+    for key, value in getattr(record, "__dict__", {}).items():
+        payload[key] = _etag_value(value)
+    return payload
+
+
+def _etag_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return _utc(value).isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _etag_value(nested) for key, nested in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_etag_value(item) for item in value]
+    return value
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _utc_or_none(value: datetime | None) -> datetime | None:
+    return _utc(value) if value is not None else None

--- a/src/services/tier_policy_invalidation.py
+++ b/src/services/tier_policy_invalidation.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class TierPolicyInvalidationResult:
+    attempted: bool
+    reloaded: bool
+    notified: bool
+    reason: str
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "attempted": self.attempted,
+            "reloaded": self.reloaded,
+            "notified": self.notified,
+            "reason": self.reason,
+        }
+        if self.error is not None:
+            payload["error"] = self.error
+        return payload
+
+
+async def reload_tier_policy(
+    request: Request,
+    *,
+    notify: bool = True,
+) -> TierPolicyInvalidationResult:
+    return await reload_tier_policy_for_app(request.app, notify=notify)
+
+
+async def reload_tier_policy_for_app(
+    app: Any,
+    *,
+    notify: bool = True,
+) -> TierPolicyInvalidationResult:
+    invalidation = getattr(app.state, "governance_invalidation_service", None)
+    service = getattr(app.state, "tier_policy_service", None)
+    if service is None and invalidation is not None:
+        service = getattr(invalidation, "tier_policy_service", None)
+
+    if _service_mode(service) == "disabled":
+        return TierPolicyInvalidationResult(
+            attempted=False,
+            reloaded=False,
+            notified=False,
+            reason="tier_policy_disabled",
+        )
+
+    if invalidation is not None and callable(getattr(invalidation, "invalidate_local", None)):
+        reloaded = True
+        local_error: str | None = None
+        try:
+            await invalidation.invalidate_local("tier_policy")
+        except Exception as exc:
+            logger.warning("failed reloading local tier policy snapshot: %s", exc)
+            reloaded = False
+            local_error = str(exc)
+
+        notify_method = getattr(invalidation, "notify", None)
+        notify_attempted = bool(notify and callable(notify_method))
+        notified = False
+        notify_error: str | None = None
+        if notify_attempted:
+            try:
+                notify_result = await notify_method("tier_policy")
+            except Exception as exc:
+                logger.warning("failed notifying tier policy snapshot invalidation: %s", exc)
+                notify_error = str(exc)
+            else:
+                notified = True if notify_result is None else bool(notify_result)
+
+        return TierPolicyInvalidationResult(
+            attempted=True,
+            reloaded=reloaded,
+            notified=notified,
+            reason=_governance_reload_reason(
+                reloaded=reloaded,
+                notified=notified,
+                notify_attempted=notify_attempted,
+                notify_error=notify_error,
+            ),
+            error=_combined_error(
+                local_error=local_error,
+                notify_error=notify_error,
+            ),
+        )
+
+    if service is not None and callable(getattr(service, "reload", None)):
+        try:
+            await service.reload()
+        except Exception as exc:
+            logger.warning("failed reloading tier policy snapshot: %s", exc)
+            return TierPolicyInvalidationResult(
+                attempted=True,
+                reloaded=False,
+                notified=False,
+                reason="reload_failed",
+                error=str(exc),
+            )
+        return TierPolicyInvalidationResult(
+            attempted=True,
+            reloaded=True,
+            notified=False,
+            reason="reloaded_without_broadcast",
+        )
+
+    return TierPolicyInvalidationResult(
+        attempted=False,
+        reloaded=False,
+        notified=False,
+        reason="service_unavailable",
+    )
+
+
+def _governance_reload_reason(
+    *,
+    reloaded: bool,
+    notified: bool,
+    notify_attempted: bool,
+    notify_error: str | None,
+) -> str:
+    if reloaded:
+        if notified:
+            return "reloaded_and_notified"
+        if notify_error is not None:
+            return "remote_notify_failed"
+        if notify_attempted:
+            return "remote_notify_unavailable"
+        return "reloaded"
+
+    if notified:
+        return "local_reload_failed_remote_notified"
+    if notify_error is not None:
+        return "local_reload_failed_remote_notify_failed"
+    if notify_attempted:
+        return "local_reload_failed_remote_notify_unavailable"
+    return "local_reload_failed"
+
+
+def _combined_error(
+    *,
+    local_error: str | None,
+    notify_error: str | None,
+) -> str | None:
+    if local_error and notify_error:
+        return f"{local_error}; remote notify failed: {notify_error}"
+    return local_error or notify_error
+
+
+def _service_mode(service: Any | None) -> str | None:
+    if service is None:
+        return None
+    mode = str(getattr(service, "mode", "") or "").strip().lower()
+    return mode or None

--- a/src/services/tier_policy_models.py
+++ b/src/services/tier_policy_models.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+FrozenMetadata = Mapping[str, Any]
+FrozenPricing = Mapping[str, float]
+
+
+@dataclass(frozen=True, slots=True)
+class TierPolicySource:
+    assignment_id: str
+    organization_id: str
+    tier_id: str
+    tier_key: str | None
+    tier_version_id: str
+    tier_version_number: int | None
+    assignment_type: str
+    assignment_weight: int
+    model_policy_id: str | None = None
+    model_policy_priority: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class TierPolicyLimits:
+    rpm_limit: int | None = None
+    tpm_limit: int | None = None
+    rph_limit: int | None = None
+    rpd_limit: int | None = None
+    tpd_limit: int | None = None
+    max_parallel_requests: int | None = None
+    batch_rpm_limit: int | None = None
+    batch_tpm_limit: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledTierModelPolicy:
+    organization_id: str
+    callable_key: str
+    access_mode: str
+    source: TierPolicySource
+    limits: TierPolicyLimits
+    pricing: FrozenPricing
+    capacity_pool_key: str | None = None
+    metadata: FrozenMetadata | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledTierPricingPolicy:
+    organization_id: str
+    callable_key: str
+    mode: str
+    pricing: FrozenPricing
+    source: TierPolicySource
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledTierRateLimitDescriptor:
+    scope: str
+    entity_id: str
+    limit: int
+    amount_kind: str
+    window_seconds: int
+    mode: str = "sync"
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledTierCapacityPoolPolicy:
+    pool_key: str
+    callable_key: str
+    rpm_capacity: int | None
+    tpm_capacity: int | None
+    max_parallel_requests: int | None
+    strategy: str
+    saturation_threshold: float | None
+    burst_multiplier: float | None
+    source_tier_version_ids: tuple[str, ...]
+    source_pool_ids: tuple[str, ...]
+    metadata: FrozenMetadata | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TierPolicySnapshot:
+    etag: str
+    generated_at: datetime
+    next_transition_at: datetime | None
+    org_allowed_callable_keys: Mapping[str, frozenset[str]]
+    org_model_policy: Mapping[tuple[str, str], CompiledTierModelPolicy]
+    pricing_policies: Mapping[tuple[str, str, str], CompiledTierPricingPolicy]
+    rate_limit_descriptors: Mapping[tuple[str, str], tuple[CompiledTierRateLimitDescriptor, ...]]
+    capacity_pool_policy: Mapping[tuple[str, str], CompiledTierCapacityPoolPolicy]
+    org_tier_keys: Mapping[str, tuple[str, ...]]
+    org_has_explicit_tier_policy: frozenset[str]
+    assignment_count: int = 0
+    model_policy_count: int = 0
+    capacity_pool_count: int = 0
+
+    @property
+    def org_count(self) -> int:
+        return len(self.org_has_explicit_tier_policy)
+
+
+def empty_tier_policy_snapshot(*, generated_at: datetime | None = None) -> TierPolicySnapshot:
+    return TierPolicySnapshot(
+        etag="empty",
+        generated_at=generated_at or datetime.now(tz=UTC),
+        next_transition_at=None,
+        org_allowed_callable_keys=MappingProxyType({}),
+        org_model_policy=MappingProxyType({}),
+        pricing_policies=MappingProxyType({}),
+        rate_limit_descriptors=MappingProxyType({}),
+        capacity_pool_policy=MappingProxyType({}),
+        org_tier_keys=MappingProxyType({}),
+        org_has_explicit_tier_policy=frozenset(),
+    )

--- a/src/services/tier_policy_service.py
+++ b/src/services/tier_policy_service.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+from src.db.tiers import TierPolicyLoadResult
+from src.services.tier_policy_compiler import compile_tier_policy_snapshot
+from src.services.tier_policy_models import (
+    CompiledTierCapacityPoolPolicy,
+    CompiledTierModelPolicy,
+    CompiledTierPricingPolicy,
+    CompiledTierRateLimitDescriptor,
+    TierPolicySnapshot,
+    empty_tier_policy_snapshot,
+)
+
+logger = logging.getLogger(__name__)
+
+TierPolicyMode = Literal["disabled", "shadow", "enforce"]
+TierPolicyMissingServiceMode = Literal["fail_open", "fail_closed"]
+
+
+class TierPolicyBackendUnavailableError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class TierPolicySnapshotInfo:
+    etag: str
+    generated_at: datetime
+    org_count: int
+    assignment_count: int
+    model_policy_count: int
+    capacity_pool_count: int
+    next_transition_at: datetime | None
+    mode: str
+    snapshot_stale: bool
+    last_reload_failed: bool
+    last_reload_error_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class TierPolicyAvailabilityDecision:
+    allowed: bool
+    reason: str
+    mode: str
+    missing_service_mode: str
+    explicit_tier_policy: bool | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "mode": self.mode,
+            "missing_service_mode": self.missing_service_mode,
+            "explicit_tier_policy": self.explicit_tier_policy,
+        }
+
+
+class TierPolicyService:
+    def __init__(
+        self,
+        *,
+        repository: Any | None,
+        mode: TierPolicyMode = "disabled",
+        missing_service_mode: TierPolicyMissingServiceMode = "fail_open",
+        refresh_interval_seconds: float = 300.0,
+        refresh_jitter_seconds: float = 1.0,
+        transition_grace_seconds: float = 0.05,
+        refresh_retry_delay_seconds: float = 5.0,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.repository = repository
+        self.mode = _normalize_mode(mode)
+        self.missing_service_mode = _normalize_missing_service_mode(missing_service_mode)
+        self.refresh_interval_seconds = _positive_float(
+            refresh_interval_seconds,
+            default=300.0,
+        )
+        self.refresh_jitter_seconds = _non_negative_float(
+            refresh_jitter_seconds,
+            default=1.0,
+        )
+        self.transition_grace_seconds = _non_negative_float(
+            transition_grace_seconds,
+            default=0.05,
+        )
+        self.refresh_retry_delay_seconds = _positive_float(
+            refresh_retry_delay_seconds,
+            default=5.0,
+        )
+        self._clock = clock or (lambda: datetime.now(tz=UTC))
+        self._reload_lock = asyncio.Lock()
+        self._refresh_wakeup = asyncio.Event()
+        self._refresh_task: asyncio.Task[None] | None = None
+        self._stopping = False
+        self._retry_after: datetime | None = None
+        self._snapshot_stale = self.mode != "disabled"
+        self._last_reload_failed = False
+        self._last_reload_error_at: datetime | None = None
+        self._snapshot = empty_tier_policy_snapshot(generated_at=self._clock())
+
+    async def start(self) -> None:
+        if self.mode == "disabled":
+            return
+        if self._refresh_task is not None and not self._refresh_task.done():
+            return
+        self._stopping = False
+        self._refresh_task = asyncio.create_task(self._refresh_loop())
+
+    async def close(self) -> None:
+        self._stopping = True
+        self._refresh_wakeup.set()
+        if self._refresh_task is None:
+            return
+        self._refresh_task.cancel()
+        try:
+            await self._refresh_task
+        except asyncio.CancelledError:
+            pass
+        self._refresh_task = None
+
+    async def reload(self, *, reason: str = "manual") -> TierPolicySnapshot:
+        async with self._reload_lock:
+            if self.mode == "disabled":
+                self._snapshot = empty_tier_policy_snapshot(generated_at=self._clock())
+                self._retry_after = None
+                self._snapshot_stale = False
+                self._last_reload_failed = False
+                self._last_reload_error_at = None
+                self._wake_refresh_loop()
+                return self._snapshot
+
+            generated_at = self._clock()
+            if self.repository is None:
+                self._mark_reload_failure()
+                raise TierPolicyBackendUnavailableError("tier policy repository unavailable")
+
+            loader = getattr(self.repository, "load_active_tier_policy_inputs", None)
+            if loader is None:
+                self._mark_reload_failure()
+                raise TierPolicyBackendUnavailableError("tier policy repository loader unavailable")
+
+            try:
+                inputs = await loader(reference_time=generated_at)
+                if not isinstance(inputs, TierPolicyLoadResult):
+                    inputs = TierPolicyLoadResult(
+                        assignments=tuple(getattr(inputs, "assignments", ()) or ()),
+                        model_policies=tuple(getattr(inputs, "model_policies", ()) or ()),
+                        capacity_pools=tuple(getattr(inputs, "capacity_pools", ()) or ()),
+                        next_transition_at=getattr(inputs, "next_transition_at", None),
+                    )
+                snapshot = compile_tier_policy_snapshot(
+                    inputs,
+                    generated_at=generated_at,
+                    reference_time=generated_at,
+                )
+            except Exception:
+                self._mark_reload_failure()
+                logger.exception("failed reloading tier policy snapshot")
+                raise
+
+            self._snapshot = snapshot
+            self._retry_after = None
+            self._snapshot_stale = False
+            self._last_reload_failed = False
+            self._last_reload_error_at = None
+            self._wake_refresh_loop()
+            logger.info(
+                "tier policy snapshot reloaded",
+                extra={
+                    "reason": reason,
+                    "etag": snapshot.etag,
+                    "org_count": snapshot.org_count,
+                    "assignment_count": snapshot.assignment_count,
+                    "model_policy_count": snapshot.model_policy_count,
+                    "capacity_pool_count": snapshot.capacity_pool_count,
+                    "next_transition_at": (
+                        snapshot.next_transition_at.isoformat()
+                        if snapshot.next_transition_at is not None
+                        else None
+                    ),
+                },
+            )
+            return snapshot
+
+    async def invalidate_all(self) -> TierPolicySnapshot:
+        return await self.reload(reason="invalidation")
+
+    def get_snapshot(self) -> TierPolicySnapshot:
+        return self._snapshot
+
+    def snapshot_info(self) -> TierPolicySnapshotInfo:
+        snapshot = self._snapshot
+        return TierPolicySnapshotInfo(
+            etag=snapshot.etag,
+            generated_at=snapshot.generated_at,
+            org_count=snapshot.org_count,
+            assignment_count=snapshot.assignment_count,
+            model_policy_count=snapshot.model_policy_count,
+            capacity_pool_count=snapshot.capacity_pool_count,
+            next_transition_at=snapshot.next_transition_at,
+            mode=self.mode,
+            snapshot_stale=self._snapshot_stale,
+            last_reload_failed=self._last_reload_failed,
+            last_reload_error_at=self._last_reload_error_at,
+        )
+
+    @property
+    def snapshot_stale(self) -> bool:
+        return self._snapshot_stale
+
+    @property
+    def last_reload_failed(self) -> bool:
+        return self._last_reload_failed
+
+    @property
+    def last_reload_error_at(self) -> datetime | None:
+        return self._last_reload_error_at
+
+    def has_explicit_tier_policy(self, organization_id: str | None) -> bool:
+        normalized = _normalize_id(organization_id)
+        return bool(normalized and normalized in self._snapshot.org_has_explicit_tier_policy)
+
+    def resolve_unavailable_decision(
+        self,
+        organization_id: str | None,
+    ) -> TierPolicyAvailabilityDecision:
+        return resolve_tier_policy_unavailable_decision(
+            self,
+            organization_id,
+            mode=self.mode,
+            missing_service_mode=self.missing_service_mode,
+        )
+
+    def resolve_org_allowed_callable_keys(
+        self,
+        organization_id: str | None,
+    ) -> frozenset[str] | None:
+        normalized = _normalize_id(organization_id)
+        if not normalized:
+            return None
+        if normalized not in self._snapshot.org_has_explicit_tier_policy:
+            return None
+        return self._snapshot.org_allowed_callable_keys.get(normalized, frozenset())
+
+    def get_model_policy(
+        self,
+        organization_id: str | None,
+        callable_key: str | None,
+    ) -> CompiledTierModelPolicy | None:
+        key = _org_model_key(organization_id, callable_key)
+        return self._snapshot.org_model_policy.get(key) if key is not None else None
+
+    def get_pricing_policy(
+        self,
+        organization_id: str | None,
+        callable_key: str | None,
+        *,
+        mode: str = "sync",
+    ) -> CompiledTierPricingPolicy | None:
+        key = _org_model_key(organization_id, callable_key)
+        if key is None:
+            return None
+        return self._snapshot.pricing_policies.get((*key, str(mode or "sync").strip().lower()))
+
+    def get_rate_limit_descriptors(
+        self,
+        organization_id: str | None,
+        callable_key: str | None,
+    ) -> tuple[CompiledTierRateLimitDescriptor, ...]:
+        key = _org_model_key(organization_id, callable_key)
+        if key is None:
+            return ()
+        return self._snapshot.rate_limit_descriptors.get(key, ())
+
+    def get_capacity_pool_policy(
+        self,
+        pool_key: str | None,
+        callable_key: str | None,
+    ) -> CompiledTierCapacityPoolPolicy | None:
+        normalized_pool_key = _normalize_id(pool_key)
+        normalized_callable_key = _normalize_id(callable_key)
+        if normalized_pool_key is None or normalized_callable_key is None:
+            return None
+        return self._snapshot.capacity_pool_policy.get(
+            (normalized_pool_key, normalized_callable_key)
+        )
+
+    async def _refresh_loop(self) -> None:
+        while not self._stopping:
+            delay_seconds = self._next_refresh_delay_seconds()
+            woke = await self._wait_for_wakeup(delay_seconds)
+            if woke or self._stopping:
+                continue
+            try:
+                await self.reload(reason="scheduled")
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("scheduled tier policy snapshot reload failed: %s", exc)
+
+    async def _wait_for_wakeup(self, delay_seconds: float) -> bool:
+        if self._refresh_wakeup.is_set():
+            self._refresh_wakeup.clear()
+            return True
+        if delay_seconds <= 0:
+            await asyncio.sleep(0)
+            return False
+        try:
+            await asyncio.wait_for(self._refresh_wakeup.wait(), timeout=delay_seconds)
+        except TimeoutError:
+            return False
+        self._refresh_wakeup.clear()
+        return True
+
+    def _next_refresh_delay_seconds(self) -> float:
+        now = _utc(self._clock())
+        if self._retry_after is not None:
+            return max((_utc(self._retry_after) - now).total_seconds(), 0.0)
+
+        delay_seconds = self.refresh_interval_seconds
+        transition_at = self._snapshot.next_transition_at
+        if transition_at is not None:
+            seconds_until_transition = (_utc(transition_at) - now).total_seconds()
+            delay_seconds = min(
+                max(seconds_until_transition + self.transition_grace_seconds, 0.0),
+                self.refresh_interval_seconds,
+            )
+        if self.refresh_jitter_seconds > 0:
+            delay_seconds += random.uniform(0.0, self.refresh_jitter_seconds)
+        return delay_seconds
+
+    def _wake_refresh_loop(self) -> None:
+        current_task = asyncio.current_task()
+        if self._refresh_task is not None and current_task is not self._refresh_task:
+            self._refresh_wakeup.set()
+
+    def _schedule_reload_retry(self, reference_time: datetime) -> None:
+        self._retry_after = _utc(reference_time) + timedelta(
+            seconds=self.refresh_retry_delay_seconds
+        )
+        self._wake_refresh_loop()
+
+    def _mark_reload_failure(self) -> None:
+        failed_at = _utc(self._clock())
+        self._snapshot_stale = True
+        self._last_reload_failed = True
+        self._last_reload_error_at = failed_at
+        self._schedule_reload_retry(failed_at)
+
+
+def _org_model_key(
+    organization_id: str | None,
+    callable_key: str | None,
+) -> tuple[str, str] | None:
+    normalized_org = _normalize_id(organization_id)
+    normalized_callable = _normalize_id(callable_key)
+    if normalized_org is None or normalized_callable is None:
+        return None
+    return normalized_org, normalized_callable
+
+
+def _normalize_id(value: str | None) -> str | None:
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _positive_float(value: float, *, default: float) -> float:
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError):
+        return default
+    return normalized if normalized > 0 else default
+
+
+def _non_negative_float(value: float, *, default: float) -> float:
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError):
+        return default
+    return normalized if normalized >= 0 else default
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _normalize_mode(value: str) -> TierPolicyMode:
+    normalized = str(value or "disabled").strip().lower()
+    if normalized not in {"disabled", "shadow", "enforce"}:
+        return "disabled"
+    return normalized  # type: ignore[return-value]
+
+
+def _normalize_missing_service_mode(value: str) -> TierPolicyMissingServiceMode:
+    normalized = str(value or "fail_open").strip().lower()
+    if normalized not in {"fail_open", "fail_closed"}:
+        return "fail_open"
+    return normalized  # type: ignore[return-value]
+
+
+def resolve_tier_policy_unavailable_decision(
+    service: TierPolicyService | None,
+    organization_id: str | None,
+    *,
+    mode: str = "disabled",
+    missing_service_mode: str = "fail_open",
+) -> TierPolicyAvailabilityDecision:
+    resolved_mode = _normalize_mode(str(getattr(service, "mode", mode) if service else mode))
+    resolved_missing_service_mode = _normalize_missing_service_mode(
+        str(
+            getattr(service, "missing_service_mode", missing_service_mode)
+            if service
+            else missing_service_mode
+        )
+    )
+    if resolved_mode == "disabled":
+        return TierPolicyAvailabilityDecision(
+            allowed=True,
+            reason="tier_policy_disabled",
+            mode=resolved_mode,
+            missing_service_mode=resolved_missing_service_mode,
+            explicit_tier_policy=False if service is not None else None,
+        )
+    if resolved_missing_service_mode == "fail_open":
+        return TierPolicyAvailabilityDecision(
+            allowed=True,
+            reason="tier_policy_unavailable_fail_open",
+            mode=resolved_mode,
+            missing_service_mode=resolved_missing_service_mode,
+            explicit_tier_policy=(
+                service.has_explicit_tier_policy(organization_id) if service is not None else None
+            ),
+        )
+
+    explicit_tier_policy = (
+        service.has_explicit_tier_policy(organization_id) if service is not None else None
+    )
+    if service is not None and service.snapshot_stale:
+        return TierPolicyAvailabilityDecision(
+            allowed=False,
+            reason="tier_policy_unavailable_snapshot_stale",
+            mode=resolved_mode,
+            missing_service_mode=resolved_missing_service_mode,
+            explicit_tier_policy=explicit_tier_policy,
+        )
+    if explicit_tier_policy is False:
+        return TierPolicyAvailabilityDecision(
+            allowed=True,
+            reason="tier_policy_unavailable_no_explicit_policy",
+            mode=resolved_mode,
+            missing_service_mode=resolved_missing_service_mode,
+            explicit_tier_policy=False,
+        )
+
+    return TierPolicyAvailabilityDecision(
+        allowed=False,
+        reason="tier_policy_unavailable_fail_closed",
+        mode=resolved_mode,
+        missing_service_mode=resolved_missing_service_mode,
+        explicit_tier_policy=explicit_tier_policy,
+    )

--- a/tests/bootstrap/test_runtime_services_bootstrap.py
+++ b/tests/bootstrap/test_runtime_services_bootstrap.py
@@ -7,10 +7,24 @@ import pytest
 from src.bootstrap.runtime_services import init_runtime_services, shutdown_runtime_services
 
 
-def _runtime_config() -> SimpleNamespace:
+def _runtime_config(
+    *,
+    tier_policy_mode: str = "shadow",
+    tier_policy_missing_service_mode: str = "fail_closed",
+    tier_policy_refresh_interval_seconds: float = 300.0,
+    tier_policy_refresh_jitter_seconds: float = 1.0,
+    tier_policy_transition_grace_seconds: float = 0.05,
+    tier_policy_refresh_retry_delay_seconds: float = 5.0,
+) -> SimpleNamespace:
     return SimpleNamespace(
         general_settings=SimpleNamespace(
             budget_alert_ttl_seconds=3600,
+            tier_policy_mode=tier_policy_mode,
+            tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+            tier_policy_refresh_interval_seconds=tier_policy_refresh_interval_seconds,
+            tier_policy_refresh_jitter_seconds=tier_policy_refresh_jitter_seconds,
+            tier_policy_transition_grace_seconds=tier_policy_transition_grace_seconds,
+            tier_policy_refresh_retry_delay_seconds=tier_policy_refresh_retry_delay_seconds,
         ),
         deltallm_settings=SimpleNamespace(
             guardrails=[{"guardrail_name": "pii"}],
@@ -19,14 +33,54 @@ def _runtime_config() -> SimpleNamespace:
             callbacks=["shared"],
             callback_settings={"shared": {"url": "https://example.com"}},
             turn_off_message_logging=True,
+        ),
+    )
+
+
+def _runtime_config_without_tier_policy_settings() -> SimpleNamespace:
+    config = _runtime_config()
+    for field_name in (
+        "tier_policy_mode",
+        "tier_policy_missing_service_mode",
+        "tier_policy_refresh_interval_seconds",
+        "tier_policy_refresh_jitter_seconds",
+        "tier_policy_transition_grace_seconds",
+        "tier_policy_refresh_retry_delay_seconds",
+    ):
+        delattr(config.general_settings, field_name)
+    return config
+
+
+def _runtime_app(*, settings: SimpleNamespace | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            settings=settings,
+            prompt_registry_repository="prompt-repo",
+            route_group_repository="route-group-repo",
+            tier_repository="tier-repo",
+            mcp_repository="mcp-repo",
+            mcp_scope_policy_repository="mcp-scope-policy-repo",
+            redis="redis-client",
+            http_client="http-client",
+            upstream_http_settings="startup-upstream-settings",
+            limit_counter="limit-counter",
+            cache_backend="cache-backend",
+            prisma_manager=SimpleNamespace(client="db-client"),
         )
     )
 
 
-@pytest.mark.asyncio
-async def test_init_and_shutdown_runtime_services(monkeypatch: pytest.MonkeyPatch) -> None:
-    created: dict[str, object] = {}
+def _status_map(runtime) -> dict[str, str]:  # noqa: ANN001
+    return {status.name: status.state for status in runtime.statuses}
 
+
+def _install_runtime_service_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    created: dict[str, object],
+    *,
+    tier_policy_reload_error: Exception | None = None,
+    prompt_registry_error: Exception | None = None,
+) -> None:
     class FakeGuardrailRegistry:
         def __init__(self) -> None:
             self.loaded = None
@@ -59,8 +113,27 @@ async def test_init_and_shutdown_runtime_services(monkeypatch: pytest.MonkeyPatc
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setattr("src.bootstrap.runtime_services.PromptRegistryService", lambda **kwargs: ("prompt-registry", kwargs))
-    monkeypatch.setattr("src.bootstrap.runtime_services.MCPRegistryService", lambda **kwargs: ("mcp-registry", kwargs))
+    class FakeTierPolicyService:
+        def __init__(self, **kwargs) -> None:  # noqa: ANN003
+            self.kwargs = kwargs
+            self.mode = kwargs["mode"]
+            self.missing_service_mode = kwargs["missing_service_mode"]
+            self.reloaded = False
+            self.started = False
+            self.closed = False
+            created["tier_policy_service"] = self
+
+        async def reload(self) -> None:
+            self.reloaded = True
+            if tier_policy_reload_error is not None:
+                raise tier_policy_reload_error
+
+        async def start(self) -> None:
+            self.started = True
+
+        async def close(self) -> None:
+            self.closed = True
+
     class FakeMCPGovernanceService:
         def __init__(self, **kwargs) -> None:  # noqa: ANN003
             self.kwargs = kwargs
@@ -69,42 +142,83 @@ async def test_init_and_shutdown_runtime_services(monkeypatch: pytest.MonkeyPatc
         async def reload(self) -> None:
             self.reloaded = True
 
-    monkeypatch.setattr("src.bootstrap.runtime_services.MCPGovernanceService", FakeMCPGovernanceService)
+    def fake_prompt_registry_service(**kwargs):  # noqa: ANN003, ANN202
+        if prompt_registry_error is not None:
+            raise prompt_registry_error
+        return ("prompt-registry", kwargs)
+
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.PromptRegistryService",
+        fake_prompt_registry_service,
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.MCPRegistryService",
+        lambda **kwargs: ("mcp-registry", kwargs),
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.MCPGovernanceService",
+        FakeMCPGovernanceService,
+    )
     monkeypatch.setattr(
         "src.bootstrap.runtime_services.StreamableHTTPMCPClient",
         lambda client, **kwargs: ("mcp-client", client, kwargs),
     )
-    monkeypatch.setattr("src.bootstrap.runtime_services.MCPHealthProbe", lambda **kwargs: ("mcp-health", kwargs))
-    monkeypatch.setattr("src.bootstrap.runtime_services.MCPToolPolicyEnforcer", lambda limit_counter: ("policy", limit_counter))
-    monkeypatch.setattr("src.bootstrap.runtime_services.MCPToolResultCache", lambda cache_backend: ("result-cache", cache_backend))
-    monkeypatch.setattr("src.bootstrap.runtime_services.MCPApprovalService", lambda repository: ("approval", repository))
-    monkeypatch.setattr("src.bootstrap.runtime_services.MCPGatewayService", lambda **kwargs: ("mcp-gateway", kwargs))
-    monkeypatch.setattr("src.bootstrap.runtime_services.GovernanceInvalidationService", FakeGovernanceInvalidationService)
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.MCPHealthProbe",
+        lambda **kwargs: ("mcp-health", kwargs),
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.MCPToolPolicyEnforcer",
+        lambda limit_counter: ("policy", limit_counter),
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.MCPToolResultCache",
+        lambda cache_backend: ("result-cache", cache_backend),
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.MCPApprovalService",
+        lambda repository: ("approval", repository),
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.MCPGatewayService",
+        lambda **kwargs: ("mcp-gateway", kwargs),
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.GovernanceInvalidationService",
+        FakeGovernanceInvalidationService,
+    )
+    monkeypatch.setattr("src.bootstrap.runtime_services.TierPolicyService", FakeTierPolicyService)
     monkeypatch.setattr("src.bootstrap.runtime_services.GuardrailRegistry", FakeGuardrailRegistry)
-    monkeypatch.setattr("src.bootstrap.runtime_services.GuardrailMiddleware", lambda **kwargs: ("guardrail-middleware", kwargs))
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.GuardrailMiddleware",
+        lambda **kwargs: ("guardrail-middleware", kwargs),
+    )
     monkeypatch.setattr("src.bootstrap.runtime_services.CallbackManager", FakeCallbackManager)
-    monkeypatch.setattr("src.bootstrap.runtime_services.AlertService", lambda **kwargs: ("alert-service", kwargs))
-    monkeypatch.setattr("src.bootstrap.runtime_services.SpendLedgerService", lambda client: ("ledger", client))
-    monkeypatch.setattr("src.bootstrap.runtime_services.SpendTrackingService", lambda **kwargs: ("tracking", kwargs))
-    monkeypatch.setattr("src.bootstrap.runtime_services.BudgetEnforcementService", lambda **kwargs: ("budget", kwargs))
-
-    app = SimpleNamespace(
-        state=SimpleNamespace(
-            prompt_registry_repository="prompt-repo",
-            route_group_repository="route-group-repo",
-            mcp_repository="mcp-repo",
-            mcp_scope_policy_repository="mcp-scope-policy-repo",
-            redis="redis-client",
-            http_client="http-client",
-            upstream_http_settings="startup-upstream-settings",
-            limit_counter="limit-counter",
-            cache_backend="cache-backend",
-            prisma_manager=SimpleNamespace(client="db-client"),
-        )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.AlertService",
+        lambda **kwargs: ("alert-service", kwargs),
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.SpendLedgerService",
+        lambda client: ("ledger", client),
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.SpendTrackingService",
+        lambda **kwargs: ("tracking", kwargs),
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.BudgetEnforcementService",
+        lambda **kwargs: ("budget", kwargs),
     )
 
-    cfg = _runtime_config()
-    runtime = await init_runtime_services(app, cfg)
+
+@pytest.mark.asyncio
+async def test_init_and_shutdown_runtime_services(monkeypatch: pytest.MonkeyPatch) -> None:
+    created: dict[str, object] = {}
+    _install_runtime_service_fakes(monkeypatch, created)
+    app = _runtime_app()
+
+    runtime = await init_runtime_services(app, _runtime_config())
 
     assert app.state.prompt_registry_service[0] == "prompt-registry"
     assert app.state.mcp_transport_client == (
@@ -114,7 +228,23 @@ async def test_init_and_shutdown_runtime_services(monkeypatch: pytest.MonkeyPatc
     )
     assert app.state.mcp_gateway_service[0] == "mcp-gateway"
     assert app.state.mcp_governance_service.reloaded is True
+    assert app.state.tier_policy_service.reloaded is True
+    assert app.state.tier_policy_service.kwargs == {
+        "repository": "tier-repo",
+        "mode": "shadow",
+        "missing_service_mode": "fail_closed",
+        "refresh_interval_seconds": 300.0,
+        "refresh_jitter_seconds": 1.0,
+        "transition_grace_seconds": 0.05,
+        "refresh_retry_delay_seconds": 5.0,
+    }
+    assert app.state.tier_policy_service.started is True
+    assert _status_map(runtime)["tier_policy"] == "ready"
     assert app.state.governance_invalidation_service.started is True
+    assert (
+        created["governance_invalidation_service"].kwargs["tier_policy_service"]
+        is app.state.tier_policy_service
+    )
     assert app.state.guardrail_registry.loaded == [{"guardrail_name": "pii"}]
     assert app.state.guardrail_middleware[0] == "guardrail-middleware"
     assert app.state.turn_off_message_logging is True
@@ -125,4 +255,143 @@ async def test_init_and_shutdown_runtime_services(monkeypatch: pytest.MonkeyPatc
     await shutdown_runtime_services(runtime)
 
     assert created["governance_invalidation_service"].closed is True
+    assert created["tier_policy_service"].closed is True
     assert created["callback_manager"].shutdown_called is True
+
+
+@pytest.mark.asyncio
+async def test_init_runtime_services_skips_tier_policy_reload_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, object] = {}
+    _install_runtime_service_fakes(monkeypatch, created, tier_policy_reload_error=RuntimeError())
+    app = _runtime_app()
+
+    runtime = await init_runtime_services(app, _runtime_config(tier_policy_mode="disabled"))
+
+    assert app.state.tier_policy_service.reloaded is False
+    assert app.state.tier_policy_service.started is False
+    assert _status_map(runtime)["tier_policy"] == "disabled"
+    assert created["governance_invalidation_service"].kwargs["tier_policy_service"] is None
+
+    await shutdown_runtime_services(runtime)
+
+
+@pytest.mark.asyncio
+async def test_init_runtime_services_degrades_tier_policy_reload_failure_when_fail_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, object] = {}
+    _install_runtime_service_fakes(monkeypatch, created, tier_policy_reload_error=RuntimeError())
+    app = _runtime_app()
+
+    runtime = await init_runtime_services(
+        app,
+        _runtime_config(
+            tier_policy_mode="shadow",
+            tier_policy_missing_service_mode="fail_open",
+        ),
+    )
+
+    assert app.state.tier_policy_service.reloaded is True
+    assert app.state.tier_policy_service.started is True
+    assert _status_map(runtime)["tier_policy"] == "degraded"
+
+    await shutdown_runtime_services(runtime)
+
+
+@pytest.mark.asyncio
+async def test_init_runtime_services_raises_tier_policy_reload_failure_when_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, object] = {}
+    _install_runtime_service_fakes(
+        monkeypatch,
+        created,
+        tier_policy_reload_error=RuntimeError("snapshot unavailable"),
+    )
+
+    with pytest.raises(RuntimeError, match="snapshot unavailable"):
+        await init_runtime_services(
+            _runtime_app(),
+            _runtime_config(
+                tier_policy_mode="shadow",
+                tier_policy_missing_service_mode="fail_closed",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_init_runtime_services_does_not_start_tier_policy_when_later_bootstrap_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, object] = {}
+    _install_runtime_service_fakes(
+        monkeypatch,
+        created,
+        prompt_registry_error=RuntimeError("prompt registry unavailable"),
+    )
+
+    with pytest.raises(RuntimeError, match="prompt registry unavailable"):
+        await init_runtime_services(_runtime_app(), _runtime_config())
+
+    tier_policy_service = created["tier_policy_service"]
+    assert tier_policy_service.reloaded is True
+    assert tier_policy_service.started is False
+
+
+@pytest.mark.asyncio
+async def test_init_runtime_services_uses_settings_fallback_for_tier_policy_when_config_omits_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, object] = {}
+    _install_runtime_service_fakes(monkeypatch, created)
+    app = _runtime_app(
+        settings=SimpleNamespace(
+            tier_policy_mode="shadow",
+            tier_policy_missing_service_mode="fail_closed",
+            tier_policy_refresh_interval_seconds=42.0,
+            tier_policy_refresh_jitter_seconds=0.0,
+            tier_policy_transition_grace_seconds=0.2,
+            tier_policy_refresh_retry_delay_seconds=3.0,
+        )
+    )
+
+    runtime = await init_runtime_services(app, _runtime_config_without_tier_policy_settings())
+
+    assert app.state.tier_policy_service.kwargs == {
+        "repository": "tier-repo",
+        "mode": "shadow",
+        "missing_service_mode": "fail_closed",
+        "refresh_interval_seconds": 42.0,
+        "refresh_jitter_seconds": 0.0,
+        "transition_grace_seconds": 0.2,
+        "refresh_retry_delay_seconds": 3.0,
+    }
+    assert app.state.tier_policy_service.started is True
+    assert _status_map(runtime)["tier_policy"] == "ready"
+
+    await shutdown_runtime_services(runtime)
+
+
+@pytest.mark.asyncio
+async def test_init_runtime_services_prefers_explicit_config_over_settings_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, object] = {}
+    _install_runtime_service_fakes(monkeypatch, created)
+    app = _runtime_app(
+        settings=SimpleNamespace(
+            tier_policy_mode="shadow",
+            tier_policy_missing_service_mode="fail_closed",
+        )
+    )
+
+    runtime = await init_runtime_services(app, _runtime_config(tier_policy_mode="disabled"))
+
+    assert app.state.tier_policy_service.kwargs["mode"] == "disabled"
+    assert app.state.tier_policy_service.reloaded is False
+    assert app.state.tier_policy_service.started is False
+    assert _status_map(runtime)["tier_policy"] == "disabled"
+
+    await shutdown_runtime_services(runtime)

--- a/tests/db/test_tier_policy_repository.py
+++ b/tests/db/test_tier_policy_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -8,9 +9,46 @@ from src.db.tiers import (
     TierCapacityPoolRecord,
     TierModelPolicyRecord,
     TierRepository,
+    TierPolicyRepositoryUnavailableError,
 )
 
 from tests.db.tier_repository_fakes import _FakePrisma
+
+
+@pytest.mark.asyncio
+async def test_load_active_tier_policy_inputs_resolves_versions_and_bulk_loads_policy() -> None:
+    next_transition_at = datetime(2026, 6, 20, tzinfo=UTC) + timedelta(minutes=10)
+    prisma = _FakePrisma(
+        current_active_version_id="ver-active",
+        next_transition_at=next_transition_at,
+    )
+    repository = TierRepository(prisma)
+
+    result = await repository.load_active_tier_policy_inputs(
+        reference_time=datetime(2026, 6, 20, tzinfo=UTC),
+    )
+
+    assert len(result.assignments) == 1
+    assert result.assignments[0].organization_id == "org-1"
+    assert result.assignments[0].effective_tier_version_id == "ver-active"
+    assert len(result.model_policies) == 1
+    assert result.model_policies[0].tier_version_id == "ver-active"
+    assert result.model_policies[0].rpm_limit == 100
+    assert len(result.capacity_pools) == 1
+    assert result.capacity_pools[0].pool_key == "shared"
+    assert result.next_transition_at == next_transition_at
+    assert "JOIN LATERAL" in prisma.calls[0][0]
+    assert "tier_version_id IN ($1)" in prisma.calls[1][0]
+    assert "tier_version_id IN ($1)" in prisma.calls[2][0]
+    assert "MIN(transition_at) AS next_transition_at" in prisma.calls[3][0]
+
+
+@pytest.mark.asyncio
+async def test_load_active_tier_policy_inputs_rejects_missing_prisma() -> None:
+    repository = TierRepository(None)
+
+    with pytest.raises(TierPolicyRepositoryUnavailableError, match="database unavailable"):
+        await repository.load_active_tier_policy_inputs()
 
 
 @pytest.mark.asyncio

--- a/tests/db/tier_repository_fakes.py
+++ b/tests/db/tier_repository_fakes.py
@@ -17,6 +17,7 @@ class _FakePrisma:
         pinned_assignment_count: int = 0,
         active_assignment_count: int = 0,
         current_active_version_id: str | None = "ver-active",
+        next_transition_at: object = None,
         assignment_rows: dict[str, dict[str, object]] | None = None,
         organization_exists: bool = True,
     ) -> None:
@@ -34,6 +35,7 @@ class _FakePrisma:
         self.pinned_assignment_count = pinned_assignment_count
         self.active_assignment_count = active_assignment_count
         self.current_active_version_id = current_active_version_id
+        self.next_transition_at = next_transition_at
         self.assignment_rows = dict(assignment_rows or {})
         self.organization_exists = organization_exists
         self.tx_clients: list[_FakePrisma] = []
@@ -64,6 +66,29 @@ class _FakePrisma:
             return [{"tier_id": params[0]}] if self.assignment_tier_exists else []
         if "FROM deltallm_organizationtable" in sql and "WHERE organization_id = $1" in sql:
             return [{"organization_id": params[0]}] if self.organization_exists else []
+        if "MIN(transition_at) AS next_transition_at" in sql:
+            return [{"next_transition_at": self.next_transition_at}]
+        if "resolved_version.tier_version_id AS effective_tier_version_id" in sql:
+            if self.current_active_version_id is None:
+                return []
+            row = _assignment_row(
+                assignment_id="assignment-active",
+                fields=_assignment_fields(
+                    organization_id="org-1",
+                    tier_id="tier-1",
+                    tier_version_id=None,
+                    assignment_type="primary",
+                    enabled=True,
+                    weight=1,
+                    starts_at=None,
+                    ends_at=None,
+                    metadata={"reason": "signup"},
+                ),
+            )
+            row["effective_tier_version_id"] = self.current_active_version_id
+            row["tier_version_number"] = 2
+            row["tier_version_status"] = "active"
+            return [row]
         if "SELECT COUNT(*)::int AS overlap_count" in sql:
             return [{"overlap_count": self.overlap_count}]
         if (
@@ -159,6 +184,21 @@ class _FakePrisma:
                     metadata=params[15],
                 )
             ]
+        if "FROM deltallm_tiermodelpolicy" in sql and "tier_version_id IN" in sql:
+            return [
+                _model_policy_row(
+                    tier_version_id=str(params[0]),
+                    callable_key="openai/gpt-4.1",
+                    enabled=True,
+                    access_mode="allow",
+                    rpm_limit=100,
+                    tpm_limit=10_000,
+                    pricing={"input_cost_per_token": 0.001},
+                    capacity_pool_key="shared",
+                    priority=10,
+                    metadata={"region": "us"},
+                )
+            ]
         if "INSERT INTO deltallm_tiercapacitypool" in sql:
             return [
                 _capacity_pool_row(
@@ -172,6 +212,21 @@ class _FakePrisma:
                     saturation_threshold=params[7],
                     burst_multiplier=params[8],
                     metadata=params[9],
+                )
+            ]
+        if "FROM deltallm_tiercapacitypool" in sql and "tier_version_id IN" in sql:
+            return [
+                _capacity_pool_row(
+                    tier_version_id=str(params[0]),
+                    pool_key="shared",
+                    callable_key="openai/gpt-4.1",
+                    rpm_capacity=1_000,
+                    tpm_capacity=500_000,
+                    max_parallel_requests=25,
+                    strategy="hard_cap",
+                    saturation_threshold=0.8,
+                    burst_multiplier=1.5,
+                    metadata={"region": "us"},
                 )
             ]
         if "INSERT INTO deltallm_organizationtierassignment" in sql:
@@ -266,6 +321,7 @@ class _FakeTxContext:
             pinned_assignment_count=self.root.pinned_assignment_count,
             active_assignment_count=self.root.active_assignment_count,
             current_active_version_id=self.root.current_active_version_id,
+            next_transition_at=self.root.next_transition_at,
             assignment_rows=self.root.assignment_rows,
             organization_exists=self.root.organization_exists,
         )

--- a/tests/services/test_tier_policy_compiler.py
+++ b/tests/services/test_tier_policy_compiler.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from time import perf_counter
+
+from src.db.tiers import (
+    TierCapacityPoolRecord,
+    TierModelPolicyRecord,
+    TierPolicyAssignmentRecord,
+    TierPolicyLoadResult,
+)
+from src.services.tier_policy_compiler import compile_tier_policy_snapshot
+
+
+def _assignment(
+    assignment_id: str,
+    *,
+    organization_id: str = "org-1",
+    tier_key: str = "standard",
+    version_id: str = "version-1",
+    assignment_type: str = "primary",
+    weight: int = 1,
+    starts_at: datetime | None = None,
+    ends_at: datetime | None = None,
+    status: str = "active",
+) -> TierPolicyAssignmentRecord:
+    return TierPolicyAssignmentRecord(
+        assignment_id=assignment_id,
+        organization_id=organization_id,
+        tier_id=f"tier-{tier_key}",
+        tier_version_id=None,
+        effective_tier_version_id=version_id,
+        assignment_type=assignment_type,
+        enabled=True,
+        weight=weight,
+        starts_at=starts_at,
+        ends_at=ends_at,
+        tier_key=tier_key,
+        tier_name=tier_key.title(),
+        tier_version_number=1,
+        tier_version_status=status,
+    )
+
+
+def _policy(
+    policy_id: str,
+    *,
+    version_id: str = "version-1",
+    callable_key: str = "gpt-4o-mini",
+    access_mode: str = "allow",
+    priority: int = 0,
+    rpm_limit: int | None = None,
+    tpm_limit: int | None = None,
+    rph_limit: int | None = None,
+    rpd_limit: int | None = None,
+    tpd_limit: int | None = None,
+    max_parallel_requests: int | None = None,
+    batch_rpm_limit: int | None = None,
+    batch_tpm_limit: int | None = None,
+    pricing: dict[str, float] | None = None,
+    capacity_pool_key: str | None = None,
+) -> TierModelPolicyRecord:
+    return TierModelPolicyRecord(
+        tier_model_policy_id=policy_id,
+        tier_version_id=version_id,
+        callable_key=callable_key,
+        access_mode=access_mode,
+        priority=priority,
+        rpm_limit=rpm_limit,
+        tpm_limit=tpm_limit,
+        rph_limit=rph_limit,
+        rpd_limit=rpd_limit,
+        tpd_limit=tpd_limit,
+        max_parallel_requests=max_parallel_requests,
+        batch_rpm_limit=batch_rpm_limit,
+        batch_tpm_limit=batch_tpm_limit,
+        pricing=pricing,
+        capacity_pool_key=capacity_pool_key,
+    )
+
+
+def _pool(
+    pool_id: str,
+    *,
+    version_id: str = "version-1",
+    pool_key: str = "shared",
+    callable_key: str = "gpt-4o-mini",
+    rpm_capacity: int | None = None,
+    tpm_capacity: int | None = None,
+    max_parallel_requests: int | None = None,
+    strategy: str = "hard_cap",
+    saturation_threshold: float | None = None,
+    burst_multiplier: float | None = None,
+) -> TierCapacityPoolRecord:
+    return TierCapacityPoolRecord(
+        tier_capacity_pool_id=pool_id,
+        tier_version_id=version_id,
+        pool_key=pool_key,
+        callable_key=callable_key,
+        rpm_capacity=rpm_capacity,
+        tpm_capacity=tpm_capacity,
+        max_parallel_requests=max_parallel_requests,
+        strategy=strategy,
+        saturation_threshold=saturation_threshold,
+        burst_multiplier=burst_multiplier,
+    )
+
+
+def _inputs(
+    *,
+    assignments: list[TierPolicyAssignmentRecord],
+    policies: list[TierModelPolicyRecord],
+    pools: list[TierCapacityPoolRecord] | None = None,
+    next_transition_at: datetime | None = None,
+) -> TierPolicyLoadResult:
+    return TierPolicyLoadResult(
+        assignments=tuple(assignments),
+        model_policies=tuple(policies),
+        capacity_pools=tuple(pools or []),
+        next_transition_at=next_transition_at,
+    )
+
+
+def test_compile_snapshot_applies_assignment_precedence_and_deny_wins() -> None:
+    generated_at = datetime(2026, 6, 20, tzinfo=UTC)
+    snapshot = compile_tier_policy_snapshot(
+        _inputs(
+            assignments=[
+                _assignment("assignment-primary", tier_key="primary", version_id="version-primary"),
+                _assignment(
+                    "assignment-addon",
+                    tier_key="addon",
+                    version_id="version-addon",
+                    assignment_type="addon",
+                ),
+                _assignment(
+                    "assignment-override",
+                    tier_key="override",
+                    version_id="version-override",
+                    assignment_type="override",
+                ),
+            ],
+            policies=[
+                _policy(
+                    "policy-primary-gpt",
+                    version_id="version-primary",
+                    pricing={"input_cost_per_token": 1.0},
+                    rpm_limit=100,
+                ),
+                _policy(
+                    "policy-addon-gpt",
+                    version_id="version-addon",
+                    pricing={"input_cost_per_token": 2.0},
+                    rpm_limit=200,
+                ),
+                _policy(
+                    "policy-override-gpt",
+                    version_id="version-override",
+                    pricing={"input_cost_per_token": 3.0},
+                    rpm_limit=50,
+                ),
+                _policy(
+                    "policy-addon-denied",
+                    version_id="version-addon",
+                    callable_key="gpt-4o",
+                    access_mode="allow",
+                ),
+                _policy(
+                    "policy-override-denied",
+                    version_id="version-override",
+                    callable_key="gpt-4o",
+                    access_mode="deny",
+                ),
+            ],
+        ),
+        generated_at=generated_at,
+    )
+
+    assert snapshot.org_allowed_callable_keys["org-1"] == frozenset({"gpt-4o-mini"})
+    assert snapshot.org_model_policy[("org-1", "gpt-4o-mini")].source.assignment_type == "override"
+    assert snapshot.org_model_policy[("org-1", "gpt-4o-mini")].limits.rpm_limit == 50
+    assert (
+        snapshot.pricing_policies[("org-1", "gpt-4o-mini", "sync")].pricing["input_cost_per_token"]
+        == 3.0
+    )
+    assert snapshot.org_model_policy[("org-1", "gpt-4o")].access_mode == "deny"
+    assert ("org-1", "gpt-4o", "sync") not in snapshot.pricing_policies
+
+
+def test_compile_snapshot_assignment_weight_precedes_model_policy_priority() -> None:
+    snapshot = compile_tier_policy_snapshot(
+        _inputs(
+            assignments=[
+                _assignment("assignment-low", version_id="version-low", weight=1),
+                _assignment("assignment-high", version_id="version-high", weight=10),
+            ],
+            policies=[
+                _policy(
+                    "policy-low",
+                    version_id="version-low",
+                    priority=100,
+                    rpm_limit=100,
+                ),
+                _policy(
+                    "policy-high",
+                    version_id="version-high",
+                    priority=1,
+                    rpm_limit=500,
+                ),
+            ],
+        ),
+        generated_at=datetime(2026, 6, 20, tzinfo=UTC),
+    )
+
+    policy = snapshot.org_model_policy[("org-1", "gpt-4o-mini")]
+    assert policy.source.assignment_id == "assignment-high"
+    assert policy.limits.rpm_limit == 500
+
+
+def test_compile_snapshot_ignores_inactive_inputs() -> None:
+    generated_at = datetime(2026, 6, 20, tzinfo=UTC)
+    future_start = generated_at + timedelta(days=1)
+    snapshot = compile_tier_policy_snapshot(
+        _inputs(
+            assignments=[
+                _assignment(
+                    "future",
+                    version_id="version-future",
+                    starts_at=future_start,
+                ),
+                _assignment(
+                    "expired",
+                    version_id="version-expired",
+                    ends_at=generated_at - timedelta(seconds=1),
+                ),
+                _assignment("active", version_id="version-active"),
+            ],
+            policies=[
+                _policy("future-policy", version_id="version-future", callable_key="future"),
+                _policy("expired-policy", version_id="version-expired", callable_key="expired"),
+                _policy("active-policy", version_id="version-active", callable_key="active"),
+            ],
+        ),
+        generated_at=generated_at,
+    )
+
+    assert snapshot.org_allowed_callable_keys["org-1"] == frozenset({"active"})
+    assert snapshot.next_transition_at == future_start
+    assert snapshot.assignment_count == 1
+    assert snapshot.model_policy_count == 1
+
+
+def test_compile_snapshot_uses_repository_next_transition_when_inputs_are_active_only() -> None:
+    generated_at = datetime(2026, 6, 20, tzinfo=UTC)
+    next_transition_at = generated_at + timedelta(hours=2)
+
+    snapshot = compile_tier_policy_snapshot(
+        _inputs(
+            assignments=[_assignment("active", version_id="version-active")],
+            policies=[_policy("active-policy", version_id="version-active", callable_key="active")],
+            next_transition_at=next_transition_at,
+        ),
+        generated_at=generated_at,
+    )
+
+    assert snapshot.next_transition_at == next_transition_at
+
+
+def test_compile_snapshot_prebuilds_pricing_and_rate_limit_descriptors() -> None:
+    snapshot = compile_tier_policy_snapshot(
+        _inputs(
+            assignments=[_assignment("assignment-1")],
+            policies=[
+                _policy(
+                    "policy-1",
+                    rpm_limit=100,
+                    tpm_limit=10_000,
+                    rph_limit=1_000,
+                    rpd_limit=10_000,
+                    tpd_limit=1_000_000,
+                    max_parallel_requests=25,
+                    batch_rpm_limit=50,
+                    batch_tpm_limit=5_000,
+                    pricing={
+                        "input_cost_per_token": 0.001,
+                        "output_cost_per_token": 0.002,
+                        "batch_input_cost_per_token": 0.0005,
+                    },
+                )
+            ],
+        ),
+        generated_at=datetime(2026, 6, 20, tzinfo=UTC),
+    )
+
+    sync_pricing = snapshot.pricing_policies[("org-1", "gpt-4o-mini", "sync")]
+    batch_pricing = snapshot.pricing_policies[("org-1", "gpt-4o-mini", "batch")]
+    assert "batch_input_cost_per_token" not in sync_pricing.pricing
+    assert batch_pricing.pricing["batch_input_cost_per_token"] == 0.0005
+
+    descriptors = snapshot.rate_limit_descriptors[("org-1", "gpt-4o-mini")]
+    descriptor_by_scope = {descriptor.scope: descriptor for descriptor in descriptors}
+    assert descriptor_by_scope["tier_org_model_rpm"].limit == 100
+    assert descriptor_by_scope["tier_org_model_tpm"].amount_kind == "tokens"
+    assert descriptor_by_scope["tier_org_model_parallel"].window_seconds == 0
+    assert descriptor_by_scope["tier_org_model_batch_tpm"].mode == "batch"
+
+
+def test_compile_snapshot_merges_capacity_pools_conservatively() -> None:
+    snapshot = compile_tier_policy_snapshot(
+        _inputs(
+            assignments=[
+                _assignment("assignment-1", version_id="version-1"),
+                _assignment("assignment-2", version_id="version-2", assignment_type="addon"),
+            ],
+            policies=[],
+            pools=[
+                _pool(
+                    "pool-1",
+                    version_id="version-1",
+                    rpm_capacity=1000,
+                    tpm_capacity=None,
+                    max_parallel_requests=50,
+                    strategy="reserved_burst",
+                    saturation_threshold=0.9,
+                    burst_multiplier=2.0,
+                ),
+                _pool(
+                    "pool-2",
+                    version_id="version-2",
+                    rpm_capacity=800,
+                    tpm_capacity=500_000,
+                    max_parallel_requests=25,
+                    strategy="hard_cap",
+                    saturation_threshold=0.8,
+                    burst_multiplier=1.5,
+                ),
+            ],
+        ),
+        generated_at=datetime(2026, 6, 20, tzinfo=UTC),
+    )
+
+    pool = snapshot.capacity_pool_policy[("shared", "gpt-4o-mini")]
+    assert pool.rpm_capacity == 800
+    assert pool.tpm_capacity == 500_000
+    assert pool.max_parallel_requests == 25
+    assert pool.strategy == "hard_cap"
+    assert pool.saturation_threshold == 0.8
+    assert pool.burst_multiplier == 1.5
+    assert pool.source_tier_version_ids == ("version-1", "version-2")
+
+
+def test_compile_snapshot_etag_is_stable_for_same_logical_inputs() -> None:
+    inputs = _inputs(
+        assignments=[_assignment("assignment-1")],
+        policies=[_policy("policy-1", pricing={"input_cost_per_token": 0.001})],
+    )
+
+    first = compile_tier_policy_snapshot(
+        inputs,
+        generated_at=datetime(2026, 6, 20, tzinfo=UTC),
+    )
+    second = compile_tier_policy_snapshot(
+        inputs,
+        generated_at=datetime(2026, 6, 21, tzinfo=UTC),
+    )
+    changed = compile_tier_policy_snapshot(
+        _inputs(
+            assignments=[_assignment("assignment-1")],
+            policies=[_policy("policy-1", pricing={"input_cost_per_token": 0.002})],
+        ),
+        generated_at=datetime(2026, 6, 20, tzinfo=UTC),
+    )
+
+    assert first.etag == second.etag
+    assert first.etag != changed.etag
+
+
+def test_compiled_lookup_overhead_is_small() -> None:
+    snapshot = compile_tier_policy_snapshot(
+        _inputs(
+            assignments=[_assignment("assignment-1")],
+            policies=[_policy("policy-1", pricing={"input_cost_per_token": 0.001})],
+        ),
+        generated_at=datetime(2026, 6, 20, tzinfo=UTC),
+    )
+
+    started = perf_counter()
+    for _ in range(50_000):
+        assert snapshot.org_model_policy.get(("org-1", "gpt-4o-mini")) is not None
+        assert snapshot.org_allowed_callable_keys.get("org-1") == frozenset({"gpt-4o-mini"})
+    elapsed = perf_counter() - started
+
+    assert elapsed < 0.5

--- a/tests/services/test_tier_policy_invalidation.py
+++ b/tests/services/test_tier_policy_invalidation.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.tier_policy_invalidation import reload_tier_policy_for_app
+
+
+class _FakeGovernanceInvalidation:
+    def __init__(
+        self,
+        *,
+        fail_local: bool = False,
+        fail_notify: bool = False,
+        notify_result: bool = True,
+    ) -> None:
+        self.fail_local = fail_local
+        self.fail_notify = fail_notify
+        self.notify_result = notify_result
+        self.local_targets: list[tuple[str, ...]] = []
+        self.notified_targets: list[tuple[str, ...]] = []
+
+    async def invalidate_local(self, *targets: str) -> None:
+        self.local_targets.append(tuple(targets))
+        if self.fail_local:
+            raise RuntimeError("reload failed")
+
+    async def notify(self, *targets: str) -> bool:
+        self.notified_targets.append(tuple(targets))
+        if self.fail_notify:
+            raise RuntimeError("notify failed")
+        return self.notify_result
+
+
+class _FakeTierPolicyService:
+    def __init__(self, *, fail_reload: bool = False, mode: str = "shadow") -> None:
+        self.fail_reload = fail_reload
+        self.mode = mode
+        self.reload_calls = 0
+
+    async def reload(self) -> None:
+        self.reload_calls += 1
+        if self.fail_reload:
+            raise RuntimeError("reload failed")
+
+
+def _app(**state_items: object) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(**state_items))
+
+
+@pytest.mark.asyncio
+async def test_reload_tier_policy_for_app_reports_governance_success() -> None:
+    invalidation = _FakeGovernanceInvalidation()
+
+    result = await reload_tier_policy_for_app(_app(governance_invalidation_service=invalidation))
+
+    assert result.to_dict() == {
+        "attempted": True,
+        "reloaded": True,
+        "notified": True,
+        "reason": "reloaded_and_notified",
+    }
+    assert invalidation.local_targets == [("tier_policy",)]
+    assert invalidation.notified_targets == [("tier_policy",)]
+
+
+@pytest.mark.asyncio
+async def test_reload_tier_policy_for_app_reports_local_reload_failure() -> None:
+    invalidation = _FakeGovernanceInvalidation(fail_local=True)
+
+    result = await reload_tier_policy_for_app(_app(governance_invalidation_service=invalidation))
+
+    payload = result.to_dict()
+    assert payload["attempted"] is True
+    assert payload["reloaded"] is False
+    assert payload["notified"] is True
+    assert payload["reason"] == "local_reload_failed_remote_notified"
+    assert "reload failed" in payload["error"]
+    assert invalidation.notified_targets == [("tier_policy",)]
+
+
+@pytest.mark.asyncio
+async def test_reload_tier_policy_for_app_reports_local_reload_and_notify_failure() -> None:
+    invalidation = _FakeGovernanceInvalidation(fail_local=True, fail_notify=True)
+
+    result = await reload_tier_policy_for_app(_app(governance_invalidation_service=invalidation))
+
+    payload = result.to_dict()
+    assert payload["attempted"] is True
+    assert payload["reloaded"] is False
+    assert payload["notified"] is False
+    assert payload["reason"] == "local_reload_failed_remote_notify_failed"
+    assert "reload failed" in payload["error"]
+    assert "notify failed" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_reload_tier_policy_for_app_reports_notify_unavailable() -> None:
+    invalidation = _FakeGovernanceInvalidation(notify_result=False)
+
+    result = await reload_tier_policy_for_app(_app(governance_invalidation_service=invalidation))
+
+    assert result.to_dict() == {
+        "attempted": True,
+        "reloaded": True,
+        "notified": False,
+        "reason": "remote_notify_unavailable",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reload_tier_policy_for_app_uses_direct_service_without_governance() -> None:
+    service = _FakeTierPolicyService()
+
+    result = await reload_tier_policy_for_app(_app(tier_policy_service=service))
+
+    assert service.reload_calls == 1
+    assert result.to_dict() == {
+        "attempted": True,
+        "reloaded": True,
+        "notified": False,
+        "reason": "reloaded_without_broadcast",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reload_tier_policy_for_app_skips_disabled_service() -> None:
+    service = _FakeTierPolicyService(mode="disabled")
+    invalidation = _FakeGovernanceInvalidation()
+
+    result = await reload_tier_policy_for_app(
+        _app(
+            tier_policy_service=service,
+            governance_invalidation_service=invalidation,
+        )
+    )
+
+    assert service.reload_calls == 0
+    assert invalidation.local_targets == []
+    assert invalidation.notified_targets == []
+    assert result.to_dict() == {
+        "attempted": False,
+        "reloaded": False,
+        "notified": False,
+        "reason": "tier_policy_disabled",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reload_tier_policy_for_app_reports_missing_service() -> None:
+    result = await reload_tier_policy_for_app(_app())
+
+    assert result.to_dict() == {
+        "attempted": False,
+        "reloaded": False,
+        "notified": False,
+        "reason": "service_unavailable",
+    }

--- a/tests/services/test_tier_policy_service.py
+++ b/tests/services/test_tier_policy_service.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.db.tiers import (
+    TierModelPolicyRecord,
+    TierPolicyAssignmentRecord,
+    TierPolicyLoadResult,
+    TierPolicyRepositoryUnavailableError,
+    TierRepository,
+)
+from src.services.tier_policy_service import (
+    TierPolicyBackendUnavailableError,
+    TierPolicyService,
+    resolve_tier_policy_unavailable_decision,
+)
+
+
+class _FakeTierPolicyRepository:
+    def __init__(self, inputs: TierPolicyLoadResult) -> None:
+        self.inputs = inputs
+        self.calls = 0
+        self.fail = False
+        self.reference_times: list[datetime] = []
+
+    async def load_active_tier_policy_inputs(
+        self,
+        *,
+        reference_time: datetime | None = None,
+    ) -> TierPolicyLoadResult:
+        self.calls += 1
+        if reference_time is not None:
+            self.reference_times.append(reference_time)
+        if self.fail:
+            raise RuntimeError("reload failed")
+        return self.inputs
+
+
+def _inputs(
+    *,
+    price: float = 0.001,
+    next_transition_at: datetime | None = None,
+) -> TierPolicyLoadResult:
+    return TierPolicyLoadResult(
+        assignments=(
+            TierPolicyAssignmentRecord(
+                assignment_id="assignment-1",
+                organization_id="org-1",
+                tier_id="tier-1",
+                tier_version_id=None,
+                effective_tier_version_id="version-1",
+                tier_key="standard",
+                tier_version_number=1,
+                tier_version_status="active",
+            ),
+        ),
+        model_policies=(
+            TierModelPolicyRecord(
+                tier_model_policy_id="policy-1",
+                tier_version_id="version-1",
+                callable_key="gpt-4o-mini",
+                rpm_limit=100,
+                pricing={"input_cost_per_token": price},
+            ),
+        ),
+        capacity_pools=(),
+        next_transition_at=next_transition_at,
+    )
+
+
+async def _wait_for(
+    condition: Callable[[], bool],
+    *,
+    timeout_seconds: float = 1.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    while asyncio.get_running_loop().time() < deadline:
+        if condition():
+            return
+        await asyncio.sleep(0.01)
+    assert condition()
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_reload_swaps_snapshot_and_serves_sync_lookups() -> None:
+    generated_at = datetime(2026, 6, 20, tzinfo=UTC)
+    repository = _FakeTierPolicyRepository(_inputs())
+    service = TierPolicyService(
+        repository=repository,
+        mode="shadow",
+        clock=lambda: generated_at,
+    )
+
+    snapshot = await service.reload()
+
+    snapshot_info = service.snapshot_info()
+    assert repository.calls == 1
+    assert repository.reference_times == [generated_at]
+    assert service.get_snapshot() is snapshot
+    assert snapshot_info.etag == snapshot.etag
+    assert snapshot_info.mode == "shadow"
+    assert snapshot_info.next_transition_at is None
+    assert snapshot_info.snapshot_stale is False
+    assert snapshot_info.last_reload_failed is False
+    assert snapshot_info.last_reload_error_at is None
+    assert service.has_explicit_tier_policy("org-1") is True
+    assert service.resolve_org_allowed_callable_keys("org-1") == frozenset({"gpt-4o-mini"})
+    assert service.get_model_policy("org-1", "gpt-4o-mini").limits.rpm_limit == 100  # type: ignore[union-attr]
+    assert (
+        service.get_pricing_policy("org-1", "gpt-4o-mini").pricing[  # type: ignore[union-attr]
+            "input_cost_per_token"
+        ]
+        == 0.001
+    )
+    assert service.get_rate_limit_descriptors("org-1", "gpt-4o-mini")[0].scope
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_failed_reload_preserves_previous_snapshot() -> None:
+    repository = _FakeTierPolicyRepository(_inputs(price=0.001))
+    service = TierPolicyService(repository=repository, mode="shadow")
+    first = await service.reload()
+
+    repository.inputs = _inputs(price=0.002)
+    repository.fail = True
+    with pytest.raises(RuntimeError, match="reload failed"):
+        await service.reload()
+
+    snapshot_info = service.snapshot_info()
+    assert service.get_snapshot() is first
+    assert service.snapshot_stale is True
+    assert service.last_reload_failed is True
+    assert service.last_reload_error_at is not None
+    assert snapshot_info.snapshot_stale is True
+    assert snapshot_info.last_reload_failed is True
+    assert snapshot_info.last_reload_error_at == service.last_reload_error_at
+    assert (
+        service.get_pricing_policy("org-1", "gpt-4o-mini").pricing[  # type: ignore[union-attr]
+            "input_cost_per_token"
+        ]
+        == 0.001
+    )
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_handles_missing_repository_as_empty_snapshot_when_disabled() -> (
+    None
+):
+    service = TierPolicyService(repository=None)
+
+    snapshot = await service.reload()
+
+    assert snapshot.org_count == 0
+    assert service.resolve_org_allowed_callable_keys("org-1") is None
+    assert service.get_rate_limit_descriptors("org-1", "gpt-4o-mini") == ()
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_rejects_missing_repository_when_enabled() -> None:
+    service = TierPolicyService(repository=None, mode="enforce")
+
+    with pytest.raises(TierPolicyBackendUnavailableError, match="repository unavailable"):
+        await service.reload()
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_rejects_repository_without_loader_when_enabled() -> None:
+    service = TierPolicyService(repository=object(), mode="shadow")
+
+    with pytest.raises(TierPolicyBackendUnavailableError, match="loader unavailable"):
+        await service.reload()
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_rejects_repository_with_missing_database_when_enabled() -> None:
+    service = TierPolicyService(repository=TierRepository(None), mode="enforce")
+
+    with pytest.raises(TierPolicyRepositoryUnavailableError, match="database unavailable"):
+        await service.reload()
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_startup_reload_failure_retries_after_retry_delay() -> None:
+    repository = _FakeTierPolicyRepository(_inputs(price=0.001))
+    repository.fail = True
+    service = TierPolicyService(
+        repository=repository,
+        mode="shadow",
+        refresh_interval_seconds=60.0,
+        refresh_jitter_seconds=0.0,
+        refresh_retry_delay_seconds=0.03,
+    )
+
+    with pytest.raises(RuntimeError, match="reload failed"):
+        await service.reload()
+
+    repository.fail = False
+    repository.inputs = _inputs(price=0.002)
+
+    try:
+        await service.start()
+        await _wait_for(lambda: repository.calls >= 2)
+    finally:
+        await service.close()
+
+    assert (
+        service.get_pricing_policy("org-1", "gpt-4o-mini").pricing[  # type: ignore[union-attr]
+            "input_cost_per_token"
+        ]
+        == 0.002
+    )
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_schedules_retry_from_failure_time() -> None:
+    now = datetime(2026, 6, 20, tzinfo=UTC)
+
+    class _SlowFailingRepository:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def load_active_tier_policy_inputs(
+            self,
+            *,
+            reference_time: datetime | None = None,
+        ) -> TierPolicyLoadResult:
+            nonlocal now
+            self.calls += 1
+            now += timedelta(seconds=10)
+            raise RuntimeError("reload failed")
+
+    repository = _SlowFailingRepository()
+    service = TierPolicyService(
+        repository=repository,
+        mode="shadow",
+        refresh_interval_seconds=60.0,
+        refresh_jitter_seconds=0.0,
+        refresh_retry_delay_seconds=5.0,
+        clock=lambda: now,
+    )
+
+    with pytest.raises(RuntimeError, match="reload failed"):
+        await service.reload()
+
+    assert repository.calls == 1
+    assert service._next_refresh_delay_seconds() == 5.0
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_scheduled_refresh_uses_next_transition() -> None:
+    transition_at = datetime.now(tz=UTC) + timedelta(seconds=0.03)
+    repository = _FakeTierPolicyRepository(_inputs(price=0.001, next_transition_at=transition_at))
+    service = TierPolicyService(
+        repository=repository,
+        mode="shadow",
+        refresh_interval_seconds=60.0,
+        refresh_jitter_seconds=0.0,
+        transition_grace_seconds=0.0,
+    )
+
+    await service.reload()
+    repository.inputs = _inputs(price=0.002)
+
+    try:
+        await service.start()
+        await _wait_for(lambda: repository.calls >= 2)
+    finally:
+        await service.close()
+
+    assert repository.calls >= 2
+    assert (
+        service.get_pricing_policy("org-1", "gpt-4o-mini").pricing[  # type: ignore[union-attr]
+            "input_cost_per_token"
+        ]
+        == 0.002
+    )
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_scheduled_reload_failure_preserves_snapshot_and_retries() -> (
+    None
+):
+    transition_at = datetime.now(tz=UTC) + timedelta(seconds=0.03)
+    repository = _FakeTierPolicyRepository(_inputs(price=0.001, next_transition_at=transition_at))
+    service = TierPolicyService(
+        repository=repository,
+        mode="shadow",
+        refresh_interval_seconds=60.0,
+        refresh_jitter_seconds=0.0,
+        transition_grace_seconds=0.0,
+        refresh_retry_delay_seconds=0.03,
+    )
+
+    await service.reload()
+    repository.fail = True
+
+    try:
+        await service.start()
+        await _wait_for(lambda: repository.calls >= 2)
+        assert (
+            service.get_pricing_policy("org-1", "gpt-4o-mini").pricing[  # type: ignore[union-attr]
+                "input_cost_per_token"
+            ]
+            == 0.001
+        )
+
+        repository.fail = False
+        repository.inputs = _inputs(price=0.002)
+        await _wait_for(lambda: repository.calls >= 3)
+    finally:
+        await service.close()
+
+    assert (
+        service.get_pricing_policy("org-1", "gpt-4o-mini").pricing[  # type: ignore[union-attr]
+            "input_cost_per_token"
+        ]
+        == 0.002
+    )
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_snapshot_lookup_data_is_immutable() -> None:
+    service = TierPolicyService(repository=_FakeTierPolicyRepository(_inputs()), mode="shadow")
+    snapshot = await service.reload()
+
+    with pytest.raises(TypeError):
+        snapshot.org_model_policy[("org-1", "gpt-4o-mini")].pricing["input_cost_per_token"] = 1.0
+
+    assert isinstance(snapshot.org_allowed_callable_keys["org-1"], frozenset)
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_unavailable_decision_uses_explicit_policy_snapshot() -> None:
+    service = TierPolicyService(
+        repository=_FakeTierPolicyRepository(_inputs()),
+        mode="enforce",
+        missing_service_mode="fail_closed",
+    )
+    await service.reload()
+
+    explicit_decision = service.resolve_unavailable_decision("org-1")
+    unassigned_decision = service.resolve_unavailable_decision("org-2")
+
+    assert explicit_decision.allowed is False
+    assert explicit_decision.reason == "tier_policy_unavailable_fail_closed"
+    assert explicit_decision.explicit_tier_policy is True
+    assert unassigned_decision.allowed is True
+    assert unassigned_decision.reason == "tier_policy_unavailable_no_explicit_policy"
+    assert unassigned_decision.explicit_tier_policy is False
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_fail_closed_blocks_when_snapshot_is_stale() -> None:
+    repository = _FakeTierPolicyRepository(_inputs())
+    service = TierPolicyService(
+        repository=repository,
+        mode="enforce",
+        missing_service_mode="fail_closed",
+    )
+    await service.reload()
+
+    repository.fail = True
+    with pytest.raises(RuntimeError, match="reload failed"):
+        await service.reload()
+
+    explicit_decision = service.resolve_unavailable_decision("org-1")
+    unassigned_decision = service.resolve_unavailable_decision("org-2")
+
+    assert explicit_decision.allowed is False
+    assert explicit_decision.reason == "tier_policy_unavailable_snapshot_stale"
+    assert explicit_decision.explicit_tier_policy is True
+    assert unassigned_decision.allowed is False
+    assert unassigned_decision.reason == "tier_policy_unavailable_snapshot_stale"
+    assert unassigned_decision.explicit_tier_policy is False
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_service_fail_open_allows_when_snapshot_is_stale() -> None:
+    repository = _FakeTierPolicyRepository(_inputs())
+    service = TierPolicyService(
+        repository=repository,
+        mode="enforce",
+        missing_service_mode="fail_open",
+    )
+    await service.reload()
+
+    repository.fail = True
+    with pytest.raises(RuntimeError, match="reload failed"):
+        await service.reload()
+
+    decision = service.resolve_unavailable_decision("org-2")
+
+    assert decision.allowed is True
+    assert decision.reason == "tier_policy_unavailable_fail_open"
+    assert decision.explicit_tier_policy is False
+
+
+def test_tier_policy_unavailable_decision_fails_open_without_service() -> None:
+    decision = resolve_tier_policy_unavailable_decision(
+        None,
+        "org-1",
+        mode="enforce",
+        missing_service_mode="fail_open",
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "tier_policy_unavailable_fail_open"
+    assert decision.explicit_tier_policy is None
+
+
+def test_tier_policy_unavailable_decision_fails_closed_without_service() -> None:
+    decision = resolve_tier_policy_unavailable_decision(
+        None,
+        "org-1",
+        mode="enforce",
+        missing_service_mode="fail_closed",
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "tier_policy_unavailable_fail_closed"
+    assert decision.explicit_tier_policy is None

--- a/tests/test_governance_invalidation.py
+++ b/tests/test_governance_invalidation.py
@@ -4,15 +4,22 @@ import asyncio
 
 import pytest
 
-from src.services.governance_invalidation import GovernanceInvalidationService
+from src.services.governance_invalidation import (
+    GovernanceInvalidationApplyError,
+    GovernanceInvalidationService,
+)
 
 
 class _FakeReloadService:
-    def __init__(self) -> None:
+    def __init__(self, *, fail_times: int = 0, mode: str = "shadow") -> None:
+        self.fail_times = fail_times
+        self.mode = mode
         self.reload_calls = 0
 
     async def reload(self) -> None:
         self.reload_calls += 1
+        if self.reload_calls <= self.fail_times:
+            raise RuntimeError("reload unavailable")
 
 
 class _FakeInvalidateService:
@@ -67,38 +74,50 @@ class _FakeRedis:
             await subscriber.queue.put({"type": "message", "data": payload})
 
 
+class _FailingRedis(_FakeRedis):
+    async def publish(self, channel: str, payload: str) -> None:
+        del channel, payload
+        raise RuntimeError("redis unavailable")
+
+
 @pytest.mark.asyncio
 async def test_governance_invalidation_service_notifies_other_instances() -> None:
     redis = _FakeRedis()
     local_callable = _FakeReloadService()
+    local_tier = _FakeReloadService()
     local_registry = _FakeInvalidateService()
     local_mcp = _FakeReloadService()
     remote_callable = _FakeReloadService()
+    remote_tier = _FakeReloadService()
     remote_registry = _FakeInvalidateService()
     remote_mcp = _FakeReloadService()
 
     local = GovernanceInvalidationService(
         redis_client=redis,
         callable_target_grant_service=local_callable,
+        tier_policy_service=local_tier,
         mcp_registry_service=local_registry,
         mcp_governance_service=local_mcp,
     )
     remote = GovernanceInvalidationService(
         redis_client=redis,
         callable_target_grant_service=remote_callable,
+        tier_policy_service=remote_tier,
         mcp_registry_service=remote_registry,
         mcp_governance_service=remote_mcp,
     )
     await local.start()
     await remote.start()
 
-    await local.notify("callable_target", "mcp")
+    await local.notify("callable_target", "mcp", "tier_policy")
     await asyncio.sleep(0.1)
 
     assert local_callable.reload_calls == 0
+    assert local_tier.reload_calls == 0
     assert local_registry.invalidate_calls == 0
     assert local_mcp.reload_calls == 0
     assert remote_callable.reload_calls == 1
+    assert remote_tier.reload_calls == 1
     assert remote_registry.invalidate_calls == 1
     assert remote_mcp.reload_calls == 1
 
@@ -107,28 +126,96 @@ async def test_governance_invalidation_service_notifies_other_instances() -> Non
 
 
 @pytest.mark.asyncio
-async def test_governance_invalidation_service_can_apply_local_invalidations_without_redis() -> None:
+async def test_governance_invalidation_service_returns_false_when_publish_fails() -> None:
+    service = GovernanceInvalidationService(redis_client=_FailingRedis())
+
+    assert await service.notify("tier_policy") is False
+
+
+@pytest.mark.asyncio
+async def test_governance_invalidation_service_can_apply_local_invalidations_without_redis() -> (
+    None
+):
     callable_target = _FakeReloadService()
+    tier_policy = _FakeReloadService()
     mcp_registry = _FakeInvalidateService()
     mcp_governance = _FakeReloadService()
     service = GovernanceInvalidationService(
         redis_client=None,
         callable_target_grant_service=callable_target,
+        tier_policy_service=tier_policy,
         mcp_registry_service=mcp_registry,
         mcp_governance_service=mcp_governance,
     )
 
-    await service.invalidate_local("callable_target", "mcp")
+    await service.invalidate_local("callable_target", "mcp", "tier_policy")
 
     assert callable_target.reload_calls == 1
+    assert tier_policy.reload_calls == 1
     assert mcp_registry.invalidate_calls == 1
     assert mcp_governance.reload_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_governance_invalidation_service_applies_remaining_local_targets_after_failure() -> (
+    None
+):
+    callable_target = _FakeReloadService(fail_times=1)
+    tier_policy = _FakeReloadService()
+    service = GovernanceInvalidationService(
+        redis_client=None,
+        callable_target_grant_service=callable_target,
+        tier_policy_service=tier_policy,
+    )
+
+    with pytest.raises(GovernanceInvalidationApplyError) as exc_info:
+        await service.invalidate_local("callable_target", "tier_policy")
+
+    assert exc_info.value.failed_targets == ("callable_target",)
+    assert callable_target.reload_calls == 1
+    assert tier_policy.reload_calls == 1
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_governance_invalidation_service_retries_failed_local_targets() -> None:
+    tier_policy = _FakeReloadService(fail_times=1)
+    service = GovernanceInvalidationService(
+        redis_client=None,
+        tier_policy_service=tier_policy,
+        remote_retry_delay_seconds=0.01,
+    )
+
+    with pytest.raises(GovernanceInvalidationApplyError) as exc_info:
+        await service.invalidate_local("tier_policy")
+    for _ in range(20):
+        if tier_policy.reload_calls >= 2:
+            break
+        await asyncio.sleep(0.02)
+
+    assert exc_info.value.failed_targets == ("tier_policy",)
+    assert tier_policy.reload_calls == 2
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_governance_invalidation_service_skips_disabled_tier_policy() -> None:
+    tier_policy = _FakeReloadService(mode="disabled")
+    service = GovernanceInvalidationService(
+        redis_client=None,
+        tier_policy_service=tier_policy,
+    )
+
+    await service.invalidate_local("tier_policy")
+
+    assert tier_policy.reload_calls == 0
 
 
 @pytest.mark.asyncio
 async def test_governance_invalidation_service_coalesces_remote_invalidations() -> None:
     redis = _FakeRedis()
     remote_callable = _FakeReloadService()
+    remote_tier = _FakeReloadService()
     remote_registry = _FakeInvalidateService()
     remote_mcp = _FakeReloadService()
 
@@ -136,6 +223,7 @@ async def test_governance_invalidation_service_coalesces_remote_invalidations() 
     remote = GovernanceInvalidationService(
         redis_client=redis,
         callable_target_grant_service=remote_callable,
+        tier_policy_service=remote_tier,
         mcp_registry_service=remote_registry,
         mcp_governance_service=remote_mcp,
         remote_apply_delay_seconds=0.01,
@@ -144,12 +232,41 @@ async def test_governance_invalidation_service_coalesces_remote_invalidations() 
     await remote.start()
 
     await local.notify("callable_target")
+    await local.notify("tier_policy")
     await local.notify("mcp")
     await asyncio.sleep(0.05)
 
     assert remote_callable.reload_calls == 1
+    assert remote_tier.reload_calls == 1
     assert remote_registry.invalidate_calls == 1
     assert remote_mcp.reload_calls == 1
+
+    await local.close()
+    await remote.close()
+
+
+@pytest.mark.asyncio
+async def test_governance_invalidation_service_retries_failed_remote_targets() -> None:
+    redis = _FakeRedis()
+    remote_tier = _FakeReloadService(fail_times=1)
+
+    local = GovernanceInvalidationService(redis_client=redis, remote_apply_delay_seconds=0.01)
+    remote = GovernanceInvalidationService(
+        redis_client=redis,
+        tier_policy_service=remote_tier,
+        remote_apply_delay_seconds=0.01,
+        remote_retry_delay_seconds=0.01,
+    )
+    await local.start()
+    await remote.start()
+
+    assert await local.notify("tier_policy") is True
+    for _ in range(20):
+        if remote_tier.reload_calls >= 2:
+            break
+        await asyncio.sleep(0.02)
+
+    assert remote_tier.reload_calls == 2
 
     await local.close()
     await remote.close()

--- a/tests/test_ui_tier_assignments_api.py
+++ b/tests/test_ui_tier_assignments_api.py
@@ -56,6 +56,23 @@ class _RecordingCacheInvalidationOutboxRepository:
         return SimpleNamespace(invalidation_id=f"invalidation-{len(self.enqueues)}")
 
 
+class _RecordingGovernanceInvalidationService:
+    def __init__(self, *, fail_local: bool = False, notify_result: bool = True) -> None:
+        self.fail_local = fail_local
+        self.notify_result = notify_result
+        self.local_targets: list[tuple[str, ...]] = []
+        self.notified_targets: list[tuple[str, ...]] = []
+
+    async def invalidate_local(self, *targets: str) -> None:
+        self.local_targets.append(tuple(targets))
+        if self.fail_local:
+            raise RuntimeError("tier policy reload unavailable")
+
+    async def notify(self, *targets: str) -> bool:
+        self.notified_targets.append(tuple(targets))
+        return self.notify_result
+
+
 class _FakeTierAssignmentRepository:
     def __init__(self) -> None:
         self.organizations = {"org-1"}
@@ -336,6 +353,7 @@ def _install_assignment_services(
         repository=outbox_repository,
         immediate_timeout_seconds=immediate_timeout_seconds,
     )
+    test_app.state.governance_invalidation_service = _RecordingGovernanceInvalidationService()
     return audit, key_service
 
 
@@ -443,6 +461,17 @@ async def test_org_tier_assignment_create_list_update_delete_audit_and_cache(
 
     assert key_service.org_invalidation_attempts == ["org-1", "org-1", "org-1"]
     assert key_service.org_invalidations == ["org-1", "org-1", "org-1"]
+    governance_invalidation = test_app.state.governance_invalidation_service
+    assert governance_invalidation.local_targets == [
+        ("tier_policy",),
+        ("tier_policy",),
+        ("tier_policy",),
+    ]
+    assert governance_invalidation.notified_targets == [
+        ("tier_policy",),
+        ("tier_policy",),
+        ("tier_policy",),
+    ]
     assert repository.locked_assignment_reads == [
         (assignment_id, "org-1"),
         (assignment_id, "org-1"),
@@ -492,11 +521,52 @@ async def test_org_tier_assignment_create_list_update_delete_audit_and_cache(
         == expected_cache_invalidation
         for event in events
     )
+    assert all(
+        event.metadata["tier_policy_invalidation"]
+        == {
+            "attempted": True,
+            "reloaded": True,
+            "notified": True,
+            "reason": "reloaded_and_notified",
+        }
+        for event in events
+    )
     assert "assignment_type" in events[1].metadata["changed_fields"]
     actions = [event.action for event in events]
     assert AuditAction.ADMIN_ORGANIZATION_TIER_ASSIGNMENT_CREATE.value in actions
     assert AuditAction.ADMIN_ORGANIZATION_TIER_ASSIGNMENT_UPDATE.value in actions
     assert AuditAction.ADMIN_ORGANIZATION_TIER_ASSIGNMENT_DELETE.value in actions
+
+
+@pytest.mark.asyncio
+async def test_org_tier_assignment_create_audits_non_fatal_tier_policy_reload_failure(
+    client,
+    test_app,
+) -> None:
+    repository = _FakeTierAssignmentRepository()
+    audit, key_service = _install_assignment_services(test_app, repository)
+    governance_invalidation = _RecordingGovernanceInvalidationService(fail_local=True)
+    test_app.state.governance_invalidation_service = governance_invalidation
+
+    response = await client.post(
+        "/ui/api/organizations/org-1/tier-assignments",
+        headers=_headers(test_app),
+        json={"tier_id": "tier-1", "tier_version_id": "version-1"},
+    )
+
+    assert response.status_code == 200
+    assert key_service.org_invalidations == ["org-1"]
+    assert governance_invalidation.local_targets == [("tier_policy",)]
+    assert governance_invalidation.notified_targets == [("tier_policy",)]
+    event, _ = audit.sync_calls[-1]
+    invalidation = event.metadata["tier_policy_invalidation"]
+    assert invalidation["attempted"] is True
+    assert invalidation["reloaded"] is False
+    assert invalidation["notified"] is True
+    assert invalidation["reason"] == "local_reload_failed_remote_notified"
+    assert "tier policy reload unavailable" in invalidation["error"]
+    response_payload = _audit_response_payloads(audit)[-1]
+    assert response_payload["tier_policy_invalidation"] == invalidation
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_tiers_api.py
+++ b/tests/test_ui_tiers_api.py
@@ -28,6 +28,23 @@ class _RecordingAuditService:
         del event, payloads, critical
 
 
+class _RecordingGovernanceInvalidationService:
+    def __init__(self, *, fail_local: bool = False, notify_result: bool = True) -> None:
+        self.fail_local = fail_local
+        self.notify_result = notify_result
+        self.local_targets: list[tuple[str, ...]] = []
+        self.notified_targets: list[tuple[str, ...]] = []
+
+    async def invalidate_local(self, *targets: str) -> None:
+        self.local_targets.append(tuple(targets))
+        if self.fail_local:
+            raise RuntimeError("tier policy reload unavailable")
+
+    async def notify(self, *targets: str) -> bool:
+        self.notified_targets.append(tuple(targets))
+        return self.notify_result
+
+
 class _FakeTierRepository:
     def __init__(self) -> None:
         self.tiers: dict[str, TierRecord] = {}
@@ -299,6 +316,15 @@ def _make_context(
     )
 
 
+def _audit_response_payloads(audit: _RecordingAuditService) -> list[dict[str, Any]]:
+    return [
+        payload.content_json
+        for _, payloads in audit.sync_calls
+        for payload in payloads
+        if payload.kind == "response" and payload.content_json is not None
+    ]
+
+
 @pytest.mark.asyncio
 async def test_tier_admin_create_list_detail_update_and_audit(client, test_app):
     repository = _FakeTierRepository()
@@ -390,8 +416,10 @@ async def test_tier_admin_version_policy_pool_publish_flow(client, test_app):
     repository = _FakeTierRepository()
     repository.seed_tier()
     audit = _RecordingAuditService()
+    governance_invalidation = _RecordingGovernanceInvalidationService()
     test_app.state.tier_repository = repository
     test_app.state.audit_service = audit
+    test_app.state.governance_invalidation_service = governance_invalidation
     headers = _headers(test_app)
 
     version_response = await client.post("/ui/api/tiers/tier-1/versions", headers=headers, json={})
@@ -455,6 +483,75 @@ async def test_tier_admin_version_policy_pool_publish_flow(client, test_app):
     assert AuditAction.ADMIN_TIER_CAPACITY_POOLS_REPLACE.value in actions
     assert AuditAction.ADMIN_TIER_MODEL_POLICIES_REPLACE.value in actions
     assert AuditAction.ADMIN_TIER_VERSION_PUBLISH.value in actions
+    assert governance_invalidation.local_targets == [
+        ("tier_policy",),
+        ("tier_policy",),
+        ("tier_policy",),
+    ]
+    assert governance_invalidation.notified_targets == [
+        ("tier_policy",),
+        ("tier_policy",),
+        ("tier_policy",),
+    ]
+    tier_policy_payloads = [
+        payload["tier_policy_invalidation"]
+        for payload in _audit_response_payloads(audit)
+        if "tier_policy_invalidation" in payload
+    ]
+    assert tier_policy_payloads == [
+        {
+            "attempted": True,
+            "reloaded": True,
+            "notified": True,
+            "reason": "reloaded_and_notified",
+        },
+        {
+            "attempted": True,
+            "reloaded": True,
+            "notified": True,
+            "reason": "reloaded_and_notified",
+        },
+        {
+            "attempted": True,
+            "reloaded": True,
+            "notified": True,
+            "reason": "reloaded_and_notified",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tier_admin_update_audits_non_fatal_tier_policy_reload_failure(
+    client,
+    test_app,
+) -> None:
+    repository = _FakeTierRepository()
+    repository.seed_tier()
+    audit = _RecordingAuditService()
+    governance_invalidation = _RecordingGovernanceInvalidationService(fail_local=True)
+    test_app.state.tier_repository = repository
+    test_app.state.audit_service = audit
+    test_app.state.governance_invalidation_service = governance_invalidation
+
+    response = await client.patch(
+        "/ui/api/tiers/tier-1",
+        headers=_headers(test_app),
+        json={"name": "Growth Plus"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Growth Plus"
+    assert governance_invalidation.local_targets == [("tier_policy",)]
+    assert governance_invalidation.notified_targets == [("tier_policy",)]
+    event, _ = audit.sync_calls[-1]
+    invalidation = event.metadata["tier_policy_invalidation"]
+    assert invalidation["attempted"] is True
+    assert invalidation["reloaded"] is False
+    assert invalidation["notified"] is True
+    assert invalidation["reason"] == "local_reload_failed_remote_notified"
+    assert "tier policy reload unavailable" in invalidation["error"]
+    response_payload = _audit_response_payloads(audit)[-1]
+    assert response_payload["tier_policy_invalidation"] == invalidation
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of #197.

## Summary
- Add the tier policy snapshot models, compiler, service, and reload scheduler.
- Add repository loaders for active tier assignments, model policies, and capacity pools.
- Wire snapshot reloads into runtime bootstrap, governance invalidation, and admin tier mutations.
- Add fail-open/fail-closed unavailable decisions with stale snapshot protection.

## Validation
- ruff check passed for the PR5 scope.
- PR5 pytest slice passed: 93 passed.
- git diff --check passed.

## Notes
- This PR builds and maintains the low-latency in-memory snapshot. Request-path enforcement and pricing consumption remain for the next implementation PR.