### PR TITLE
Tier model access enforcement integration

### DIFF
--- a/src/batch/create/service.py
+++ b/src/batch/create/service.py
@@ -31,6 +31,8 @@ from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorag
 from src.models.responses import UserAPIKeyAuth
 from src.services.callable_target_grants import CallableTargetGrantService
 from src.services.model_visibility import CallableTargetPolicyMode, ensure_batch_model_allowed
+from src.services.tier_model_access import TierPolicyMode
+from src.services.tier_policy_service import TierPolicyService
 from src.metrics import increment_batch_artifact_failure, increment_batch_mixed_model_job
 
 logger = logging.getLogger(__name__)
@@ -57,7 +59,10 @@ class BatchCreateSessionService:
         storage_chunk_size: int,
         max_pending_batches_per_scope: int = 20,
         callable_target_grant_service: CallableTargetGrantService | None = None,
+        tier_policy_service: TierPolicyService | None = None,
         callable_target_scope_policy_mode: CallableTargetPolicyMode | str = "enforce",
+        tier_policy_mode: TierPolicyMode | str = "disabled",
+        tier_policy_missing_service_mode: str = "fail_open",
         idempotency_enabled: bool = False,
         model_group_resolver: Any | None = None,
         scheduler_enabled: bool = False,
@@ -79,7 +84,10 @@ class BatchCreateSessionService:
         self.storage_chunk_size = max(1, int(storage_chunk_size))
         self.max_pending_batches_per_scope = max(0, int(max_pending_batches_per_scope))
         self.callable_target_grant_service = callable_target_grant_service
+        self.tier_policy_service = tier_policy_service
         self.callable_target_scope_policy_mode = callable_target_scope_policy_mode
+        self.tier_policy_mode = tier_policy_mode
+        self.tier_policy_missing_service_mode = tier_policy_missing_service_mode
         self.idempotency_enabled = bool(idempotency_enabled)
         self.model_group_resolver = model_group_resolver
         self.scheduler_enabled = bool(scheduler_enabled)
@@ -470,6 +478,9 @@ class BatchCreateSessionService:
             seen_custom_ids=seen_custom_ids,
             callable_target_grant_service=self.callable_target_grant_service,
             callable_target_scope_policy_mode=self.callable_target_scope_policy_mode,
+            tier_policy_service=self.tier_policy_service,
+            tier_policy_mode=self.tier_policy_mode,
+            tier_policy_missing_service_mode=self.tier_policy_missing_service_mode,
             model_access_validator=ensure_batch_model_allowed,
         )
         if parsed is None:

--- a/src/batch/policy.py
+++ b/src/batch/policy.py
@@ -24,7 +24,12 @@ from src.metrics import (
     observe_batch_preflight_latency,
 )
 from src.models.responses import UserAPIKeyAuth
-from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
+from src.services.model_visibility import (
+    ensure_model_allowed,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +98,10 @@ async def run_batch_request_preflight(
             auth,
             str(getattr(payload, "model", "")),
             callable_target_grant_service=grant_service,
+            tier_policy_service=getattr(app.state, "tier_policy_service", None),
             policy_mode=get_callable_target_policy_mode_from_app(app),
+            tier_policy_mode=get_tier_policy_mode_from_app(app),
+            tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(app),
             emit_shadow_log=True,
         )
 

--- a/src/batch/request_validation.py
+++ b/src/batch/request_validation.py
@@ -18,6 +18,8 @@ from src.models.requests import ChatCompletionRequest, EmbeddingRequest, MCPTool
 from src.models.responses import UserAPIKeyAuth
 from src.services.callable_target_grants import CallableTargetGrantService
 from src.services.model_visibility import CallableTargetPolicyMode, ensure_batch_model_allowed
+from src.services.tier_model_access import TierPolicyMode
+from src.services.tier_policy_service import TierPolicyService
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,6 +39,9 @@ def parse_batch_input_line(
     seen_custom_ids: set[str],
     callable_target_grant_service: CallableTargetGrantService | None,
     callable_target_scope_policy_mode: CallableTargetPolicyMode | str,
+    tier_policy_service: TierPolicyService | None = None,
+    tier_policy_mode: TierPolicyMode | str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
     model_access_validator: Callable[..., None] = ensure_batch_model_allowed,
 ) -> ParsedBatchInputLine | None:
     endpoint = str(endpoint or "").strip()
@@ -83,7 +88,10 @@ def parse_batch_input_line(
         auth,
         model,
         callable_target_grant_service=callable_target_grant_service,
+        tier_policy_service=tier_policy_service,
         policy_mode=callable_target_scope_policy_mode,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
     )
     return ParsedBatchInputLine(
         line_number=line_number,

--- a/src/batch/service.py
+++ b/src/batch/service.py
@@ -20,6 +20,8 @@ from src.metrics import (
 from src.models.responses import UserAPIKeyAuth
 from src.services.callable_target_grants import CallableTargetGrantService
 from src.services.model_visibility import CallableTargetPolicyMode
+from src.services.tier_model_access import TierPolicyMode
+from src.services.tier_policy_service import TierPolicyService
 
 if TYPE_CHECKING:
     from src.batch.create import BatchCreateSessionService
@@ -59,7 +61,10 @@ class BatchService:
         max_items_per_batch: int = 10_000,
         max_line_bytes: int = 1_048_576,
         callable_target_grant_service: CallableTargetGrantService | None = None,
+        tier_policy_service: TierPolicyService | None = None,
         callable_target_scope_policy_mode: CallableTargetPolicyMode | str = "enforce",
+        tier_policy_mode: TierPolicyMode | str = "disabled",
+        tier_policy_missing_service_mode: str = "fail_open",
         create_session_service: "BatchCreateSessionService" | None = None,
         model_group_resolver: Any | None = None,
     ) -> None:
@@ -77,7 +82,10 @@ class BatchService:
         self.max_items_per_batch = max_items_per_batch
         self.max_line_bytes = max_line_bytes
         self.callable_target_grant_service = callable_target_grant_service
+        self.tier_policy_service = tier_policy_service
         self.callable_target_scope_policy_mode = callable_target_scope_policy_mode
+        self.tier_policy_mode = tier_policy_mode
+        self.tier_policy_missing_service_mode = tier_policy_missing_service_mode
         self.create_session_service = create_session_service
         self.model_group_resolver = model_group_resolver
 
@@ -178,6 +186,9 @@ class BatchService:
             seen_custom_ids=seen_custom_ids,
             callable_target_grant_service=self.callable_target_grant_service,
             callable_target_scope_policy_mode=self.callable_target_scope_policy_mode,
+            tier_policy_service=self.tier_policy_service,
+            tier_policy_mode=self.tier_policy_mode,
+            tier_policy_missing_service_mode=self.tier_policy_missing_service_mode,
         )
         if parsed is None:
             return None, None

--- a/src/bootstrap/batch.py
+++ b/src/bootstrap/batch.py
@@ -57,6 +57,7 @@ logger = logging.getLogger(__name__)
 _WORKER_SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 30.0
 _BATCH_WORKER_BOOT_ID = uuid4().hex[:12]
 _BATCH_SCHEDULER_MODE_STATE_KEY = "batch_scheduler_modes"
+_MISSING = object()
 
 
 def _safe_worker_id_part(value: object, *, fallback: str) -> str:
@@ -65,6 +66,24 @@ def _safe_worker_id_part(value: object, *, fallback: str) -> str:
         for char in str(value or "").strip()
     ).strip("-._")
     return safe or fallback
+
+
+def _batch_runtime_setting(app: Any, cfg: Any, field_name: str, *, default: Any) -> Any:
+    general_settings = getattr(cfg, "general_settings", None)
+    value = _explicit_general_setting(general_settings, field_name)
+    if value is not _MISSING:
+        return value
+    settings = getattr(getattr(app, "state", None), "settings", None)
+    return getattr(settings, field_name, default)
+
+
+def _explicit_general_setting(general_settings: Any, field_name: str) -> Any:
+    if general_settings is None:
+        return _MISSING
+    fields_set = getattr(general_settings, "model_fields_set", None)
+    if fields_set is not None and field_name not in fields_set:
+        return _MISSING
+    return getattr(general_settings, field_name, _MISSING)
 
 
 def _batch_worker_id(role: str) -> str:
@@ -591,6 +610,26 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
     app.state.batch_tenant_fair_share_config = tenant_fair_share_config
     app.state.batch_size_aging_config = size_aging_config
     app.state.batch_scheduler_modes = scheduler_modes
+    callable_target_scope_policy_mode = normalize_callable_target_policy_mode(
+        _batch_runtime_setting(
+            app,
+            cfg,
+            "callable_target_scope_policy_mode",
+            default="enforce",
+        )
+    )
+    tier_policy_mode = _batch_runtime_setting(
+        app,
+        cfg,
+        "tier_policy_mode",
+        default="disabled",
+    )
+    tier_policy_missing_service_mode = _batch_runtime_setting(
+        app,
+        cfg,
+        "tier_policy_missing_service_mode",
+        default="fail_open",
+    )
     app.state.batch_service = BatchService(
         repository=repository,
         storage=batch_storage,
@@ -601,9 +640,10 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
         max_items_per_batch=cfg.general_settings.embeddings_batch_max_items_per_batch,
         max_line_bytes=cfg.general_settings.embeddings_batch_max_line_bytes,
         callable_target_grant_service=getattr(app.state, "callable_target_grant_service", None),
-        callable_target_scope_policy_mode=normalize_callable_target_policy_mode(
-            getattr(cfg.general_settings, "callable_target_scope_policy_mode", "enforce")
-        ),
+        tier_policy_service=getattr(app.state, "tier_policy_service", None),
+        callable_target_scope_policy_mode=callable_target_scope_policy_mode,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
         model_group_resolver=model_group_resolver,
     )
 
