### PR TITLE
Prepare tiers release readiness fixes

### DIFF
--- a/docs/admin-ui/index.md
+++ b/docs/admin-ui/index.md
@@ -18,7 +18,7 @@ The current UI is organized by operator intent:
 
 - **Dashboard**: health and spend overview
 - **API Keys**: credential issuance and limits
-- **AI Gateway**: [Models](models.md), [Named Credentials](named-credentials.md), [Route Groups](route-groups.md), [Prompt Registry](prompt-registry.md), and [MCP Servers](mcp.md)
+- **AI Gateway**: [Models](models.md), [Tiers](tiers.md), [Named Credentials](named-credentials.md), [Route Groups](route-groups.md), [Prompt Registry](prompt-registry.md), and [MCP Servers](mcp.md)
 - **Access**: [Organizations](organizations.md), [Teams](teams.md), and [People & Access](people-and-access.md)
 - **Operations**: [Usage & Spend](usage.md), [Audit Logs](audit-logs.md), [Batch Jobs](batch-jobs.md), [Guardrails](guardrails.md), and [Settings](settings.md)
 
@@ -37,6 +37,7 @@ Parent menu sections start collapsed by default and expand only when the operato
 | --- | --- |
 | [Dashboard](dashboard.md) | Spend, request, and model activity overview |
 | [Models](models.md) | Provider-backed deployments and health |
+| [Tiers](tiers.md) | Reusable model packages with access, pricing, RPM, TPM, and shared capacity controls |
 | [Named Credentials](named-credentials.md) | Shared provider connection settings and credential rotation |
 | [Route Groups](route-groups.md) | Group-level routing, membership, prompt binding, and usage |
 | [Prompt Registry](prompt-registry.md) | Prompt shells, versions, labels, tests, and history |

--- a/docs/admin-ui/organizations.md
+++ b/docs/admin-ui/organizations.md
@@ -42,6 +42,8 @@ Platform admins can bootstrap runtime model and route-group visibility directly 
 
 Organization asset access defines the parent access universe. Grant direct callable targets when the tenant should see specific model names or route groups. Grant access groups when the tenant should see every callable target labelled with a group such as `support`, `finance`, or `beta`.
 
+If the organization uses tiers, the active tier assignment can define the organization's model package. Team, API key, and runtime user Asset Access can still narrow that tier package. Asset Access also remains the control surface for route groups. See [Tiers](tiers.md#tiers-and-asset-access) for examples.
+
 Access-group grants are valid even before a group has current model members. When a model is later labelled with that group and the runtime reloads, the organization can receive the new callable target without adding another direct binding.
 
 Use organization grants deliberately:

--- a/docs/admin-ui/tiers.md
+++ b/docs/admin-ui/tiers.md
@@ -1,0 +1,238 @@
+# Tiers
+
+Tiers are reusable model packages for organizations.
+
+A tier answers:
+
+- which models an organization can use
+- what customer price applies for those models
+- what RPM and TPM limits apply
+- which shared capacity pool protects scarce model capacity
+
+Use tiers when you want to manage customer plans such as `starter`, `growth`, or `enterprise` without configuring every organization one by one.
+
+## Simple Mental Model
+
+Think of a tier as a plan.
+
+Example plans:
+
+| Tier | Models | Limits | Pricing | Best for |
+| --- | --- | --- | --- | --- |
+| Starter | Low-cost models only | Low RPM and TPM | Standard pricing | Trials and small customers |
+| Growth | Low-cost models plus selected premium models | Medium RPM and TPM | Discounted or custom pricing | Paying teams |
+| Enterprise | Approved premium models | High RPM and TPM | Contract pricing | Large customers |
+
+Instead of editing every organization separately, create the tier once and assign it to organizations.
+
+## Main Concepts
+
+### Tier
+
+The package itself.
+
+Example: `Growth`.
+
+### Tier Version
+
+The editable definition of the tier.
+
+Use draft versions for changes, then publish when ready. This prevents accidental live changes while an admin is still editing model access, pricing, or limits.
+
+### Model Policy
+
+The rule for one model inside a tier.
+
+For each model, choose:
+
+- whether the model is allowed
+- the customer-facing price
+- RPM and TPM limits
+- optional batch and cache pricing
+- optional capacity pool
+
+Example `Growth` tier model policy:
+
+| Model | Allowed | RPM | TPM | Capacity pool |
+| --- | --- | ---: | ---: | --- |
+| `gpt-4o-mini` | Yes | 1000 | 1,000,000 | None |
+| `gpt-4o` | Yes | 100 | 250,000 | `growth-premium-pool` |
+| `claude-opus` | No | - | - | - |
+
+### Organization Assignment
+
+The link between an organization and a tier.
+
+Example:
+
+- Organization: `Acme`
+- Primary tier: `Growth`
+- Optional add-on tier: `GPT-4o Launch Promo`
+
+The primary tier is the normal package. Add-on tiers are useful for exceptions without creating a custom tier for every organization.
+
+## Tiers and Asset Access
+
+Tiers and Asset Access answer different questions.
+
+| Control | Main question | Typical use |
+| --- | --- | --- |
+| Tier assignment | What model package is this organization on? | Plans such as `starter`, `growth`, or `enterprise` |
+| Asset Access | Which runtime scope is allowed to use which callable target? | Organization bootstrap, route groups, and team/key/user restrictions |
+
+For model access, an active tier assignment can define the organization's model package. This is useful when you want tiers to replace manual per-organization model grants.
+
+Team, API key, and runtime user Asset Access can still narrow the tier package. They do not expand it.
+
+Simple rule:
+
+1. If the organization has no active tier policy, normal Asset Access controls model visibility.
+2. If the organization has an active tier policy, the tier's model policies define the organization's model package.
+3. Direct team, API key, and runtime user restrictions are applied on top of the tier package.
+4. Deny rules win.
+
+Examples:
+
+| Tier allows | Lower-scope Asset Access | Final access |
+| --- | --- | --- |
+| `gpt-4o-mini`, `gpt-4o` | No team/key/user restriction | `gpt-4o-mini`, `gpt-4o` |
+| `gpt-4o-mini`, `gpt-4o` | Team restricted to `gpt-4o-mini` | `gpt-4o-mini` only |
+| `gpt-4o-mini` | API key restricted to `gpt-4o` | No model access |
+| Tier denies `gpt-4o` | Asset Access grants `gpt-4o` | Denied |
+| No active tier policy | Organization Asset Access grants `gpt-4o-mini` | `gpt-4o-mini` |
+
+Use tiers for organization-level product packaging. Use Asset Access for route groups and for narrower team, key, or user controls.
+
+## Capacity Pools
+
+A capacity pool is a shared bucket of usage.
+
+Use it when many organizations share the same scarce or expensive model capacity.
+
+Imagine a premium model where your provider only gives you:
+
+- `1,000 RPM`
+- `2,000,000 TPM`
+
+Without a capacity pool, you might accidentally promise too much:
+
+| Organization | Org limit |
+| --- | ---: |
+| Org A | 500 RPM |
+| Org B | 500 RPM |
+| Org C | 500 RPM |
+
+Total possible usage is `1,500 RPM`, but the provider only gives you `1,000 RPM`.
+
+With a capacity pool:
+
+| Scope | Limit |
+| --- | ---: |
+| Org A | 500 RPM |
+| Org B | 500 RPM |
+| Org C | 500 RPM |
+| Shared pool | 1,000 RPM |
+
+Now each organization has its own limit, but all Growth organizations together still stay under the shared provider capacity.
+
+A simple analogy:
+
+- organization model limit = each apartment's tap
+- capacity pool = the building's main water pipe
+
+Both limits matter. A request is allowed only if the organization has room and the shared pool has room.
+
+Use capacity pools for:
+
+- premium models
+- scarce provider quota
+- GPU-backed models
+- limited concurrency
+- shared enterprise or growth capacity
+
+Do not create pools for every cheap/default model. For common models, organization-level RPM and TPM limits are usually enough.
+
+## Recommended User Journey
+
+1. Open **AI Gateway > Tiers**
+2. Create a tier, such as `Starter`, `Growth`, or `Enterprise`
+3. Create or edit a draft version
+4. Add model policies for the models in that package
+5. Set prices, RPM, TPM, and capacity pools per model
+6. Publish the version
+7. Open an organization detail page
+8. Assign the tier to the organization
+9. Review the effective policy preview
+10. Run a simulation for an example request
+
+The preview answers: what can this organization actually use?
+
+The simulation answers: would this request be allowed, what would it cost, and which limit would block it?
+
+## Efficient Tier Design
+
+Start with a small number of base tiers:
+
+- `starter`
+- `growth`
+- `enterprise`
+
+Use add-on tiers for exceptions:
+
+- temporary premium model access
+- launch discounts
+- customer-specific model access
+- short-term capacity boosts
+
+Keep capacity pools focused on scarce capacity. A tier can have many model policies, but only premium or constrained models usually need a pool.
+
+Use draft versions for every meaningful change. Publish only after previewing the tier and simulating representative requests.
+
+## Pricing by Model Type
+
+Pricing is not always token pricing. Choose the pricing shape that matches the model.
+
+| Model type | Common pricing fields | Example |
+| --- | --- | --- |
+| Chat | Input token, output token, cached token, batch token | `0.000001/input token`, `0.000003/output token` |
+| Embeddings | Input token | `0.00000002/input token` |
+| Image generation | Image price, request price | `0.04/image` |
+| Text-to-speech | Character, audio token, second, or request price | `0.00005/character` |
+| Transcription | Second, audio token, or request price | `0.00006/second` |
+| Rerank | Token or request price | `0.000001/input token` or `0.01/request` |
+
+Use token pricing for chat and embeddings. Use image pricing for image models. Use character pricing for most text-to-speech models when the provider bills by input text length. Use second pricing for transcription when the provider bills by audio duration.
+
+Flat request pricing is useful when the upstream provider charges per request or when you sell a fixed internal package.
+
+The Tier editor keeps advanced supported pricing fields available, but only the common fields for the selected pricing profile are shown first. Existing hidden pricing values are preserved unless you clear them.
+
+## Important Rules
+
+- A tier can define the organization's model package.
+- Tiers do not replace organization, team, user, or key rate and budget limits.
+- Direct team, API key, and runtime user restrictions can still narrow tier access.
+- Deny or restriction rules should be treated as hard boundaries.
+- Published versions affect assigned organizations.
+- Draft versions are for editing and review.
+- Shared capacity pools protect the platform when several organizations burst at the same time.
+
+## Practical Example
+
+You want to sell a Growth plan:
+
+- `gpt-4o-mini` is available with high limits
+- `gpt-4o` is available with lower limits
+- `gpt-4o` uses `growth-premium-pool`
+- customer price is lower than pay-as-you-go
+
+Create one `Growth` tier, publish it, and assign it to every Growth customer.
+
+When a customer upgrades to Enterprise, assign the Enterprise tier instead of manually changing model access, prices, and limits on that organization.
+
+## Related Pages
+
+- [Models](models.md)
+- [Organizations](organizations.md)
+- [Usage & Spend](usage.md)
+- [Rate Limiting](../features/rate-limiting.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Dashboard: admin-ui/dashboard.md
       - AI Gateway:
           - Models: admin-ui/models.md
+          - Tiers: admin-ui/tiers.md
           - Named Credentials: admin-ui/named-credentials.md
           - Route Groups: admin-ui/route-groups.md
           - Prompt Registry: admin-ui/prompt-registry.md

--- a/src/db/cache_invalidation_outbox.py
+++ b/src/db/cache_invalidation_outbox.py
@@ -96,6 +96,24 @@ _RETURNING_COLUMNS = """
     processed_at
 """
 
+_RETURNING_COLUMNS_FROM_OUTBOX_ALIAS = """
+    o.invalidation_id,
+    o.scope_type,
+    o.scope_id,
+    o.reason,
+    o.metadata,
+    o.status,
+    o.attempt_count,
+    o.max_attempts,
+    o.next_attempt_at,
+    o.last_error,
+    o.locked_by,
+    o.lease_expires_at,
+    o.created_at,
+    o.updated_at,
+    o.processed_at
+"""
+
 
 @dataclass(frozen=True)
 class CacheInvalidationOutboxRecord:
@@ -226,7 +244,7 @@ class CacheInvalidationOutboxRepository:
                 updated_at = NOW()
             FROM due
             WHERE o.invalidation_id = due.invalidation_id
-            RETURNING {_RETURNING_COLUMNS}
+            RETURNING {_RETURNING_COLUMNS_FROM_OUTBOX_ALIAS}
             """,
             max(1, min(limit, 500)),
             str(worker_id or "").strip() or "cache-invalidation-worker",

--- a/src/db/tier_assignment_repository.py
+++ b/src/db/tier_assignment_repository.py
@@ -400,12 +400,12 @@ class TierAssignmentRepositoryMixin:
             raise ValueError("enabled tier assignments require an active tier version")
 
     async def _lock_primary_assignment_namespace(self, organization_id: str) -> None:
-        await self.prisma.query_raw(
+        await self.prisma.execute_raw(
             """
             SELECT pg_advisory_xact_lock(
                 hashtext('tier-primary-assignment'),
                 hashtext($1::text)
-            ) AS locked
+            )
             """,
             organization_id,
         )

--- a/tests/db/tier_repository_fakes.py
+++ b/tests/db/tier_repository_fakes.py
@@ -297,6 +297,8 @@ class _FakePrisma:
 
     async def execute_raw(self, sql: str, *params: object) -> int:
         self.executions.append((sql, params))
+        if "pg_advisory_xact_lock" in sql:
+            self.calls.append((sql, params))
         if self.fail_on_sql and self.fail_on_sql in sql:
             raise RuntimeError("simulated execute failure")
         return 1

--- a/ui/src/components/tiers/TierModelPolicyGrid.tsx
+++ b/ui/src/components/tiers/TierModelPolicyGrid.tsx
@@ -9,14 +9,18 @@ import {
   modelPolicyFormToPayload,
   modelPolicyToForm,
   poolOptionsForCallable,
+  pricingProfileForModelMode,
+  summarizePricing,
   type TierCapacityPoolOption,
   type TierModelPolicyForm,
 } from '../../lib/tiers';
+import TierPricingFields from './TierPricingFields';
 
 type TierModelPolicyGridProps = {
   policies: TierModelPolicy[];
   poolOptions: TierCapacityPoolOption[];
   callableOptions?: string[];
+  callableModes?: Record<string, string>;
   readOnly: boolean;
   saving: boolean;
   error: string | null;
@@ -27,6 +31,7 @@ export default function TierModelPolicyGrid({
   policies,
   poolOptions,
   callableOptions = [],
+  callableModes = {},
   readOnly,
   saving,
   error,
@@ -35,7 +40,7 @@ export default function TierModelPolicyGrid({
   const [editingIndex, setEditingIndex] = useState<number | 'new' | null>(null);
   const [form, setForm] = useState<TierModelPolicyForm>(emptyModelPolicyForm());
   const [localError, setLocalError] = useState<string | null>(null);
-  const [bulk, setBulk] = useState({ rpm_limit: '', tpm_limit: '', input_cost_per_token: '', output_cost_per_token: '' });
+  const [bulk, setBulk] = useState({ rpm_limit: '', tpm_limit: '' });
   const locked = readOnly || saving;
   const inputClassName = 'w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500';
 
@@ -47,6 +52,12 @@ export default function TierModelPolicyGrid({
     () => poolOptionsForCallable(poolOptions, form.callable_key),
     [form.callable_key, poolOptions],
   );
+  const inferredMode = form.callable_key ? callableModes[form.callable_key] || null : null;
+
+  const pricingProfileForCallable = (callableKey: string) => {
+    const mode = callableModes[callableKey];
+    return mode ? pricingProfileForModelMode(mode) : null;
+  };
 
   const openNew = () => {
     if (locked) return;
@@ -58,7 +69,7 @@ export default function TierModelPolicyGrid({
   const openEdit = (policy: TierModelPolicy) => {
     if (locked) return;
     setEditingIndex(policies.indexOf(policy));
-    setForm(modelPolicyToForm(policy));
+    setForm(modelPolicyToForm(policy, pricingProfileForCallable(policy.callable_key)));
     setLocalError(null);
   };
 
@@ -103,13 +114,11 @@ export default function TierModelPolicyGrid({
           ...policyForm,
           rpm_limit: bulk.rpm_limit.trim() ? bulk.rpm_limit : policyForm.rpm_limit,
           tpm_limit: bulk.tpm_limit.trim() ? bulk.tpm_limit : policyForm.tpm_limit,
-          input_cost_per_token: bulk.input_cost_per_token.trim() ? bulk.input_cost_per_token : policyForm.input_cost_per_token,
-          output_cost_per_token: bulk.output_cost_per_token.trim() ? bulk.output_cost_per_token : policyForm.output_cost_per_token,
         }, policy);
       });
       setLocalError(null);
       await onSave(next);
-      setBulk({ rpm_limit: '', tpm_limit: '', input_cost_per_token: '', output_cost_per_token: '' });
+      setBulk({ rpm_limit: '', tpm_limit: '' });
     } catch (err: unknown) {
       setLocalError(errorMessage(err, 'Failed to apply bulk policy updates.'));
     }
@@ -119,9 +128,11 @@ export default function TierModelPolicyGrid({
     if (locked) return;
     const matchingPools = poolOptionsForCallable(poolOptions, callableKey);
     const keepPool = matchingPools.some((option) => option.pool_key === form.capacity_pool_key);
+    const inferredPricingProfile = pricingProfileForCallable(callableKey);
     setForm({
       ...form,
       callable_key: callableKey,
+      pricing_profile: inferredPricingProfile || form.pricing_profile,
       capacity_pool_key: keepPool ? form.capacity_pool_key : '',
     });
   };
@@ -155,11 +166,9 @@ export default function TierModelPolicyGrid({
       {!readOnly && policies.length > 0 ? (
         <div className="m-4 rounded-xl border border-gray-100 bg-gray-50 p-3">
           <div className="mb-2 text-xs font-semibold uppercase text-gray-400">Bulk apply</div>
-          <div className="grid grid-cols-2 gap-2 md:grid-cols-5">
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
             <BulkInput label="RPM" value={bulk.rpm_limit} disabled={locked} onChange={(value) => setBulk({ ...bulk, rpm_limit: value })} />
             <BulkInput label="TPM" value={bulk.tpm_limit} disabled={locked} onChange={(value) => setBulk({ ...bulk, tpm_limit: value })} />
-            <BulkInput label="Input price" value={bulk.input_cost_per_token} disabled={locked} onChange={(value) => setBulk({ ...bulk, input_cost_per_token: value })} />
-            <BulkInput label="Output price" value={bulk.output_cost_per_token} disabled={locked} onChange={(value) => setBulk({ ...bulk, output_cost_per_token: value })} />
             <button
               type="button"
               onClick={applyBulk}
@@ -180,6 +189,7 @@ export default function TierModelPolicyGrid({
               <th className="px-4 py-2 text-left">Access</th>
               <th className="px-4 py-2 text-left">RPM</th>
               <th className="px-4 py-2 text-left">TPM</th>
+              <th className="px-4 py-2 text-left">Pricing</th>
               <th className="px-4 py-2 text-left">Pool</th>
               <th className="px-4 py-2 text-right">Actions</th>
             </tr>
@@ -187,7 +197,7 @@ export default function TierModelPolicyGrid({
           <tbody className="divide-y divide-gray-100">
             {sortedPolicies.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-400">No model policies yet.</td>
+                <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-400">No model policies yet.</td>
               </tr>
             ) : sortedPolicies.map((policy) => (
               <tr key={`${policy.callable_key}:${policy.priority}`}>
@@ -195,6 +205,9 @@ export default function TierModelPolicyGrid({
                 <td className="px-4 py-3 text-xs font-semibold text-gray-700">{policy.access_mode}</td>
                 <td className="px-4 py-3 text-xs text-gray-600">{formatLimit(policy.rpm_limit)}</td>
                 <td className="px-4 py-3 text-xs text-gray-600">{formatLimit(policy.tpm_limit)}</td>
+                <td className="max-w-xs px-4 py-3 text-xs text-gray-600">
+                  {summarizePricing(policy.pricing, pricingProfileForCallable(policy.callable_key))}
+                </td>
                 <td className="px-4 py-3 text-xs text-gray-500">{policy.capacity_pool_key || '-'}</td>
                 <td className="px-4 py-3">
                   <div className="flex justify-end gap-1">
@@ -232,101 +245,117 @@ export default function TierModelPolicyGrid({
               <X className="h-4 w-4" />
             </button>
           </div>
-          <div className="grid grid-cols-1 gap-3 lg:grid-cols-5">
-            <Field label="Model or callable key">
-              <input
-                list="tier-policy-callables"
-                value={form.callable_key}
-                onChange={(event) => updateCallableKey(event.target.value)}
-                disabled={locked}
-                className={inputClassName}
-              />
-              <datalist id="tier-policy-callables">
-                {callableOptions.map((option) => <option key={option} value={option} />)}
-              </datalist>
-            </Field>
-            <Field label="Access">
-              <select
-                value={form.access_mode}
-                onChange={(event) => setForm({ ...form, access_mode: event.target.value })}
-                disabled={locked}
-                className={inputClassName}
-              >
-                <option value="allow">Allow</option>
-                <option value="deny">Deny</option>
-              </select>
-            </Field>
-            <Field label="Capacity pool">
-              <input
-                list="tier-policy-pools"
-                value={form.capacity_pool_key}
-                onChange={(event) => setForm({ ...form, capacity_pool_key: event.target.value })}
-                disabled={locked}
-                className={inputClassName}
-              />
-              <datalist id="tier-policy-pools">
-                {matchingPoolOptions.map((option) => (
-                  <option
-                    key={`${option.pool_key}:${option.callable_key}`}
-                    value={option.pool_key}
+          <div className="space-y-4">
+            <FormSection
+              title="Target and Access"
+              description="Choose the callable target and whether this tier allows or denies it."
+            >
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_120px_120px]">
+                <Field label="Model or callable key">
+                  <input
+                    list="tier-policy-callables"
+                    value={form.callable_key}
+                    onChange={(event) => updateCallableKey(event.target.value)}
+                    disabled={locked}
+                    className={inputClassName}
                   />
+                  <datalist id="tier-policy-callables">
+                    {callableOptions.map((option) => <option key={option} value={option} />)}
+                  </datalist>
+                </Field>
+                <Field label="Access">
+                  <select
+                    value={form.access_mode}
+                    onChange={(event) => setForm({ ...form, access_mode: event.target.value })}
+                    disabled={locked}
+                    className={inputClassName}
+                  >
+                    <option value="allow">Allow</option>
+                    <option value="deny">Deny</option>
+                  </select>
+                </Field>
+                <Field label="Priority">
+                  <input value={form.priority} onChange={(event) => setForm({ ...form, priority: event.target.value })} disabled={locked} className={inputClassName} />
+                </Field>
+                <label className={`flex items-center justify-between rounded-lg border border-gray-200 bg-white px-3 py-2 ${locked ? 'cursor-not-allowed opacity-70' : ''}`}>
+                  <span className="text-xs font-semibold text-gray-500">Enabled</span>
+                  <input
+                    type="checkbox"
+                    checked={form.enabled}
+                    onChange={(event) => setForm({ ...form, enabled: event.target.checked })}
+                    disabled={locked}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                </label>
+              </div>
+            </FormSection>
+
+            <FormSection
+              title="Capacity"
+              description="Attach this model policy to a shared pool when provider or GPU capacity is scarce."
+            >
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,360px)_minmax(0,1fr)]">
+                <Field label="Capacity pool">
+                  <input
+                    list="tier-policy-pools"
+                    value={form.capacity_pool_key}
+                    onChange={(event) => setForm({ ...form, capacity_pool_key: event.target.value })}
+                    disabled={locked}
+                    className={inputClassName}
+                  />
+                  <datalist id="tier-policy-pools">
+                    {matchingPoolOptions.map((option) => (
+                      <option
+                        key={`${option.pool_key}:${option.callable_key}`}
+                        value={option.pool_key}
+                      />
+                    ))}
+                  </datalist>
+                </Field>
+                <div className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 text-xs text-gray-500">
+                  {form.callable_key && matchingPoolOptions.length > 0
+                    ? `${matchingPoolOptions.length} compatible pool${matchingPoolOptions.length === 1 ? '' : 's'} for this model.`
+                    : form.callable_key
+                      ? 'No compatible pool is defined for this model. Leave empty or create a matching pool above.'
+                      : 'Select a model to see compatible pools.'}
+                </div>
+              </div>
+            </FormSection>
+
+            <FormSection
+              title="Rate Limits"
+              description="Set model-level limits for organizations assigned to this tier. Blank means unlimited at this tier layer."
+            >
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-8">
+                {[
+                  ['RPM', 'rpm_limit'],
+                  ['TPM', 'tpm_limit'],
+                  ['RPH', 'rph_limit'],
+                  ['RPD', 'rpd_limit'],
+                  ['TPD', 'tpd_limit'],
+                  ['Parallel', 'max_parallel_requests'],
+                  ['Batch RPM', 'batch_rpm_limit'],
+                  ['Batch TPM', 'batch_tpm_limit'],
+                ].map(([label, key]) => (
+                  <Field key={key} label={label}>
+                    <input
+                      value={form[key as keyof TierModelPolicyForm] as string}
+                      onChange={(event) => setForm({ ...form, [key]: event.target.value })}
+                      disabled={locked}
+                      className={inputClassName}
+                    />
+                  </Field>
                 ))}
-              </datalist>
-            </Field>
-            <Field label="Priority">
-              <input value={form.priority} onChange={(event) => setForm({ ...form, priority: event.target.value })} disabled={locked} className={inputClassName} />
-            </Field>
-            <label className={`flex items-center justify-between rounded-lg border border-gray-200 bg-white px-3 py-2 ${locked ? 'cursor-not-allowed opacity-70' : ''}`}>
-              <span className="text-xs font-semibold text-gray-500">Enabled</span>
-              <input
-                type="checkbox"
-                checked={form.enabled}
-                onChange={(event) => setForm({ ...form, enabled: event.target.checked })}
-                disabled={locked}
-                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-            </label>
-          </div>
+              </div>
+            </FormSection>
 
-          <div className="mt-3 grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-8">
-            {[
-              ['RPM', 'rpm_limit'],
-              ['TPM', 'tpm_limit'],
-              ['RPH', 'rph_limit'],
-              ['RPD', 'rpd_limit'],
-              ['TPD', 'tpd_limit'],
-              ['Parallel', 'max_parallel_requests'],
-              ['Batch RPM', 'batch_rpm_limit'],
-              ['Batch TPM', 'batch_tpm_limit'],
-            ].map(([label, key]) => (
-              <Field key={key} label={label}>
-                <input
-                  value={form[key as keyof TierModelPolicyForm] as string}
-                  onChange={(event) => setForm({ ...form, [key]: event.target.value })}
-                  disabled={locked}
-                  className={inputClassName}
-                />
-              </Field>
-            ))}
-          </div>
-
-          <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-5">
-            {[
-              ['Input price', 'input_cost_per_token'],
-              ['Output price', 'output_cost_per_token'],
-              ['Cached input', 'cached_input_cost_per_token'],
-              ['Batch input', 'batch_input_cost_per_token'],
-              ['Batch output', 'batch_output_cost_per_token'],
-            ].map(([label, key]) => (
-              <Field key={key} label={label}>
-                <input
-                  value={form[key as keyof TierModelPolicyForm] as string}
-                  onChange={(event) => setForm({ ...form, [key]: event.target.value })}
-                  disabled={locked}
-                  className={inputClassName}
-                />
-              </Field>
-            ))}
+            <TierPricingFields
+              form={form}
+              locked={locked}
+              inputClassName={inputClassName}
+              inferredMode={inferredMode}
+              onChange={setForm}
+            />
           </div>
 
           <div className="mt-4 flex justify-end">
@@ -342,6 +371,26 @@ export default function TierModelPolicyGrid({
           </div>
         </div>
       ) : null}
+    </section>
+  );
+}
+
+function FormSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3 border-b border-gray-200 pb-4 last:border-b-0">
+      <div>
+        <h5 className="text-sm font-semibold text-gray-900">{title}</h5>
+        <p className="mt-0.5 text-xs text-gray-500">{description}</p>
+      </div>
+      {children}
     </section>
   );
 }

--- a/ui/src/components/tiers/TierPolicyPreviewPanel.tsx
+++ b/ui/src/components/tiers/TierPolicyPreviewPanel.tsx
@@ -1,7 +1,14 @@
 import { AlertTriangle, CheckCircle2, Database, Gauge, Layers, Tag } from 'lucide-react';
 import type { ElementType } from 'react';
 import type { OrganizationTierPolicyPreview } from '../../lib/api';
-import { describeRateLimit, formatDateTime, formatLimit } from '../../lib/tiers';
+import {
+  describeRateLimit,
+  formatDateTime,
+  formatLimit,
+  formatPricingValue,
+  pricingEntries,
+  summarizePricing,
+} from '../../lib/tiers';
 
 type TierPolicyPreviewPanelProps = {
   preview: OrganizationTierPolicyPreview | null;
@@ -155,10 +162,11 @@ export default function TierPolicyPreviewPanel({
                       <p className="font-mono text-xs font-semibold text-gray-700">{policy.callable_key}</p>
                       <span className="text-xs font-medium text-gray-500">{policy.mode}</span>
                     </div>
+                    <p className="mt-1 text-xs text-gray-600">{summarizePricing(policy.pricing)}</p>
                     <div className="mt-2 flex flex-wrap gap-1.5">
-                      {Object.entries(policy.pricing).map(([key, value]) => (
-                        <span key={key} className="rounded bg-white px-2 py-0.5 text-[11px] text-gray-600">
-                          {key}: {value}
+                      {pricingEntries(policy.pricing).map((entry) => (
+                        <span key={entry.payloadField} className="rounded bg-white px-2 py-0.5 text-[11px] text-gray-600">
+                          {entry.shortLabel}: {formatPricingValue(entry.value, entry.unit)}
                         </span>
                       ))}
                     </div>

--- a/ui/src/components/tiers/TierPricingFields.tsx
+++ b/ui/src/components/tiers/TierPricingFields.tsx
@@ -1,0 +1,157 @@
+import type { ReactNode } from 'react';
+import {
+  advancedPricingFieldsForProfile,
+  pricingFieldsForProfile,
+  pricingProfileLabel,
+  TIER_PRICING_PROFILES,
+  type TierModelPolicyForm,
+  type TierPricingFieldDefinition,
+  type TierPricingProfile,
+} from '../../lib/tiers';
+
+type TierPricingFieldsProps = {
+  form: TierModelPolicyForm;
+  locked: boolean;
+  inputClassName: string;
+  inferredMode?: string | null;
+  onChange: (form: TierModelPolicyForm) => void;
+};
+
+export default function TierPricingFields({
+  form,
+  locked,
+  inputClassName,
+  inferredMode,
+  onChange,
+}: TierPricingFieldsProps) {
+  const primaryFields = pricingFieldsForProfile(form.pricing_profile);
+  const advancedFields = advancedPricingFieldsForProfile(form.pricing_profile);
+  const profile = TIER_PRICING_PROFILES.find((item) => item.value === form.pricing_profile)
+    || TIER_PRICING_PROFILES[0];
+  const hasAdvancedValues = advancedFields.some((field) => String(form[field.formField] || '').trim());
+
+  const updateField = (field: TierPricingFieldDefinition, value: string) => {
+    onChange({ ...form, [field.formField]: value });
+  };
+
+  const updateProfile = (pricingProfile: TierPricingProfile) => {
+    onChange({ ...form, pricing_profile: pricingProfile });
+  };
+
+  return (
+    <FormSection
+      title="Pricing"
+      description="Choose the billing shape for this model, then set only the prices that apply."
+    >
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[260px_minmax(0,1fr)]">
+        <label className="block">
+          <span className="mb-1 block text-xs font-semibold text-gray-500">Pricing profile</span>
+          <select
+            value={form.pricing_profile}
+            onChange={(event) => updateProfile(event.target.value as TierPricingProfile)}
+            disabled={locked}
+            className={inputClassName}
+          >
+            {TIER_PRICING_PROFILES.map((item) => (
+              <option key={item.value} value={item.value}>{item.label}</option>
+            ))}
+          </select>
+        </label>
+        <div className="rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-blue-800">
+          <p className="font-semibold">{pricingProfileLabel(profile.value)}</p>
+          <p className="mt-0.5">{profile.description}</p>
+          {inferredMode ? (
+            <p className="mt-1 text-blue-700/80">Inferred from model mode: <span className="font-mono">{inferredMode}</span></p>
+          ) : (
+            <p className="mt-1 text-blue-700/80">Mode could not be inferred; choose the closest billing profile.</p>
+          )}
+        </div>
+      </div>
+
+      <PricingGrid
+        fields={primaryFields}
+        form={form}
+        locked={locked}
+        inputClassName={inputClassName}
+        onChange={updateField}
+      />
+
+      {advancedFields.length > 0 ? (
+        <details className="rounded-lg border border-gray-200 bg-white p-3" open={hasAdvancedValues}>
+          <summary className="cursor-pointer text-xs font-semibold text-gray-600">
+            Advanced supported pricing fields
+          </summary>
+          <p className="mt-1 text-xs text-gray-500">
+            Values here are preserved even when hidden by the selected profile.
+          </p>
+          <PricingGrid
+            fields={advancedFields}
+            form={form}
+            locked={locked}
+            inputClassName={inputClassName}
+            onChange={updateField}
+          />
+        </details>
+      ) : null}
+    </FormSection>
+  );
+}
+
+function PricingGrid({
+  fields,
+  form,
+  locked,
+  inputClassName,
+  onChange,
+}: {
+  fields: TierPricingFieldDefinition[];
+  form: TierModelPolicyForm;
+  locked: boolean;
+  inputClassName: string;
+  onChange: (field: TierPricingFieldDefinition, value: string) => void;
+}) {
+  if (fields.length === 0) {
+    return <p className="text-sm text-gray-400">No pricing fields for this profile.</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {fields.map((field) => (
+        <label key={field.payloadField} className="block rounded-lg border border-gray-100 bg-gray-50 p-3">
+          <span className="mb-1 flex items-center justify-between gap-2 text-xs font-semibold text-gray-600">
+            <span>{field.label}</span>
+            <span className="font-normal text-gray-400">{field.unit}</span>
+          </span>
+          <input
+            value={String(form[field.formField] || '')}
+            onChange={(event) => onChange(field, event.target.value)}
+            disabled={locked}
+            placeholder="Unset"
+            className={inputClassName}
+          />
+          <span className="mt-1 block text-[11px] leading-4 text-gray-400">{field.help}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+function FormSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3 border-b border-gray-200 pb-4 last:border-b-0">
+      <div>
+        <h5 className="text-sm font-semibold text-gray-900">{title}</h5>
+        <p className="mt-0.5 text-xs text-gray-500">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/ui/src/components/tiers/TierSimulationPanel.tsx
+++ b/ui/src/components/tiers/TierSimulationPanel.tsx
@@ -5,8 +5,11 @@ import type { TierPolicySimulation, TierPolicySimulationPayload } from '../../li
 import {
   describeRateLimit,
   errorMessage,
+  formatPricingValue,
   parseNonNegativeIntegerInput,
   parsePositiveIntegerInput,
+  pricingEntries,
+  summarizePricing,
   summarizeSimulation,
 } from '../../lib/tiers';
 
@@ -160,10 +163,11 @@ export default function TierSimulationPanel({
               {simulation.pricing ? (
                 <div>
                   <p className="mb-2 text-xs font-semibold uppercase text-gray-400">Pricing</p>
+                  <p className="mb-2 text-xs text-gray-600">{summarizePricing(simulation.pricing.pricing)}</p>
                   <div className="flex flex-wrap gap-1.5">
-                    {Object.entries(simulation.pricing.pricing).map(([key, value]) => (
-                      <span key={key} className="rounded bg-white px-2 py-0.5 text-[11px] text-gray-600">
-                        {key}: {value}
+                    {pricingEntries(simulation.pricing.pricing).map((entry) => (
+                      <span key={entry.payloadField} className="rounded bg-white px-2 py-0.5 text-[11px] text-gray-600">
+                        {entry.shortLabel}: {formatPricingValue(entry.value, entry.unit)}
                       </span>
                     ))}
                   </div>

--- a/ui/src/lib/tierPricing.ts
+++ b/ui/src/lib/tierPricing.ts
@@ -1,0 +1,309 @@
+export type TierPricingProfile =
+  | 'token'
+  | 'image_generation'
+  | 'audio_speech'
+  | 'audio_transcription'
+  | 'rerank'
+  | 'request'
+  | 'custom';
+
+export type PricingFieldGroup = 'token' | 'cache' | 'batch' | 'image' | 'audio' | 'request';
+
+export type PricingFormField =
+  | 'input_cost_per_token'
+  | 'output_cost_per_token'
+  | 'cached_input_cost_per_token'
+  | 'cached_output_cost_per_token'
+  | 'batch_input_cost_per_token'
+  | 'batch_output_cost_per_token'
+  | 'batch_price_multiplier'
+  | 'input_cost_per_character'
+  | 'output_cost_per_character'
+  | 'input_cost_per_second'
+  | 'output_cost_per_second'
+  | 'input_cost_per_image'
+  | 'output_cost_per_image'
+  | 'input_cost_per_audio_token'
+  | 'output_cost_per_audio_token'
+  | 'cost_per_request';
+
+export type TierPricingFieldDefinition = {
+  formField: PricingFormField;
+  payloadField: string;
+  label: string;
+  shortLabel: string;
+  unit: string;
+  group: PricingFieldGroup;
+  profiles: TierPricingProfile[];
+  help: string;
+};
+
+export const TIER_PRICING_PROFILES: Array<{
+  value: TierPricingProfile;
+  label: string;
+  description: string;
+}> = [
+  { value: 'token', label: 'Token', description: 'Chat, embeddings, and token-metered models.' },
+  { value: 'image_generation', label: 'Image', description: 'Image models billed per image or request.' },
+  { value: 'audio_speech', label: 'Text-to-speech', description: 'Speech generation billed by character, audio token, second, or request.' },
+  { value: 'audio_transcription', label: 'Transcription', description: 'Speech-to-text billed by second, audio token, or request.' },
+  { value: 'rerank', label: 'Rerank', description: 'Rerank models billed by token or flat request price.' },
+  { value: 'request', label: 'Request', description: 'Flat price per request.' },
+  { value: 'custom', label: 'Custom', description: 'Show every supported pricing key.' },
+];
+
+export const TIER_PRICING_FIELDS: TierPricingFieldDefinition[] = [
+  {
+    formField: 'input_cost_per_token',
+    payloadField: 'input_cost_per_token',
+    label: 'Input token price',
+    shortLabel: 'Input token',
+    unit: '/token',
+    group: 'token',
+    profiles: ['token', 'audio_speech', 'audio_transcription', 'rerank'],
+    help: 'Customer price per input or prompt token.',
+  },
+  {
+    formField: 'output_cost_per_token',
+    payloadField: 'output_cost_per_token',
+    label: 'Output token price',
+    shortLabel: 'Output token',
+    unit: '/token',
+    group: 'token',
+    profiles: ['token', 'audio_speech', 'audio_transcription', 'rerank'],
+    help: 'Customer price per generated token.',
+  },
+  {
+    formField: 'cached_input_cost_per_token',
+    payloadField: 'input_cost_per_token_cache_hit',
+    label: 'Cached input token price',
+    shortLabel: 'Cached input',
+    unit: '/token',
+    group: 'cache',
+    profiles: ['token'],
+    help: 'Price for cached prompt/input tokens when cache accounting is available.',
+  },
+  {
+    formField: 'cached_output_cost_per_token',
+    payloadField: 'output_cost_per_token_cache_hit',
+    label: 'Cached output token price',
+    shortLabel: 'Cached output',
+    unit: '/token',
+    group: 'cache',
+    profiles: ['token'],
+    help: 'Price for cached output tokens when cache accounting is available.',
+  },
+  {
+    formField: 'batch_input_cost_per_token',
+    payloadField: 'batch_input_cost_per_token',
+    label: 'Batch input token price',
+    shortLabel: 'Batch input',
+    unit: '/token',
+    group: 'batch',
+    profiles: ['token'],
+    help: 'Input token price used by batch jobs.',
+  },
+  {
+    formField: 'batch_output_cost_per_token',
+    payloadField: 'batch_output_cost_per_token',
+    label: 'Batch output token price',
+    shortLabel: 'Batch output',
+    unit: '/token',
+    group: 'batch',
+    profiles: ['token'],
+    help: 'Output token price used by batch jobs.',
+  },
+  {
+    formField: 'batch_price_multiplier',
+    payloadField: 'batch_price_multiplier',
+    label: 'Batch price multiplier',
+    shortLabel: 'Batch multiplier',
+    unit: 'x',
+    group: 'batch',
+    profiles: ['token'],
+    help: 'Multiplier applied to sync token pricing for batch jobs when explicit batch prices are not set.',
+  },
+  {
+    formField: 'input_cost_per_image',
+    payloadField: 'input_cost_per_image',
+    label: 'Image price',
+    shortLabel: 'Image',
+    unit: '/image',
+    group: 'image',
+    profiles: ['image_generation'],
+    help: 'Customer price per generated image.',
+  },
+  {
+    formField: 'output_cost_per_image',
+    payloadField: 'output_cost_per_image',
+    label: 'Output image price',
+    shortLabel: 'Output image',
+    unit: '/image',
+    group: 'image',
+    profiles: ['custom'],
+    help: 'Supported pricing key for providers that separate input and output image pricing.',
+  },
+  {
+    formField: 'input_cost_per_character',
+    payloadField: 'input_cost_per_character',
+    label: 'Input character price',
+    shortLabel: 'Input char',
+    unit: '/char',
+    group: 'audio',
+    profiles: ['audio_speech'],
+    help: 'Customer price per input character for text-to-speech.',
+  },
+  {
+    formField: 'output_cost_per_character',
+    payloadField: 'output_cost_per_character',
+    label: 'Output character price',
+    shortLabel: 'Output char',
+    unit: '/char',
+    group: 'audio',
+    profiles: ['audio_speech'],
+    help: 'Customer price per output character when a provider reports it.',
+  },
+  {
+    formField: 'input_cost_per_second',
+    payloadField: 'input_cost_per_second',
+    label: 'Input second price',
+    shortLabel: 'Input sec',
+    unit: '/sec',
+    group: 'audio',
+    profiles: ['audio_speech', 'audio_transcription'],
+    help: 'Customer price per input or billable audio second.',
+  },
+  {
+    formField: 'output_cost_per_second',
+    payloadField: 'output_cost_per_second',
+    label: 'Output second price',
+    shortLabel: 'Output sec',
+    unit: '/sec',
+    group: 'audio',
+    profiles: ['audio_speech', 'audio_transcription'],
+    help: 'Customer price per output audio second when a provider reports it.',
+  },
+  {
+    formField: 'input_cost_per_audio_token',
+    payloadField: 'input_cost_per_audio_token',
+    label: 'Input audio token price',
+    shortLabel: 'Input audio token',
+    unit: '/audio token',
+    group: 'audio',
+    profiles: ['audio_speech', 'audio_transcription'],
+    help: 'Customer price per input audio token.',
+  },
+  {
+    formField: 'output_cost_per_audio_token',
+    payloadField: 'output_cost_per_audio_token',
+    label: 'Output audio token price',
+    shortLabel: 'Output audio token',
+    unit: '/audio token',
+    group: 'audio',
+    profiles: ['audio_speech'],
+    help: 'Customer price per output audio token.',
+  },
+  {
+    formField: 'cost_per_request',
+    payloadField: 'cost_per_request',
+    label: 'Request price',
+    shortLabel: 'Request',
+    unit: '/request',
+    group: 'request',
+    profiles: ['token', 'image_generation', 'audio_speech', 'audio_transcription', 'rerank', 'request'],
+    help: 'Flat customer price added once per request.',
+  },
+];
+
+export function pricingProfileForModelMode(mode?: string | null): TierPricingProfile {
+  switch (String(mode || '').trim().toLowerCase()) {
+    case 'chat':
+    case 'completion':
+    case 'responses':
+    case 'embedding':
+      return 'token';
+    case 'image':
+    case 'image_generation':
+      return 'image_generation';
+    case 'audio_speech':
+    case 'speech':
+    case 'text_to_speech':
+      return 'audio_speech';
+    case 'audio_transcription':
+    case 'transcription':
+    case 'speech_to_text':
+      return 'audio_transcription';
+    case 'rerank':
+      return 'rerank';
+    default:
+      return 'token';
+  }
+}
+
+export function pricingProfileLabel(profile: TierPricingProfile): string {
+  return TIER_PRICING_PROFILES.find((item) => item.value === profile)?.label || 'Token';
+}
+
+export function pricingFieldsForProfile(profile: TierPricingProfile): TierPricingFieldDefinition[] {
+  if (profile === 'custom') return [...TIER_PRICING_FIELDS];
+  return TIER_PRICING_FIELDS.filter((field) => field.profiles.includes(profile));
+}
+
+export function advancedPricingFieldsForProfile(profile: TierPricingProfile): TierPricingFieldDefinition[] {
+  const primary = new Set(pricingFieldsForProfile(profile).map((field) => field.payloadField));
+  if (profile === 'custom') return [];
+  return TIER_PRICING_FIELDS.filter((field) => !primary.has(field.payloadField));
+}
+
+export function pricingEntries(
+  pricing?: Record<string, number> | null,
+): Array<TierPricingFieldDefinition & { value: number }> {
+  const data = pricing || {};
+  return TIER_PRICING_FIELDS
+    .map((field) => {
+      const value = data[field.payloadField];
+      return Number.isFinite(value) ? { ...field, value } : null;
+    })
+    .filter((entry): entry is TierPricingFieldDefinition & { value: number } => entry !== null);
+}
+
+export function formatPricingValue(value: number, unit?: string): string {
+  const normalized = Number(value);
+  if (!Number.isFinite(normalized)) return '-';
+  return `${normalized.toLocaleString(undefined, { maximumSignificantDigits: 8 })}${unit ? ` ${unit}` : ''}`;
+}
+
+export function summarizePricing(
+  pricing?: Record<string, number> | null,
+  profile?: TierPricingProfile | null,
+): string {
+  const entries = pricingEntries(pricing);
+  if (entries.length === 0) return 'No price override';
+  const preferred = profile
+    ? entries.filter((entry) => profile === 'custom' || entry.profiles.includes(profile))
+    : entries;
+  const visible = (preferred.length ? preferred : entries).slice(0, 3);
+  const summary = visible.map((entry) => `${entry.shortLabel} ${formatPricingValue(entry.value, entry.unit)}`).join(' · ');
+  const remaining = entries.length - visible.length;
+  return remaining > 0 ? `${summary} · +${remaining}` : summary;
+}
+
+export function inferPricingProfileFromPricing(pricing?: Record<string, number> | null): TierPricingProfile {
+  const fields = new Set(Object.keys(pricing || {}));
+  if (fields.has('input_cost_per_image') || fields.has('output_cost_per_image')) {
+    return 'image_generation';
+  }
+  if (fields.has('input_cost_per_character') || fields.has('output_cost_per_character')) {
+    return 'audio_speech';
+  }
+  if (fields.has('input_cost_per_second') || fields.has('output_cost_per_second')) {
+    return 'audio_transcription';
+  }
+  if (fields.has('input_cost_per_audio_token') || fields.has('output_cost_per_audio_token')) {
+    return 'audio_transcription';
+  }
+  if (fields.size === 1 && fields.has('cost_per_request')) {
+    return 'request';
+  }
+  return 'token';
+}

--- a/ui/src/lib/tiers.ts
+++ b/ui/src/lib/tiers.ts
@@ -8,6 +8,29 @@ import type {
   TierRateLimitDescriptor,
   TierVersion,
 } from './api';
+import {
+  inferPricingProfileFromPricing,
+  TIER_PRICING_FIELDS,
+  type TierPricingProfile,
+} from './tierPricing';
+
+export {
+  advancedPricingFieldsForProfile,
+  formatPricingValue,
+  pricingEntries,
+  pricingFieldsForProfile,
+  pricingProfileForModelMode,
+  pricingProfileLabel,
+  summarizePricing,
+  TIER_PRICING_FIELDS,
+  TIER_PRICING_PROFILES,
+} from './tierPricing';
+export type {
+  PricingFieldGroup,
+  PricingFormField,
+  TierPricingFieldDefinition,
+  TierPricingProfile,
+} from './tierPricing';
 
 export type TierFormValues = {
   tier_key: string;
@@ -20,6 +43,7 @@ export type TierModelPolicyForm = {
   callable_key: string;
   enabled: boolean;
   access_mode: string;
+  pricing_profile: TierPricingProfile;
   rpm_limit: string;
   tpm_limit: string;
   rph_limit: string;
@@ -31,8 +55,19 @@ export type TierModelPolicyForm = {
   input_cost_per_token: string;
   output_cost_per_token: string;
   cached_input_cost_per_token: string;
+  cached_output_cost_per_token: string;
   batch_input_cost_per_token: string;
   batch_output_cost_per_token: string;
+  batch_price_multiplier: string;
+  input_cost_per_character: string;
+  output_cost_per_character: string;
+  input_cost_per_second: string;
+  output_cost_per_second: string;
+  input_cost_per_image: string;
+  output_cost_per_image: string;
+  input_cost_per_audio_token: string;
+  output_cost_per_audio_token: string;
+  cost_per_request: string;
   capacity_pool_key: string;
   priority: string;
 };
@@ -50,16 +85,10 @@ export type TierCapacityPoolForm = {
 
 export type TierCapacityPoolOption = Pick<TierCapacityPool, 'pool_key' | 'callable_key'>;
 
-const PRICING_FIELDS = [
-  ['input_cost_per_token', 'input_cost_per_token', 'Input price'],
-  ['output_cost_per_token', 'output_cost_per_token', 'Output price'],
-  ['cached_input_cost_per_token', 'input_cost_per_token_cache_hit', 'Cached input price'],
-  ['batch_input_cost_per_token', 'batch_input_cost_per_token', 'Batch input price'],
-  ['batch_output_cost_per_token', 'batch_output_cost_per_token', 'Batch output price'],
-] as const;
+const PRICING_FIELDS = TIER_PRICING_FIELDS;
 
 const EDITABLE_PRICING_PAYLOAD_FIELDS = new Set<string>(
-  PRICING_FIELDS.map(([, payloadField]) => payloadField),
+  PRICING_FIELDS.map((field) => field.payloadField),
 );
 
 const DECIMAL_PATTERN = /^(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i;
@@ -130,11 +159,12 @@ export function pickEditableVersion(versions: TierVersion[]): TierVersion | null
     || null;
 }
 
-export function emptyModelPolicyForm(): TierModelPolicyForm {
+export function emptyModelPolicyForm(pricingProfile: TierPricingProfile = 'token'): TierModelPolicyForm {
   return {
     callable_key: '',
     enabled: true,
     access_mode: 'allow',
+    pricing_profile: pricingProfile,
     rpm_limit: '',
     tpm_limit: '',
     rph_limit: '',
@@ -146,19 +176,35 @@ export function emptyModelPolicyForm(): TierModelPolicyForm {
     input_cost_per_token: '',
     output_cost_per_token: '',
     cached_input_cost_per_token: '',
+    cached_output_cost_per_token: '',
     batch_input_cost_per_token: '',
     batch_output_cost_per_token: '',
+    batch_price_multiplier: '',
+    input_cost_per_character: '',
+    output_cost_per_character: '',
+    input_cost_per_second: '',
+    output_cost_per_second: '',
+    input_cost_per_image: '',
+    output_cost_per_image: '',
+    input_cost_per_audio_token: '',
+    output_cost_per_audio_token: '',
+    cost_per_request: '',
     capacity_pool_key: '',
     priority: '0',
   };
 }
 
-export function modelPolicyToForm(policy?: TierModelPolicy | null): TierModelPolicyForm {
+export function modelPolicyToForm(
+  policy?: TierModelPolicy | null,
+  pricingProfile?: TierPricingProfile | null,
+): TierModelPolicyForm {
   const pricing = policy?.pricing || {};
+  const resolvedPricingProfile = pricingProfile || inferPricingProfileFromPricing(pricing);
   return {
     callable_key: policy?.callable_key || '',
     enabled: policy?.enabled ?? true,
     access_mode: policy?.access_mode || 'allow',
+    pricing_profile: resolvedPricingProfile,
     rpm_limit: numberToInput(policy?.rpm_limit),
     tpm_limit: numberToInput(policy?.tpm_limit),
     rph_limit: numberToInput(policy?.rph_limit),
@@ -170,8 +216,19 @@ export function modelPolicyToForm(policy?: TierModelPolicy | null): TierModelPol
     input_cost_per_token: numberToInput(pricing.input_cost_per_token),
     output_cost_per_token: numberToInput(pricing.output_cost_per_token),
     cached_input_cost_per_token: numberToInput(pricing.input_cost_per_token_cache_hit),
+    cached_output_cost_per_token: numberToInput(pricing.output_cost_per_token_cache_hit),
     batch_input_cost_per_token: numberToInput(pricing.batch_input_cost_per_token),
     batch_output_cost_per_token: numberToInput(pricing.batch_output_cost_per_token),
+    batch_price_multiplier: numberToInput(pricing.batch_price_multiplier),
+    input_cost_per_character: numberToInput(pricing.input_cost_per_character),
+    output_cost_per_character: numberToInput(pricing.output_cost_per_character),
+    input_cost_per_second: numberToInput(pricing.input_cost_per_second),
+    output_cost_per_second: numberToInput(pricing.output_cost_per_second),
+    input_cost_per_image: numberToInput(pricing.input_cost_per_image),
+    output_cost_per_image: numberToInput(pricing.output_cost_per_image),
+    input_cost_per_audio_token: numberToInput(pricing.input_cost_per_audio_token),
+    output_cost_per_audio_token: numberToInput(pricing.output_cost_per_audio_token),
+    cost_per_request: numberToInput(pricing.cost_per_request),
     capacity_pool_key: policy?.capacity_pool_key || '',
     priority: numberToInput(policy?.priority ?? 0) || '0',
   };
@@ -396,12 +453,13 @@ function pricingFormToPayload(
     }
   }
 
-  for (const [formField, payloadField, label] of PRICING_FIELDS) {
-    if (!form[formField].trim()) {
+  for (const { formField, payloadField, label } of PRICING_FIELDS) {
+    const rawValue = String(form[formField] || '');
+    if (!rawValue.trim()) {
       delete pricing[payloadField];
       continue;
     }
-    const value = parseOptionalNonNegativeNumber(form[formField], label);
+    const value = parseOptionalNonNegativeNumber(rawValue, label);
     if (value != null) {
       pricing[payloadField] = value;
     }

--- a/ui/src/pages/TierDetail.tsx
+++ b/ui/src/pages/TierDetail.tsx
@@ -10,6 +10,7 @@ import TierVersionOverview from '../components/tiers/TierVersionOverview';
 import { useToast } from '../components/ToastProvider';
 import {
   callableTargets,
+  models,
   tiers,
   type TierCapacityPool,
   type TierModelPolicy,
@@ -97,7 +98,22 @@ export default function TierDetail() {
     () => callableTargets.listAll({ target_type: 'model' }),
     [],
   );
+  const { data: modelPage } = useApi(
+    () => models.list({ limit: 500 }),
+    [],
+  );
   const callableOptions = (callablePage || []).map((item) => item.callable_key);
+  const callableModes = useMemo(() => {
+    const modes: Record<string, string> = {};
+    for (const item of modelPage?.data || []) {
+      const modelName = String(item.model_name || '').trim();
+      const mode = String(item.mode || item.model_info?.mode || '').trim();
+      if (modelName && mode && modes[modelName] === undefined) {
+        modes[modelName] = mode;
+      }
+    }
+    return modes;
+  }, [modelPage]);
   const currentVersionDetail = (
     versionDetail?.tier_version?.tier_version_id === selectedVersionId
     && versionDetail.tier_version?.tier_id === tierId
@@ -491,6 +507,7 @@ export default function TierDetail() {
                 policies={currentVersionDetail.model_policies}
                 poolOptions={poolOptions}
                 callableOptions={callableOptions}
+                callableModes={callableModes}
                 readOnly={!canEditVersion}
                 saving={isMutating}
                 error={policyError}

--- a/ui/tests/tierHelpers.test.ts
+++ b/ui/tests/tierHelpers.test.ts
@@ -13,7 +13,10 @@ import {
   modelPolicyToPayload,
   parseNonNegativeIntegerInput,
   parsePositiveIntegerInput,
+  pricingEntries,
+  pricingProfileForModelMode,
   poolOptionsForCallable,
+  summarizePricing,
   summarizeSimulation,
   tierAssignmentRequiresActiveVersion,
 } from '../src/lib/tiers';
@@ -42,6 +45,60 @@ test('modelPolicyFormToPayload normalizes optional limits and pricing', () => {
   });
   assert.equal(payload.capacity_pool_key, 'shared-chat');
   assert.equal(payload.priority, 3);
+});
+
+test('modelPolicyFormToPayload supports full token pricing fields', () => {
+  const payload = modelPolicyFormToPayload({
+    ...emptyModelPolicyForm('token'),
+    callable_key: 'gpt-4o-mini',
+    input_cost_per_token: '0.01',
+    output_cost_per_token: '0.02',
+    cached_input_cost_per_token: '0.005',
+    cached_output_cost_per_token: '0.006',
+    batch_input_cost_per_token: '0.004',
+    batch_output_cost_per_token: '0.008',
+    batch_price_multiplier: '0.5',
+    cost_per_request: '0.001',
+  });
+
+  assert.deepEqual(payload.pricing, {
+    input_cost_per_token: 0.01,
+    output_cost_per_token: 0.02,
+    input_cost_per_token_cache_hit: 0.005,
+    output_cost_per_token_cache_hit: 0.006,
+    batch_input_cost_per_token: 0.004,
+    batch_output_cost_per_token: 0.008,
+    batch_price_multiplier: 0.5,
+    cost_per_request: 0.001,
+  });
+});
+
+test('modelPolicyFormToPayload supports image and audio pricing fields', () => {
+  const imagePayload = modelPolicyFormToPayload({
+    ...emptyModelPolicyForm('image_generation'),
+    callable_key: 'image-model',
+    input_cost_per_image: '0.25',
+    cost_per_request: '0.75',
+  });
+  const audioPayload = modelPolicyFormToPayload({
+    ...emptyModelPolicyForm('audio_speech'),
+    callable_key: 'tts-model',
+    input_cost_per_character: '0.002',
+    output_cost_per_second: '0.03',
+    input_cost_per_audio_token: '0.04',
+    output_cost_per_audio_token: '0.05',
+  });
+
+  assert.deepEqual(imagePayload.pricing, {
+    input_cost_per_image: 0.25,
+    cost_per_request: 0.75,
+  });
+  assert.deepEqual(audioPayload.pricing, {
+    input_cost_per_character: 0.002,
+    output_cost_per_second: 0.03,
+    input_cost_per_audio_token: 0.04,
+    output_cost_per_audio_token: 0.05,
+  });
 });
 
 test('model policy payload helpers preserve metadata and strip response-only fields', () => {
@@ -135,6 +192,38 @@ test('modelPolicyFormToPayload preserves all pricing during bulk-style limit edi
 
   assert.equal(payload.rpm_limit, 240);
   assert.deepEqual(payload.pricing, existing.pricing);
+});
+
+test('modelPolicyToForm infers non-token pricing profiles from existing pricing', () => {
+  assert.equal(modelPolicyToForm({
+    callable_key: 'image-model',
+    enabled: true,
+    access_mode: 'allow',
+    pricing: { input_cost_per_image: 0.25 },
+    priority: 0,
+  }).pricing_profile, 'image_generation');
+
+  assert.equal(modelPolicyToForm({
+    callable_key: 'tts-model',
+    enabled: true,
+    access_mode: 'allow',
+    pricing: { input_cost_per_character: 0.001 },
+    priority: 0,
+  }).pricing_profile, 'audio_speech');
+
+  assert.equal(pricingProfileForModelMode('audio_transcription'), 'audio_transcription');
+  assert.equal(pricingProfileForModelMode('embedding'), 'token');
+});
+
+test('pricing summaries use human labels and billing units', () => {
+  const pricing = {
+    input_cost_per_image: 0.25,
+    cost_per_request: 0.75,
+  };
+  const entries = pricingEntries(pricing);
+
+  assert.deepEqual(entries.map((entry) => entry.shortLabel), ['Image', 'Request']);
+  assert.equal(summarizePricing(pricing, 'image_generation'), 'Image 0.25 /image · Request 0.75 /request');
 });
 
 test('modelPolicyFormToPayload rejects partial or non-positive numeric limits', () => {


### PR DESCRIPTION
## Summary

- Add clearer tiers admin documentation, including the relationship between tiers, capacity pools, and Asset Access.
- Update the tier model policy UI to support pricing profiles for non-chat model modes and reorganize policy fields into cleaner sections.
- Fix two backend query issues found during local tier E2E testing: advisory-lock deserialization on assignment creation and ambiguous outbox columns in cache invalidation claiming.

## Validation

- git diff --check
- uv run pytest tests/db/test_cache_invalidation_outbox.py tests/test_ui_tier_assignments_api.py tests/db/test_tier_assignment_repository_integration.py -q
- Local Docker tier E2E passed for tier creation, publish, org assignment, preview, simulation, runtime model visibility, denied model behavior, Asset Access narrowing, and cleanup.

## Notes

The local stack was restored after E2E testing: tier policy mode returned to disabled with fail_open, temporary E2E data was removed, and services were healthy after restart.