### PR TITLE
Add tier rate limit controls

### DIFF
--- a/src/batch/policy.py
+++ b/src/batch/policy.py
@@ -157,17 +157,26 @@ async def acquire_batch_policy_lease(*, app: Any, payload: BaseModel, auth: User
         auth=auth,
         tokens=estimate_tokens(data),
         model=str(getattr(payload, "model", "") or ""),
+        tier_policy_service=getattr(app.state, "tier_policy_service", None),
+        tier_policy_mode=get_tier_policy_mode_from_app(app),
+        tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(app),
+        mode="batch",
     )
     return BatchPolicyLease(rate_limit_lease=lease)
 
 
-async def release_batch_policy_lease(*, app: Any, lease: BatchPolicyLease | None) -> None:
+async def release_batch_policy_lease(*, app: Any, lease: BatchPolicyLease | None) -> bool:
     if lease is None:
-        return
+        return True
+    if not lease.rate_limit_lease.pending_parallel_acquisitions:
+        return True
     limiter = getattr(app.state, "limit_counter", None)
     if limiter is None:
-        return
+        logger.warning("batch policy rate-limit release skipped because limit counter is unavailable")
+        return False
     try:
         await release_rate_limit_controls(limiter=limiter, lease=lease.rate_limit_lease)
     except Exception as exc:
         logger.warning("batch policy rate-limit release failed error=%s", exc, exc_info=True)
+        return False
+    return not bool(lease.rate_limit_lease.pending_parallel_acquisitions)

--- a/src/batch/worker.py
+++ b/src/batch/worker.py
@@ -317,6 +317,7 @@ class BatchExecutorWorker:
         return self._applied_scheduler_config_generation
 
     async def process_once(self) -> bool:
+        await self._execution_engine._drain_policy_lease_release_retries()
         self._reap_shadow_tasks()
         active_mode = self._active_scheduler_mode()
         shadow_mode = self._shadow_scheduler_mode()

--- a/src/batch/worker_persistence.py
+++ b/src/batch/worker_persistence.py
@@ -1,22 +1,102 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 import contextlib
+from dataclasses import dataclass
 from datetime import UTC, datetime
 import logging
+import random
 from time import perf_counter
 from typing import Any, Awaitable
 
 from src.batch.endpoints import batch_call_type_for_endpoint
-from src.batch.policy import acquire_batch_policy_lease, release_batch_policy_lease
+from src.batch.policy import BatchPolicyLease, acquire_batch_policy_lease, release_batch_policy_lease
 from src.batch.worker_types import BatchItemLeaseLostError, _PreparedChatItem, _PreparedEmbeddingItem
 from src.billing.cost import completion_cost
 from src.billing.tier_pricing import PricingResolution, resolve_deployment_tier_pricing
+from src.rate_limit_lease_refresh import RateLimitLeaseRefresher
 
 logger = logging.getLogger(__name__)
+_POLICY_RELEASE_RETRY_DRAIN_LIMIT = 16
+_POLICY_RELEASE_RETRY_QUEUE_LIMIT = 1024
+_POLICY_RELEASE_RETRY_INITIAL_SECONDS = 0.5
+_POLICY_RELEASE_RETRY_MAX_SECONDS = 30.0
+
+
+@dataclass(frozen=True, slots=True)
+class _PolicyReleaseRetry:
+    lease: BatchPolicyLease
+    attempt_count: int
+    next_attempt_at: float
+
+
+def _policy_release_retry_delay_seconds(attempt_count: int) -> float:
+    exponential_delay = _POLICY_RELEASE_RETRY_INITIAL_SECONDS * (2 ** max(0, int(attempt_count)))
+    capped_delay = min(_POLICY_RELEASE_RETRY_MAX_SECONDS, exponential_delay)
+    jitter = random.uniform(0.0, capped_delay * 0.2)
+    return capped_delay + jitter
 
 
 class WorkerPersistenceMixin:
+    def _policy_release_retry_queue(self) -> deque[_PolicyReleaseRetry]:
+        queue = getattr(self, "_pending_policy_release_retries", None)
+        if queue is None:
+            queue = deque()
+            self._pending_policy_release_retries = queue
+        return queue
+
+    def _queue_policy_lease_release_retry(
+        self,
+        lease: BatchPolicyLease,
+        *,
+        attempt_count: int = 0,
+    ) -> None:
+        if not lease.rate_limit_lease.pending_parallel_acquisitions:
+            return
+        delay_seconds = _policy_release_retry_delay_seconds(attempt_count)
+        entry = _PolicyReleaseRetry(
+            lease=lease,
+            attempt_count=attempt_count,
+            next_attempt_at=perf_counter() + delay_seconds,
+        )
+        self._insert_policy_release_retry(entry)
+
+    def _insert_policy_release_retry(self, entry: _PolicyReleaseRetry) -> None:
+        queue = self._policy_release_retry_queue()
+        if len(queue) >= _POLICY_RELEASE_RETRY_QUEUE_LIMIT:
+            logger.error(
+                "batch policy release retry queue full pending=%s",
+                len(queue),
+            )
+            return
+        for index, queued in enumerate(queue):
+            if entry.next_attempt_at < queued.next_attempt_at:
+                queue.insert(index, entry)
+                return
+        queue.append(entry)
+
+    async def _drain_policy_lease_release_retries(
+        self,
+        *,
+        max_releases: int = _POLICY_RELEASE_RETRY_DRAIN_LIMIT,
+    ) -> None:
+        queue = self._policy_release_retry_queue()
+        if not queue:
+            return
+        attempts = 0
+        now = perf_counter()
+        max_attempts = max(0, int(max_releases))
+        while queue and attempts < max_attempts and queue[0].next_attempt_at <= now:
+            retry = queue.popleft()
+            released = await release_batch_policy_lease(app=self.app, lease=retry.lease)
+            attempts += 1
+            if not released:
+                self._queue_policy_lease_release_retry(
+                    retry.lease,
+                    attempt_count=retry.attempt_count + 1,
+                )
+
     def _resolve_batch_item_pricing(
         self,
         *,
@@ -102,11 +182,38 @@ class WorkerPersistenceMixin:
             payload=prepared.payload,
             auth=prepared.policy_auth,
         )
+        self._start_prepared_policy_lease_refresher(prepared)
 
     async def _release_prepared_policy_lease(self, prepared: _PreparedEmbeddingItem | _PreparedChatItem) -> None:
+        await self._stop_prepared_policy_lease_refresher(prepared)
         lease = prepared.policy_lease
+        if lease is None:
+            return
+        released = await release_batch_policy_lease(app=self.app, lease=lease)
+        if released:
+            prepared.policy_lease = None
+            return
+        self._queue_policy_lease_release_retry(lease)
         prepared.policy_lease = None
-        await release_batch_policy_lease(app=self.app, lease=lease)
+
+    def _start_prepared_policy_lease_refresher(self, prepared: _PreparedEmbeddingItem | _PreparedChatItem) -> None:
+        lease = prepared.policy_lease
+        limiter = getattr(getattr(self.app, "state", None), "limit_counter", None)
+        if lease is None or limiter is None:
+            return
+        refresher = RateLimitLeaseRefresher(
+            limiter=limiter,
+            lease=lease.rate_limit_lease,
+        )
+        if refresher.start():
+            prepared.policy_lease_refresher = refresher
+
+    async def _stop_prepared_policy_lease_refresher(self, prepared: _PreparedEmbeddingItem | _PreparedChatItem) -> None:
+        refresher = getattr(prepared, "policy_lease_refresher", None)
+        if refresher is None:
+            return
+        prepared.policy_lease_refresher = None
+        await refresher.stop()
 
     async def _release_prepared_policy_leases(self, prepared_items: list[_PreparedEmbeddingItem] | list[_PreparedChatItem]) -> None:
         for prepared in prepared_items:

--- a/src/batch/worker_types.py
+++ b/src/batch/worker_types.py
@@ -100,6 +100,7 @@ class _PreparedEmbeddingItem:
     execution_signature: _ExecutionSignature
     policy_auth: Any | None = None
     policy_lease: Any | None = None
+    policy_lease_refresher: Any | None = None
 
 
 @dataclass(slots=True)
@@ -115,3 +116,4 @@ class _PreparedChatItem:
     request_shim: _RequestShim
     policy_auth: Any | None = None
     policy_lease: Any | None = None
+    policy_lease_refresher: Any | None = None

--- a/src/mcp/policy.py
+++ b/src/mcp/policy.py
@@ -1,18 +1,28 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 
 from src.db.mcp import MCPToolPolicyRecord
 from src.models.errors import RateLimitError
-from src.services.limit_counter import LimitCounter
+from src.services.limit_counter import LegacyParallelLease, LimitCounter
 
 from .exceptions import MCPRateLimitError
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class MCPToolPolicyLease:
-    scope: str
-    entity_id: str
+    parallel_lease: LegacyParallelLease
+
+    @property
+    def scope(self) -> str:
+        return self.parallel_lease.scope
+
+    @property
+    def entity_id(self) -> str:
+        return self.parallel_lease.entity_id
 
 
 class MCPToolPolicyEnforcer:
@@ -39,8 +49,13 @@ class MCPToolPolicyEnforcer:
             if policy.max_rpm is not None and policy.max_rpm > 0:
                 await self.rate_limiter.check_rate_limit("mcp_tool_rpm", entity_id, policy.max_rpm, 1)
             if policy.max_concurrency is not None and policy.max_concurrency > 0:
-                await self.rate_limiter.acquire_parallel("mcp_tool", entity_id, policy.max_concurrency)
-                return MCPToolPolicyLease(scope="mcp_tool", entity_id=entity_id)
+                parallel_lease = await self.rate_limiter.acquire_legacy_parallel_lease(
+                    "mcp_tool",
+                    entity_id,
+                    policy.max_concurrency,
+                )
+                if parallel_lease is not None:
+                    return MCPToolPolicyLease(parallel_lease=parallel_lease)
         except RateLimitError as exc:
             raise MCPRateLimitError(exc.message, retry_after=exc.retry_after) from exc
         return None
@@ -48,7 +63,17 @@ class MCPToolPolicyEnforcer:
     async def release(self, lease: MCPToolPolicyLease | None) -> None:
         if lease is None or self.rate_limiter is None:
             return
-        await self.rate_limiter.release_parallel(lease.scope, lease.entity_id)
+        try:
+            await self.rate_limiter.release_legacy_parallel_lease(lease.parallel_lease)
+        except Exception as exc:
+            logger.warning(
+                "mcp tool policy release failed scope=%s entity_id=%s backend=%s error=%s",
+                lease.scope,
+                lease.entity_id,
+                lease.parallel_lease.backend,
+                exc,
+                exc_info=True,
+            )
 
     @staticmethod
     def _entity_id(*, scope_type: str, scope_id: str, server_key: str, tool_name: str) -> str:

--- a/src/middleware/rate_limit.py
+++ b/src/middleware/rate_limit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from email.parser import BytesParser
 from email.policy import default
 import json
+import logging
 import math
 import time
 from typing import Any
@@ -11,6 +12,8 @@ from urllib.parse import parse_qs
 from fastapi import Request
 
 from src.models.errors import InvalidRequestError, RateLimitError