@@ -812,9 +852,10 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
         storage_chunk_size=cfg.general_settings.embeddings_batch_storage_chunk_size,
         max_pending_batches_per_scope=cfg.general_settings.embeddings_batch_max_pending_batches_per_scope,
         callable_target_grant_service=getattr(app.state, "callable_target_grant_service", None),
-        callable_target_scope_policy_mode=normalize_callable_target_policy_mode(
-            getattr(cfg.general_settings, "callable_target_scope_policy_mode", "enforce")
-        ),
+        tier_policy_service=getattr(app.state, "tier_policy_service", None),
+        callable_target_scope_policy_mode=callable_target_scope_policy_mode,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
         idempotency_enabled=cfg.general_settings.embeddings_batch_create_idempotency_enabled,
         model_group_resolver=model_group_resolver,
         scheduler_enabled=_batch_scheduler_active_enabled_for_creation(cfg.general_settings),

--- a/src/chat/preflight.py
+++ b/src/chat/preflight.py
@@ -10,7 +10,12 @@ from src.chat.audit import emit_prompt_resolution_audit_event
 from src.models.errors import InvalidRequestError
 from src.models.requests import ChatCompletionRequest
 from src.routers.routing_decision import set_prompt_provenance
-from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
+from src.services.model_visibility import (
+    ensure_model_allowed,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
+)
 from src.services.prompt_registry import apply_route_preferences_to_metadata, parse_prompt_reference
 
 
@@ -25,7 +30,10 @@ async def run_text_preflight(
         auth,
         payload.model,
         callable_target_grant_service=getattr(request.app.state, "callable_target_grant_service", None),
+        tier_policy_service=getattr(request.app.state, "tier_policy_service", None),
         policy_mode=get_callable_target_policy_mode_from_app(request.app),
+        tier_policy_mode=get_tier_policy_mode_from_app(request.app),
+        tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(request.app),
         emit_shadow_log=True,
     )
 

--- a/src/metrics/__init__.py
+++ b/src/metrics/__init__.py
@@ -116,6 +116,7 @@ from src.metrics.counters import (
     increment_request,
     increment_request_failure,
     increment_spend,
+    increment_tier_policy_shadow_mismatch,
     increment_usage,
 )
 from src.metrics.gauges import (
@@ -239,6 +240,7 @@ __all__ = [
     "increment_cache_miss",
     "increment_callable_target_policy_shadow_mismatch",
     "increment_callable_target_policy_fallback",
+    "increment_tier_policy_shadow_mismatch",
     "increment_config_reload",
     "increment_prompt_cache_lookup",
     "increment_prompt_resolution",

--- a/src/metrics/counters.py
+++ b/src/metrics/counters.py
@@ -87,6 +87,13 @@ deltallm_callable_target_policy_fallback_metric = Counter(
     registry=get_prometheus_registry(),
 )
 
+deltallm_tier_policy_shadow_mismatch_metric = Counter(
+    "deltallm_tier_policy_shadow_mismatches_total",
+    "Tier policy shadow mismatches",
+    ["auth_source", "difference_type", "reason"],
+    registry=get_prometheus_registry(),
+)
+
 deltallm_config_reload_events_metric = Counter(
     "deltallm_config_reload_events_total",
     "Dynamic config reload events by source and result",
@@ -226,5 +233,18 @@ def increment_callable_target_policy_fallback(
     deltallm_callable_target_policy_fallback_metric.labels(
         policy_mode=sanitize_label(policy_mode),
         auth_source=sanitize_label(auth_source),
+        reason=sanitize_label(reason, "none"),
+    ).inc()
+
+
+def increment_tier_policy_shadow_mismatch(
+    *,
+    auth_source: str | None,
+    difference_type: str,
+    reason: str | None,
+) -> None:
+    deltallm_tier_policy_shadow_mismatch_metric.labels(
+        auth_source=sanitize_label(auth_source),
+        difference_type=sanitize_label(difference_type),
         reason=sanitize_label(reason, "none"),
     ).inc()

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -46,7 +46,12 @@ from src.routers.routing_decision import (
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
-from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
+from src.services.model_visibility import (
+    ensure_model_allowed,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
+)
 
 router = APIRouter(prefix="/v1", tags=["audio"])
 
@@ -188,7 +193,10 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
         auth,
         payload.model,
         callable_target_grant_service=getattr(request.app.state, "callable_target_grant_service", None),
+        tier_policy_service=getattr(request.app.state, "tier_policy_service", None),
         policy_mode=get_callable_target_policy_mode_from_app(request.app),
+        tier_policy_mode=get_tier_policy_mode_from_app(request.app),
+        tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(request.app),
         emit_shadow_log=True,
     )
     await enforce_budget_if_configured(request, model=payload.model, auth=auth)

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -45,7 +45,12 @@ from src.routers.routing_decision import (
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
-from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
+from src.services.model_visibility import (
+    ensure_model_allowed,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
+)
 
 DEFAULT_AUDIO_TRANSCRIPTION_TIMEOUT_SECONDS = 600.0
 
@@ -184,7 +189,10 @@ async def audio_transcriptions(
         auth,
         model,
         callable_target_grant_service=getattr(request.app.state, "callable_target_grant_service", None),
+        tier_policy_service=getattr(request.app.state, "tier_policy_service", None),
         policy_mode=get_callable_target_policy_mode_from_app(request.app),
+        tier_policy_mode=get_tier_policy_mode_from_app(request.app),
+        tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(request.app),
         emit_shadow_log=True,
     )
     await enforce_budget_if_configured(request, model=model, auth=auth)

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -39,7 +39,12 @@ from src.routers.routing_decision import (
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
-from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
+from src.services.model_visibility import (
+    ensure_model_allowed,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
+)
 from src.services.audit_service import AuditEventInput, AuditPayloadInput, AuditService
 from src.audit.actions import AuditAction
 from src.audit.errors import derive_audit_error_code
@@ -174,7 +179,10 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
         auth,
         payload.model,
         callable_target_grant_service=getattr(request.app.state, "callable_target_grant_service", None),
+        tier_policy_service=getattr(request.app.state, "tier_policy_service", None),
         policy_mode=get_callable_target_policy_mode_from_app(request.app),
+        tier_policy_mode=get_tier_policy_mode_from_app(request.app),
+        tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(request.app),
         emit_shadow_log=True,
     )
     await enforce_budget_if_configured(request, model=payload.model, auth=auth)

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -43,7 +43,12 @@ from src.routers.routing_decision import (
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
-from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
+from src.services.model_visibility import (
+    ensure_model_allowed,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
+)
 
 router = APIRouter(prefix="/v1", tags=["images"])
 
@@ -117,7 +122,10 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
         auth,
         payload.model,
         callable_target_grant_service=getattr(request.app.state, "callable_target_grant_service", None),
+        tier_policy_service=getattr(request.app.state, "tier_policy_service", None),
         policy_mode=get_callable_target_policy_mode_from_app(request.app),
+        tier_policy_mode=get_tier_policy_mode_from_app(request.app),
+        tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(request.app),
         emit_shadow_log=True,
     )
     await enforce_budget_if_configured(request, model=payload.model, auth=auth)

--- a/src/routers/models.py
+++ b/src/routers/models.py
@@ -6,7 +6,12 @@ from fastapi import APIRouter, Depends, Request
 
 from src.middleware.auth import require_api_key
 from src.services.callable_targets import list_callable_target_ids
-from src.services.model_visibility import filter_visible_models, get_callable_target_policy_mode_from_app
+from src.services.model_visibility import (
+    filter_visible_models,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
+)
 
 router = APIRouter(prefix="/v1", tags=["models"])
 
@@ -28,7 +33,10 @@ async def models(request: Request) -> dict[str, object]:
             callable_ids,
             auth,
             callable_target_grant_service=getattr(request.app.state, "callable_target_grant_service", None),
+            tier_policy_service=getattr(request.app.state, "tier_policy_service", None),
             policy_mode=get_callable_target_policy_mode_from_app(request.app),
+            tier_policy_mode=get_tier_policy_mode_from_app(request.app),
+            tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(request.app),
             emit_shadow_log=True,
         )
     )

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -39,7 +39,12 @@ from src.routers.routing_decision import (
     update_served_route_decision,
 )
 from src.routers.utils import enforce_budget_if_configured, fire_and_forget
-from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
+from src.services.model_visibility import (
+    ensure_model_allowed,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
+)
 
 router = APIRouter(prefix="/v1", tags=["rerank"])
 
@@ -108,7 +113,10 @@ async def rerank(request: Request, payload: RerankRequest):
         auth,
         payload.model,
         callable_target_grant_service=getattr(request.app.state, "callable_target_grant_service", None),
+        tier_policy_service=getattr(request.app.state, "tier_policy_service", None),
         policy_mode=get_callable_target_policy_mode_from_app(request.app),
+        tier_policy_mode=get_tier_policy_mode_from_app(request.app),
+        tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(request.app),
         emit_shadow_log=True,
     )
     await enforce_budget_if_configured(request, model=payload.model, auth=auth)

--- a/src/services/callable_target_grants.py
+++ b/src/services/callable_target_grants.py
@@ -175,11 +175,19 @@ class CallableTargetGrantService:
                 authoritative=True,
             )
 
-        if scope_context.team_id is not None and self._get_scope_mode(snapshot, "team", scope_context.team_id) == "restrict":
+        if (
+            scope_context.team_id is not None
+            and self._get_scope_mode(snapshot, "team", scope_context.team_id) == "restrict"
+        ):
             effective.intersection_update(snapshot.enabled_by_scope.get(("team", scope_context.team_id), ()))
 
-        if scope_context.api_key_scope_id is not None and self._get_scope_mode(snapshot, "api_key", scope_context.api_key_scope_id) == "restrict":
-            effective.intersection_update(snapshot.enabled_by_scope.get(("api_key", scope_context.api_key_scope_id), ()))
+        if (
+            scope_context.api_key_scope_id is not None
+            and self._get_scope_mode(snapshot, "api_key", scope_context.api_key_scope_id) == "restrict"
+        ):
+            effective.intersection_update(
+                snapshot.enabled_by_scope.get(("api_key", scope_context.api_key_scope_id), ())
+            )
 
         user_scope = ("user", scope_context.user_id) if scope_context.user_id is not None else None
         if user_scope is not None and self._should_restrict_user_scope(snapshot, user_scope):
@@ -189,6 +197,41 @@ class CallableTargetGrantService:
             allowlist=frozenset(effective),
             authoritative=True,
         )