+from src.rate_limit_lease_refresh import RateLimitLeaseRefresher
+from src.rate_limit_release_retry import get_rate_limit_release_retry_queue
 from src.rate_limit_policy import (
     RateLimitState,
     _model_limit as _model_limit,
@@ -18,10 +21,16 @@ from src.rate_limit_policy import (
     build_rate_limit_checks,
     compute_rate_limit_state,
     estimate_tokens,
+    release_rate_limit_controls,
 )
 from src.services.limit_counter import LimitCounter, RateLimitCheck
+from src.services.model_visibility import (
+    get_tier_policy_missing_service_mode_from_app,
+    get_tier_policy_mode_from_app,
+)
 
 _compute_rate_limit_state = compute_rate_limit_state
+logger = logging.getLogger(__name__)
 
 
 def _normalize_model(model: Any) -> str | None:
@@ -151,6 +160,24 @@ def _build_429_state(
     return state
 
 
+def _rate_limit_error_checks(exc: RateLimitError) -> list[RateLimitCheck] | None:
+    checks = getattr(exc, "rate_limit_checks", None)
+    if checks is None:
+        return None
+    try:
+        check_list = list(checks)
+    except TypeError:
+        return None
+    if not all(isinstance(check, RateLimitCheck) for check in check_list):
+        return None
+    return check_list
+
+
+def _rate_limit_error_state(exc: RateLimitError) -> RateLimitState | None:
+    state = getattr(exc, "rate_limit_state", None)
+    return state if isinstance(state, RateLimitState) else None
+
+
 def build_rate_limit_headers(state: RateLimitState) -> dict[str, str]:
     headers: dict[str, str] = {}
     if state.rpm_limit > 0 or state.tpm_limit > 0:
@@ -208,6 +235,9 @@ async def _check_and_acquire_rate_limits(request: Request) -> None:
 
     model = await _extract_model_from_request(request, body)
     request.state._rate_limit_model = model
+    tier_policy_service = getattr(request.app.state, "tier_policy_service", None)
+    tier_policy_mode = get_tier_policy_mode_from_app(request.app)
+    tier_policy_missing_service_mode = get_tier_policy_missing_service_mode_from_app(request.app)
 
     try:
         lease, rate_limit_state = await acquire_rate_limit_controls(
@@ -215,28 +245,75 @@ async def _check_and_acquire_rate_limits(request: Request) -> None:
             auth=auth,
             tokens=tokens,
             model=model,
+            tier_policy_service=tier_policy_service,
+            tier_policy_mode=tier_policy_mode,
+            tier_policy_missing_service_mode=tier_policy_missing_service_mode,
         )
         request.state._rate_limit_state = rate_limit_state
     except RateLimitError as exc:
-        checks = build_rate_limit_checks(auth=auth, tokens=tokens, model=model)
-        now = time.time()
-        min_window = min((c.window_seconds for c in checks), default=60)
-        window_reset_at = int((math.floor(now / min_window) + 1) * min_window)
-        state_429 = _build_429_state(checks, exc, window_reset_at)
+        state_429 = _rate_limit_error_state(exc)
+        if state_429 is None:
+            checks = _rate_limit_error_checks(exc)
+            if checks is None:
+                try:
+                    checks = build_rate_limit_checks(
+                        auth=auth,
+                        tokens=tokens,
+                        model=model,
+                        tier_policy_service=tier_policy_service,
+                        tier_policy_mode=tier_policy_mode,
+                        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+                    )
+                except Exception:
+                    checks = []
+            now = time.time()
+            min_window = min((c.window_seconds for c in checks), default=60)
+            window_reset_at = int((math.floor(now / min_window) + 1) * min_window)
+            state_429 = _build_429_state(checks, exc, window_reset_at)
         request.state._rate_limit_state = state_429
         raise
 
     request.state._rate_limit_checked = True
-    request.state._rate_limit_parallel_key = lease.parallel_entity_id
+    request.state._rate_limit_lease = lease
+    refresher = RateLimitLeaseRefresher(limiter=limiter, lease=lease)
+    if refresher.start():
+        request.state._rate_limit_lease_refresher = refresher
 
 
 async def _release_rate_limits(request: Request) -> None:
     if bool(getattr(request.state, "_rate_limit_released", False)):
         return
-    api_key = getattr(request.state, "_rate_limit_parallel_key", None)
-    if not api_key:
+    lease = getattr(request.state, "_rate_limit_lease", None)
+    if lease is None:
         request.state._rate_limit_released = True
         return
     limiter: LimitCounter = request.app.state.limit_counter
-    await limiter.release_parallel("key", api_key)
+    await _stop_rate_limit_lease_refresher(request)
+    try:
+        await release_rate_limit_controls(limiter=limiter, lease=lease)
+    except Exception as exc:
+        pending_count = len(lease.pending_parallel_acquisitions)
+        queued = False
+        if pending_count > 0:
+            queued = get_rate_limit_release_retry_queue(request.app).enqueue(
+                limiter=limiter,
+                lease=lease,
+            )
+        logger.warning(
+            "rate-limit release failed pending=%s queued=%s error=%s",
+            pending_count,
+            queued,
+            exc,
+            exc_info=True,
+        )
+        request.state._rate_limit_released = pending_count == 0
+        return
     request.state._rate_limit_released = True
+
+
+async def _stop_rate_limit_lease_refresher(request: Request) -> None:
+    refresher = getattr(request.state, "_rate_limit_lease_refresher", None)
+    if refresher is None:
+        return
+    request.state._rate_limit_lease_refresher = None
+    await refresher.stop()

--- a/src/rate_limit_lease_refresh.py
+++ b/src/rate_limit_lease_refresh.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+import logging
+
+from src.rate_limit_policy import RateLimitLease
+from src.services.limit_counter import LimitCounter
+
+logger = logging.getLogger(__name__)
+_DEFAULT_MAX_REFRESH_INTERVAL_SECONDS = 60.0
+
+
+class RateLimitLeaseRefresher:
+    def __init__(
+        self,
+        *,
+        limiter: LimitCounter,
+        lease: RateLimitLease,
+        max_interval_seconds: float = _DEFAULT_MAX_REFRESH_INTERVAL_SECONDS,
+    ) -> None:
+        self._limiter = limiter
+        self._lease = lease
+        self._max_interval_seconds = max(1.0, float(max_interval_seconds))
+        self._task: asyncio.Task[None] | None = None
+        self._failure_count = 0
+
+    def start(self) -> bool:
+        if self._task is not None:
+            return True
+        if not self._has_refreshable_leases():
+            return False
+        self._task = asyncio.create_task(self._run())
+        return True
+
+    async def stop(self) -> None:
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    async def _run(self) -> None:
+        while True:
+            interval_seconds = self._next_interval_seconds()
+            await asyncio.sleep(interval_seconds)
+            parallel_leases = list(self._lease.refreshable_parallel_leases)
+            legacy_lease = self._lease.refreshable_legacy_parallel_lease
+            if not parallel_leases and legacy_lease is None:
+                return
+
+            refresh_failed = False
+            if parallel_leases:
+                try:
+                    await self._limiter.refresh_parallel_leases(parallel_leases)
+                except Exception as exc:
+                    refresh_failed = True
+                    self._record_refresh_failure(exc)
+
+            if legacy_lease is not None:
+                try:
+                    await self._limiter.refresh_legacy_parallel_lease(legacy_lease)
+                except Exception as exc:
+                    refresh_failed = True
+                    self._record_refresh_failure(exc)
+
+            if not refresh_failed:
+                self._failure_count = 0
+
+    def _record_refresh_failure(self, exc: Exception) -> None:
+        self._failure_count += 1
+        if self._failure_count == 1 or self._failure_count % 5 == 0:
+            logger.warning(
+                "rate-limit parallel lease refresh failed failures=%s error=%s",
+                self._failure_count,
+                exc,
+                exc_info=True,
+            )
+
+    def _has_refreshable_leases(self) -> bool:
+        return bool(self._lease.refreshable_parallel_leases or self._lease.refreshable_legacy_parallel_lease)
+
+    def _refreshable_ttls(self) -> list[int]:
+        ttls = [max(1, int(lease.ttl_seconds)) for lease in self._lease.refreshable_parallel_leases]
+        legacy_lease = self._lease.refreshable_legacy_parallel_lease
+        if legacy_lease is not None:
+            ttls.append(max(1, int(legacy_lease.ttl_seconds)))
+        return ttls
+
+    def _next_interval_seconds(self) -> float:
+        ttls = self._refreshable_ttls()
+        if not ttls:
+            return self._max_interval_seconds
+        min_ttl = min(ttls)
+        return max(1.0, min(self._max_interval_seconds, min_ttl / 3))

--- a/src/rate_limit_policy.py
+++ b/src/rate_limit_policy.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
+from contextlib import suppress
 import json
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import Any
 
-from src.services.limit_counter import LimitCounter, RateLimitCheck, RateLimitResult
+from src.models.errors import RateLimitError
+from src.services.limit_counter import (
+    LegacyParallelLease,
+    LimitCounter,
+    ParallelLimitCheck,
+    ParallelLimitLease,
+    RateLimitCheck,
+    RateLimitResult,
+)
+from src.tier_rate_limit_policy import RateLimitMode, build_tier_limit_controls, build_tier_rate_limit_checks
 
 
 def estimate_tokens(payload: Any) -> int:
@@ -54,8 +65,51 @@ class RateLimitState:
 
 @dataclass(slots=True)
 class RateLimitLease:
-    parallel_scope: str | None = None
-    parallel_entity_id: str | None = None
+    legacy_parallel_lease: LegacyParallelLease | None = None
+    parallel_leases: tuple[ParallelLimitLease, ...] = ()
+    _pending_parallel_leases: list[ParallelLimitLease] = field(init=False, repr=False)
+    _legacy_parallel_pending: bool = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._pending_parallel_leases = list(self.parallel_leases)
+        self._legacy_parallel_pending = self.legacy_parallel_lease is not None
+
+    @property
+    def pending_parallel_acquisitions(self) -> tuple[ParallelLimitCheck, ...]:
+        checks = []
+        if self._legacy_parallel_pending and self.legacy_parallel_lease is not None:
+            checks.append(self.legacy_parallel_lease.check)
+        checks.extend(lease.check for lease in self._pending_parallel_leases)
+        return tuple(checks)
+
+    @property
+    def pending_parallel_leases(self) -> tuple[ParallelLimitLease, ...]:
+        return tuple(self._pending_parallel_leases)
+
+    @property
+    def pending_legacy_parallel_lease(self) -> LegacyParallelLease | None:
+        if not self._legacy_parallel_pending:
+            return None
+        return self.legacy_parallel_lease
+
+    @property
+    def refreshable_parallel_leases(self) -> tuple[ParallelLimitLease, ...]:
+        return tuple(lease for lease in self._pending_parallel_leases if lease.backend == "redis")
+
+    @property
+    def refreshable_legacy_parallel_lease(self) -> LegacyParallelLease | None:
+        if not self._legacy_parallel_pending:
+            return None
+        if self.legacy_parallel_lease is None or self.legacy_parallel_lease.backend != "redis":
+            return None
+        return self.legacy_parallel_lease
+
+    def mark_parallel_released(self, lease: ParallelLimitLease) -> None:
+        with suppress(ValueError):
+            self._pending_parallel_leases.remove(lease)
+
+    def mark_legacy_parallel_released(self) -> None:
+        self._legacy_parallel_pending = False
 
 
 def compute_rate_limit_state(result: RateLimitResult, checks: list[RateLimitCheck]) -> RateLimitState:
@@ -117,7 +171,12 @@ def compute_rate_limit_state(result: RateLimitResult, checks: list[RateLimitChec
     return state
 
 
-def build_rate_limit_checks(*, auth: Any, tokens: int, model: str | None) -> list[RateLimitCheck]:
+def _build_standard_rate_limit_checks(
+    *,
+    auth: Any,
+    tokens: int,
+    model: str | None,
+) -> list[RateLimitCheck]:
     key_rpm_limit = auth.key_rpm_limit if auth.key_rpm_limit is not None else auth.rpm_limit
     key_tpm_limit = auth.key_tpm_limit if auth.key_tpm_limit is not None else auth.tpm_limit
     checks: list[RateLimitCheck] = []
@@ -180,26 +239,247 @@ def build_rate_limit_checks(*, auth: Any, tokens: int, model: str | None) -> lis
     return checks
 
 
+def build_rate_limit_checks(
+    *,
+    auth: Any,
+    tokens: int,
+    model: str | None,
+    tier_policy_service: Any | None = None,
+    tier_policy_mode: str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
+    mode: RateLimitMode | str = "sync",
+) -> list[RateLimitCheck]:
+    checks = _build_standard_rate_limit_checks(auth=auth, tokens=tokens, model=model)
+    checks.extend(
+        build_tier_rate_limit_checks(
+            auth=auth,
+            tokens=tokens,
+            model=model,
+            tier_policy_service=tier_policy_service,
+            tier_policy_mode=tier_policy_mode,
+            tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+            mode=mode,
+        )
+    )
+
+    return checks
+
+
+def build_parallel_limit_checks(
+    *,
+    auth: Any,
+    tier_parallel_checks: tuple[ParallelLimitCheck, ...] = (),
+) -> list[ParallelLimitCheck]:
+    checks: list[ParallelLimitCheck] = []
+    key_check = _parallel_limit_check("key", getattr(auth, "api_key", None), getattr(auth, "max_parallel_requests", None))
+    if key_check is not None:
+        checks.append(key_check)
+    checks.extend(tier_parallel_checks)
+    return checks
+
+
 async def acquire_rate_limit_controls(
     *,
     limiter: LimitCounter,
     auth: Any,
     tokens: int,
     model: str | None,
+    tier_policy_service: Any | None = None,
+    tier_policy_mode: str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
+    mode: RateLimitMode | str = "sync",
 ) -> tuple[RateLimitLease, RateLimitState]:
-    checks = build_rate_limit_checks(auth=auth, tokens=tokens, model=model)
-    result = await limiter.check_rate_limits_atomic(checks)
+    checks = _build_standard_rate_limit_checks(auth=auth, tokens=tokens, model=model)
+    tier_controls = build_tier_limit_controls(
+        auth=auth,
+        tokens=tokens,
+        model=model,
+        tier_policy_service=tier_policy_service,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+        mode=mode,
+    )
+    checks.extend(tier_controls.rate_checks)
+    try:
+        result = await limiter.check_rate_limits_atomic(checks)
+    except RateLimitError as exc:
+        _annotate_rate_limit_error(exc, checks=checks)
+        raise
     rate_limit_state = compute_rate_limit_state(result, checks)
 
-    await limiter.acquire_parallel("key", auth.api_key, auth.max_parallel_requests)
-    parallel_entity_id = auth.api_key if auth.api_key and auth.max_parallel_requests and auth.max_parallel_requests > 0 else None
+    legacy_parallel_check = _parallel_limit_check(
+        "key",
+        getattr(auth, "api_key", None),
+        getattr(auth, "max_parallel_requests", None),
+    )
+    acquired_legacy_parallel_lease = None
+    tier_parallel_leases: list[ParallelLimitLease] = []
+    try:
+        if legacy_parallel_check is not None:
+            acquired_legacy_parallel_lease = await _acquire_legacy_parallel_limit_check(
+                limiter=limiter,
+                check=legacy_parallel_check,
+                rate_checks=checks,
+            )
+        tier_parallel_leases = await _acquire_parallel_limit_checks(
+            limiter=limiter,
+            checks=list(tier_controls.parallel_checks),
+            rate_checks=checks,
+        )
+    except Exception:
+        await _release_acquired_parallel_controls(
+            limiter=limiter,
+            legacy_lease=acquired_legacy_parallel_lease,
+            leases=tier_parallel_leases,
+        )
+        raise
+
     return RateLimitLease(
-        parallel_scope="key" if parallel_entity_id else None,
-        parallel_entity_id=parallel_entity_id,
+        legacy_parallel_lease=acquired_legacy_parallel_lease,
+        parallel_leases=tuple(tier_parallel_leases),
     ), rate_limit_state
 
 
 async def release_rate_limit_controls(*, limiter: LimitCounter, lease: RateLimitLease) -> None:
-    if not lease.parallel_scope or not lease.parallel_entity_id:
+    pending = list(reversed(lease.pending_parallel_leases))
+    legacy_lease = lease.pending_legacy_parallel_lease
+    if not pending and legacy_lease is None:
         return
-    await limiter.release_parallel(lease.parallel_scope, lease.parallel_entity_id)
+
+    release_error: Exception | None = None
+    if pending:
+        try:
+            await limiter.release_parallel_leases(pending)
+        except Exception as exc:
+            release_error = exc
+        else:
+            for parallel_lease in pending:
+                lease.mark_parallel_released(parallel_lease)
+
+    if legacy_lease is not None:
+        try:
+            await limiter.release_legacy_parallel_lease(legacy_lease)
+        except Exception as exc:
+            if release_error is None:
+                release_error = exc
+        else:
+            lease.mark_legacy_parallel_released()
+
+    if release_error is not None:
+        raise release_error
+
+
+def _parallel_limit_check(scope: str, entity_id: object, limit: object) -> ParallelLimitCheck | None:
+    normalized_entity_id = _normalize_id(entity_id)
+    normalized_limit = _positive_int_or_none(limit)
+    if normalized_entity_id is None or normalized_limit is None:
+        return None
+    return ParallelLimitCheck(scope=scope, entity_id=normalized_entity_id, limit=normalized_limit)
+
+
+async def _acquire_parallel_limit_checks(
+    *,
+    limiter: LimitCounter,
+    checks: list[ParallelLimitCheck],
+    rate_checks: list[RateLimitCheck],
+) -> list[ParallelLimitLease]:
+    try:
+        return list(await limiter.acquire_parallel_leases(checks))
+    except RateLimitError as exc:
+        failed_check = _parallel_check_for_error(exc, checks)
+        _ensure_parallel_error_fields(exc, failed_check)
+        _annotate_rate_limit_error(
+            exc,
+            checks=rate_checks,
+            state=_parallel_429_state(failed_check, retry_after=getattr(exc, "retry_after", None)),
+        )
+        raise
+
+
+async def _acquire_legacy_parallel_limit_check(
+    *,
+    limiter: LimitCounter,
+    check: ParallelLimitCheck,
+    rate_checks: list[RateLimitCheck],
+) -> LegacyParallelLease | None:
+    try:
+        return await limiter.acquire_legacy_parallel_lease(check.scope, check.entity_id, check.limit)
+    except RateLimitError as exc:
+        _ensure_parallel_error_fields(exc, check)
+        _annotate_rate_limit_error(
+            exc,
+            checks=rate_checks,
+            state=_parallel_429_state(check, retry_after=getattr(exc, "retry_after", None)),
+        )
+        raise
+
+
+async def _release_acquired_parallel_controls(
+    *,
+    limiter: LimitCounter,
+    legacy_lease: LegacyParallelLease | None,
+    leases: list[ParallelLimitLease],
+) -> None:
+    if leases:
+        with suppress(Exception):
+            await limiter.release_parallel_leases(list(reversed(leases)))
+    if legacy_lease is not None:
+        with suppress(Exception):
+            await limiter.release_legacy_parallel_lease(legacy_lease)
+
+
+def _parallel_check_for_error(exc: RateLimitError, checks: list[ParallelLimitCheck]) -> ParallelLimitCheck:
+    failed_scope = getattr(exc, "param", None)
+    if failed_scope is not None:
+        for check in checks:
+            if check.scope == failed_scope:
+                return check
+    return checks[0] if checks else ParallelLimitCheck(scope="key", entity_id="", limit=1)
+
+
+def _annotate_rate_limit_error(
+    exc: RateLimitError,
+    *,
+    checks: list[RateLimitCheck],
+    state: RateLimitState | None = None,
+) -> None:
+    setattr(exc, "rate_limit_checks", list(checks))
+    if state is not None:
+        setattr(exc, "rate_limit_state", state)
+
+
+def _ensure_parallel_error_fields(exc: RateLimitError, check: ParallelLimitCheck) -> None:
+    if check.scope == "key":
+        return
+    if getattr(exc, "param", None) is None:
+        exc.param = check.scope
+    if getattr(exc, "code", None) is None:
+        exc.code = _parallel_limit_error_code(check.scope)
+
+
+def _parallel_429_state(check: ParallelLimitCheck, *, retry_after: object) -> RateLimitState:
+    retry_after_seconds = _positive_int_or_none(retry_after) or 1
+    return RateLimitState(
+        rpm_limit=check.limit,
+        rpm_remaining=0,
+        rpm_reset=int(time.time()) + retry_after_seconds,
+        rpm_scope=check.scope,
+        warning="near_limit",
+    )
+
+
+def _normalize_id(value: object) -> str | None:
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _positive_int_or_none(value: object) -> int | None:
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return None
+    return normalized if normalized > 0 else None
+
+
+def _parallel_limit_error_code(scope: str) -> str:
+    return f"{scope}_exceeded" if scope.endswith("_parallel") else f"{scope}_parallel_exceeded"

--- a/src/rate_limit_release_retry.py
+++ b/src/rate_limit_release_retry.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from contextlib import suppress
+from dataclasses import dataclass
+import logging
+import random
+from time import perf_counter
+from typing import Any, Callable
+
+from src.rate_limit_policy import RateLimitLease, release_rate_limit_controls
+from src.services.limit_counter import LimitCounter
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_RELEASE_RETRY_DRAIN_LIMIT = 16
+_DEFAULT_RELEASE_RETRY_QUEUE_LIMIT = 1024
+_DEFAULT_RELEASE_RETRY_INITIAL_SECONDS = 0.5
+_DEFAULT_RELEASE_RETRY_MAX_SECONDS = 30.0
+
+
+@dataclass(frozen=True, slots=True)
+class _RateLimitReleaseRetry:
+    limiter: LimitCounter
+    lease: RateLimitLease
+    attempt_count: int
+    next_attempt_at: float
+
+
+def rate_limit_release_retry_delay_seconds(attempt_count: int) -> float:
+    exponential_delay = _DEFAULT_RELEASE_RETRY_INITIAL_SECONDS * (2 ** max(0, int(attempt_count)))
+    capped_delay = min(_DEFAULT_RELEASE_RETRY_MAX_SECONDS, exponential_delay)
+    jitter = random.uniform(0.0, capped_delay * 0.2)
+    return capped_delay + jitter
+
+
+class RateLimitReleaseRetryQueue:
+    def __init__(
+        self,
+        *,
+        max_size: int = _DEFAULT_RELEASE_RETRY_QUEUE_LIMIT,
+        drain_limit: int = _DEFAULT_RELEASE_RETRY_DRAIN_LIMIT,
+        delay_seconds: Callable[[int], float] = rate_limit_release_retry_delay_seconds,
+        auto_start: bool = True,
+    ) -> None:
+        self._queue: deque[_RateLimitReleaseRetry] = deque()
+        self._max_size = max(1, int(max_size))
+        self._drain_limit = max(1, int(drain_limit))
+        self._delay_seconds = delay_seconds
+        self._auto_start = auto_start
+        self._task: asyncio.Task[None] | None = None
+        self._wakeup: asyncio.Event | None = None
+        self._stopped = False
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._queue)
+
+    def enqueue(
+        self,
+        *,
+        limiter: LimitCounter,
+        lease: RateLimitLease,
+        attempt_count: int = 0,
+    ) -> bool:
+        if not lease.pending_parallel_acquisitions:
+            return True
+
+        delay_seconds = max(0.0, float(self._delay_seconds(attempt_count)))
+        inserted = self._insert_retry(
+            _RateLimitReleaseRetry(
+                limiter=limiter,
+                lease=lease,
+                attempt_count=max(0, int(attempt_count)),
+                next_attempt_at=perf_counter() + delay_seconds,
+            )
+        )
+        if inserted:
+            if self._auto_start:
+                self._ensure_worker()
+                self._wake_worker()
+        return inserted
+
+    async def drain_due(self, *, max_releases: int | None = None) -> None:
+        attempts = 0
+        now = perf_counter()
+        release_limit = self._drain_limit if max_releases is None else max(0, int(max_releases))
+        while self._queue and attempts < release_limit and self._queue[0].next_attempt_at <= now:
+            retry = self._queue.popleft()
+            attempts += 1
+            released = await self._release(retry)
+            if not released:
+                self.enqueue(
+                    limiter=retry.limiter,
+                    lease=retry.lease,
+                    attempt_count=retry.attempt_count + 1,
+                )
+
+    async def stop(self) -> None:
+        self._stopped = True
+        self._wake_worker()
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    def _insert_retry(self, retry: _RateLimitReleaseRetry) -> bool:
+        if len(self._queue) >= self._max_size:
+            logger.error(
+                "rate-limit release retry queue full pending=%s",
+                len(self._queue),
+            )
+            return False
+        for index, queued in enumerate(self._queue):
+            if retry.next_attempt_at < queued.next_attempt_at:
+                self._queue.insert(index, retry)
+                return True
+        self._queue.append(retry)
+        return True
+
+    async def _release(self, retry: _RateLimitReleaseRetry) -> bool:
+        if not retry.lease.pending_parallel_acquisitions:
+            return True
+        try:
+            await release_rate_limit_controls(limiter=retry.limiter, lease=retry.lease)
+        except Exception as exc:
+            pending_count = len(retry.lease.pending_parallel_acquisitions)
+            logger.warning(
+                "rate-limit release retry failed pending=%s attempt=%s error=%s",
+                pending_count,
+                retry.attempt_count + 1,
+                exc,
+                exc_info=True,
+            )
+            return pending_count == 0
+        return not bool(retry.lease.pending_parallel_acquisitions)
+
+    def _ensure_worker(self) -> None:
+        if self._stopped:
+            return
+        if self._task is not None and not self._task.done():
+            return
+        self._wakeup = asyncio.Event()
+        self._task = asyncio.create_task(self._run())
+
+    def _wake_worker(self) -> None:
+        if self._wakeup is not None:
+            self._wakeup.set()
+
+    async def _run(self) -> None:
+        while not self._stopped:
+            if not self._queue:
+                return
+            delay_seconds = max(0.0, self._queue[0].next_attempt_at - perf_counter())
+            if delay_seconds > 0:
+                wakeup = self._wakeup
+                if wakeup is None:
+                    self._wakeup = asyncio.Event()
+                    wakeup = self._wakeup
+                try:
+                    await asyncio.wait_for(wakeup.wait(), timeout=delay_seconds)
+                except TimeoutError:
+                    pass
+                wakeup.clear()
+                continue
+            await self.drain_due()
+
+
+def get_rate_limit_release_retry_queue(app: Any) -> RateLimitReleaseRetryQueue:
+    state = getattr(app, "state", app)
+    queue = getattr(state, "rate_limit_release_retry_queue", None)
+    if isinstance(queue, RateLimitReleaseRetryQueue):
+        return queue
+    queue = RateLimitReleaseRetryQueue()
+    setattr(state, "rate_limit_release_retry_queue", queue)
+    return queue

--- a/src/services/limit_counter.py
+++ b/src/services/limit_counter.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 import math
+import secrets
 import time
-from typing import Any
+from typing import Any, Literal
 
 from src.models.errors import RateLimitError, ServiceUnavailableError
+
+_PARALLEL_LEASE_TTL_SECONDS = 300
 
 
 @dataclass(frozen=True)
@@ -16,6 +19,46 @@ class RateLimitCheck:
     limit: int
     amount: int = 1
     window_seconds: int = 60
+
+
+@dataclass(frozen=True)
+class ParallelLimitCheck:
+    scope: str
+    entity_id: str
+    limit: int
+
+
+@dataclass(frozen=True)
+class LegacyParallelLease:
+    scope: str
+    entity_id: str
+    limit: int
+    backend: Literal["redis", "fallback"]
+    ttl_seconds: int = _PARALLEL_LEASE_TTL_SECONDS
+
+    @property
+    def check(self) -> ParallelLimitCheck:
+        return ParallelLimitCheck(scope=self.scope, entity_id=self.entity_id, limit=self.limit)
+
+
+@dataclass(frozen=True)
+class ParallelLimitLease:
+    scope: str
+    entity_id: str
+    limit: int
+    token: str
+    backend: Literal["redis", "fallback"]
+    ttl_seconds: int = _PARALLEL_LEASE_TTL_SECONDS
+
+    @property
+    def check(self) -> ParallelLimitCheck:
+        return ParallelLimitCheck(scope=self.scope, entity_id=self.entity_id, limit=self.limit)
+
+
+@dataclass(frozen=True)
+class _ParallelLeaseGroup:
+    check: ParallelLimitCheck
+    requested_count: int
 
 
 @dataclass
@@ -143,41 +186,305 @@ return results
         )
 
     async def acquire_parallel(self, scope: str, entity_id: str, limit: int | None) -> None:
-        if limit is None or limit <= 0:
-            return
-        if self.redis is None:
-            await self._acquire_parallel_fallback(scope, entity_id, limit)
-            return
-
-        key = f"parallel:{scope}:{entity_id}"
-        try:
-            current = await self.redis.incr(key)
-        except Exception:
-            await self._handle_redis_degraded()
-            await self._acquire_parallel_fallback(scope, entity_id, limit)
-            return
-        if current == 1:
-            try:
-                await self.redis.expire(key, 300)
-            except Exception:
-                await self._handle_redis_degraded()
-        if current > limit:
-            try:
-                await self.redis.decr(key)
-            except Exception:
-                await self._handle_redis_degraded()
-            raise RateLimitError(message="Parallel request limit exceeded", retry_after=1)
+        await self.acquire_legacy_parallel_lease(scope, entity_id, limit)
 
     async def release_parallel(self, scope: str, entity_id: str) -> None:
         if self.redis is None:
             await self._release_parallel_fallback(scope, entity_id)
             return
-        key = f"parallel:{scope}:{entity_id}"
+        key = _legacy_parallel_key(scope, entity_id)
+        script = """
+local current = tonumber(redis.call('GET', KEYS[1]) or '0') or 0
+if current <= 1 then
+  redis.call('DEL', KEYS[1])
+  return {1, 0}
+end
+local next_value = redis.call('DECR', KEYS[1])
+return {1, next_value}
+"""
         try:
-            await self.redis.decr(key)
+            await self.redis.eval(script, 1, key)
         except Exception:
             await self._handle_redis_degraded()
             await self._release_parallel_fallback(scope, entity_id)
+
+    async def acquire_legacy_parallel_lease(
+        self,
+        scope: str,
+        entity_id: str,
+        limit: int | None,
+        *,
+        ttl_seconds: int = _PARALLEL_LEASE_TTL_SECONDS,
+    ) -> LegacyParallelLease | None:
+        if limit is None or limit <= 0 or not entity_id:
+            return None
+
+        normalized_ttl_seconds = max(1, int(ttl_seconds))
+        normalized_limit = int(limit)
+        if self.redis is None:
+            await self._acquire_parallel_fallback(scope, entity_id, normalized_limit)
+            return LegacyParallelLease(
+                scope=scope,
+                entity_id=entity_id,
+                limit=normalized_limit,
+                backend="fallback",
+                ttl_seconds=normalized_ttl_seconds,
+            )
+
+        key = _legacy_parallel_key(scope, entity_id)
+        script = """
+local current = tonumber(redis.call('GET', KEYS[1]) or '0') or 0
+if current < 0 then
+  current = 0
+end
+local limit = tonumber(ARGV[1]) or 0
+local ttl_seconds = tonumber(ARGV[2]) or 300
+if current + 1 > limit then
+  return {0, current}
+end
+local next_value = current + 1
+redis.call('SET', KEYS[1], next_value)
+redis.call('EXPIRE', KEYS[1], ttl_seconds)
+return {1, next_value}
+"""
+        try:
+            raw = await self.redis.eval(
+                script,
+                1,
+                key,
+                str(normalized_limit),
+                str(normalized_ttl_seconds),
+            )
+        except Exception:
+            await self._handle_redis_degraded()
+            await self._acquire_parallel_fallback(scope, entity_id, normalized_limit)
+            return LegacyParallelLease(
+                scope=scope,
+                entity_id=entity_id,
+                limit=normalized_limit,
+                backend="fallback",
+                ttl_seconds=normalized_ttl_seconds,
+            )
+
+        ok = int(raw[0]) if isinstance(raw, (list, tuple)) and len(raw) >= 1 else 1
+        if ok == 1:
+            return LegacyParallelLease(
+                scope=scope,
+                entity_id=entity_id,
+                limit=normalized_limit,
+                backend="redis",
+                ttl_seconds=normalized_ttl_seconds,
+            )
+        raise _parallel_limit_error(scope)
+
+    async def release_legacy_parallel_lease(self, lease: LegacyParallelLease) -> None:
+        if lease.backend == "fallback":
+            await self._release_parallel_fallback(lease.scope, lease.entity_id)
+            return
+        if lease.backend != "redis":
+            raise ServiceUnavailableError(message="Rate limit backend unavailable")
+        if self.redis is None:
+            raise ServiceUnavailableError(message="Rate limit backend unavailable")
+
+        key = _legacy_parallel_key(lease.scope, lease.entity_id)
+        script = """
+local current = tonumber(redis.call('GET', KEYS[1]) or '0') or 0
+if current <= 1 then
+  redis.call('DEL', KEYS[1])
+  return {1, 0}
+end
+local next_value = redis.call('DECR', KEYS[1])
+return {1, next_value}
+"""
+        try:
+            await self.redis.eval(script, 1, key)
+        except Exception as exc:
+            raise ServiceUnavailableError(message="Rate limit backend unavailable") from exc
+
+    async def refresh_legacy_parallel_lease(
+        self,
+        lease: LegacyParallelLease,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        if lease.backend != "redis":
+            return
+        if self.redis is None:
+            raise ServiceUnavailableError(message="Rate limit backend unavailable")
+
+        key = _legacy_parallel_key(lease.scope, lease.entity_id)
+        normalized_ttl_seconds = max(1, int(ttl_seconds if ttl_seconds is not None else lease.ttl_seconds))
+        script = """
+local current = tonumber(redis.call('GET', KEYS[1]) or '0') or 0
+if current <= 0 then
+  redis.call('DEL', KEYS[1])
+  return {1, 0}
+end
+redis.call('EXPIRE', KEYS[1], ARGV[1])
+return {1, current}
+"""
+        try:
+            await self.redis.eval(script, 1, key, str(normalized_ttl_seconds))
+        except Exception as exc:
+            raise ServiceUnavailableError(message="Rate limit backend unavailable") from exc
+
+    async def acquire_parallel_leases(
+        self,
+        checks: list[ParallelLimitCheck],
+        *,
+        ttl_seconds: int = _PARALLEL_LEASE_TTL_SECONDS,
+    ) -> tuple[ParallelLimitLease, ...]:
+        groups = _coalesce_parallel_limit_checks(checks)
+        if not groups:
+            return ()
+
+        normalized_ttl_seconds = max(1, int(ttl_seconds))
+        if self.redis is None:
+            return await self._acquire_parallel_leases_fallback(
+                groups,
+                ttl_seconds=normalized_ttl_seconds,
+            )
+
+        leases = tuple(
+            ParallelLimitLease(
+                scope=group.check.scope,
+                entity_id=group.check.entity_id,
+                limit=group.check.limit,
+                token=secrets.token_urlsafe(18),
+                backend="redis",
+                ttl_seconds=normalized_ttl_seconds,
+            )
+            for group in groups
+            for _ in range(group.requested_count)
+        )
+        keys = [_parallel_lease_key(group.check.scope, group.check.entity_id) for group in groups]
+        now_ms = int(time.time() * 1000)
+        expires_at_ms = now_ms + (normalized_ttl_seconds * 1000)
+        limits = [str(int(group.check.limit)) for group in groups]
+        requested_counts = [str(int(group.requested_count)) for group in groups]
+        tokens = [lease.token for lease in leases]
+
+        script = """
+local n = #KEYS
+local now_ms = tonumber(ARGV[1]) or 0
+local expires_at_ms = tonumber(ARGV[2]) or 0
+for i = 1, n do
+  redis.call('ZREMRANGEBYSCORE', KEYS[i], '-inf', now_ms)
+  local limit = tonumber(ARGV[2 + i]) or 0
+  local requested = tonumber(ARGV[2 + n + i]) or 0
+  local current = redis.call('ZCARD', KEYS[i])
+  if current + requested > limit then
+    return {0, i}
+  end
+end
+local token_index = 2 + (2 * n)
+for i = 1, n do
+  local requested = tonumber(ARGV[2 + n + i]) or 0
+  for _ = 1, requested do
+    token_index = token_index + 1
+    local token = ARGV[token_index]
+    redis.call('ZADD', KEYS[i], expires_at_ms, token)
+  end
+  redis.call('EXPIRE', KEYS[i], math.ceil((expires_at_ms - now_ms) / 1000))
+end
+return {1, 0}
+"""
+        try:
+            raw = await self.redis.eval(
+                script,
+                len(keys),
+                *keys,
+                str(now_ms),
+                str(expires_at_ms),
+                *limits,
+                *requested_counts,
+                *tokens,
+            )
+        except Exception:
+            await self._handle_redis_degraded()
+            return await self._acquire_parallel_leases_fallback(
+                groups,
+                ttl_seconds=normalized_ttl_seconds,
+            )
+
+        ok = int(raw[0]) if isinstance(raw, (list, tuple)) and len(raw) >= 1 else 1
+        if ok == 1:
+            return leases
+
+        failed_index = int(raw[1]) - 1 if isinstance(raw, (list, tuple)) and len(raw) >= 2 else 0
+        failed = groups[max(0, min(failed_index, len(groups) - 1))].check
+        raise _parallel_limit_error(failed.scope)
+
+    async def release_parallel_leases(self, leases: list[ParallelLimitLease]) -> None:
+        if not leases:
+            return
+
+        fallback_leases = [lease for lease in leases if lease.backend == "fallback"]
+        redis_leases = [lease for lease in leases if lease.backend == "redis"]
+
+        if redis_leases:
+            if self.redis is None:
+                raise ServiceUnavailableError(message="Rate limit backend unavailable")
+
+            keys = [_parallel_lease_key(lease.scope, lease.entity_id) for lease in redis_leases]
+            tokens = [lease.token for lease in redis_leases]
+            script = """
+local n = #KEYS
+for i = 1, n do
+  redis.call('ZREM', KEYS[i], ARGV[i])
+  if redis.call('ZCARD', KEYS[i]) == 0 then
+    redis.call('DEL', KEYS[i])
+  end
+end
+return {1, 0}
+"""
+            try:
+                await self.redis.eval(script, len(keys), *keys, *tokens)
+            except Exception as exc:
+                raise ServiceUnavailableError(message="Rate limit backend unavailable") from exc
+
+        if fallback_leases:
+            await self._release_parallel_leases_fallback(fallback_leases)
+
+    async def refresh_parallel_leases(
+        self,
+        leases: list[ParallelLimitLease],
+        *,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        if not leases:
+            return
+
+        redis_leases = [lease for lease in leases if lease.backend == "redis"]
+        if not redis_leases:
+            return
+        if self.redis is None:
+            raise ServiceUnavailableError(message="Rate limit backend unavailable")
+
+        keys = [_parallel_lease_key(lease.scope, lease.entity_id) for lease in redis_leases]
+        tokens = [lease.token for lease in redis_leases]
+        now_ms = int(time.time() * 1000)
+        expires_at_values = [
+            str(now_ms + (max(1, int(ttl_seconds if ttl_seconds is not None else lease.ttl_seconds)) * 1000))
+            for lease in redis_leases
+        ]
+        script = """
+local n = #KEYS
+local now_ms = tonumber(ARGV[(2 * n) + 1]) or 0
+for i = 1, n do
+  local token = ARGV[i]
+  local expires_at_ms = tonumber(ARGV[n + i]) or 0
+  if redis.call('ZSCORE', KEYS[i], token) then
+    redis.call('ZADD', KEYS[i], expires_at_ms, token)
+    redis.call('EXPIRE', KEYS[i], math.ceil((expires_at_ms - now_ms) / 1000))
+  end
+end
+return {1, 0}
+"""
+        try:
+            await self.redis.eval(script, len(keys), *keys, *tokens, *expires_at_values, str(now_ms))
+        except Exception as exc:
+            raise ServiceUnavailableError(message="Rate limit backend unavailable") from exc
 
     async def _handle_redis_degraded(self) -> None:
         if self.degraded_mode == "fail_closed":
@@ -267,7 +574,7 @@ return results
         if current > limit:
             async with self._fallback_lock:
                 self._fallback_parallel[key] = max(0, int(self._fallback_parallel.get(key, 1)) - 1)
-            raise RateLimitError(message="Parallel request limit exceeded", retry_after=1)
+            raise _parallel_limit_error(scope)
 
     async def _release_parallel_fallback(self, scope: str, entity_id: str) -> None:
         key = f"{scope}:{entity_id}"
@@ -277,3 +584,97 @@ return results
                 self._fallback_parallel.pop(key, None)
             else:
                 self._fallback_parallel[key] = current
+
+    async def _acquire_parallel_leases_fallback(
+        self,
+        groups: tuple[_ParallelLeaseGroup, ...],
+        *,
+        ttl_seconds: int,
+    ) -> tuple[ParallelLimitLease, ...]:
+        if self.degraded_mode == "fail_closed":
+            raise ServiceUnavailableError(message="Rate limit backend unavailable")
+
+        async with self._fallback_lock:
+            for group in groups:
+                key = f"{group.check.scope}:{group.check.entity_id}"
+                current = int(self._fallback_parallel.get(key, 0))
+                if current + group.requested_count > group.check.limit:
+                    raise _parallel_limit_error(group.check.scope)
+
+            leases = tuple(
+                ParallelLimitLease(
+                    scope=group.check.scope,
+                    entity_id=group.check.entity_id,
+                    limit=group.check.limit,
+                    token=secrets.token_urlsafe(18),
+                    backend="fallback",
+                    ttl_seconds=ttl_seconds,
+                )
+                for group in groups
+                for _ in range(group.requested_count)
+            )
+            for lease in leases:
+                key = f"{lease.scope}:{lease.entity_id}"
+                self._fallback_parallel[key] = int(self._fallback_parallel.get(key, 0)) + 1
+            return leases
+
+    async def _release_parallel_leases_fallback(self, leases: list[ParallelLimitLease]) -> None:
+        async with self._fallback_lock:
+            for lease in leases:
+                key = f"{lease.scope}:{lease.entity_id}"
+                current = max(0, int(self._fallback_parallel.get(key, 0)) - 1)
+                if current == 0:
+                    self._fallback_parallel.pop(key, None)
+                else:
+                    self._fallback_parallel[key] = current
+
+
+def _parallel_limit_error(scope: str) -> RateLimitError:
+    if scope == "key":
+        return RateLimitError(message="Parallel request limit exceeded", retry_after=1)
+    return RateLimitError(
+        message=f"Parallel request limit exceeded for scope '{scope}'",
+        param=scope,
+        code=_parallel_limit_error_code(scope),
+        retry_after=1,
+    )
+
+
+def _parallel_limit_error_code(scope: str) -> str:
+    return f"{scope}_exceeded" if scope.endswith("_parallel") else f"{scope}_parallel_exceeded"
+
+
+def _parallel_lease_key(scope: str, entity_id: str) -> str:
+    return f"parallel_lease:{scope}:{entity_id}"
+
+
+def _legacy_parallel_key(scope: str, entity_id: str) -> str:
+    return f"parallel:{scope}:{entity_id}"
+
+
+def _coalesce_parallel_limit_checks(checks: list[ParallelLimitCheck]) -> tuple[_ParallelLeaseGroup, ...]:
+    groups: dict[tuple[str, str], _ParallelLeaseGroup] = {}
+    for check in checks:
+        if check.limit <= 0 or not check.entity_id:
+            continue
+        key = (check.scope, check.entity_id)
+        existing = groups.get(key)
+        if existing is None:
+            groups[key] = _ParallelLeaseGroup(
+                check=ParallelLimitCheck(
+                    scope=check.scope,
+                    entity_id=check.entity_id,
+                    limit=int(check.limit),
+                ),
+                requested_count=1,
+            )
+            continue
+        groups[key] = _ParallelLeaseGroup(
+            check=ParallelLimitCheck(
+                scope=existing.check.scope,
+                entity_id=existing.check.entity_id,
+                limit=min(existing.check.limit, int(check.limit)),
+            ),
+            requested_count=existing.requested_count + 1,
+        )
+    return tuple(groups.values())

--- a/src/services/tier_policy_builders.py
+++ b/src/services/tier_policy_builders.py
@@ -104,13 +104,6 @@ def compile_rate_limit_descriptors(
         _descriptor("tier_org_model_rpd", entity_id, limits.rpd_limit, "requests", 86400),
         _descriptor("tier_org_model_tpd", entity_id, limits.tpd_limit, "tokens", 86400),
         _descriptor(
-            "tier_org_model_parallel",
-            entity_id,
-            limits.max_parallel_requests,
-            "concurrency",
-            0,
-        ),
-        _descriptor(
             "tier_org_model_batch_rpm",
             entity_id,
             limits.batch_rpm_limit,
@@ -156,6 +149,12 @@ def compile_capacity_pools(
             source_tier_version_ids=(pool.tier_version_id,),
             source_pool_ids=(pool.tier_capacity_pool_id,),
             metadata=_freeze_metadata(pool.metadata),
+            rate_limit_descriptors=_compile_capacity_pool_rate_limit_descriptors(
+                pool_key=pool.pool_key,
+                callable_key=pool.callable_key,
+                rpm_capacity=pool.rpm_capacity,
+                tpm_capacity=pool.tpm_capacity,
+            ),
         )
         existing = compiled.get(key)
         compiled[key] = (
@@ -193,11 +192,13 @@ def _merge_capacity_pool(
         (left.strategy, right.strategy),
         key=lambda item: _CAPACITY_STRATEGY_RANK.get(item, 99),
     )
+    rpm_capacity = _min_optional_int(left.rpm_capacity, right.rpm_capacity)
+    tpm_capacity = _min_optional_int(left.tpm_capacity, right.tpm_capacity)
     return CompiledTierCapacityPoolPolicy(
         pool_key=left.pool_key,
         callable_key=left.callable_key,
-        rpm_capacity=_min_optional_int(left.rpm_capacity, right.rpm_capacity),
-        tpm_capacity=_min_optional_int(left.tpm_capacity, right.tpm_capacity),
+        rpm_capacity=rpm_capacity,
+        tpm_capacity=tpm_capacity,
         max_parallel_requests=_min_optional_int(
             left.max_parallel_requests,
             right.max_parallel_requests,
@@ -213,7 +214,28 @@ def _merge_capacity_pool(
         ),
         source_pool_ids=tuple(sorted(set(left.source_pool_ids) | set(right.source_pool_ids))),
         metadata=left.metadata or right.metadata,
+        rate_limit_descriptors=_compile_capacity_pool_rate_limit_descriptors(
+            pool_key=left.pool_key,
+            callable_key=left.callable_key,
+            rpm_capacity=rpm_capacity,
+            tpm_capacity=tpm_capacity,
+        ),
     )
+
+
+def _compile_capacity_pool_rate_limit_descriptors(
+    *,
+    pool_key: str,
+    callable_key: str,
+    rpm_capacity: int | None,
+    tpm_capacity: int | None,
+) -> tuple[CompiledTierRateLimitDescriptor, ...]:
+    entity_id = f"{pool_key}:{callable_key}"
+    descriptors = [
+        _descriptor("tier_pool_model_rpm", entity_id, rpm_capacity, "requests", 60, mode="all"),
+        _descriptor("tier_pool_model_tpm", entity_id, tpm_capacity, "tokens", 60, mode="all"),
+    ]
+    return tuple(descriptor for descriptor in descriptors if descriptor is not None)
 
 
 def _freeze_pricing(pricing: Mapping[str, Any] | None) -> Mapping[str, float]:
@@ -252,4 +274,3 @@ def _min_optional_float(left: float | None, right: float | None) -> float | None
     if right is None:
         return left
     return min(left, right)
-

--- a/src/services/tier_policy_models.py
+++ b/src/services/tier_policy_models.py
@@ -80,6 +80,7 @@ class CompiledTierCapacityPoolPolicy:
     source_tier_version_ids: tuple[str, ...]
     source_pool_ids: tuple[str, ...]
     metadata: FrozenMetadata | None = None
+    rate_limit_descriptors: tuple[CompiledTierRateLimitDescriptor, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/tier_rate_limit_policy.py
+++ b/src/tier_rate_limit_policy.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from src.models.errors import ServiceUnavailableError
+from src.services.limit_counter import ParallelLimitCheck, RateLimitCheck
+from src.services.tier_policy_service import resolve_tier_policy_unavailable_decision
+
+RateLimitMode = Literal["sync", "batch"]
+
+_TIER_POLICY_UNAVAILABLE_MESSAGE = "Tier policy unavailable for rate limiting"
+_BATCH_SCOPE_FALLBACKS = {
+    "tier_org_model_batch_rpm": "tier_org_model_rpm",
+    "tier_org_model_batch_tpm": "tier_org_model_tpm",
+}
+_BATCH_FALLBACK_SYNC_SCOPES = frozenset(_BATCH_SCOPE_FALLBACKS.values())
+
+
+@dataclass(frozen=True, slots=True)
+class TierLimitControls:
+    rate_checks: tuple[RateLimitCheck, ...] = ()
+    parallel_checks: tuple[ParallelLimitCheck, ...] = ()
+
+
+def build_tier_rate_limit_checks(
+    *,
+    auth: Any,
+    tokens: int,
+    model: str | None,
+    tier_policy_service: Any | None,
+    tier_policy_mode: str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
+    mode: RateLimitMode | str = "sync",
+) -> list[RateLimitCheck]:
+    return list(
+        build_tier_limit_controls(
+            auth=auth,
+            tokens=tokens,
+            model=model,
+            tier_policy_service=tier_policy_service,
+            tier_policy_mode=tier_policy_mode,
+            tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+            mode=mode,
+        ).rate_checks
+    )
+
+
+def build_tier_parallel_limit_checks(
+    *,
+    auth: Any,
+    model: str | None,
+    tier_policy_service: Any | None,
+    tier_policy_mode: str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
+    mode: RateLimitMode | str = "sync",
+) -> list[ParallelLimitCheck]:
+    return list(
+        build_tier_limit_controls(
+            auth=auth,
+            tokens=0,
+            model=model,
+            tier_policy_service=tier_policy_service,
+            tier_policy_mode=tier_policy_mode,
+            tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+            mode=mode,
+        ).parallel_checks
+    )
+
+
+def build_tier_limit_controls(
+    *,
+    auth: Any,
+    tokens: int,
+    model: str | None,
+    tier_policy_service: Any | None,
+    tier_policy_mode: str = "disabled",
+    tier_policy_missing_service_mode: str = "fail_open",
+    mode: RateLimitMode | str = "sync",
+) -> TierLimitControls:
+    organization_id = _normalize_id(getattr(auth, "organization_id", None))
+    callable_key = _normalize_id(model)
+    if organization_id is None or callable_key is None:
+        return TierLimitControls()
+
+    policy_mode = _effective_tier_policy_mode(tier_policy_service, tier_policy_mode)
+    if policy_mode != "enforce":
+        return TierLimitControls()
+
+    if not _tier_policy_service_has_rate_limit_lookups(tier_policy_service):
+        _ensure_tier_policy_available(
+            tier_policy_service,
+            organization_id=organization_id,
+            tier_policy_mode=policy_mode,
+            tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+        )
+        return TierLimitControls()
+
+    if bool(getattr(tier_policy_service, "snapshot_stale", False)):
+        _ensure_tier_policy_available(
+            tier_policy_service,
+            organization_id=organization_id,
+            tier_policy_mode=policy_mode,
+            tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+        )
+        return TierLimitControls()
+
+    request_mode = _normalize_rate_limit_mode(mode)
+    try:
+        return _build_tier_controls_from_service(
+            tier_policy_service=tier_policy_service,
+            organization_id=organization_id,
+            callable_key=callable_key,
+            tokens=tokens,
+            request_mode=request_mode,
+        )
+    except Exception as exc:
+        _ensure_tier_policy_available(
+            tier_policy_service,
+            organization_id=organization_id,
+            tier_policy_mode=policy_mode,
+            tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+            cause=exc,
+        )
+        return TierLimitControls()
+
+
+def _build_tier_controls_from_service(
+    *,
+    tier_policy_service: Any,
+    organization_id: str,
+    callable_key: str,
+    tokens: int,
+    request_mode: RateLimitMode,
+) -> TierLimitControls:
+    checks: list[RateLimitCheck] = []
+    descriptors = _select_rate_limit_descriptors(
+        tier_policy_service.get_rate_limit_descriptors(organization_id, callable_key),
+        request_mode=request_mode,
+    )
+    for descriptor in descriptors:
+        check = _rate_limit_check_from_descriptor(
+            descriptor,
+            tokens=tokens,
+        )
+        if check is not None:
+            checks.append(check)
+
+    model_policy = tier_policy_service.get_model_policy(organization_id, callable_key)
+    if str(getattr(model_policy, "access_mode", "allow") or "allow").strip().lower() == "deny":
+        return TierLimitControls(rate_checks=tuple(checks))
+
+    parallel_checks = [
+        check
+        for check in (
+            _model_parallel_limit_check(model_policy, organization_id, callable_key),
+        )
+        if check is not None
+    ]
+
+    capacity_pool_key = _normalize_id(getattr(model_policy, "capacity_pool_key", None))
+    if capacity_pool_key is None:
+        return TierLimitControls(rate_checks=tuple(checks), parallel_checks=tuple(parallel_checks))
+
+    pool_policy = tier_policy_service.get_capacity_pool_policy(capacity_pool_key, callable_key)
+    checks.extend(
+        _capacity_pool_rate_limit_checks(
+            pool_policy,
+            tokens=tokens,
+            request_mode=request_mode,
+        )
+    )
+    pool_parallel_check = _pool_parallel_limit_check(
+        pool_policy,
+        fallback_pool_key=capacity_pool_key,
+        fallback_callable_key=callable_key,
+    )
+    if pool_parallel_check is not None:
+        parallel_checks.append(pool_parallel_check)
+    return TierLimitControls(rate_checks=tuple(checks), parallel_checks=tuple(parallel_checks))
+
+
+def _capacity_pool_rate_limit_checks(
+    pool_policy: Any | None,
+    *,
+    tokens: int,
+    request_mode: RateLimitMode,
+) -> list[RateLimitCheck]:
+    descriptors = _select_rate_limit_descriptors(
+        getattr(pool_policy, "rate_limit_descriptors", ()) if pool_policy is not None else (),
+        request_mode=request_mode,
+    )
+    checks: list[RateLimitCheck] = []
+    for descriptor in descriptors:
+        check = _rate_limit_check_from_descriptor(
+            descriptor,
+            tokens=tokens,
+        )
+        if check is not None:
+            checks.append(check)
+    return checks
+
+
+def _select_rate_limit_descriptors(
+    descriptors: Any,
+    *,
+    request_mode: RateLimitMode,
+) -> tuple[Any, ...]:
+    descriptor_tuple = tuple(descriptors or ())
+    if request_mode == "sync":
+        return tuple(
+            descriptor
+            for descriptor in descriptor_tuple
+            if _descriptor_mode(descriptor) in {"sync", "all"}
+        )
+
+    batch_override_targets = _batch_override_targets(descriptor_tuple)
+    selected = []
+    for descriptor in descriptor_tuple:
+        descriptor_mode = _descriptor_mode(descriptor)
+        scope = _descriptor_scope(descriptor)
+        if descriptor_mode in {"batch", "all"}:
+            selected.append(descriptor)
+        elif (
+            descriptor_mode == "sync"
+            and scope in _BATCH_FALLBACK_SYNC_SCOPES
+            and scope not in batch_override_targets
+        ):
+            selected.append(descriptor)
+    return tuple(selected)
+
+
+def _batch_override_targets(descriptors: tuple[Any, ...]) -> set[str]:
+    targets: set[str] = set()
+    for descriptor in descriptors:
+        if _descriptor_mode(descriptor) != "batch":
+            continue
+        scope = _descriptor_scope(descriptor)
+        fallback_scope = _BATCH_SCOPE_FALLBACKS.get(scope)
+        if fallback_scope is not None:
+            targets.add(fallback_scope)
+    return targets
+
+
+def _rate_limit_check_from_descriptor(
+    descriptor: Any,
+    *,
+    tokens: int,
+) -> RateLimitCheck | None:
+    amount_kind = str(getattr(descriptor, "amount_kind", "") or "").strip().lower()
+    if amount_kind == "requests":
+        amount = 1
+    elif amount_kind == "tokens":
+        amount = int(tokens)
+    else:
+        return None
+
+    scope = _normalize_id(getattr(descriptor, "scope", None))
+    entity_id = _normalize_id(getattr(descriptor, "entity_id", None))
+    limit = _positive_int_or_none(getattr(descriptor, "limit", None))
+    window_seconds = _positive_int_or_none(getattr(descriptor, "window_seconds", None))
+    if scope is None or entity_id is None or limit is None or window_seconds is None or amount <= 0:
+        return None
+
+    return RateLimitCheck(
+        scope=scope,
+        entity_id=entity_id,
+        limit=limit,
+        amount=amount,
+        window_seconds=window_seconds,
+    )
+
+
+def _model_parallel_limit_check(
+    model_policy: Any | None,
+    organization_id: str,
+    callable_key: str,
+) -> ParallelLimitCheck | None:
+    limits = getattr(model_policy, "limits", None)
+    limit = _positive_int_or_none(getattr(limits, "max_parallel_requests", None))
+    if limit is None:
+        return None
+    return ParallelLimitCheck(
+        scope="tier_org_model_parallel",
+        entity_id=f"{organization_id}:{callable_key}",
+        limit=limit,
+    )
+
+
+def _pool_parallel_limit_check(
+    pool_policy: Any | None,
+    *,
+    fallback_pool_key: str,
+    fallback_callable_key: str,
+) -> ParallelLimitCheck | None:
+    if pool_policy is None:
+        return None
+    limit = _positive_int_or_none(getattr(pool_policy, "max_parallel_requests", None))
+    if limit is None:
+        return None
+    pool_key = _normalize_id(getattr(pool_policy, "pool_key", None)) or fallback_pool_key
+    callable_key = _normalize_id(getattr(pool_policy, "callable_key", None)) or fallback_callable_key
+    return ParallelLimitCheck(
+        scope="tier_pool_model_parallel",
+        entity_id=f"{pool_key}:{callable_key}",
+        limit=limit,
+    )
+
+
+def _tier_policy_service_has_rate_limit_lookups(tier_policy_service: Any | None) -> bool:
+    return (
+        tier_policy_service is not None
+        and callable(getattr(tier_policy_service, "get_rate_limit_descriptors", None))
+        and callable(getattr(tier_policy_service, "get_model_policy", None))
+        and callable(getattr(tier_policy_service, "get_capacity_pool_policy", None))
+    )
+
+
+def _ensure_tier_policy_available(
+    tier_policy_service: Any | None,
+    *,
+    organization_id: str | None,
+    tier_policy_mode: str,
+    tier_policy_missing_service_mode: str,
+    cause: Exception | None = None,
+) -> None:
+    decision = _resolve_tier_unavailable_decision(
+        tier_policy_service,
+        organization_id=organization_id,
+        tier_policy_mode=tier_policy_mode,
+        tier_policy_missing_service_mode=tier_policy_missing_service_mode,
+    )
+    if bool(getattr(decision, "allowed", False)):
+        return
+    raise ServiceUnavailableError(
+        message=_TIER_POLICY_UNAVAILABLE_MESSAGE,
+        code=str(getattr(decision, "reason", "tier_policy_unavailable")),
+    ) from cause
+
+
+def _resolve_tier_unavailable_decision(
+    tier_policy_service: Any | None,
+    *,
+    organization_id: str | None,
+    tier_policy_mode: str,
+    tier_policy_missing_service_mode: str,
+) -> Any:
+    resolver = getattr(tier_policy_service, "resolve_unavailable_decision", None)
+    if callable(resolver):
+        try:
+            return resolver(organization_id)
+        except Exception:
+            pass
+
+    service_for_decision = (
+        tier_policy_service
+        if callable(getattr(tier_policy_service, "has_explicit_tier_policy", None))
+        else None
+    )
+    return resolve_tier_policy_unavailable_decision(
+        service_for_decision,
+        organization_id,
+        mode=tier_policy_mode,
+        missing_service_mode=str(
+            getattr(tier_policy_service, "missing_service_mode", tier_policy_missing_service_mode)
+            if tier_policy_service is not None
+            else tier_policy_missing_service_mode
+        ),
+    )
+
+
+def _effective_tier_policy_mode(tier_policy_service: Any | None, tier_policy_mode: str) -> str:
+    return _normalize_tier_policy_mode(
+        getattr(tier_policy_service, "mode", tier_policy_mode)
+        if tier_policy_service is not None
+        else tier_policy_mode
+    )
+
+
+def _normalize_tier_policy_mode(value: object) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized not in {"disabled", "shadow", "enforce"}:
+        return "disabled"
+    return normalized
+
+
+def _normalize_rate_limit_mode(value: object) -> RateLimitMode:
+    return "batch" if str(value or "").strip().lower() == "batch" else "sync"
+
+
+def _descriptor_mode(descriptor: Any) -> str:
+    return str(getattr(descriptor, "mode", "sync") or "sync").strip().lower()
+
+
+def _descriptor_scope(descriptor: Any) -> str:
+    return str(getattr(descriptor, "scope", "") or "").strip()
+
+
+def _normalize_id(value: object) -> str | None:
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _positive_int_or_none(value: object) -> int | None:
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return None
+    return normalized if normalized > 0 else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,12 +52,14 @@ class FakeRedis:
         self.store: dict[str, int | str] = {}
         self.hash_store: dict[str, dict[str, str]] = {}
         self.zset_store: dict[str, list[tuple[int, str]]] = {}
+        self.ttl_store: dict[str, int] = {}
 
     async def get(self, key: str):
         return self.store.get(key)
 
     async def setex(self, key: str, ttl: int, value: str):
         self.store[key] = value
+        self.ttl_store[key] = int(ttl)
 
     async def set(self, key: str, value: str, ex: int | None = None, nx: bool = False):
         del ex
@@ -69,6 +71,7 @@ class FakeRedis:
     async def getdel(self, key: str):
         value = self.store.get(key)
         self.store.pop(key, None)
+        self.ttl_store.pop(key, None)
         return value
 
     async def incr(self, key: str):
@@ -84,9 +87,13 @@ class FakeRedis:
         return int(self.store[key])
 
     async def expire(self, key: str, ttl: int):
+        if key in self.store or key in self.hash_store or key in self.zset_store:
+            self.ttl_store[key] = int(ttl)
         return True
 
     async def pexpire(self, key: str, ttl: int):
+        if key in self.store or key in self.hash_store or key in self.zset_store:
+            self.ttl_store[key] = max(1, int(ttl) // 1000)
         return True
 
     async def mget(self, keys):
@@ -97,6 +104,7 @@ class FakeRedis:
             self.store.pop(key, None)
             self.hash_store.pop(key, None)
             self.zset_store.pop(key, None)
+            self.ttl_store.pop(key, None)
 
     async def exists(self, key: str):
         return 1 if key in self.store else 0
@@ -140,10 +148,96 @@ class FakeRedis:
         return True
 
     async def eval(self, script: str, numkeys: int, *args):
-        del script
         keys = [str(item) for item in args[:numkeys]]
         argv = [str(item) for item in args[numkeys:]]
         n = len(keys)
+        if keys and all(key.startswith("parallel:") for key in keys):
+            key = keys[0]
+            if len(argv) == 2:
+                limit = int(argv[0])
+                ttl = int(argv[1])
+                current = max(0, int(self.store.get(key, 0)))
+                if current + 1 > limit:
+                    return [0, current]
+                self.store[key] = current + 1
+                self.ttl_store[key] = ttl
+                return [1, current + 1]
+
+            if len(argv) == 1:
+                ttl = int(argv[0])
+                current = int(self.store.get(key, 0))
+                if current <= 0:
+                    self.store.pop(key, None)
+                    self.ttl_store.pop(key, None)
+                    return [1, 0]
+                self.ttl_store[key] = ttl
+                return [1, current]
+
+            current = int(self.store.get(key, 0))
+            if current <= 1:
+                self.store.pop(key, None)
+                self.ttl_store.pop(key, None)
+                return [1, 0]
+            next_value = current - 1
+            self.store[key] = next_value
+            return [1, next_value]
+
+        if keys and all(key.startswith("parallel_lease:") for key in keys):
+            if "ZSCORE" in script:
+                tokens = argv[:n]
+                expires_at_values = [int(value) for value in argv[n : 2 * n]]
+                for idx, key in enumerate(keys):
+                    token = tokens[idx]
+                    if not any(member == token for _score, member in self.zset_store.get(key, [])):
+                        continue
+                    self.zset_store[key] = [
+                        (score, member)
+                        for score, member in self.zset_store.get(key, [])
+                        if member != token
+                    ]
+                    self.zset_store.setdefault(key, []).append((expires_at_values[idx], token))
+                    self.ttl_store[key] = max(1, (expires_at_values[idx] - int(argv[(2 * n)])) // 1000)
+                return [1, 0]
+
+            if len(argv) == n:
+                for idx, key in enumerate(keys):
+                    token = argv[idx]
+                    self.zset_store[key] = [
+                        (score, member)
+                        for score, member in self.zset_store.get(key, [])
+                        if member != token
+                    ]
+                    if not self.zset_store[key]:
+                        self.zset_store.pop(key, None)
+                        self.ttl_store.pop(key, None)
+                return [1, 0]
+
+            now_ms = int(argv[0])
+            expires_at_ms = int(argv[1])
+            limits = [int(argv[2 + i]) for i in range(n)]
+            requested_counts = [int(argv[2 + n + i]) for i in range(n)]
+            token_index = 2 + (2 * n)
+            for idx, key in enumerate(keys):
+                self.zset_store[key] = [
+                    (score, member)
+                    for score, member in self.zset_store.get(key, [])
+                    if score > now_ms
+                ]
+                if len(self.zset_store.get(key, [])) + requested_counts[idx] > limits[idx]:
+                    return [0, idx + 1]
+            for idx, key in enumerate(keys):
+                for _ in range(requested_counts[idx]):
+                    token = argv[token_index]
+                    token_index += 1
+                    self.zset_store[key] = [
+                        (score, member)
+                        for score, member in self.zset_store.get(key, [])
+                        if member != token
+                    ]
+                    self.zset_store.setdefault(key, []).append((expires_at_ms, token))
+                self.ttl_store[key] = max(1, (expires_at_ms - now_ms) // 1000)
+            return [1, 0]
+
         amounts = [int(argv[i]) for i in range(n)]
         limits = [int(argv[n + i]) for i in range(n)]
 
@@ -156,6 +250,7 @@ class FakeRedis:
         for idx, key in enumerate(keys):
             new_val = int(self.store.get(key, 0)) + amounts[idx]
             self.store[key] = new_val
+            self.ttl_store[key] = 60
             result.append(new_val)
 
         return result

--- a/tests/services/test_tier_policy_compiler.py
+++ b/tests/services/test_tier_policy_compiler.py
@@ -301,7 +301,8 @@ def test_compile_snapshot_prebuilds_pricing_and_rate_limit_descriptors() -> None
     descriptor_by_scope = {descriptor.scope: descriptor for descriptor in descriptors}
     assert descriptor_by_scope["tier_org_model_rpm"].limit == 100
     assert descriptor_by_scope["tier_org_model_tpm"].amount_kind == "tokens"
-    assert descriptor_by_scope["tier_org_model_parallel"].window_seconds == 0
+    assert "tier_org_model_parallel" not in descriptor_by_scope
+    assert snapshot.org_model_policy[("org-1", "gpt-4o-mini")].limits.max_parallel_requests == 25
     assert descriptor_by_scope["tier_org_model_batch_tpm"].mode == "batch"
 
 
@@ -347,6 +348,12 @@ def test_compile_snapshot_merges_capacity_pools_conservatively() -> None:
     assert pool.saturation_threshold == 0.8
     assert pool.burst_multiplier == 1.5
     assert pool.source_tier_version_ids == ("version-1", "version-2")
+    descriptors = {descriptor.scope: descriptor for descriptor in pool.rate_limit_descriptors}
+    assert descriptors["tier_pool_model_rpm"].entity_id == "shared:gpt-4o-mini"
+    assert descriptors["tier_pool_model_rpm"].limit == 800
+    assert descriptors["tier_pool_model_rpm"].mode == "all"
+    assert descriptors["tier_pool_model_tpm"].limit == 500_000
+    assert descriptors["tier_pool_model_tpm"].amount_kind == "tokens"
 
 
 def test_compile_snapshot_etag_is_stable_for_same_logical_inputs() -> None:

--- a/tests/test_mcp_gateway.py
+++ b/tests/test_mcp_gateway.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -27,6 +28,38 @@ from src.mcp.result_cache import MCPToolResultCache
 from src.models.responses import UserAPIKeyAuth
 from src.services.limit_counter import LimitCounter
 from src.services.runtime_scopes import annotate_auth_metadata
+from tests.conftest import FakeRedis
+
+
+class _FailingOnceRedis(FakeRedis):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_next_eval = True
+
+    async def eval(self, script: str, numkeys: int, *args):  # noqa: ANN001, ANN201
+        if self.fail_next_eval:
+            self.fail_next_eval = False
+            raise RuntimeError("redis unavailable")
+        return await super().eval(script, numkeys, *args)
+
+
+class _ReleaseFailingRedis(FakeRedis):
+    def __init__(self, *, fail_release_count: int = 1) -> None:
+        super().__init__()
+        self.fail_release_count = fail_release_count
+
+    async def eval(self, script: str, numkeys: int, *args):  # noqa: ANN001, ANN201
+        keys = [str(item) for item in args[:numkeys]]
+        argv = args[numkeys:]
+        if (
+            self.fail_release_count > 0
+            and keys
+            and all(key.startswith("parallel:") for key in keys)
+            and not argv
+        ):
+            self.fail_release_count -= 1
+            raise RuntimeError("redis release unavailable")
+        return await super().eval(script, numkeys, *args)
 
 
 def _server(
@@ -689,6 +722,97 @@ async def test_gateway_service_uses_governance_snapshot_instead_of_registry_bind
         await gateway.call_tool(
             auth, namespaced_tool_name="docs.search", arguments={"query": "again"}
         )
+
+
+@pytest.mark.asyncio
+async def test_policy_enforcer_releases_fallback_concurrency_after_redis_recovery() -> None:
+    redis = _FailingOnceRedis()
+    limiter = LimitCounter(redis_client=redis, degraded_mode="fail_open")
+    enforcer = MCPToolPolicyEnforcer(limiter)
+    policy = MCPToolPolicyRecord(
+        "policy-team",
+        "srv-docs",
+        "search",
+        "team",
+        "team-ops",
+        True,
+        None,
+        None,
+        1,
+        None,
+        None,
+    )
+
+    lease = await enforcer.acquire(server_key="docs", tool_name="search", policy=policy)
+
+    assert lease is not None
+    assert lease.parallel_lease.backend == "fallback"
+    assert limiter._fallback_parallel["mcp_tool:team:team-ops:docs:search"] == 1  # noqa: SLF001
+
+    await enforcer.release(lease)
+
+    assert "mcp_tool:team:team-ops:docs:search" not in limiter._fallback_parallel  # noqa: SLF001
+    assert "parallel:mcp_tool:team:team-ops:docs:search" not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_gateway_returns_tool_result_when_policy_release_backend_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    redis = _ReleaseFailingRedis()
+    limiter = LimitCounter(redis_client=redis, degraded_mode="fail_open")
+    transport = _FakeTransport()
+    registry = _FakeRegistry(
+        servers=[
+            _server(
+                "srv-docs",
+                "docs",
+                capabilities=[
+                    MCPToolSchema(
+                        name="search", description="Search docs", input_schema={"type": "object"}
+                    )
+                ],
+            )
+        ],
+        bindings=[MCPServerBindingRecord("bind-1", "srv-docs", "team", "team-ops", True, None)],
+        policies=[
+            MCPToolPolicyRecord(
+                "policy-1",
+                "srv-docs",
+                "search",
+                "team",
+                "team-ops",
+                True,
+                None,
+                None,
+                1,
+                None,
+                None,
+            )
+        ],
+    )
+    gateway = MCPGatewayService(
+        registry,
+        transport,
+        MCPToolPolicyEnforcer(limiter),
+    )  # type: ignore[arg-type]
+    auth = type(
+        "Auth",
+        (),
+        {"api_key": "sk-test", "team_id": "team-ops", "organization_id": None, "metadata": None},
+    )()
+    caplog.set_level(logging.WARNING, logger="src.mcp.policy")
+
+    result = await gateway.call_tool(
+        auth,
+        namespaced_tool_name="docs.search",
+        arguments={"query": "hello"},
+    )
+
+    assert result.structured_content["tool"] == "search"
+    assert transport.calls == [("docs", "search", None, {"query": "hello"})]
+    assert "mcp tool policy release failed" in caplog.text
+    assert "team:team-ops:docs:search" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_tier_rate_limits.py
+++ b/tests/test_tier_rate_limits.py
@@ -1,0 +1,1489 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from src.batch.policy import BatchPolicyLease, acquire_batch_policy_lease
+from src.batch import worker_persistence as worker_persistence_module
+from src.batch.worker_persistence import WorkerPersistenceMixin
+from src.middleware.rate_limit import _release_rate_limits
+from src.models.errors import RateLimitError, ServiceUnavailableError
+from src.models.responses import UserAPIKeyAuth
+from src.rate_limit_lease_refresh import RateLimitLeaseRefresher
+from src.rate_limit_release_retry import RateLimitReleaseRetryQueue
+from src.rate_limit_policy import RateLimitLease, acquire_rate_limit_controls, build_rate_limit_checks, release_rate_limit_controls
+from src.services.limit_counter import LegacyParallelLease, LimitCounter, ParallelLimitCheck, ParallelLimitLease
+from src.services.tier_policy_models import (
+    CompiledTierCapacityPoolPolicy,
+    CompiledTierRateLimitDescriptor,
+)
+from src.services.tier_policy_service import resolve_tier_policy_unavailable_decision
+from tests.conftest import FakeRedis
+
+
+class _TierRateLimitService:
+    def __init__(
+        self,
+        *,
+        descriptors: dict[tuple[str, str], tuple[CompiledTierRateLimitDescriptor, ...]] | None = None,
+        model_policies: dict[tuple[str, str], Any] | None = None,
+        pool_policies: dict[tuple[str, str], CompiledTierCapacityPoolPolicy] | None = None,
+        allowed_by_org: dict[str, set[str]] | None = None,
+        explicit_orgs: set[str] | None = None,
+        mode: str = "enforce",
+        missing_service_mode: str = "fail_open",
+        snapshot_stale: bool = False,
+        fail_lookup: bool = False,
+    ) -> None:
+        self.descriptors = descriptors or {}
+        self.model_policies = model_policies or {}
+        self.pool_policies = pool_policies or {}
+        self.allowed_by_org = {
+            org_id: frozenset(models)
+            for org_id, models in (allowed_by_org or {}).items()
+        }
+        self.explicit_orgs = set(explicit_orgs or self.allowed_by_org or {"org-1"})
+        self.mode = mode
+        self.missing_service_mode = missing_service_mode
+        self.snapshot_stale = snapshot_stale
+        self.fail_lookup = fail_lookup
+
+    def has_explicit_tier_policy(self, organization_id: str | None) -> bool:
+        return str(organization_id or "").strip() in self.explicit_orgs
+
+    def resolve_org_allowed_callable_keys(self, organization_id: str | None) -> frozenset[str] | None:
+        normalized = str(organization_id or "").strip()
+        if normalized not in self.explicit_orgs:
+            return None
+        return self.allowed_by_org.get(normalized, frozenset({"gpt-4o-mini"}))
+
+    def resolve_unavailable_decision(self, organization_id: str | None) -> object:
+        return resolve_tier_policy_unavailable_decision(
+            self,
+            organization_id,
+            mode=self.mode,
+            missing_service_mode=self.missing_service_mode,
+        )
+
+    def get_rate_limit_descriptors(
+        self,
+        organization_id: str | None,
+        callable_key: str | None,
+    ) -> tuple[CompiledTierRateLimitDescriptor, ...]:
+        if self.fail_lookup:
+            raise RuntimeError("snapshot lookup failed")
+        return self.descriptors.get((str(organization_id), str(callable_key)), ())
+
+    def get_model_policy(self, organization_id: str | None, callable_key: str | None) -> object:
+        if self.fail_lookup:
+            raise RuntimeError("snapshot lookup failed")
+        return self.model_policies.get(
+            (str(organization_id), str(callable_key)),
+            SimpleNamespace(access_mode="allow", capacity_pool_key=None),
+        )
+
+    def get_capacity_pool_policy(
+        self,
+        pool_key: str | None,
+        callable_key: str | None,
+    ) -> CompiledTierCapacityPoolPolicy | None:
+        if self.fail_lookup:
+            raise RuntimeError("snapshot lookup failed")
+        return self.pool_policies.get((str(pool_key), str(callable_key)))
+
+    def snapshot_info(self) -> object:
+        return SimpleNamespace(etag="test-tier-snapshot", org_count=len(self.explicit_orgs))
+
+
+class _FailingRedis:
+    async def eval(self, *args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise RuntimeError("redis unavailable")
+
+
+class _RecordingLimitCounter(LimitCounter):
+    def __init__(self) -> None:
+        super().__init__(redis_client=None, degraded_mode="fail_open")
+        self.atomic_calls = 0
+        self.seen_checks: list[list[str]] = []
+
+    async def check_rate_limits_atomic(self, checks):
+        self.atomic_calls += 1
+        self.seen_checks.append([check.scope for check in checks])
+        return await super().check_rate_limits_atomic(checks)
+
+
+class _SnapshotMutatingLimitCounter(LimitCounter):
+    def __init__(self, *, service: _TierRateLimitService, failed_scope: str) -> None:
+        super().__init__(redis_client=None, degraded_mode="fail_open")
+        self.service = service
+        self.failed_scope = failed_scope
+
+    async def check_rate_limits_atomic(self, checks):
+        self.service.snapshot_stale = True
+        self.service.missing_service_mode = "fail_closed"
+        raise RateLimitError(
+            message=f"Rate limit exceeded for scope '{self.failed_scope}'",
+            param=self.failed_scope,
+            code=f"{self.failed_scope}_exceeded",
+            retry_after=60,
+        )
+
+
+class _SnapshotMutatingParallelLimitCounter(LimitCounter):
+    def __init__(self, *, service: _TierRateLimitService, failed_scope: str = "key") -> None:
+        super().__init__(redis_client=None, degraded_mode="fail_open")
+        self.service = service
+        self.failed_scope = failed_scope
+
+    async def acquire_parallel(self, scope: str, entity_id: str, limit: int | None) -> None:
+        del entity_id, limit
+        self.service.snapshot_stale = True
+        self.service.missing_service_mode = "fail_closed"
+        if self.failed_scope == "key":
+            raise RateLimitError(message="Parallel request limit exceeded", retry_after=1)
+        raise RateLimitError(
+            message=f"Parallel request limit exceeded for scope '{scope}'",
+            param=self.failed_scope,
+            code=f"{self.failed_scope}_parallel_exceeded",
+            retry_after=1,
+        )
+
+    async def acquire_legacy_parallel_lease(
+        self,
+        scope: str,
+        entity_id: str,
+        limit: int | None,
+        *,
+        ttl_seconds: int = 300,
+    ):
+        await self.acquire_parallel(scope, entity_id, limit)
+        return LegacyParallelLease(
+            scope=scope,
+            entity_id=entity_id,
+            limit=int(limit or 1),
+            backend="fallback",
+            ttl_seconds=ttl_seconds,
+        )
+
+    async def acquire_parallel_leases(self, checks, *, ttl_seconds=300):
+        del ttl_seconds
+        failed = next((check for check in checks if check.scope == self.failed_scope), checks[0])
+        await self.acquire_parallel(failed.scope, failed.entity_id, failed.limit)
+        return ()
+
+
+class _PoolAcquireUnavailableLimitCounter(LimitCounter):
+    async def acquire_parallel(self, scope: str, entity_id: str, limit: int | None) -> None:
+        if scope == "tier_pool_model_parallel":
+            raise ServiceUnavailableError(message="Rate limit backend unavailable")
+        await super().acquire_parallel(scope, entity_id, limit)
+
+    async def acquire_parallel_leases(self, checks, *, ttl_seconds=300):
+        if any(check.scope == "tier_pool_model_parallel" for check in checks):
+            raise ServiceUnavailableError(message="Rate limit backend unavailable")
+        return await super().acquire_parallel_leases(checks, ttl_seconds=ttl_seconds)
+
+
+class _FlakyReleaseLimitCounter:
+    def __init__(self, *, fail_scope: str, failure_count: int) -> None:
+        self.fail_scope = fail_scope
+        self.failure_count = failure_count
+        self.release_calls: list[tuple[str, str]] = []
+
+    async def release_parallel(self, scope: str, entity_id: str) -> None:
+        self.release_calls.append((scope, entity_id))
+        if scope == self.fail_scope and self.failure_count > 0:
+            self.failure_count -= 1
+            raise ServiceUnavailableError(message="Rate limit backend unavailable")
+
+    async def release_legacy_parallel_lease(self, lease: LegacyParallelLease) -> None:
+        await self.release_parallel(lease.scope, lease.entity_id)
+
+    async def release_parallel_leases(self, leases) -> None:
+        self.release_calls.extend((lease.scope, lease.entity_id) for lease in leases)
+        if any(lease.scope == self.fail_scope for lease in leases) and self.failure_count > 0:
+            self.failure_count -= 1
+            raise ServiceUnavailableError(message="Rate limit backend unavailable")
+
+
+class _RecordingRedis:
+    def __init__(self, *, fail_release_count: int = 0) -> None:
+        self.fail_release_count = fail_release_count
+        self.eval_calls: list[tuple[int, tuple[object, ...]]] = []
+
+    async def eval(self, script: str, key_count: int, *args: object) -> list[int]:
+        del script
+        self.eval_calls.append((key_count, args))
+        if len(self.eval_calls) > 1 and self.fail_release_count > 0:
+            self.fail_release_count -= 1
+            raise RuntimeError("redis release unavailable")
+        return [1, 0]
+
+
+class _FailingOnceRedis(FakeRedis):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_next_eval = True
+
+    async def eval(self, script: str, numkeys: int, *args):
+        if self.fail_next_eval:
+            self.fail_next_eval = False
+            raise RuntimeError("redis unavailable")
+        return await super().eval(script, numkeys, *args)
+
+
+class _PolicyReleaseWorker(WorkerPersistenceMixin):
+    def __init__(self, app: object) -> None:
+        self.app = app
+
+
+class _BatchPayload(BaseModel):
+    model: str
+    input: str = "hello"
+
+
+def _auth(
+    *,
+    api_key: str = "key-1",
+    organization_id: str = "org-1",
+    rpm_limit: int | None = 100,
+    tpm_limit: int | None = 100_000,
+    max_parallel_requests: int | None = None,
+) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key=api_key,
+        organization_id=organization_id,
+        rpm_limit=rpm_limit,
+        tpm_limit=tpm_limit,
+        max_parallel_requests=max_parallel_requests,
+    )
+
+
+def _descriptor(
+    scope: str,
+    *,
+    entity_id: str = "org-1:gpt-4o-mini",
+    limit: int = 1,
+    amount_kind: str = "requests",
+    window_seconds: int = 60,
+    mode: str = "sync",
+) -> CompiledTierRateLimitDescriptor:
+    return CompiledTierRateLimitDescriptor(
+        scope=scope,
+        entity_id=entity_id,
+        limit=limit,
+        amount_kind=amount_kind,
+        window_seconds=window_seconds,
+        mode=mode,
+    )
+
+
+def _pool_policy(
+    *,
+    pool_key: str = "shared",
+    callable_key: str = "gpt-4o-mini",
+    rpm_capacity: int | None = None,
+    tpm_capacity: int | None = None,
+    max_parallel_requests: int | None = None,
+) -> CompiledTierCapacityPoolPolicy:
+    descriptors = []
+    entity_id = f"{pool_key}:{callable_key}"
+    if rpm_capacity is not None:
+        descriptors.append(
+            _descriptor(
+                "tier_pool_model_rpm",
+                entity_id=entity_id,
+                limit=rpm_capacity,
+                mode="all",
+            )
+        )
+    if tpm_capacity is not None:
+        descriptors.append(
+            _descriptor(
+                "tier_pool_model_tpm",
+                entity_id=entity_id,
+                limit=tpm_capacity,
+                amount_kind="tokens",
+                mode="all",
+            )
+        )
+    return CompiledTierCapacityPoolPolicy(
+        pool_key=pool_key,
+        callable_key=callable_key,
+        rpm_capacity=rpm_capacity,
+        tpm_capacity=tpm_capacity,
+        max_parallel_requests=max_parallel_requests,
+        strategy="hard_cap",
+        saturation_threshold=None,
+        burst_multiplier=None,
+        source_tier_version_ids=("version-1",),
+        source_pool_ids=("pool-1",),
+        rate_limit_descriptors=tuple(descriptors),
+    )
+
+
+def _parallel_lease() -> RateLimitLease:
+    return RateLimitLease(
+        parallel_leases=(
+            ParallelLimitLease(
+                scope="tier_org_model_parallel",
+                entity_id="org-1:gpt-4o-mini",
+                limit=1,
+                token="org-token",
+                backend="fallback",
+            ),
+            ParallelLimitLease(
+                scope="tier_pool_model_parallel",
+                entity_id="shared:gpt-4o-mini",
+                limit=1,
+                token="pool-token",
+                backend="fallback",
+            ),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_tier_org_model_rpm_is_enforced() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=1),
+            )
+        }
+    )
+    limiter = LimitCounter(redis_client=None, degraded_mode="fail_open")
+
+    await acquire_rate_limit_controls(
+        limiter=limiter,
+        auth=_auth(),
+        tokens=10,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    with pytest.raises(RateLimitError) as exc_info:
+        await acquire_rate_limit_controls(
+            limiter=limiter,
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+
+    assert exc_info.value.param == "tier_org_model_rpm"
+    assert exc_info.value.code == "tier_org_model_rpm_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_tier_org_model_tpm_is_enforced() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_tpm", limit=10, amount_kind="tokens"),
+            )
+        }
+    )
+
+    with pytest.raises(RateLimitError) as exc_info:
+        await acquire_rate_limit_controls(
+            limiter=LimitCounter(redis_client=None, degraded_mode="fail_open"),
+            auth=_auth(),
+            tokens=11,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+
+    assert exc_info.value.param == "tier_org_model_tpm"
+    assert exc_info.value.code == "tier_org_model_tpm_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_shared_pool_rpm_is_enforced_across_organizations() -> None:
+    service = _TierRateLimitService(
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(access_mode="allow", capacity_pool_key="shared"),
+            ("org-2", "gpt-4o-mini"): SimpleNamespace(access_mode="allow", capacity_pool_key="shared"),
+        },
+        pool_policies={("shared", "gpt-4o-mini"): _pool_policy(rpm_capacity=1)},
+        allowed_by_org={"org-1": {"gpt-4o-mini"}, "org-2": {"gpt-4o-mini"}},
+    )
+    limiter = LimitCounter(redis_client=None, degraded_mode="fail_open")
+
+    await acquire_rate_limit_controls(
+        limiter=limiter,
+        auth=_auth(organization_id="org-1", api_key="key-1"),
+        tokens=10,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    with pytest.raises(RateLimitError) as exc_info:
+        await acquire_rate_limit_controls(
+            limiter=limiter,
+            auth=_auth(organization_id="org-2", api_key="key-2"),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+
+    assert exc_info.value.param == "tier_pool_model_rpm"
+    assert exc_info.value.code == "tier_pool_model_rpm_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_shared_pool_tpm_is_enforced_across_organizations() -> None:
+    service = _TierRateLimitService(
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(access_mode="allow", capacity_pool_key="shared"),
+            ("org-2", "gpt-4o-mini"): SimpleNamespace(access_mode="allow", capacity_pool_key="shared"),
+        },
+        pool_policies={("shared", "gpt-4o-mini"): _pool_policy(tpm_capacity=10)},
+        allowed_by_org={"org-1": {"gpt-4o-mini"}, "org-2": {"gpt-4o-mini"}},
+    )
+    limiter = LimitCounter(redis_client=None, degraded_mode="fail_open")
+
+    await acquire_rate_limit_controls(
+        limiter=limiter,
+        auth=_auth(organization_id="org-1", api_key="key-1"),
+        tokens=6,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    with pytest.raises(RateLimitError) as exc_info:
+        await acquire_rate_limit_controls(
+            limiter=limiter,
+            auth=_auth(organization_id="org-2", api_key="key-2"),
+            tokens=6,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+
+    assert exc_info.value.param == "tier_pool_model_tpm"
+    assert exc_info.value.code == "tier_pool_model_tpm_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_tier_checks_are_sent_in_one_atomic_rate_limit_call() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=100),
+                _descriptor("tier_org_model_tpm", limit=100_000, amount_kind="tokens"),
+            )
+        },
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(access_mode="allow", capacity_pool_key="shared"),
+        },
+        pool_policies={("shared", "gpt-4o-mini"): _pool_policy(rpm_capacity=500, tpm_capacity=500_000)},
+    )
+    limiter = _RecordingLimitCounter()
+
+    await acquire_rate_limit_controls(
+        limiter=limiter,
+        auth=_auth(),
+        tokens=25,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+
+    assert limiter.atomic_calls == 1
+    assert "tier_org_model_rpm" in limiter.seen_checks[0]
+    assert "tier_org_model_tpm" in limiter.seen_checks[0]
+    assert "tier_pool_model_rpm" in limiter.seen_checks[0]
+    assert "tier_pool_model_tpm" in limiter.seen_checks[0]
+
+
+@pytest.mark.asyncio
+async def test_existing_key_limit_remains_hard_cap_when_tier_limit_is_higher() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=100),
+            )
+        }
+    )
+    limiter = LimitCounter(redis_client=None, degraded_mode="fail_open")
+    auth = _auth(rpm_limit=1)
+
+    await acquire_rate_limit_controls(
+        limiter=limiter,
+        auth=auth,
+        tokens=10,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    with pytest.raises(RateLimitError) as exc_info:
+        await acquire_rate_limit_controls(
+            limiter=limiter,
+            auth=auth,
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+
+    assert exc_info.value.param == "key_rpm"
+    assert exc_info.value.code == "key_rpm_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_tier_model_parallel_limit_is_enforced_and_released() -> None:
+    service = _TierRateLimitService(
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(
+                access_mode="allow",
+                capacity_pool_key=None,
+                limits=SimpleNamespace(max_parallel_requests=1),
+            ),
+        },
+    )
+    limiter = LimitCounter(redis_client=None, degraded_mode="fail_open")
+
+    lease, _state = await acquire_rate_limit_controls(
+        limiter=limiter,
+        auth=_auth(),
+        tokens=10,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    with pytest.raises(RateLimitError) as exc_info:
+        await acquire_rate_limit_controls(
+            limiter=limiter,
+            auth=_auth(api_key="key-2"),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+    )
+
+    assert exc_info.value.param == "tier_org_model_parallel"
+    assert exc_info.value.code == "tier_org_model_parallel_exceeded"
+
+    await release_rate_limit_controls(limiter=limiter, lease=lease)
+    lease_after_release, _state = await acquire_rate_limit_controls(
+        limiter=limiter,
+        auth=_auth(api_key="key-2"),
+        tokens=10,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    await release_rate_limit_controls(limiter=limiter, lease=lease_after_release)
+
+
+@pytest.mark.asyncio
+async def test_key_parallel_limit_uses_legacy_redis_counter_for_rollout_compatibility() -> None:
+    redis = FakeRedis()
+    limiter = LimitCounter(redis_client=redis, degraded_mode="fail_open")
+    await limiter.acquire_parallel("key", "key-1", 1)
+
+    try:
+        with pytest.raises(RateLimitError):
+            await acquire_rate_limit_controls(
+                limiter=limiter,
+                auth=_auth(max_parallel_requests=1),
+                tokens=10,
+                model="gpt-4o-mini",
+            )
+    finally:
+        await limiter.release_parallel("key", "key-1")
+
+
+@pytest.mark.asyncio
+async def test_legacy_parallel_lease_tracks_fallback_backend_across_redis_recovery() -> None:
+    redis = _FailingOnceRedis()
+    limiter = LimitCounter(redis_client=redis, degraded_mode="fail_open")
+
+    lease = await limiter.acquire_legacy_parallel_lease("key", "key-1", 1)
+
+    assert lease is not None
+    assert lease.backend == "fallback"
+    assert limiter._fallback_parallel["key:key-1"] == 1
+
+    await limiter.release_legacy_parallel_lease(lease)
+
+    assert "key:key-1" not in limiter._fallback_parallel
+    assert "parallel:key:key-1" not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_legacy_parallel_redis_release_does_not_create_negative_counter() -> None:
+    redis = FakeRedis()
+    limiter = LimitCounter(redis_client=redis, degraded_mode="fail_open")
+    lease = LegacyParallelLease(scope="key", entity_id="key-1", limit=1, backend="redis")
+    key = "parallel:key:key-1"
+
+    redis.store[key] = 0
+    await limiter.release_legacy_parallel_lease(lease)
+
+    assert key not in redis.store
+
+    redis.store[key] = -3
+    await limiter.release_legacy_parallel_lease(lease)
+
+    assert key not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_legacy_parallel_lease_refresh_extends_redis_ttl() -> None:
+    redis = FakeRedis()
+    limiter = LimitCounter(redis_client=redis, degraded_mode="fail_open")
+    lease = await limiter.acquire_legacy_parallel_lease("key", "key-1", 1, ttl_seconds=5)
+    key = "parallel:key:key-1"
+
+    assert lease is not None
+    assert lease.backend == "redis"
+    assert redis.ttl_store[key] == 5
+
+    await limiter.refresh_legacy_parallel_lease(lease, ttl_seconds=30)
+
+    assert redis.ttl_store[key] == 30
+    await limiter.release_legacy_parallel_lease(lease)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_refresher_starts_for_legacy_key_lease_only() -> None:
+    limiter = LimitCounter(redis_client=FakeRedis(), degraded_mode="fail_open")
+    lease = RateLimitLease(
+        legacy_parallel_lease=LegacyParallelLease(
+            scope="key",
+            entity_id="key-1",
+            limit=1,
+            backend="redis",
+        )
+    )
+    refresher = RateLimitLeaseRefresher(limiter=limiter, lease=lease)
+
+    assert refresher.start() is True
+    await refresher.stop()
+
+
+@pytest.mark.asyncio
+async def test_tier_parallel_failure_releases_previously_acquired_key_slot() -> None:
+    service = _TierRateLimitService(
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(
+                access_mode="allow",
+                capacity_pool_key=None,
+                limits=SimpleNamespace(max_parallel_requests=1),
+            ),
+        },
+    )
+    limiter = LimitCounter(redis_client=None, degraded_mode="fail_open")
+    await limiter.acquire_parallel("tier_org_model_parallel", "org-1:gpt-4o-mini", 1)
+
+    try:
+        with pytest.raises(RateLimitError):
+            await acquire_rate_limit_controls(
+                limiter=limiter,
+                auth=_auth(max_parallel_requests=1),
+                tokens=10,
+                model="gpt-4o-mini",
+                tier_policy_service=service,
+                tier_policy_mode="enforce",
+            )
+        assert "key:key-1" not in limiter._fallback_parallel
+    finally:
+        await limiter.release_parallel("tier_org_model_parallel", "org-1:gpt-4o-mini")
+
+
+@pytest.mark.asyncio
+async def test_tier_pool_parallel_limit_is_shared_across_organizations() -> None:
+    service = _TierRateLimitService(
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(access_mode="allow", capacity_pool_key="shared"),
+            ("org-2", "gpt-4o-mini"): SimpleNamespace(access_mode="allow", capacity_pool_key="shared"),
+        },
+        pool_policies={("shared", "gpt-4o-mini"): _pool_policy(max_parallel_requests=1)},
+        allowed_by_org={"org-1": {"gpt-4o-mini"}, "org-2": {"gpt-4o-mini"}},
+    )
+    limiter = LimitCounter(redis_client=None, degraded_mode="fail_open")
+
+    lease, _state = await acquire_rate_limit_controls(
+        limiter=limiter,
+        auth=_auth(organization_id="org-1", api_key="key-1"),
+        tokens=10,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    with pytest.raises(RateLimitError) as exc_info:
+        await acquire_rate_limit_controls(
+            limiter=limiter,
+            auth=_auth(organization_id="org-2", api_key="key-2"),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+
+    assert exc_info.value.param == "tier_pool_model_parallel"
+    assert exc_info.value.code == "tier_pool_model_parallel_exceeded"
+    await release_rate_limit_controls(limiter=limiter, lease=lease)
+
+
+@pytest.mark.asyncio
+async def test_partial_tier_parallel_acquisition_is_released_when_pool_limit_fails() -> None:
+    service = _TierRateLimitService(
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(
+                access_mode="allow",
+                capacity_pool_key="shared",
+                limits=SimpleNamespace(max_parallel_requests=1),
+            ),
+        },
+        pool_policies={("shared", "gpt-4o-mini"): _pool_policy(max_parallel_requests=1)},
+    )
+    limiter = LimitCounter(redis_client=None, degraded_mode="fail_open")
+    await limiter.acquire_parallel("tier_pool_model_parallel", "shared:gpt-4o-mini", 1)
+
+    try:
+        with pytest.raises(RateLimitError) as exc_info:
+            await acquire_rate_limit_controls(
+                limiter=limiter,
+                auth=_auth(),
+                tokens=10,
+                model="gpt-4o-mini",
+                tier_policy_service=service,
+                tier_policy_mode="enforce",
+            )
+
+        assert exc_info.value.param == "tier_pool_model_parallel"
+        assert "tier_org_model_parallel:org-1:gpt-4o-mini" not in limiter._fallback_parallel
+    finally:
+        await limiter.release_parallel("tier_pool_model_parallel", "shared:gpt-4o-mini")
+
+    lease, _state = await acquire_rate_limit_controls(
+        limiter=limiter,
+        auth=_auth(),
+        tokens=10,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    await release_rate_limit_controls(limiter=limiter, lease=lease)
+
+
+@pytest.mark.asyncio
+async def test_partial_tier_parallel_acquisition_is_released_when_pool_backend_fails() -> None:
+    service = _TierRateLimitService(
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(
+                access_mode="allow",
+                capacity_pool_key="shared",
+                limits=SimpleNamespace(max_parallel_requests=1),
+            ),
+        },
+        pool_policies={("shared", "gpt-4o-mini"): _pool_policy(max_parallel_requests=1)},
+    )
+    limiter = _PoolAcquireUnavailableLimitCounter(redis_client=None, degraded_mode="fail_open")
+
+    with pytest.raises(ServiceUnavailableError):
+        await acquire_rate_limit_controls(
+            limiter=limiter,
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+
+    assert "tier_org_model_parallel:org-1:gpt-4o-mini" not in limiter._fallback_parallel
+
+
+@pytest.mark.asyncio
+async def test_partial_release_retries_pending_parallel_leases_after_backend_failure() -> None:
+    lease = _parallel_lease()
+    limiter = _FlakyReleaseLimitCounter(
+        fail_scope="tier_pool_model_parallel",
+        failure_count=1,
+    )
+
+    with pytest.raises(ServiceUnavailableError):
+        await release_rate_limit_controls(limiter=limiter, lease=lease)
+
+    assert len(lease.pending_parallel_acquisitions) == 2
+    assert limiter.release_calls == [
+        ("tier_pool_model_parallel", "shared:gpt-4o-mini"),
+        ("tier_org_model_parallel", "org-1:gpt-4o-mini"),
+    ]
+
+    await release_rate_limit_controls(limiter=limiter, lease=lease)
+    await release_rate_limit_controls(limiter=limiter, lease=lease)
+
+    assert lease.pending_parallel_acquisitions == ()
+    assert limiter.release_calls == [
+        ("tier_pool_model_parallel", "shared:gpt-4o-mini"),
+        ("tier_org_model_parallel", "org-1:gpt-4o-mini"),
+        ("tier_pool_model_parallel", "shared:gpt-4o-mini"),
+        ("tier_org_model_parallel", "org-1:gpt-4o-mini"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_parallel_lease_acquire_and_release_use_single_redis_round_trip_each() -> None:
+    redis = _RecordingRedis()
+    limiter = LimitCounter(redis_client=redis, degraded_mode="fail_open")
+    checks = [
+        ParallelLimitCheck(scope="key", entity_id="key-1", limit=2),
+        ParallelLimitCheck(scope="tier_pool_model_parallel", entity_id="shared:gpt-4o-mini", limit=1),
+    ]
+
+    leases = await limiter.acquire_parallel_leases(checks)
+    await limiter.release_parallel_leases(list(leases))
+
+    assert len(redis.eval_calls) == 2
+    assert redis.eval_calls[0][0] == 2
+    assert redis.eval_calls[1][0] == 2
+    assert [lease.backend for lease in leases] == ["redis", "redis"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_lease_acquire_coalesces_duplicate_checks() -> None:
+    limiter = LimitCounter(redis_client=None, degraded_mode="fail_open")
+    checks = [
+        ParallelLimitCheck(scope="tier_pool_model_parallel", entity_id="shared:gpt-4o-mini", limit=1),
+        ParallelLimitCheck(scope="tier_pool_model_parallel", entity_id="shared:gpt-4o-mini", limit=1),
+    ]
+
+    with pytest.raises(RateLimitError):
+        await limiter.acquire_parallel_leases(checks)
+
+    assert "tier_pool_model_parallel:shared:gpt-4o-mini" not in limiter._fallback_parallel
+
+
+@pytest.mark.asyncio
+async def test_parallel_lease_refresh_extends_redis_token_expiry() -> None:
+    redis = FakeRedis()
+    limiter = LimitCounter(redis_client=redis, degraded_mode="fail_open")
+    leases = await limiter.acquire_parallel_leases(
+        [
+            ParallelLimitCheck(scope="tier_pool_model_parallel", entity_id="shared:gpt-4o-mini", limit=1),
+        ],
+        ttl_seconds=1,
+    )
+    key = "parallel_lease:tier_pool_model_parallel:shared:gpt-4o-mini"
+    original_expiry = redis.zset_store[key][0][0]
+
+    await limiter.refresh_parallel_leases(list(leases), ttl_seconds=10)
+
+    assert redis.zset_store[key][0][0] > original_expiry
+    await limiter.release_parallel_leases(list(leases))
+
+
+@pytest.mark.asyncio
+async def test_parallel_lease_redis_release_failure_remains_retryable() -> None:
+    redis = _RecordingRedis(fail_release_count=1)
+    limiter = LimitCounter(redis_client=redis, degraded_mode="fail_open")
+    leases = await limiter.acquire_parallel_leases(
+        [
+            ParallelLimitCheck(scope="key", entity_id="key-1", limit=2),
+            ParallelLimitCheck(scope="tier_pool_model_parallel", entity_id="shared:gpt-4o-mini", limit=1),
+        ]
+    )
+    lease = RateLimitLease(parallel_leases=leases)
+
+    with pytest.raises(ServiceUnavailableError):
+        await release_rate_limit_controls(limiter=limiter, lease=lease)
+
+    assert len(lease.pending_parallel_acquisitions) == 2
+
+    await release_rate_limit_controls(limiter=limiter, lease=lease)
+
+    assert lease.pending_parallel_acquisitions == ()
+    assert len(redis.eval_calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_request_rate_limit_release_retries_pending_slots_after_transient_failure() -> None:
+    lease = _parallel_lease()
+    limiter = _FlakyReleaseLimitCounter(
+        fail_scope="tier_pool_model_parallel",
+        failure_count=1,
+    )
+    request = SimpleNamespace(
+        state=SimpleNamespace(_rate_limit_lease=lease),
+        app=SimpleNamespace(state=SimpleNamespace(limit_counter=limiter)),
+    )
+
+    await _release_rate_limits(request)
+
+    assert request.state._rate_limit_released is False
+    assert len(lease.pending_parallel_acquisitions) == 2
+
+    await _release_rate_limits(request)
+    await _release_rate_limits(request)
+
+    assert request.state._rate_limit_released is True
+    assert lease.pending_parallel_acquisitions == ()
+    assert limiter.release_calls == [
+        ("tier_pool_model_parallel", "shared:gpt-4o-mini"),
+        ("tier_org_model_parallel", "org-1:gpt-4o-mini"),
+        ("tier_pool_model_parallel", "shared:gpt-4o-mini"),
+        ("tier_org_model_parallel", "org-1:gpt-4o-mini"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_rate_limit_release_keeps_retrying_pending_slots() -> None:
+    lease = _parallel_lease()
+    limiter = _FlakyReleaseLimitCounter(
+        fail_scope="tier_pool_model_parallel",
+        failure_count=10,
+    )
+    request = SimpleNamespace(
+        state=SimpleNamespace(_rate_limit_lease=lease),
+        app=SimpleNamespace(state=SimpleNamespace(limit_counter=limiter)),
+    )
+
+    await _release_rate_limits(request)
+    await _release_rate_limits(request)
+
+    assert request.state._rate_limit_released is False
+    assert len(lease.pending_parallel_acquisitions) == 2
+    assert limiter.release_calls == [
+        ("tier_pool_model_parallel", "shared:gpt-4o-mini"),
+        ("tier_org_model_parallel", "org-1:gpt-4o-mini"),
+        ("tier_pool_model_parallel", "shared:gpt-4o-mini"),
+        ("tier_org_model_parallel", "org-1:gpt-4o-mini"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_rate_limit_release_failure_is_queued_for_retry() -> None:
+    lease = _parallel_lease()
+    limiter = _FlakyReleaseLimitCounter(
+        fail_scope="tier_pool_model_parallel",
+        failure_count=1,
+    )
+    retry_queue = RateLimitReleaseRetryQueue(
+        delay_seconds=lambda attempt_count: 0.0,
+        auto_start=False,
+    )
+    request = SimpleNamespace(
+        state=SimpleNamespace(_rate_limit_lease=lease),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                limit_counter=limiter,
+                rate_limit_release_retry_queue=retry_queue,
+            )
+        ),
+    )
+
+    await _release_rate_limits(request)
+
+    assert request.state._rate_limit_released is False
+    assert retry_queue.pending_count == 1
+    assert len(lease.pending_parallel_acquisitions) == 2
+
+    await retry_queue.drain_due()
+
+    assert retry_queue.pending_count == 0
+    assert lease.pending_parallel_acquisitions == ()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_release_retry_queue_waits_for_backoff() -> None:
+    lease = _parallel_lease()
+    limiter = _FlakyReleaseLimitCounter(
+        fail_scope="tier_pool_model_parallel",
+        failure_count=0,
+    )
+    retry_queue = RateLimitReleaseRetryQueue(
+        delay_seconds=lambda attempt_count: 30.0,
+        auto_start=False,
+    )
+
+    assert retry_queue.enqueue(limiter=limiter, lease=lease)
+    await retry_queue.drain_due()
+
+    assert retry_queue.pending_count == 1
+    assert limiter.release_calls == []
+    assert len(lease.pending_parallel_acquisitions) == 2
+
+
+def test_rate_limit_release_retry_queue_ignores_empty_leases() -> None:
+    retry_queue = RateLimitReleaseRetryQueue(auto_start=False)
+    limiter = _FlakyReleaseLimitCounter(
+        fail_scope="tier_pool_model_parallel",
+        failure_count=0,
+    )
+
+    assert retry_queue.enqueue(limiter=limiter, lease=RateLimitLease())
+
+    assert retry_queue.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_batch_policy_release_failure_is_queued_for_retry(monkeypatch) -> None:
+    monkeypatch.setattr(worker_persistence_module, "_policy_release_retry_delay_seconds", lambda attempt_count: 0.0)
+    lease = BatchPolicyLease(rate_limit_lease=_parallel_lease())
+    limiter = _FlakyReleaseLimitCounter(
+        fail_scope="tier_pool_model_parallel",
+        failure_count=1,
+    )
+    worker = _PolicyReleaseWorker(
+        SimpleNamespace(state=SimpleNamespace(limit_counter=limiter)),
+    )
+    prepared = SimpleNamespace(policy_lease=lease)
+
+    await worker._release_prepared_policy_lease(prepared)
+
+    assert prepared.policy_lease is None
+    assert len(worker._policy_release_retry_queue()) == 1
+    assert len(lease.rate_limit_lease.pending_parallel_acquisitions) == 2
+
+    await worker._drain_policy_lease_release_retries()
+
+    assert len(worker._policy_release_retry_queue()) == 0
+    assert lease.rate_limit_lease.pending_parallel_acquisitions == ()
+
+
+@pytest.mark.asyncio
+async def test_batch_policy_release_retry_waits_for_backoff() -> None:
+    lease = BatchPolicyLease(rate_limit_lease=_parallel_lease())
+    limiter = _FlakyReleaseLimitCounter(
+        fail_scope="tier_pool_model_parallel",
+        failure_count=2,
+    )
+    worker = _PolicyReleaseWorker(
+        SimpleNamespace(state=SimpleNamespace(limit_counter=limiter)),
+    )
+    prepared = SimpleNamespace(policy_lease=lease, policy_lease_refresher=None)
+
+    await worker._release_prepared_policy_lease(prepared)
+    release_calls_after_initial_failure = list(limiter.release_calls)
+    await worker._drain_policy_lease_release_retries()
+
+    assert len(worker._policy_release_retry_queue()) == 1
+    assert limiter.release_calls == release_calls_after_initial_failure
+
+
+def test_build_rate_limit_checks_filters_by_tier_mode_and_request_mode() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=10, mode="sync"),
+                _descriptor("tier_org_model_batch_rpm", limit=5, mode="batch"),
+            )
+        },
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(access_mode="allow", capacity_pool_key="shared"),
+        },
+        pool_policies={("shared", "gpt-4o-mini"): _pool_policy(rpm_capacity=20)},
+    )
+
+    sync_scopes = {
+        check.scope
+        for check in build_rate_limit_checks(
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+            mode="sync",
+        )
+    }
+    batch_scopes = {
+        check.scope
+        for check in build_rate_limit_checks(
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+            mode="batch",
+        )
+    }
+    shadow_scopes = {
+        check.scope
+        for check in build_rate_limit_checks(
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=_TierRateLimitService(
+                descriptors=service.descriptors,
+                mode="shadow",
+            ),
+            tier_policy_mode="shadow",
+            mode="sync",
+        )
+    }
+
+    assert "tier_org_model_rpm" in sync_scopes
+    assert "tier_org_model_batch_rpm" not in sync_scopes
+    assert "tier_pool_model_rpm" in sync_scopes
+    assert "tier_org_model_batch_rpm" in batch_scopes
+    assert "tier_org_model_rpm" not in batch_scopes
+    assert "tier_pool_model_rpm" in batch_scopes
+    assert "tier_org_model_rpm" not in shadow_scopes
+
+
+def test_batch_tier_limits_fall_back_to_sync_rpm_tpm_when_batch_overrides_absent() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=10, mode="sync"),
+                _descriptor("tier_org_model_tpm", limit=100, amount_kind="tokens", mode="sync"),
+                _descriptor("tier_org_model_rph", limit=1_000, window_seconds=3600, mode="sync"),
+            )
+        }
+    )
+
+    scopes = {
+        check.scope
+        for check in build_rate_limit_checks(
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+            mode="batch",
+        )
+    }
+
+    assert "tier_org_model_rpm" in scopes
+    assert "tier_org_model_tpm" in scopes
+    assert "tier_org_model_rph" not in scopes
+
+
+def test_batch_tier_limits_use_batch_override_per_dimension() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=10, mode="sync"),
+                _descriptor("tier_org_model_tpm", limit=100, amount_kind="tokens", mode="sync"),
+                _descriptor("tier_org_model_batch_tpm", limit=50, amount_kind="tokens", mode="batch"),
+            )
+        }
+    )
+
+    scopes = {
+        check.scope
+        for check in build_rate_limit_checks(
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+            mode="batch",
+        )
+    }
+
+    assert "tier_org_model_rpm" in scopes
+    assert "tier_org_model_tpm" not in scopes
+    assert "tier_org_model_batch_tpm" in scopes
+
+
+def test_build_rate_limit_checks_skips_pool_for_denied_tier_model_policy() -> None:
+    service = _TierRateLimitService(
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(access_mode="deny", capacity_pool_key="shared"),
+        },
+        pool_policies={("shared", "gpt-4o-mini"): _pool_policy(rpm_capacity=1)},
+    )
+
+    scopes = {
+        check.scope
+        for check in build_rate_limit_checks(
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+    }
+
+    assert "tier_pool_model_rpm" not in scopes
+
+
+@pytest.mark.asyncio
+async def test_tier_snapshot_stale_fail_closed_blocks_rate_limits() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=1),
+            )
+        },
+        missing_service_mode="fail_closed",
+        snapshot_stale=True,
+    )
+
+    with pytest.raises(ServiceUnavailableError) as exc_info:
+        await acquire_rate_limit_controls(
+            limiter=LimitCounter(redis_client=None, degraded_mode="fail_open"),
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+            tier_policy_missing_service_mode="fail_closed",
+        )
+
+    assert exc_info.value.code == "tier_policy_unavailable_snapshot_stale"
+
+
+@pytest.mark.asyncio
+async def test_tier_lookup_failure_follows_missing_service_mode() -> None:
+    fail_open_service = _TierRateLimitService(fail_lookup=True, missing_service_mode="fail_open")
+    await acquire_rate_limit_controls(
+        limiter=LimitCounter(redis_client=None, degraded_mode="fail_open"),
+        auth=_auth(),
+        tokens=10,
+        model="gpt-4o-mini",
+        tier_policy_service=fail_open_service,
+        tier_policy_mode="enforce",
+        tier_policy_missing_service_mode="fail_open",
+    )
+
+    fail_closed_service = _TierRateLimitService(
+        fail_lookup=True,
+        missing_service_mode="fail_closed",
+    )
+    with pytest.raises(ServiceUnavailableError) as exc_info:
+        await acquire_rate_limit_controls(
+            limiter=LimitCounter(redis_client=None, degraded_mode="fail_open"),
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=fail_closed_service,
+            tier_policy_mode="enforce",
+            tier_policy_missing_service_mode="fail_closed",
+        )
+
+    assert exc_info.value.code == "tier_policy_unavailable_fail_closed"
+
+
+@pytest.mark.asyncio
+async def test_redis_degraded_mode_applies_to_tier_checks() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=1),
+            )
+        }
+    )
+    fail_open_limiter = LimitCounter(redis_client=_FailingRedis(), degraded_mode="fail_open")
+
+    await acquire_rate_limit_controls(
+        limiter=fail_open_limiter,
+        auth=_auth(),
+        tokens=10,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    with pytest.raises(RateLimitError) as rate_exc:
+        await acquire_rate_limit_controls(
+            limiter=fail_open_limiter,
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+    assert rate_exc.value.param == "tier_org_model_rpm"
+
+    fail_closed_limiter = LimitCounter(redis_client=_FailingRedis(), degraded_mode="fail_closed")
+    with pytest.raises(ServiceUnavailableError):
+        await acquire_rate_limit_controls(
+            limiter=fail_closed_limiter,
+            auth=_auth(),
+            tokens=10,
+            model="gpt-4o-mini",
+            tier_policy_service=service,
+            tier_policy_mode="enforce",
+        )
+
+
+@pytest.mark.asyncio
+async def test_batch_policy_lease_uses_batch_tier_limits() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=100, mode="sync"),
+                _descriptor("tier_org_model_batch_rpm", limit=1, mode="batch"),
+            )
+        }
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            limit_counter=LimitCounter(redis_client=None, degraded_mode="fail_open"),
+            tier_policy_service=service,
+            app_config=None,
+            settings=None,
+        )
+    )
+    payload = _BatchPayload(model="gpt-4o-mini")
+
+    assert await acquire_batch_policy_lease(app=app, payload=payload, auth=_auth()) is not None
+    with pytest.raises(RateLimitError) as exc_info:
+        await acquire_batch_policy_lease(app=app, payload=payload, auth=_auth())
+
+    assert exc_info.value.param == "tier_org_model_batch_rpm"
+
+
+@pytest.mark.asyncio
+async def test_batch_policy_lease_falls_back_to_sync_tier_limit_when_batch_limit_absent() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=1, mode="sync"),
+            )
+        }
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            limit_counter=LimitCounter(redis_client=None, degraded_mode="fail_open"),
+            tier_policy_service=service,
+            app_config=None,
+            settings=None,
+        )
+    )
+    payload = _BatchPayload(model="gpt-4o-mini")
+
+    assert await acquire_batch_policy_lease(app=app, payload=payload, auth=_auth()) is not None
+    with pytest.raises(RateLimitError) as exc_info:
+        await acquire_batch_policy_lease(app=app, payload=payload, auth=_auth())
+
+    assert exc_info.value.param == "tier_org_model_rpm"
+
+
+@pytest.mark.asyncio
+async def test_tier_rate_limit_429_uses_tier_scope_headers(client, test_app) -> None:
+    test_app.state.tier_policy_service = _TierRateLimitService(
+        descriptors={
+            ("org-default", "gpt-4o-mini"): (
+                _descriptor(
+                    "tier_org_model_rpm",
+                    entity_id="org-default:gpt-4o-mini",
+                    limit=1,
+                ),
+            )
+        },
+        allowed_by_org={"org-default": {"gpt-4o-mini"}},
+        explicit_orgs={"org-default"},
+    )
+
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]}
+
+    ok = await client.post("/v1/chat/completions", headers=headers, json=body)
+    blocked = await client.post("/v1/chat/completions", headers=headers, json=body)
+
+    assert ok.status_code == 200
+    assert blocked.status_code == 429
+    assert blocked.json()["error"]["code"] == "tier_org_model_rpm_exceeded"
+    assert blocked.json()["error"]["param"] == "tier_org_model_rpm"
+    assert "tier_org_model_rpm" in blocked.headers["x-deltallm-ratelimit-scope"].split(",")
+
+
+@pytest.mark.asyncio
+async def test_tier_rate_limit_429_uses_original_checks_when_snapshot_changes(client, test_app) -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-default", "gpt-4o-mini"): (
+                _descriptor(
+                    "tier_org_model_rpm",
+                    entity_id="org-default:gpt-4o-mini",
+                    limit=1,
+                ),
+            )
+        },
+        allowed_by_org={"org-default": {"gpt-4o-mini"}},
+        explicit_orgs={"org-default"},
+    )
+    test_app.state.tier_policy_service = service
+    test_app.state.limit_counter = _SnapshotMutatingLimitCounter(
+        service=service,
+        failed_scope="tier_org_model_rpm",
+    )
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "tier_org_model_rpm_exceeded"
+    assert "tier_org_model_rpm" in response.headers["x-deltallm-ratelimit-scope"].split(",")
+
+
+@pytest.mark.asyncio
+async def test_parallel_429_uses_original_state_when_snapshot_changes(client, test_app) -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-default", "gpt-4o-mini"): (
+                _descriptor(
+                    "tier_org_model_rpm",
+                    entity_id="org-default:gpt-4o-mini",
+                    limit=100,
+                ),
+            )
+        },
+        allowed_by_org={"org-default": {"gpt-4o-mini"}},
+        explicit_orgs={"org-default"},
+    )
+    test_app.state.tier_policy_service = service
+    test_app.state.limit_counter = _SnapshotMutatingParallelLimitCounter(service=service)
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 429
+    assert response.json()["error"]["type"] == "rate_limit_error"
+    assert response.headers["x-deltallm-ratelimit-scope"] == "key"
+
+
+def test_tier_rate_limit_check_construction_uses_compiled_tier_and_pool_checks() -> None:
+    service = _TierRateLimitService(
+        descriptors={
+            ("org-1", "gpt-4o-mini"): (
+                _descriptor("tier_org_model_rpm", limit=100),
+                _descriptor("tier_org_model_tpm", limit=100_000, amount_kind="tokens"),
+                _descriptor("tier_org_model_rph", limit=1_000, window_seconds=3600),
+                _descriptor("tier_org_model_tpd", limit=1_000_000, amount_kind="tokens", window_seconds=86400),
+            )
+        },
+        model_policies={
+            ("org-1", "gpt-4o-mini"): SimpleNamespace(access_mode="allow", capacity_pool_key="shared"),
+        },
+        pool_policies={("shared", "gpt-4o-mini"): _pool_policy(rpm_capacity=500, tpm_capacity=500_000)},
+    )
+    auth = _auth()
+
+    checks = build_rate_limit_checks(
+        auth=auth,
+        tokens=250,
+        model="gpt-4o-mini",
+        tier_policy_service=service,
+        tier_policy_mode="enforce",
+    )
+    tier_checks = [check for check in checks if check.scope.startswith("tier_")]
+
+    assert [check.scope for check in tier_checks] == [
+        "tier_org_model_rpm",
+        "tier_org_model_tpm",
+        "tier_org_model_rph",
+        "tier_org_model_tpd",
+        "tier_pool_model_rpm",
+        "tier_pool_model_tpm",
+    ]
+    assert tier_checks[-1].entity_id == "shared:gpt-4o-mini"


### PR DESCRIPTION
## Summary
- compile tier model and capacity-pool rate-limit controls into request-time policy checks
- add tokenized Redis parallel leases with refresh and retry-backed cleanup
- enforce tier limits across sync, batch, and MCP paths while preserving low-latency snapshot lookups

## Validation
- uv run ruff check src/rate_limit_policy.py src/tier_rate_limit_policy.py src/rate_limit_lease_refresh.py src/rate_limit_release_retry.py src/services/limit_counter.py src/middleware/rate_limit.py src/batch/policy.py src/batch/worker_persistence.py src/mcp/policy.py tests/test_tier_rate_limits.py tests/test_mcp_gateway.py
- uv run pytest tests/test_tier_rate_limits.py tests/test_mcp_gateway.py tests/test_rate_limit.py tests/test_rate_limit_headers.py
- uv run pytest tests/test_batch_worker.py tests/test_batch_worker_microbatch.py