+
+    def resolve_direct_restrict_allowlist(self, auth: UserAPIKeyAuth) -> frozenset[str] | None:
+        scope_context = resolve_runtime_scope_context(auth)
+        if scope_context.is_master_key:
+            return None
+
+        snapshot = self._snapshot
+        restrict_allowlists: list[set[str]] = []
+        if (
+            scope_context.team_id is not None
+            and self._get_scope_mode(snapshot, "team", scope_context.team_id) == "restrict"
+        ):
+            restrict_allowlists.append(
+                set(snapshot.enabled_by_scope.get(("team", scope_context.team_id), ()))
+            )
+
+        if (
+            scope_context.api_key_scope_id is not None
+            and self._get_scope_mode(snapshot, "api_key", scope_context.api_key_scope_id) == "restrict"
+        ):
+            restrict_allowlists.append(
+                set(snapshot.enabled_by_scope.get(("api_key", scope_context.api_key_scope_id), ()))
+            )
+
+        user_scope = ("user", scope_context.user_id) if scope_context.user_id is not None else None
+        if user_scope is not None and self._should_restrict_user_scope(snapshot, user_scope):
+            restrict_allowlists.append(set(snapshot.enabled_by_scope.get(user_scope, ())))
+
+        if not restrict_allowlists:
+            return None
+
+        effective = set(restrict_allowlists[0])
+        for allowlist in restrict_allowlists[1:]:
+            effective.intersection_update(allowlist)
+        return frozenset(effective)
 
     def _resolve_base_allowlist(
         self,

--- a/src/services/model_visibility.py
+++ b/src/services/model_visibility.py
@@ -14,38 +14,61 @@ from src.metrics import (
 from src.models.errors import PermissionDeniedError
 from src.models.responses import UserAPIKeyAuth
 from src.services.runtime_scopes import resolve_runtime_scope_context
+from src.services.tier_model_access import (
+    TierPolicyMode,
+    log_tier_policy_denial_if_applicable,
+    log_tier_policy_shadow_mismatch,
+    normalize_tier_policy_mode,
+    resolve_tier_model_access,
+)
 
 if TYPE_CHECKING:
     from src.services.callable_target_grants import CallableTargetGrantService
+    from src.services.tier_policy_service import TierPolicyService
 
 logger = logging.getLogger(__name__)
 
 CallableTargetPolicyMode = Literal["shadow", "enforce"]
 _ALLOWED_POLICY_MODES = {"shadow", "enforce"}
+_MISSING = object()
 
 
 @dataclass(frozen=True, slots=True)
 class ModelAllowlistResolution:
     effective_allowlist: set[str] | None
+    pre_tier_allowlist: set[str] | None
     hybrid_allowlist: set[str] | None
     policy_allowlist: set[str] | None
     policy_authoritative: bool
     policy_fallback_reason: str | None
     policy_mode: CallableTargetPolicyMode
     shadow_mismatch: bool = False
+    tier_mode: TierPolicyMode = "disabled"
+    tier_allowlist: set[str] | None = None
+    tier_effective_allowlist: set[str] | None = None
+    tier_applied: bool = False
+    tier_authoritative: bool = True
+    tier_unavailable_reason: str | None = None
+    tier_shadow_mismatch: bool = False
 
 
 def resolve_effective_model_allowlist(
     auth: UserAPIKeyAuth,
     *,
     callable_target_grant_service: CallableTargetGrantService | None = None,
+    tier_policy_service: TierPolicyService | None = None,
     policy_mode: CallableTargetPolicyMode | str = "enforce",
+    tier_policy_mode: TierPolicyMode | str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
     emit_shadow_log: bool = False,
 ) -> set[str] | None:
     resolution = resolve_model_allowlist_resolution(
         auth,
         callable_target_grant_service=callable_target_grant_service,
+        tier_policy_service=tier_policy_service,
         policy_mode=policy_mode,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
         emit_shadow_log=emit_shadow_log,
     )
     return resolution.effective_allowlist
@@ -55,13 +78,17 @@ def resolve_model_allowlist_resolution(
     auth: UserAPIKeyAuth,
     *,
     callable_target_grant_service: CallableTargetGrantService | None = None,
+    tier_policy_service: TierPolicyService | None = None,
     policy_mode: CallableTargetPolicyMode | str = "enforce",
+    tier_policy_mode: TierPolicyMode | str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
     emit_shadow_log: bool = False,
 ) -> ModelAllowlistResolution:
     normalized_policy_mode = normalize_callable_target_policy_mode(policy_mode)
     if resolve_runtime_scope_context(auth).is_master_key:
         return ModelAllowlistResolution(
             effective_allowlist=None,
+            pre_tier_allowlist=None,
             hybrid_allowlist=None,
             policy_allowlist=None,
             policy_authoritative=True,
@@ -69,7 +96,11 @@ def resolve_model_allowlist_resolution(
             policy_mode=normalized_policy_mode,
         )
 
-    hybrid_allowlist = _resolve_legacy_model_allowlist(auth) if normalized_policy_mode == "shadow" else None
+    hybrid_allowlist = (
+        _resolve_legacy_model_allowlist(auth)
+        if normalized_policy_mode == "shadow"
+        else None
+    )
 
     if callable_target_grant_service is None:
         policy_allowlist: set[str] | None = set()
@@ -85,9 +116,15 @@ def resolve_model_allowlist_resolution(
             else None
         )
 
-    effective_allowlist = policy_allowlist
+    direct_restrict_allowlist = _resolve_direct_restrict_allowlist(
+        auth,
+        callable_target_grant_service=callable_target_grant_service,
+        policy_mode=normalized_policy_mode,
+        policy_fallback_reason=policy_fallback_reason,
+    )
+    pre_tier_allowlist = policy_allowlist
     if normalized_policy_mode == "shadow":
-        effective_allowlist = hybrid_allowlist
+        pre_tier_allowlist = hybrid_allowlist
 
     shadow_mismatch = (
         normalized_policy_mode == "shadow"
@@ -108,14 +145,39 @@ def resolve_model_allowlist_resolution(
             reason=policy_fallback_reason,
         )
 
+    tier_resolution = resolve_tier_model_access(
+        auth,
+        pre_tier_allowlist=pre_tier_allowlist,
+        direct_restrict_allowlist=direct_restrict_allowlist,
+        tier_policy_service=tier_policy_service,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+    )
+    if tier_resolution.tier_shadow_mismatch and emit_shadow_log:
+        log_tier_policy_shadow_mismatch(
+            auth,
+            current_allowlist=pre_tier_allowlist,
+            tier_effective_allowlist=tier_resolution.tier_effective_allowlist,
+            reason=tier_resolution.tier_unavailable_reason,
+            tier_policy_service=tier_policy_service,
+        )
+
     return ModelAllowlistResolution(
-        effective_allowlist=effective_allowlist,
+        effective_allowlist=tier_resolution.effective_allowlist,
+        pre_tier_allowlist=pre_tier_allowlist,
         hybrid_allowlist=hybrid_allowlist,
         policy_allowlist=policy_allowlist,
         policy_authoritative=policy_authoritative,
         policy_fallback_reason=policy_fallback_reason,
         policy_mode=normalized_policy_mode,
         shadow_mismatch=shadow_mismatch,
+        tier_mode=tier_resolution.tier_mode,
+        tier_allowlist=tier_resolution.tier_allowlist,
+        tier_effective_allowlist=tier_resolution.tier_effective_allowlist,
+        tier_applied=tier_resolution.tier_applied,
+        tier_authoritative=tier_resolution.tier_authoritative,
+        tier_unavailable_reason=tier_resolution.tier_unavailable_reason,
+        tier_shadow_mismatch=tier_resolution.tier_shadow_mismatch,
     )
 
 
@@ -124,13 +186,19 @@ def filter_visible_models(
     auth: UserAPIKeyAuth,
     *,
     callable_target_grant_service: CallableTargetGrantService | None = None,
+    tier_policy_service: TierPolicyService | None = None,
     policy_mode: CallableTargetPolicyMode | str = "enforce",
+    tier_policy_mode: TierPolicyMode | str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
     emit_shadow_log: bool = False,
 ) -> list[str]:
     allowed_models = resolve_effective_model_allowlist(
         auth,
         callable_target_grant_service=callable_target_grant_service,
+        tier_policy_service=tier_policy_service,
         policy_mode=policy_mode,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
         emit_shadow_log=emit_shadow_log,
     )
     if allowed_models is None:
@@ -143,16 +211,30 @@ def ensure_model_allowed(
     model: str,
     *,
     callable_target_grant_service: CallableTargetGrantService | None = None,
+    tier_policy_service: TierPolicyService | None = None,
     policy_mode: CallableTargetPolicyMode | str = "enforce",
+    tier_policy_mode: TierPolicyMode | str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
     emit_shadow_log: bool = False,
 ) -> None:
-    allowed_models = resolve_effective_model_allowlist(
+    resolution = resolve_model_allowlist_resolution(
         auth,
         callable_target_grant_service=callable_target_grant_service,
+        tier_policy_service=tier_policy_service,
         policy_mode=policy_mode,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
         emit_shadow_log=emit_shadow_log,
     )
-    if allowed_models is not None and model not in allowed_models:
+    if log_tier_policy_denial_if_applicable(
+        auth,
+        model,
+        pre_tier_allowlist=resolution.pre_tier_allowlist,
+        tier_resolution=resolution,
+        tier_policy_service=tier_policy_service,
+    ):
+        raise PermissionDeniedError(message=model_not_allowed_message(model))
+    if resolution.effective_allowlist is not None and model not in resolution.effective_allowlist:
         raise PermissionDeniedError(message=model_not_allowed_message(model))
 
 
@@ -161,16 +243,33 @@ def ensure_batch_model_allowed(
     model: str,
     *,
     callable_target_grant_service: CallableTargetGrantService | None = None,
+    tier_policy_service: TierPolicyService | None = None,
     policy_mode: CallableTargetPolicyMode | str = "enforce",
+    tier_policy_mode: TierPolicyMode | str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
     emit_shadow_log: bool = False,
 ) -> None:
-    allowed_models = resolve_effective_model_allowlist(
+    resolution = resolve_model_allowlist_resolution(
         auth,
         callable_target_grant_service=callable_target_grant_service,
+        tier_policy_service=tier_policy_service,
         policy_mode=policy_mode,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
         emit_shadow_log=emit_shadow_log,
     )
-    if allowed_models is not None and model not in allowed_models:
+    if log_tier_policy_denial_if_applicable(
+        auth,
+        model,
+        pre_tier_allowlist=resolution.pre_tier_allowlist,
+        tier_resolution=resolution,
+        tier_policy_service=tier_policy_service,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=model_not_allowed_message(model),
+        )
+    if resolution.effective_allowlist is not None and model not in resolution.effective_allowlist:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=model_not_allowed_message(model),
@@ -182,12 +281,35 @@ def model_not_allowed_message(model: str) -> str:
 
 
 def get_callable_target_policy_mode_from_app(app: Any) -> CallableTargetPolicyMode:
-    app_config = getattr(app.state, "app_config", None)
-    general_settings = getattr(app_config, "general_settings", None)
-    if general_settings is not None and hasattr(general_settings, "callable_target_scope_policy_mode"):
-        return normalize_callable_target_policy_mode(getattr(general_settings, "callable_target_scope_policy_mode"))
-    settings = getattr(app.state, "settings", None)
-    return normalize_callable_target_policy_mode(getattr(settings, "callable_target_scope_policy_mode", "enforce"))
+    return normalize_callable_target_policy_mode(
+        _app_setting(
+            app,
+            "callable_target_scope_policy_mode",
+            default="enforce",
+        )
+    )
+
+
+def get_tier_policy_mode_from_app(app: Any) -> TierPolicyMode:
+    service = getattr(app.state, "tier_policy_service", None)
+    if service is not None and hasattr(service, "mode"):
+        return normalize_tier_policy_mode(getattr(service, "mode"))
+    return normalize_tier_policy_mode(
+        _app_setting(app, "tier_policy_mode", default="disabled")
+    )
+
+
+def get_tier_policy_missing_service_mode_from_app(app: Any) -> str:
+    service = getattr(app.state, "tier_policy_service", None)
+    if service is not None and hasattr(service, "missing_service_mode"):
+        return normalize_tier_policy_missing_service_mode(getattr(service, "missing_service_mode"))
+    return normalize_tier_policy_missing_service_mode(
+        _app_setting(
+            app,
+            "tier_policy_missing_service_mode",
+            default="fail_open",
+        )
+    )
 
 
 def normalize_callable_target_policy_mode(value: object) -> CallableTargetPolicyMode:
@@ -197,6 +319,56 @@ def normalize_callable_target_policy_mode(value: object) -> CallableTargetPolicy
     if normalized not in _ALLOWED_POLICY_MODES:
         return "enforce"
     return normalized  # type: ignore[return-value]
+
+
+def normalize_tier_policy_missing_service_mode(value: object) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized not in {"fail_open", "fail_closed"}:
+        return "fail_open"
+    return normalized
+
+
+def _resolve_direct_restrict_allowlist(
+    auth: UserAPIKeyAuth,
+    *,
+    callable_target_grant_service: CallableTargetGrantService | None,
+    policy_mode: CallableTargetPolicyMode,
+    policy_fallback_reason: str | None,
+) -> frozenset[str] | None:
+    if policy_mode == "shadow":
+        return None
+    if policy_mode == "enforce" and policy_fallback_reason is not None:
+        return frozenset()
+    if callable_target_grant_service is None:
+        return None
+
+    resolver = getattr(callable_target_grant_service, "resolve_direct_restrict_allowlist", None)
+    if not callable(resolver):
+        return None
+
+    direct_restrict_allowlist = resolver(auth)
+    if direct_restrict_allowlist is None:
+        return None
+    return frozenset(_normalize_allowlist(direct_restrict_allowlist))
+
+
+def _app_setting(app: Any, field_name: str, *, default: Any) -> Any:
+    app_config = getattr(app.state, "app_config", None)
+    general_settings = getattr(app_config, "general_settings", None)
+    value = _explicit_general_setting(general_settings, field_name)
+    if value is not _MISSING:
+        return value
+    settings = getattr(app.state, "settings", None)
+    return getattr(settings, field_name, default)
+
+
+def _explicit_general_setting(general_settings: Any, field_name: str) -> Any:
+    if general_settings is None:
+        return _MISSING
+    fields_set = getattr(general_settings, "model_fields_set", None)
+    if fields_set is not None and field_name not in fields_set:
+        return _MISSING
+    return getattr(general_settings, field_name, _MISSING)
 
 
 def _normalize_allowlist(values: Iterable[str] | None) -> set[str]:

--- a/src/services/tier_model_access.py
+++ b/src/services/tier_model_access.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+from src.metrics import increment_tier_policy_shadow_mismatch
+from src.models.responses import UserAPIKeyAuth
+from src.services.runtime_scopes import resolve_runtime_scope_context
+from src.services.tier_policy_service import resolve_tier_policy_unavailable_decision
+
+if TYPE_CHECKING:
+    from src.services.tier_policy_service import TierPolicyService
+
+logger = logging.getLogger(__name__)
+
+TierPolicyMode = Literal["disabled", "shadow", "enforce"]
+_ALLOWED_TIER_POLICY_MODES = {"disabled", "shadow", "enforce"}
+_LOG_MODEL_LIMIT = 25
+
+
+@dataclass(frozen=True, slots=True)
+class TierModelAccessResolution:
+    effective_allowlist: set[str] | None
+    tier_mode: TierPolicyMode
+    tier_allowlist: set[str] | None = None
+    tier_effective_allowlist: set[str] | None = None
+    tier_applied: bool = False
+    tier_authoritative: bool = True
+    tier_unavailable_reason: str | None = None
+    tier_shadow_mismatch: bool = False
+
+
+class TierModelAccessResolutionView(Protocol):
+    tier_mode: TierPolicyMode
+    tier_allowlist: set[str] | None
+    tier_effective_allowlist: set[str] | None
+    tier_applied: bool
+    tier_authoritative: bool
+    tier_unavailable_reason: str | None
+
+
+def normalize_tier_policy_mode(value: object) -> TierPolicyMode:
+    normalized = str(value or "").strip().lower()
+    if normalized not in _ALLOWED_TIER_POLICY_MODES:
+        return "disabled"
+    return normalized  # type: ignore[return-value]
+
+
+def resolve_tier_model_access(
+    auth: UserAPIKeyAuth,
+    *,
+    pre_tier_allowlist: set[str] | None,
+    direct_restrict_allowlist: set[str] | frozenset[str] | None = None,
+    tier_policy_service: TierPolicyService | None,
+    tier_policy_mode: TierPolicyMode | str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
+) -> TierModelAccessResolution:
+    tier_mode = normalize_tier_policy_mode(
+        getattr(tier_policy_service, "mode", tier_policy_mode)
+        if tier_policy_service is not None
+        else tier_policy_mode
+    )
+    if tier_mode == "disabled":
+        return TierModelAccessResolution(
+            effective_allowlist=pre_tier_allowlist,
+            tier_mode=tier_mode,
+        )
+
+    scope_context = resolve_runtime_scope_context(auth)
+    if scope_context.is_master_key or scope_context.organization_id is None:
+        return TierModelAccessResolution(
+            effective_allowlist=pre_tier_allowlist,
+            tier_mode=tier_mode,
+        )
+
+    if tier_policy_service is None or not callable(
+        getattr(tier_policy_service, "resolve_org_allowed_callable_keys", None)
+    ):
+        decision = _resolve_tier_unavailable_decision(
+            tier_policy_service,
+            organization_id=scope_context.organization_id,
+            tier_mode=tier_mode,
+            missing_service_mode=tier_policy_missing_service_mode,
+        )
+        return _resolve_unavailable_tier_access(
+            pre_tier_allowlist=pre_tier_allowlist,
+            tier_mode=tier_mode,
+            decision=decision,
+        )
+
+    if bool(getattr(tier_policy_service, "snapshot_stale", False)):
+        decision = _resolve_tier_unavailable_decision(
+            tier_policy_service,
+            organization_id=scope_context.organization_id,
+            tier_mode=tier_mode,
+            missing_service_mode=tier_policy_missing_service_mode,
+        )
+        if not bool(getattr(decision, "allowed", False)):
+            return _resolve_unavailable_tier_access(
+                pre_tier_allowlist=pre_tier_allowlist,
+                tier_mode=tier_mode,
+                decision=decision,
+            )
+        return TierModelAccessResolution(
+            effective_allowlist=pre_tier_allowlist,
+            tier_mode=tier_mode,
+            tier_authoritative=False,
+            tier_unavailable_reason=str(getattr(decision, "reason", "tier_policy_unavailable")),
+        )
+
+    org_allowlist = tier_policy_service.resolve_org_allowed_callable_keys(
+        scope_context.organization_id
+    )
+    if org_allowlist is None:
+        return TierModelAccessResolution(
+            effective_allowlist=pre_tier_allowlist,
+            tier_mode=tier_mode,
+        )
+
+    tier_allowlist = _normalize_allowlist(org_allowlist)
+    tier_effective_allowlist = _apply_direct_restrict_allowlist(
+        tier_allowlist,
+        direct_restrict_allowlist,
+    )
+    tier_shadow_mismatch = tier_mode == "shadow" and _allowlists_differ(
+        pre_tier_allowlist,
+        tier_effective_allowlist,
+    )
+    return TierModelAccessResolution(
+        effective_allowlist=tier_effective_allowlist if tier_mode == "enforce" else pre_tier_allowlist,
+        tier_mode=tier_mode,
+        tier_allowlist=tier_allowlist,
+        tier_effective_allowlist=tier_effective_allowlist,
+        tier_applied=True,
+        tier_shadow_mismatch=tier_shadow_mismatch,
+    )
+
+
+def log_tier_policy_shadow_mismatch(
+    auth: UserAPIKeyAuth,
+    *,
+    current_allowlist: set[str] | None,
+    tier_effective_allowlist: set[str] | None,
+    reason: str | None,
+    tier_policy_service: TierPolicyService | None,
+) -> None:
+    scope_context = resolve_runtime_scope_context(auth)
+    current = current_allowlist or set()
+    tier_effective = tier_effective_allowlist or set()
+    removed_models = (
+        _bounded_sorted_values(current - tier_effective)
+        if current_allowlist is not None and tier_effective_allowlist is not None
+        else []
+    )
+    added_models = (
+        _bounded_sorted_values(tier_effective - current)
+        if current_allowlist is not None and tier_effective_allowlist is not None
+        else []
+    )
+    difference_type = _tier_difference_type(
+        current_allowlist=current_allowlist,
+        tier_effective_allowlist=tier_effective_allowlist,
+        removed_models=removed_models,
+        added_models=added_models,
+    )
+    increment_tier_policy_shadow_mismatch(
+        auth_source=scope_context.auth_source,
+        difference_type=difference_type,
+        reason=reason,
+    )
+    logger.info(
+        "tier_policy_shadow_mismatch",
+        extra={
+            "actor_id": scope_context.actor_id,
+            "auth_source": scope_context.auth_source,
+            "organization_id": scope_context.organization_id,
+            "team_id": scope_context.team_id,
+            "api_key_scope_id": scope_context.api_key_scope_id,
+            "current_count": None if current_allowlist is None else len(current),
+            "tier_effective_count": (
+                None if tier_effective_allowlist is None else len(tier_effective)
+            ),
+            "current_unrestricted": current_allowlist is None,
+            "tier_effective_unrestricted": tier_effective_allowlist is None,
+            "removed_models": removed_models,
+            "added_models": added_models,
+            "difference_type": difference_type,
+            "reason": reason,
+            **_tier_snapshot_log_fields(tier_policy_service),
+        },
+    )
+
+
+def log_tier_policy_denial_if_applicable(
+    auth: UserAPIKeyAuth,
+    model: str,
+    *,
+    pre_tier_allowlist: set[str] | None,
+    tier_resolution: TierModelAccessResolutionView,
+    tier_policy_service: TierPolicyService | None,
+) -> bool:
+    reason = _tier_policy_denial_reason(
+        auth,
+        model,
+        pre_tier_allowlist=pre_tier_allowlist,
+        tier_resolution=tier_resolution,
+        tier_policy_service=tier_policy_service,
+    )
+    if reason is None:
+        return False
+
+    scope_context = resolve_runtime_scope_context(auth)
+    logger.info(
+        "tier_policy_model_access_denied",
+        extra={
+            "actor_id": scope_context.actor_id,
+            "auth_source": scope_context.auth_source,
+            "organization_id": scope_context.organization_id,
+            "team_id": scope_context.team_id,
+            "api_key_scope_id": scope_context.api_key_scope_id,
+            "model": model,
+            "tier_mode": tier_resolution.tier_mode,
+            "reason": reason,
+            "pre_tier_count": None if pre_tier_allowlist is None else len(pre_tier_allowlist),
+            "tier_allowlist_count": (
+                None
+                if tier_resolution.tier_allowlist is None
+                else len(tier_resolution.tier_allowlist)
+            ),
+            "tier_effective_count": (
+                None
+                if tier_resolution.tier_effective_allowlist is None
+                else len(tier_resolution.tier_effective_allowlist)
+            ),
+            "tier_unavailable_reason": tier_resolution.tier_unavailable_reason,
+            **_tier_snapshot_log_fields(tier_policy_service),
+        },
+    )
+    return True
+
+
+def _resolve_tier_unavailable_decision(
+    tier_policy_service: TierPolicyService | None,
+    *,
+    organization_id: str | None,
+    tier_mode: TierPolicyMode,
+    missing_service_mode: str,
+) -> Any:
+    resolver = getattr(tier_policy_service, "resolve_unavailable_decision", None)
+    if callable(resolver):
+        return resolver(organization_id)
+
+    service_for_decision = (
+        tier_policy_service
+        if callable(getattr(tier_policy_service, "has_explicit_tier_policy", None))
+        else None
+    )
+    return resolve_tier_policy_unavailable_decision(
+        service_for_decision,
+        organization_id,
+        mode=tier_mode,
+        missing_service_mode=str(
+            getattr(tier_policy_service, "missing_service_mode", missing_service_mode)
+            if tier_policy_service is not None
+            else missing_service_mode
+        ),
+    )
+
+
+def _resolve_unavailable_tier_access(
+    *,
+    pre_tier_allowlist: set[str] | None,
+    tier_mode: TierPolicyMode,
+    decision: Any,
+) -> TierModelAccessResolution:
+    reason = str(getattr(decision, "reason", "tier_policy_unavailable"))
+    if bool(getattr(decision, "allowed", False)):
+        return TierModelAccessResolution(
+            effective_allowlist=pre_tier_allowlist,
+            tier_mode=tier_mode,
+            tier_authoritative=False,
+            tier_unavailable_reason=reason,
+        )
+
+    tier_allowlist: set[str] = set()
+    tier_effective_allowlist = set()
+    tier_shadow_mismatch = tier_mode == "shadow" and _allowlists_differ(
+        pre_tier_allowlist,
+        tier_effective_allowlist,
+    )
+    return TierModelAccessResolution(
+        effective_allowlist=tier_effective_allowlist if tier_mode == "enforce" else pre_tier_allowlist,
+        tier_mode=tier_mode,
+        tier_allowlist=tier_allowlist,
+        tier_effective_allowlist=tier_effective_allowlist,
+        tier_applied=True,
+        tier_authoritative=False,
+        tier_unavailable_reason=reason,
+        tier_shadow_mismatch=tier_shadow_mismatch,
+    )
+
+
+def _apply_direct_restrict_allowlist(
+    base_allowlist: set[str],
+    direct_restrict_allowlist: set[str] | frozenset[str] | None,
+) -> set[str]:
+    if direct_restrict_allowlist is None:
+        return set(base_allowlist)
+    return set(base_allowlist).intersection(direct_restrict_allowlist)
+
+
+def _normalize_allowlist(values: Iterable[str] | None) -> set[str]:
+    normalized: set[str] = set()
+    if values is None:
+        return normalized
+    for value in values:
+        item = str(value).strip()
+        if item:
+            normalized.add(item)
+    return normalized
+
+
+def _allowlists_differ(left: set[str] | None, right: set[str] | None) -> bool:
+    if left is None and right is None:
+        return False
+    if left is None or right is None:
+        return True
+    return left != right
+
+
+def _tier_policy_denial_reason(
+    auth: UserAPIKeyAuth,
+    model: str,
+    *,
+    pre_tier_allowlist: set[str] | None,
+    tier_resolution: TierModelAccessResolutionView,
+    tier_policy_service: TierPolicyService | None,
+) -> str | None:
+    if tier_resolution.tier_mode != "enforce" or not tier_resolution.tier_applied:
+        return None
+    policy = _get_tier_model_policy(auth, model, tier_policy_service)
+    if str(getattr(policy, "access_mode", "")).strip().lower() == "deny":
+        return "tier_policy_deny"
+    if (
+        tier_resolution.tier_effective_allowlist is None
+        or model in tier_resolution.tier_effective_allowlist
+    ):
+        return None
+    if (
+        tier_resolution.tier_unavailable_reason is not None
+        and not tier_resolution.tier_authoritative
+    ):
+        return tier_resolution.tier_unavailable_reason
+
+    if tier_resolution.tier_allowlist is not None:
+        if model not in tier_resolution.tier_allowlist:
+            return "tier_policy_allowlist_excluded"
+        return None
+    if pre_tier_allowlist is not None and model not in pre_tier_allowlist:
+        return None
+    return "tier_policy_allowlist_excluded"
+
+
+def _get_tier_model_policy(
+    auth: UserAPIKeyAuth,
+    model: str,
+    tier_policy_service: TierPolicyService | None,
+) -> Any | None:
+    getter = getattr(tier_policy_service, "get_model_policy", None)
+    if not callable(getter):
+        return None
+    return getter(resolve_runtime_scope_context(auth).organization_id, model)
+
+
+def _tier_snapshot_log_fields(tier_policy_service: TierPolicyService | None) -> dict[str, Any]:
+    fields: dict[str, Any] = {
+        "tier_snapshot_stale": bool(getattr(tier_policy_service, "snapshot_stale", False)),
+    }
+    info_getter = getattr(tier_policy_service, "snapshot_info", None)
+    if not callable(info_getter):
+        return fields
+    try:
+        info = info_getter()
+    except Exception:
+        logger.debug("tier policy snapshot info unavailable", exc_info=True)
+        return fields
+    fields.update(
+        {
+            "tier_snapshot_etag": getattr(info, "etag", None),
+            "tier_snapshot_org_count": getattr(info, "org_count", None),
+        }
+    )
+    return fields
+
+
+def _difference_type(*, removed_models: list[str], added_models: list[str]) -> str:
+    if removed_models and added_models:
+        return "both"
+    if removed_models:
+        return "removed_only"
+    if added_models:
+        return "added_only"
+    return "none"
+
+
+def _tier_difference_type(
+    *,
+    current_allowlist: set[str] | None,
+    tier_effective_allowlist: set[str] | None,
+    removed_models: list[str],
+    added_models: list[str],
+) -> str:
+    if current_allowlist is None or tier_effective_allowlist is None:
+        return "unrestricted_changed"
+    return _difference_type(removed_models=removed_models, added_models=added_models)
+
+
+def _bounded_sorted_values(values: set[str]) -> list[str]:
+    return sorted(values)[:_LOG_MODEL_LIMIT]

--- a/tests/bootstrap/test_optional_bootstrap.py
+++ b/tests/bootstrap/test_optional_bootstrap.py
@@ -284,10 +284,15 @@ async def test_init_and_shutdown_batch_runtime_enabled(monkeypatch: pytest.Monke
             max_items_per_batch=10_000,  # noqa: ANN001
             max_line_bytes=1_048_576,  # noqa: ANN001
             callable_target_grant_service=None,  # noqa: ANN001
+            tier_policy_service=None,  # noqa: ANN001
             callable_target_scope_policy_mode="enforce",  # noqa: ANN001
+            tier_policy_mode="disabled",  # noqa: ANN001
+            tier_policy_missing_service_mode="fail_open",  # noqa: ANN001
             model_group_resolver=None,  # noqa: ANN001
+            **kwargs,  # noqa: ANN003
         ) -> None:
             del model_group_resolver
+            del kwargs, tier_policy_service, tier_policy_mode, tier_policy_missing_service_mode
             self.repository = repository
             self.storage = storage
             self.storage_registry = storage_registry
@@ -831,6 +836,78 @@ async def test_init_batch_runtime_builds_create_session_public_service(
 
 
 @pytest.mark.asyncio
+async def test_init_batch_runtime_uses_settings_fallback_for_policy_modes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, object] = {}
+
+    class FakeBatchService:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            del args
+            self.kwargs = kwargs
+            self.create_session_service = None
+            created["batch_service"] = self
+
+        def bind_create_session_service(self, create_session_service) -> None:  # noqa: ANN001
+            self.create_session_service = create_session_service
+
+    class FakeBatchCreateSessionService:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            del args
+            self.kwargs = kwargs
+            created["create_session_service"] = self
+
+    monkeypatch.setattr("src.bootstrap.batch.LocalBatchArtifactStorage", lambda path: {"path": path})
+    monkeypatch.setattr("src.bootstrap.batch.BatchService", FakeBatchService)
+    monkeypatch.setattr("src.bootstrap.batch.BatchCreateSessionService", FakeBatchCreateSessionService)
+    monkeypatch.setattr(
+        "src.bootstrap.batch.BatchCreateArtifactStorageBackend",
+        lambda **kwargs: {"kind": "staging", **kwargs},
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.batch.BatchCreateSessionPromoter",
+        lambda **kwargs: {"kind": "promoter", **kwargs},
+    )
+    monkeypatch.setattr(
+        "src.bootstrap.batch.BatchCreateSessionAdminService",
+        lambda **kwargs: {"kind": "admin-service", **kwargs},
+    )
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            settings=SimpleNamespace(
+                callable_target_scope_policy_mode="shadow",
+                tier_policy_mode="enforce",
+                tier_policy_missing_service_mode="fail_closed",
+            )
+        )
+    )
+    repository = SimpleNamespace(create_sessions=_FakeCreateSessionRepository())
+
+    runtime = await init_batch_runtime(
+        app,
+        _batch_config(
+            enabled=True,
+            worker_enabled=False,
+            gc_enabled=False,
+            completion_outbox_worker_enabled=False,
+        ),
+        repository=repository,
+    )
+
+    batch_kwargs = created["batch_service"].kwargs
+    create_session_kwargs = created["create_session_service"].kwargs
+    assert batch_kwargs["callable_target_scope_policy_mode"] == "shadow"
+    assert batch_kwargs["tier_policy_mode"] == "enforce"
+    assert batch_kwargs["tier_policy_missing_service_mode"] == "fail_closed"
+    assert create_session_kwargs["callable_target_scope_policy_mode"] == "shadow"
+    assert create_session_kwargs["tier_policy_mode"] == "enforce"
+    assert create_session_kwargs["tier_policy_missing_service_mode"] == "fail_closed"
+
+    await shutdown_batch_runtime(runtime)
+
+
+@pytest.mark.asyncio
 async def test_init_batch_runtime_selects_s3_storage(monkeypatch: pytest.MonkeyPatch) -> None:
     created: dict[str, object] = {}
 
@@ -846,13 +923,18 @@ async def test_init_batch_runtime_selects_s3_storage(monkeypatch: pytest.MonkeyP
             max_items_per_batch=10_000,
             max_line_bytes=1_048_576,
             callable_target_grant_service=None,
+            tier_policy_service=None,
             callable_target_scope_policy_mode="enforce",
+            tier_policy_mode="disabled",
+            tier_policy_missing_service_mode="fail_open",
             model_group_resolver=None,
+            **kwargs,
         ) -> None:  # noqa: ANN001
             del model_group_resolver
             del metadata_retention_days, storage_chunk_size, max_file_bytes
             del max_items_per_batch, max_line_bytes
             del callable_target_grant_service, callable_target_scope_policy_mode
+            del tier_policy_service, tier_policy_mode, tier_policy_missing_service_mode, kwargs
             self.repository = repository
             self.storage = storage
             self.storage_registry = storage_registry

--- a/tests/test_model_visibility.py
+++ b/tests/test_model_visibility.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 
 import pytest
 
@@ -14,6 +15,9 @@ from src.services.callable_targets import CallableTarget, DuplicateCallableTarge
 from src.services.model_deployments import build_model_registry_from_config
 from src.services.model_visibility import (
     filter_visible_models,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
     resolve_effective_model_allowlist,
     resolve_model_allowlist_resolution,
 )
@@ -93,6 +97,60 @@ def test_callable_target_policy_mode_accepts_legacy_config_alias(monkeypatch) ->
     monkeypatch.delenv("DELTALLM_SALT_KEY", raising=False)
     assert GeneralSettings(callable_target_scope_policy_mode="legacy").callable_target_scope_policy_mode == "legacy"
     assert Settings(callable_target_scope_policy_mode="legacy").callable_target_scope_policy_mode == "legacy"
+
+
+def test_policy_getters_use_settings_when_general_settings_omits_fields() -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            app_config=SimpleNamespace(
+                general_settings=SimpleNamespace(
+                    model_fields_set=set(),
+                    callable_target_scope_policy_mode="enforce",
+                    tier_policy_mode="disabled",
+                    tier_policy_missing_service_mode="fail_open",
+                )
+            ),
+            settings=SimpleNamespace(
+                callable_target_scope_policy_mode="shadow",
+                tier_policy_mode="enforce",
+                tier_policy_missing_service_mode="fail_closed",
+            ),
+            tier_policy_service=None,
+        )
+    )
+
+    assert get_callable_target_policy_mode_from_app(app) == "shadow"
+    assert get_tier_policy_mode_from_app(app) == "enforce"
+    assert get_tier_policy_missing_service_mode_from_app(app) == "fail_closed"
+
+
+def test_policy_getters_prefer_explicit_general_settings() -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            app_config=SimpleNamespace(
+                general_settings=SimpleNamespace(
+                    model_fields_set={
+                        "callable_target_scope_policy_mode",
+                        "tier_policy_mode",
+                        "tier_policy_missing_service_mode",
+                    },
+                    callable_target_scope_policy_mode="enforce",
+                    tier_policy_mode="shadow",
+                    tier_policy_missing_service_mode="fail_open",
+                )
+            ),
+            settings=SimpleNamespace(
+                callable_target_scope_policy_mode="shadow",
+                tier_policy_mode="enforce",
+                tier_policy_missing_service_mode="fail_closed",
+            ),
+            tier_policy_service=None,
+        )
+    )
+
+    assert get_callable_target_policy_mode_from_app(app) == "enforce"
+    assert get_tier_policy_mode_from_app(app) == "shadow"
+    assert get_tier_policy_missing_service_mode_from_app(app) == "fail_open"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tier_model_access.py
+++ b/tests/test_tier_model_access.py
@@ -1,0 +1,556 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import pytest
+from fastapi import HTTPException
+
+from src.batch.endpoints import BATCH_ENDPOINT_CHAT_COMPLETIONS
+from src.batch.request_validation import parse_batch_input_line
+from src.db.callable_targets import CallableTargetBindingRecord
+from src.db.callable_target_policies import CallableTargetScopePolicyRecord
+from src.models.errors import PermissionDeniedError
+from src.models.responses import UserAPIKeyAuth
+from src.services.callable_target_grants import CallableTargetGrantService
+from src.services.model_visibility import (
+    ensure_model_allowed,
+    resolve_effective_model_allowlist,
+    resolve_model_allowlist_resolution,
+)
+from src.services.tier_policy_service import resolve_tier_policy_unavailable_decision
+
+
+class _FakeCallableTargetBindingRepository:
+    def __init__(self, bindings: list[CallableTargetBindingRecord]) -> None:
+        self.bindings = list(bindings)
+
+    async def list_bindings(self, *, callable_key=None, scope_type=None, scope_id=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+        items = list(self.bindings)
+        if callable_key:
+            items = [item for item in items if item.callable_key == callable_key]
+        if scope_type:
+            items = [item for item in items if item.scope_type == scope_type]
+        if scope_id:
+            items = [item for item in items if item.scope_id == scope_id]
+        return items[offset : offset + limit], len(items)
+
+
+class _FakeCallableTargetScopePolicyRepository:
+    def __init__(self, policies: list[CallableTargetScopePolicyRecord]) -> None:
+        self.policies = list(policies)
+
+    async def list_policies(self, *, scope_type=None, scope_id=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+        items = list(self.policies)
+        if scope_type:
+            items = [item for item in items if item.scope_type == scope_type]
+        if scope_id:
+            items = [item for item in items if item.scope_id == scope_id]
+        return items[offset : offset + limit], len(items)
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeTierModelPolicy:
+    access_mode: str
+
+
+class _FakeTierSnapshotInfo:
+    etag = "fake-tier-snapshot"
+    org_count = 1
+
+
+class _FakeTierPolicyService:
+    def __init__(
+        self,
+        *,
+        allowed_by_org: dict[str, set[str] | frozenset[str]] | None = None,
+        denied: set[tuple[str, str]] | None = None,
+        explicit_orgs: set[str] | None = None,
+        mode: str = "enforce",
+        missing_service_mode: str = "fail_open",
+        snapshot_stale: bool = False,
+    ) -> None:
+        self.allowed_by_org = {
+            org_id: frozenset(values)
+            for org_id, values in (allowed_by_org or {}).items()
+        }
+        self.denied = set(denied or set())
+        self.explicit_orgs = set(explicit_orgs or set(self.allowed_by_org))
+        self.mode = mode
+        self.missing_service_mode = missing_service_mode
+        self.snapshot_stale = snapshot_stale
+
+    def has_explicit_tier_policy(self, organization_id: str | None) -> bool:
+        return str(organization_id or "").strip() in self.explicit_orgs
+
+    def resolve_unavailable_decision(self, organization_id: str | None) -> object:
+        return resolve_tier_policy_unavailable_decision(
+            self,
+            organization_id,
+            mode=self.mode,
+            missing_service_mode=self.missing_service_mode,
+        )
+
+    def resolve_org_allowed_callable_keys(
+        self,
+        organization_id: str | None,
+    ) -> frozenset[str] | None:
+        normalized = str(organization_id or "").strip()
+        if normalized not in self.explicit_orgs:
+            return None
+        return self.allowed_by_org.get(normalized, frozenset())
+
+    def get_model_policy(
+        self,
+        organization_id: str | None,
+        callable_key: str | None,
+    ) -> _FakeTierModelPolicy | None:
+        key = (str(organization_id or "").strip(), str(callable_key or "").strip())
+        if key in self.denied:
+            return _FakeTierModelPolicy("deny")
+        return None
+
+    def snapshot_info(self) -> _FakeTierSnapshotInfo:
+        return _FakeTierSnapshotInfo()
+
+
+async def _loaded_grant_service(
+    *,
+    bindings: list[CallableTargetBindingRecord],
+    policies: list[CallableTargetScopePolicyRecord] | None = None,
+) -> CallableTargetGrantService:
+    service = CallableTargetGrantService(
+        repository=_FakeCallableTargetBindingRepository(bindings),
+        policy_repository=_FakeCallableTargetScopePolicyRepository(policies or []),
+    )
+    await service.reload()
+    return service
+
+
+def _binding(
+    record_id: str,
+    *,
+    callable_key: str,
+    scope_type: str = "organization",
+    scope_id: str = "org-1",
+) -> CallableTargetBindingRecord:
+    return CallableTargetBindingRecord(
+        callable_target_binding_id=record_id,
+        callable_key=callable_key,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        enabled=True,
+    )
+
+
+def _scope_policy(
+    record_id: str,
+    *,
+    scope_type: str,
+    scope_id: str,
+    mode: str,
+) -> CallableTargetScopePolicyRecord:
+    return CallableTargetScopePolicyRecord(
+        callable_target_scope_policy_id=record_id,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        mode=mode,
+    )
+
+
+def _org_model_bindings() -> list[CallableTargetBindingRecord]:
+    return [
+        _binding("ctb-org-1", callable_key="gpt-4o-mini"),
+        _binding("ctb-org-2", callable_key="text-embedding-3-small"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_primary_access_grants_without_callable_target_org_bindings() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(bindings=[])
+    tier_service = _FakeTierPolicyService(allowed_by_org={"org-1": {"gpt-4o-mini"}})
+
+    resolution = resolve_model_allowlist_resolution(
+        auth,
+        callable_target_grant_service=grant_service,
+        tier_policy_service=tier_service,
+    )
+
+    assert resolution.pre_tier_allowlist == set()
+    assert resolution.tier_allowlist == {"gpt-4o-mini"}
+    assert resolution.effective_allowlist == {"gpt-4o-mini"}
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_add_on_union_allows_multiple_models() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(bindings=[])
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"gpt-4o-mini", "text-embedding-3-small"}},
+    )
+
+    assert resolve_effective_model_allowlist(
+        auth,
+        callable_target_grant_service=grant_service,
+        tier_policy_service=tier_service,
+    ) == {"gpt-4o-mini", "text-embedding-3-small"}
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_without_explicit_org_leaves_access_unchanged() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(bindings=_org_model_bindings())
+    tier_service = _FakeTierPolicyService()
+
+    resolution = resolve_model_allowlist_resolution(
+        auth,
+        callable_target_grant_service=grant_service,
+        tier_policy_service=tier_service,
+    )
+
+    assert resolution.tier_applied is False
+    assert resolution.effective_allowlist == {"gpt-4o-mini", "text-embedding-3-small"}
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_deny_rule_wins_and_logs_denial(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(bindings=[])
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"text-embedding-3-small"}},
+        denied={("org-1", "text-embedding-3-small")},
+    )
+
+    with caplog.at_level(logging.INFO), pytest.raises(PermissionDeniedError):
+        ensure_model_allowed(
+            auth,
+            "text-embedding-3-small",
+            callable_target_grant_service=grant_service,
+            tier_policy_service=tier_service,
+        )
+
+    assert "tier_policy_model_access_denied" in caplog.text
+    assert caplog.records[-1].reason == "tier_policy_deny"
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_allowlist_exclusion_logs_without_callable_target_org_bindings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(bindings=[])
+    tier_service = _FakeTierPolicyService(allowed_by_org={"org-1": {"gpt-4o-mini"}})
+
+    with caplog.at_level(logging.INFO), pytest.raises(PermissionDeniedError):
+        ensure_model_allowed(
+            auth,
+            "text-embedding-3-small",
+            callable_target_grant_service=grant_service,
+            tier_policy_service=tier_service,
+        )
+
+    assert "tier_policy_model_access_denied" in caplog.text
+    assert caplog.records[-1].reason == "tier_policy_allowlist_excluded"
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_intersects_restricted_team_scope() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", team_id="team-1", organization_id="org-1")
+    grant_service = await _loaded_grant_service(
+        bindings=[
+            _binding(
+                "ctb-team-1",
+                callable_key="gpt-4o-mini",
+                scope_type="team",
+                scope_id="team-1",
+            ),
+        ],
+        policies=[
+            _scope_policy(
+                "ctp-team-1",
+                scope_type="team",
+                scope_id="team-1",
+                mode="restrict",
+            )
+        ],
+    )
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"gpt-4o-mini", "text-embedding-3-small"}},
+    )
+
+    assert resolve_effective_model_allowlist(
+        auth,
+        callable_target_grant_service=grant_service,
+        tier_policy_service=tier_service,
+    ) == {"gpt-4o-mini"}
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_intersects_restricted_api_key_scope() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(
+        bindings=[
+            _binding(
+                "ctb-key-1",
+                callable_key="text-embedding-3-small",
+                scope_type="api_key",
+                scope_id="sk-test",
+            ),
+        ],
+        policies=[
+            _scope_policy(
+                "ctp-key-1",
+                scope_type="api_key",
+                scope_id="sk-test",
+                mode="restrict",
+            )
+        ],
+    )
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"gpt-4o-mini", "text-embedding-3-small"}},
+    )
+
+    assert resolve_effective_model_allowlist(
+        auth,
+        callable_target_grant_service=grant_service,
+        tier_policy_service=tier_service,
+    ) == {"text-embedding-3-small"}
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_intersects_default_restricted_user_scope() -> None:
+    auth = UserAPIKeyAuth(
+        api_key="sk-test",
+        organization_id="org-1",
+        user_id="user-1",
+    )
+    grant_service = await _loaded_grant_service(
+        bindings=[
+            _binding(
+                "ctb-user-1",
+                callable_key="gpt-4o-mini",
+                scope_type="user",
+                scope_id="user-1",
+            ),
+        ],
+    )
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"gpt-4o-mini", "text-embedding-3-small"}},
+    )
+
+    assert resolve_effective_model_allowlist(
+        auth,
+        callable_target_grant_service=grant_service,
+        tier_policy_service=tier_service,
+    ) == {"gpt-4o-mini"}
+
+
+@pytest.mark.asyncio
+async def test_tier_enforce_does_not_apply_direct_restricts_when_callable_policy_shadow() -> None:
+    auth = UserAPIKeyAuth(
+        api_key="sk-test",
+        team_id="team-1",
+        organization_id="org-1",
+        models=["gpt-4o-mini", "text-embedding-3-small"],
+        team_models=["gpt-4o-mini", "text-embedding-3-small"],
+    )
+    grant_service = await _loaded_grant_service(
+        bindings=[
+            _binding(
+                "ctb-team-1",
+                callable_key="gpt-4o-mini",
+                scope_type="team",
+                scope_id="team-1",
+            ),
+        ],
+        policies=[
+            _scope_policy(
+                "ctp-team-1",
+                scope_type="team",
+                scope_id="team-1",
+                mode="restrict",
+            )
+        ],
+    )
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"gpt-4o-mini", "text-embedding-3-small"}},
+    )
+
+    resolution = resolve_model_allowlist_resolution(
+        auth,
+        callable_target_grant_service=grant_service,
+        tier_policy_service=tier_service,
+        policy_mode="shadow",
+    )
+
+    assert resolution.policy_mode == "shadow"
+    assert resolution.pre_tier_allowlist == {"gpt-4o-mini", "text-embedding-3-small"}
+    assert resolution.tier_effective_allowlist == {"gpt-4o-mini", "text-embedding-3-small"}
+    assert resolution.effective_allowlist == {"gpt-4o-mini", "text-embedding-3-small"}
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_shadow_logs_mismatch_without_enforcing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(bindings=_org_model_bindings())
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"gpt-4o-mini"}},
+        mode="shadow",
+    )
+
+    with caplog.at_level(logging.INFO):
+        resolution = resolve_model_allowlist_resolution(
+            auth,
+            callable_target_grant_service=grant_service,
+            tier_policy_service=tier_service,
+            emit_shadow_log=True,
+        )
+
+    assert resolution.effective_allowlist == {"gpt-4o-mini", "text-embedding-3-small"}
+    assert resolution.tier_effective_allowlist == {"gpt-4o-mini"}
+    assert resolution.tier_shadow_mismatch is True
+    assert "tier_policy_shadow_mismatch" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_fail_closed_unavailable_blocks_explicit_org() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(
+        bindings=[_binding("ctb-org-1", callable_key="gpt-4o-mini")]
+    )
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"gpt-4o-mini"}},
+        missing_service_mode="fail_closed",
+        snapshot_stale=True,
+    )
+
+    with pytest.raises(PermissionDeniedError):
+        ensure_model_allowed(
+            auth,
+            "gpt-4o-mini",
+            callable_target_grant_service=grant_service,
+            tier_policy_service=tier_service,
+        )
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_fail_open_unavailable_preserves_access() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(bindings=_org_model_bindings())
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"gpt-4o-mini"}},
+        missing_service_mode="fail_open",
+        snapshot_stale=True,
+    )
+
+    resolution = resolve_model_allowlist_resolution(
+        auth,
+        callable_target_grant_service=grant_service,
+        tier_policy_service=tier_service,
+    )
+
+    assert resolution.tier_applied is False
+    assert resolution.tier_authoritative is False
+    assert resolution.effective_allowlist == {"gpt-4o-mini", "text-embedding-3-small"}
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_missing_service_fail_closed_blocks_when_enforced() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(
+        bindings=[_binding("ctb-org-1", callable_key="gpt-4o-mini")]
+    )
+
+    with pytest.raises(PermissionDeniedError):
+        ensure_model_allowed(
+            auth,
+            "gpt-4o-mini",
+            callable_target_grant_service=grant_service,
+            tier_policy_service=None,
+            tier_policy_mode="enforce",
+            tier_policy_missing_service_mode="fail_closed",
+        )
+
+
+@pytest.mark.asyncio
+async def test_tier_policy_missing_service_fail_open_preserves_access() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(
+        bindings=[_binding("ctb-org-1", callable_key="gpt-4o-mini")]
+    )
+
+    resolution = resolve_model_allowlist_resolution(
+        auth,
+        callable_target_grant_service=grant_service,
+        tier_policy_service=None,
+        tier_policy_mode="enforce",
+        tier_policy_missing_service_mode="fail_open",
+    )
+
+    assert resolution.tier_authoritative is False
+    assert resolution.tier_unavailable_reason == "tier_policy_unavailable_fail_open"
+    assert resolution.effective_allowlist == {"gpt-4o-mini"}
+
+
+@pytest.mark.asyncio
+async def test_master_key_bypasses_tier_policy_access() -> None:
+    auth = UserAPIKeyAuth(api_key="master_key", organization_id="org-1")
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": set()},
+        denied={("org-1", "gpt-4o-mini")},
+    )
+
+    assert resolve_effective_model_allowlist(auth, tier_policy_service=tier_service) is None
+    ensure_model_allowed(auth, "gpt-4o-mini", tier_policy_service=tier_service)
+
+
+@pytest.mark.asyncio
+async def test_v1_models_filters_by_tier_policy(client, test_app) -> None:
+    record = next(iter(test_app.state._test_repo.records.values()))
+    record.organization_id = "org-1"
+    test_app.state.callable_target_grant_service = await _loaded_grant_service(
+        bindings=[]
+    )
+    test_app.state.tier_policy_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"gpt-4o-mini"}},
+    )
+
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    response = await client.get("/v1/models", headers=headers)
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["data"]] == ["gpt-4o-mini"]
+
+
+@pytest.mark.asyncio
+async def test_batch_input_line_enforces_tier_policy() -> None:
+    auth = UserAPIKeyAuth(api_key="sk-test", organization_id="org-1")
+    grant_service = await _loaded_grant_service(
+        bindings=[_binding("ctb-org-1", callable_key="gpt-4o-mini")]
+    )
+    tier_service = _FakeTierPolicyService(
+        allowed_by_org={"org-1": {"text-embedding-3-small"}},
+    )
+    raw_line = (
+        '{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions",'
+        '"body":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}}'
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        parse_batch_input_line(
+            raw_line,
+            line_number=1,
+            endpoint=BATCH_ENDPOINT_CHAT_COMPLETIONS,
+            auth=auth,
+            seen_custom_ids=set(),
+            callable_target_grant_service=grant_service,
+            callable_target_scope_policy_mode="enforce",
+            tier_policy_service=tier_service,
+        )
+
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary
- integrate tier model access enforcement into chat, completions, responses, embeddings, images, audio, rerank, and /v1/models
- wire tier policy checks into batch creation and batch execution revalidation
- add in-memory tier access resolution with shadow mismatch metrics, denial logging, and fail-open/fail-closed behavior
- preserve low-latency request paths by using preloaded policy snapshots only

## Tests
- git diff --check
- uv run --extra dev ruff check src/services/model_visibility.py src/services/tier_model_access.py src/services/callable_target_grants.py src/bootstrap/batch.py src/batch/create/service.py src/batch/request_validation.py src/batch/service.py src/batch/policy.py src/chat/preflight.py src/routers/models.py src/routers/audio_speech.py src/routers/audio_transcription.py src/routers/embeddings.py src/routers/images.py src/routers/rerank.py tests/test_tier_model_access.py tests/test_model_visibility.py tests/bootstrap/test_optional_bootstrap.py
- uv run --extra dev pytest tests/test_tier_model_access.py tests/test_model_visibility.py tests/bootstrap/test_optional_bootstrap.py tests/test_batch_service.py tests/test_batch_create_service.py tests/services/test_tier_policy_compiler.py tests/bootstrap/test_runtime_services_bootstrap.py

Refs #197