### PR TITLE
Optimize batch detail loading

### DIFF
--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -15,7 +15,7 @@ from src.auth.roles import Permission
 from src.api.admin.endpoints.common import db_or_503, emit_admin_mutation_audit, to_json_value, get_auth_scope
 from src.audit.actions import AuditAction
 from src.batch.repository import BatchRepository
-from src.batch.models import BATCH_JOB_STATUS_SET, decode_operator_failed_reason, encode_operator_failed_reason
+from src.batch.models import BATCH_JOB_STATUS_SET, encode_operator_failed_reason
 from src.batch.scheduling import (
     API_KEY_TENANT_SCOPE_PREFIX,
     BatchJobRankInput,
@@ -962,6 +962,7 @@ async def get_batch(
     batch_id: str,
     items_limit: int = Query(default=50, ge=1, le=500),
     items_offset: int = Query(default=0, ge=0),
+    after_line_number: int | None = Query(default=None, ge=0),
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
@@ -970,8 +971,13 @@ async def get_batch(
 
     rows = await db.query_raw(
         """
-        SELECT j.*, t.team_alias, t.organization_id
-        , COALESCE(j.created_by_organization_id, t.organization_id) AS organization_id
+        SELECT
+            j.batch_id, j.endpoint, j.status, j.model, j.execution_mode,
+            j.total_items, j.completed_items, j.failed_items, j.cancelled_items, j.in_progress_items,
+            j.created_by_api_key, j.created_by_team_id, j.created_by_organization_id,
+            j.created_at, j.started_at, j.completed_at, j.cancel_requested_at, j.expires_at,
+            t.team_alias,
+            COALESCE(j.created_by_organization_id, t.organization_id) AS organization_id
         FROM deltallm_batch_job j
         LEFT JOIN deltallm_teamtable t ON t.team_id = j.created_by_team_id
         WHERE j.batch_id = $1
@@ -984,44 +990,55 @@ async def get_batch(
 
     job = dict(rows[0])
     await _enforce_batch_update_scope(db=db, scope=scope, job=job)
-    size_aging_config = _batch_size_aging_config_or_default(request)
 
-    cost_rows = await db.query_raw(
-        """
-        SELECT COALESCE(SUM(provider_cost), 0) AS total_provider_cost,
-               COALESCE(SUM(billed_cost), 0) AS total_billed_cost
-        FROM deltallm_batch_item
-        WHERE batch_id = $1
-        """,
-        batch_id,
-    )
-    cost_row = dict(cost_rows[0]) if cost_rows else {}
-
-    items_count_rows = await db.query_raw(
-        "SELECT COUNT(*) AS total FROM deltallm_batch_item WHERE batch_id = $1",
-        batch_id,
-    )
-    items_total = int((items_count_rows[0] if items_count_rows else {}).get("total") or 0)
-
-    item_rows = await db.query_raw(
-        """
-        SELECT item_id, line_number, custom_id, status, attempts, provider_cost, billed_cost,
-               last_error, request_body, response_body, error_body, usage,
-               scheduling_model, scheduling_model_group, estimated_work_units, not_before_at,
-               last_scheduled_at,
-               created_at, started_at, completed_at
-        FROM deltallm_batch_item
-        WHERE batch_id = $1
-        ORDER BY line_number ASC
-        LIMIT $2 OFFSET $3
-        """,
-        batch_id,
-        items_limit,
-        items_offset,
+    items_total = int(job.get("total_items") or 0)
+    fetch_limit = items_limit + 1
+    if after_line_number is None:
+        item_rows = await db.query_raw(
+            """
+            SELECT item_id, line_number, custom_id, status, attempts, provider_cost, billed_cost,
+                   last_error,
+                   request_body IS NOT NULL AS has_request_body,
+                   response_body IS NOT NULL AS has_response_body,
+                   error_body IS NOT NULL AS has_error_body,
+                   usage IS NOT NULL AS has_usage
+            FROM deltallm_batch_item
+            WHERE batch_id = $1
+            ORDER BY line_number ASC
+            LIMIT $2 OFFSET $3
+            """,
+            batch_id,
+            fetch_limit,
+            items_offset,
+        )
+    else:
+        item_rows = await db.query_raw(
+            """
+            SELECT item_id, line_number, custom_id, status, attempts, provider_cost, billed_cost,
+                   last_error,
+                   request_body IS NOT NULL AS has_request_body,
+                   response_body IS NOT NULL AS has_response_body,
+                   error_body IS NOT NULL AS has_error_body,
+                   usage IS NOT NULL AS has_usage
+            FROM deltallm_batch_item
+            WHERE batch_id = $1
+              AND line_number > $2
+            ORDER BY line_number ASC
+            LIMIT $3
+            """,
+            batch_id,
+            after_line_number,
+            fetch_limit,
+        )
+    item_rows_page = [dict(r) for r in item_rows[:items_limit]]
+    has_more_items = len(item_rows) > items_limit
+    next_after_line_number = (
+        int(item_rows_page[-1].get("line_number"))
+        if has_more_items and item_rows_page and item_rows_page[-1].get("line_number") is not None
+        else None
     )
 
     masked_key = _mask_api_key(job.get("created_by_api_key"))
-    scheduler_policy_fields = _scheduler_policy_fields(job, size_aging_config=size_aging_config)
 
     return {
         "batch_id": job.get("batch_id"),
@@ -1029,34 +1046,11 @@ async def get_batch(
         "status": job.get("status"),
         "model": job.get("model"),
         "execution_mode": job.get("execution_mode"),
-        "metadata": to_json_value(job.get("metadata")),
-        "provider_error": decode_operator_failed_reason(job.get("provider_error")),
         "total_items": int(job.get("total_items") or 0),
         "completed_items": int(job.get("completed_items") or 0),
         "failed_items": int(job.get("failed_items") or 0),
         "cancelled_items": int(job.get("cancelled_items") or 0),
         "in_progress_items": int(job.get("in_progress_items") or 0),
-        "scheduler_version": job.get("scheduler_version"),
-        "scheduling_model": job.get("scheduling_model"),
-        "scheduling_model_group": job.get("scheduling_model_group"),
-        "scheduling_endpoint": job.get("scheduling_endpoint"),
-        "tenant_scope_type": job.get("tenant_scope_type"),
-        "tenant_scope_id": _display_tenant_scope_id(
-            scope_type=job.get("tenant_scope_type"),
-            scope_id=job.get("tenant_scope_id"),
-        ),
-        "service_tier": job.get("service_tier"),
-        "estimated_work_units": int(job.get("estimated_work_units") or 0),
-        "remaining_work_units": int(job.get("remaining_work_units") or 0),
-        "size_class": job.get("size_class"),
-        "queue_entered_at": to_json_value(job.get("queue_entered_at")),
-        "first_claimed_at": to_json_value(job.get("first_claimed_at")),
-        "last_claimed_at": to_json_value(job.get("last_claimed_at")),
-        "last_scheduled_at": to_json_value(job.get("last_scheduled_at")),
-        **scheduler_policy_fields,
-        "scheduler_debug": to_json_value(job.get("scheduler_debug")),
-        "total_provider_cost": float(cost_row.get("total_provider_cost") or 0),
-        "total_billed_cost": float(cost_row.get("total_billed_cost") or 0),
         "created_by_api_key": masked_key,
         "created_by_team_id": job.get("created_by_team_id"),
         "created_by_organization_id": job.get("created_by_organization_id") or job.get("organization_id"),
@@ -1068,15 +1062,76 @@ async def get_batch(
         "expires_at": to_json_value(job.get("expires_at")),
         "capabilities": build_batch_capabilities(scope, job),
         "items": {
-            "data": [to_json_value(dict(r)) for r in item_rows],
+            "data": [to_json_value(r) for r in item_rows_page],
             "pagination": {
                 "total": items_total,
                 "limit": items_limit,
                 "offset": items_offset,
-                "has_more": items_offset + items_limit < items_total,
+                "has_more": has_more_items,
+                "after_line_number": after_line_number,
+                "next_after_line_number": next_after_line_number,
             },
         },
     }
+
+
+@router.get("/ui/api/batches/{batch_id}/costs")
+async def get_batch_costs(
+    request: Request,
+    batch_id: str,
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
+) -> dict[str, Any]:
+    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.KEY_READ)
+    db = db_or_503(request)
+    job = await _load_batch_scope_row(db, batch_id)
+    await _enforce_batch_update_scope(db=db, scope=scope, job=job)
+
+    rows = await db.query_raw(
+        """
+        SELECT COALESCE(SUM(provider_cost), 0) AS total_provider_cost,
+               COALESCE(SUM(billed_cost), 0) AS total_billed_cost
+        FROM deltallm_batch_item
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    row = dict(rows[0]) if rows else {}
+    return {
+        "batch_id": batch_id,
+        "total_provider_cost": float(row.get("total_provider_cost") or 0),
+        "total_billed_cost": float(row.get("total_billed_cost") or 0),
+    }
+
+
+@router.get("/ui/api/batches/{batch_id}/items/{item_id}")
+async def get_batch_item(
+    request: Request,
+    batch_id: str,
+    item_id: str,
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
+) -> dict[str, Any]:
+    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.KEY_READ)
+    db = db_or_503(request)
+    job = await _load_batch_scope_row(db, batch_id)
+    await _enforce_batch_update_scope(db=db, scope=scope, job=job)
+
+    rows = await db.query_raw(
+        """
+        SELECT item_id, batch_id, line_number, custom_id, status, attempts, provider_cost, billed_cost,
+               last_error, request_body, response_body, error_body, usage,
+               created_at, started_at, completed_at
+        FROM deltallm_batch_item
+        WHERE batch_id = $1 AND item_id = $2
+        LIMIT 1
+        """,
+        batch_id,
+        item_id,
+    )
+    if not rows:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Batch item not found")
+    return to_json_value(dict(rows[0]))
 
 
 @router.post("/ui/api/batches/{batch_id}/cancel")

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -13,6 +13,7 @@ from src.services.ui_authorization import build_batch_create_session_capabilitie
 class FakeAuthorizationDB:
     def __init__(self) -> None:
         now = datetime.now(tz=UTC)
+        self.queries: list[tuple[str, tuple[object, ...]]] = []
         self.organizations = {
             "org-1": {
                 "organization_id": "org-1",
@@ -89,6 +90,7 @@ class FakeAuthorizationDB:
         self.batch_items = [
             {
                 "item_id": "item-1",
+                "batch_id": "batch-1",
                 "line_number": 1,
                 "custom_id": "req-1",
                 "status": "completed",
@@ -96,17 +98,39 @@ class FakeAuthorizationDB:
                 "provider_cost": 0.1,
                 "billed_cost": 0.125,
                 "last_error": None,
-                "request_body": {},
-                "response_body": {},
+                "request_body": {"model": "gpt-4o-mini", "input": "large prompt"},
+                "response_body": {"object": "embedding", "data": [{"embedding": [0.1]}]},
                 "error_body": None,
-                "usage": {},
+                "usage": {"prompt_tokens": 3, "total_tokens": 3},
                 "created_at": now,
                 "started_at": now,
                 "completed_at": now,
             },
         ]
+        for index in range(2, 5):
+            self.batch_items.append(
+                {
+                    "item_id": f"item-{index}",
+                    "batch_id": "batch-1",
+                    "line_number": index,
+                    "custom_id": f"req-{index}",
+                    "status": "pending",
+                    "attempts": 0,
+                    "provider_cost": 0.0,
+                    "billed_cost": 0.0,
+                    "last_error": None,
+                    "request_body": {"model": "gpt-4o-mini", "input": f"prompt-{index}"},
+                    "response_body": None,
+                    "error_body": None,
+                    "usage": None,
+                    "created_at": now,
+                    "started_at": None,
+                    "completed_at": None,
+                }
+            )
 
     async def query_raw(self, query: str, *params):
+        self.queries.append((query, params))
         if "COUNT(*) AS total FROM deltallm_teamtable" in query:
             return [{"total": 1}]
         if "FROM deltallm_teamtable t" in query and "SELECT" in query:
@@ -121,6 +145,16 @@ class FakeAuthorizationDB:
             return [{"total": 1}]
         if "COUNT(*) FILTER (WHERE status IN ('in_progress', 'finalizing')) AS in_progress" in query:
             return [{"total": 1, "queued": 0, "in_progress": 1, "completed": 0, "failed": 0, "cancelled": 0}]
+        if "FROM deltallm_batch_job" in query and "WHERE batch_id = $1" in query and "LEFT JOIN" not in query:
+            row = self.batches.get(str(params[0]))
+            if not row:
+                return []
+            return [{
+                "batch_id": row["batch_id"],
+                "status": row["status"],
+                "created_by_team_id": row["created_by_team_id"],
+                "created_by_organization_id": row["created_by_organization_id"],
+            }]
         if "FROM deltallm_batch_job j" in query and "LEFT JOIN deltallm_teamtable t" in query:
             if "WHERE j.batch_id = $1" in query:
                 row = self.batches.get(str(params[0]))
@@ -137,6 +171,44 @@ class FakeAuthorizationDB:
         if "SELECT COUNT(*) AS total FROM deltallm_batch_item" in query:
             return [{"total": len(self.batch_items)}]
         if "FROM deltallm_batch_item" in query:
+            if "WHERE batch_id = $1 AND item_id = $2" in query:
+                batch_id = str(params[0])
+                item_id = str(params[1])
+                return [
+                    item
+                    for item in self.batch_items
+                    if item.get("item_id") == item_id and self.batches.get(batch_id)
+                ]
+            if "request_body IS NOT NULL AS has_request_body" in query:
+                if "line_number > $2" in query:
+                    after_line_number = int(params[1])
+                    limit = int(params[2])
+                    page_items = [
+                        item
+                        for item in self.batch_items
+                        if int(item["line_number"]) > after_line_number
+                    ][:limit]
+                else:
+                    limit = int(params[1])
+                    offset = int(params[2])
+                    page_items = self.batch_items[offset : offset + limit]
+                return [
+                    {
+                        "item_id": item["item_id"],
+                        "line_number": item["line_number"],
+                        "custom_id": item["custom_id"],
+                        "status": item["status"],
+                        "attempts": item["attempts"],
+                        "provider_cost": item["provider_cost"],
+                        "billed_cost": item["billed_cost"],
+                        "last_error": item["last_error"],
+                        "has_request_body": item.get("request_body") is not None,
+                        "has_response_body": item.get("response_body") is not None,
+                        "has_error_body": item.get("error_body") is not None,
+                        "has_usage": item.get("usage") is not None,
+                    }
+                    for item in page_items
+                ]
             return list(self.batch_items)
         return []
 
@@ -410,6 +482,150 @@ async def test_list_batches_exposes_repair_capabilities_for_updating_scope(clien
         "requeue_stale": True,
         "mark_failed": True,
     }
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_returns_skinny_paginated_items(client, test_app, monkeypatch):
+    fake_db = FakeAuthorizationDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.batches.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=False,
+            org_ids=[],
+            team_ids=["team-1"],
+            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ}},
+        ),
+    )
+
+    response = await client.get(
+        "/ui/api/batches/batch-1?items_limit=1&items_offset=0",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"]["pagination"] == {
+        "total": 4,
+        "limit": 1,
+        "offset": 0,
+        "has_more": True,
+        "after_line_number": None,
+        "next_after_line_number": 1,
+    }
+    item = payload["items"]["data"][0]
+    assert item["item_id"] == "item-1"
+    assert item["has_request_body"] is True
+    assert item["has_response_body"] is True
+    assert item["has_error_body"] is False
+    assert item["has_usage"] is True
+    assert "request_body" not in item
+    assert "response_body" not in item
+    assert "error_body" not in item
+    assert "usage" not in item
+    assert "metadata" not in payload
+    assert "total_billed_cost" not in payload
+    assert "total_provider_cost" not in payload
+    assert not any("COUNT(*) AS total FROM deltallm_batch_item" in query for query, _ in fake_db.queries)
+    assert not any("SUM(provider_cost)" in query for query, _ in fake_db.queries)
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_supports_cursor_item_pagination(client, test_app, monkeypatch):
+    fake_db = FakeAuthorizationDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.batches.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=False,
+            org_ids=[],
+            team_ids=["team-1"],
+            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ}},
+        ),
+    )
+
+    response = await client.get(
+        "/ui/api/batches/batch-1?items_limit=1&items_offset=1&after_line_number=1",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"]["data"][0]["item_id"] == "item-2"
+    assert payload["items"]["pagination"] == {
+        "total": 4,
+        "limit": 1,
+        "offset": 1,
+        "has_more": True,
+        "after_line_number": 1,
+        "next_after_line_number": 2,
+    }
+    assert any("line_number > $2" in query for query, _ in fake_db.queries)
+    assert not any("OFFSET $3" in query for query, _ in fake_db.queries)
+
+
+@pytest.mark.asyncio
+async def test_get_batch_costs_returns_totals_on_demand(client, test_app, monkeypatch):
+    fake_db = FakeAuthorizationDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.batches.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=False,
+            org_ids=[],
+            team_ids=["team-1"],
+            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ}},
+        ),
+    )
+
+    response = await client.get(
+        "/ui/api/batches/batch-1/costs",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "batch_id": "batch-1",
+        "total_provider_cost": 0.2,
+        "total_billed_cost": 0.25,
+    }
+    assert any("SUM(provider_cost)" in query for query, _ in fake_db.queries)
+
+
+@pytest.mark.asyncio
+async def test_get_batch_item_returns_payload_on_demand(client, test_app, monkeypatch):
+    fake_db = FakeAuthorizationDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.batches.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=False,
+            org_ids=[],
+            team_ids=["team-1"],
+            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ}},
+        ),
+    )
+
+    response = await client.get(
+        "/ui/api/batches/batch-1/items/item-1",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["batch_id"] == "batch-1"
+    assert payload["item_id"] == "item-1"
+    assert payload["request_body"] == {"model": "gpt-4o-mini", "input": "large prompt"}
+    assert payload["response_body"] == {"object": "embedding", "data": [{"embedding": [0.1]}]}
+    assert payload["usage"] == {"prompt_tokens": 3, "total_tokens": 3}
 
 
 @pytest.mark.asyncio

--- a/ui/src/components/DataTable.tsx
+++ b/ui/src/components/DataTable.tsx
@@ -17,6 +17,8 @@ interface DataTableProps<T> {
   onRowClick?: (row: T) => void;
   pagination?: Pagination;
   onPageChange?: (offset: number) => void;
+  onPreviousPage?: () => void;
+  onNextPage?: () => void;
 }
 
 export default function DataTable<T extends Record<string, any>>({
@@ -27,6 +29,8 @@ export default function DataTable<T extends Record<string, any>>({
   onRowClick,
   pagination,
   onPageChange,
+  onPreviousPage,
+  onNextPage,
 }: DataTableProps<T>) {
   if (loading) {
     return (
@@ -40,6 +44,9 @@ export default function DataTable<T extends Record<string, any>>({
 
   const currentPage = pagination ? Math.floor(pagination.offset / pagination.limit) + 1 : 1;
   const totalPages = pagination ? Math.ceil(pagination.total / pagination.limit) : 1;
+  const canPage = Boolean(onPageChange || (onPreviousPage && onNextPage));
+  const goPrevious = onPreviousPage ?? (() => onPageChange?.(Math.max(0, (pagination?.offset || 0) - (pagination?.limit || 0))));
+  const goNext = onNextPage ?? (() => onPageChange?.((pagination?.offset || 0) + (pagination?.limit || 0)));
 
   return (
     <div>
@@ -88,7 +95,7 @@ export default function DataTable<T extends Record<string, any>>({
           </tbody>
         </table>
       </div>
-      {pagination && pagination.total > 0 && onPageChange && (
+      {pagination && pagination.total > 0 && canPage && (
         <div className="flex items-center justify-between px-4 py-3 border-t border-gray-100">
           <span className="text-xs text-gray-500">
             Showing {pagination.offset + 1}–{Math.min(pagination.offset + pagination.limit, pagination.total)} of {pagination.total}
@@ -96,7 +103,7 @@ export default function DataTable<T extends Record<string, any>>({
           {totalPages > 1 && (
             <div className="flex items-center gap-1">
               <button
-                onClick={() => onPageChange(Math.max(0, pagination.offset - pagination.limit))}
+                onClick={goPrevious}
                 disabled={pagination.offset === 0}
                 className="p-1.5 rounded-lg hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed"
               >
@@ -106,7 +113,7 @@ export default function DataTable<T extends Record<string, any>>({
                 Page {currentPage} of {totalPages}
               </span>
               <button
-                onClick={() => onPageChange(pagination.offset + pagination.limit)}
+                onClick={goNext}
                 disabled={!pagination.has_more}
                 className="p-1.5 rounded-lg hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed"
               >

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -73,6 +73,8 @@ export interface Pagination {
   limit: number;
   offset: number;
   has_more: boolean;
+  after_line_number?: number | null;
+  next_after_line_number?: number | null;
 }
 
 export interface Paginated<T> {
@@ -387,6 +389,12 @@ export interface BatchJobSummary {
   cancelled: number;
 }
 
+export interface BatchJobCosts {
+  batch_id: string;
+  total_provider_cost: number;
+  total_billed_cost: number;
+}
+
 export interface BatchJobItem {
   item_id: string;
   line_number: number;
@@ -396,10 +404,18 @@ export interface BatchJobItem {
   provider_cost?: number | null;
   billed_cost?: number | null;
   last_error?: string | null;
+  has_request_body?: boolean;
+  has_response_body?: boolean;
+  has_error_body?: boolean;
+  has_usage?: boolean;
   request_body?: Record<string, unknown> | null;
   response_body?: Record<string, unknown> | null;
   error_body?: Record<string, unknown> | null;
   usage?: Record<string, unknown> | null;
+}
+
+export interface BatchJobItemDetail extends BatchJobItem {
+  batch_id: string;
   created_at?: string | null;
   started_at?: string | null;
   completed_at?: string | null;
@@ -417,8 +433,8 @@ export interface BatchJobDetail {
   failed_items: number;
   cancelled_items: number;
   in_progress_items: number;
-  total_provider_cost: number;
-  total_billed_cost: number;
+  total_provider_cost?: number | null;
+  total_billed_cost?: number | null;
   created_by_api_key?: string | null;
   created_by_team_id?: string | null;
   team_alias?: string | null;
@@ -1132,8 +1148,12 @@ export const batches = {
   list: (params?: { search?: string; status?: string; limit?: number; offset?: number }) =>
     apiFetch<Paginated<BatchJobListItem>>(withQuery('/ui/api/batches', params as any)),
   summary: () => apiFetch<BatchJobSummary>('/ui/api/batches/summary'),
-  get: (batchId: string, params?: { items_limit?: number; items_offset?: number }) =>
+  get: (batchId: string, params?: { items_limit?: number; items_offset?: number; after_line_number?: number | null }) =>
     apiFetch<BatchJobDetail>(withQuery(`/ui/api/batches/${encodeURIComponent(batchId)}`, params as any)),
+  costs: (batchId: string) =>
+    apiFetch<BatchJobCosts>(`/ui/api/batches/${encodeURIComponent(batchId)}/costs`),
+  getItem: (batchId: string, itemId: string) =>
+    apiFetch<BatchJobItemDetail>(`/ui/api/batches/${encodeURIComponent(batchId)}/items/${encodeURIComponent(itemId)}`),
   cancel: (batchId: string) => apiFetch<{ batch_id: string; status: string }>(`/ui/api/batches/${encodeURIComponent(batchId)}/cancel`, { method: 'POST' }),
 };
 

--- a/ui/src/pages/BatchJobDetail.tsx
+++ b/ui/src/pages/BatchJobDetail.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useApi } from '../lib/hooks';
-import { batches, type BatchJobDetail, type BatchJobItem } from '../lib/api';
+import { batches, type BatchJobCosts, type BatchJobDetail, type BatchJobItem, type BatchJobItemDetail } from '../lib/api';
 import Card from '../components/Card';
 import DataTable from '../components/DataTable';
 import { RecordDetailShell } from '../components/admin/shells';
-import { ArrowLeft, XCircle, Clock, DollarSign, Hash, ChevronDown, ChevronUp } from 'lucide-react';
+import { ArrowLeft, XCircle, Clock, DollarSign, Hash, ChevronDown, ChevronUp, RefreshCw } from 'lucide-react';
 import clsx from 'clsx';
 
 const STATUS_COLORS: Record<string, string> = {
@@ -32,6 +32,8 @@ const STATUS_LABELS: Record<string, string> = {
   pending: 'Pending',
 };
 
+const ITEMS_PAGE_SIZE = 50;
+
 function StatusBadge({ status }: { status: string }) {
   return (
     <span className={clsx('inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium', STATUS_COLORS[status] || 'bg-gray-100 text-gray-600')}>
@@ -56,6 +58,15 @@ function formatDuration(start: string | null | undefined, end: string | null | u
   if (mins < 60) return `${mins}m ${secs % 60}s`;
   const hrs = Math.floor(mins / 60);
   return `${hrs}h ${mins % 60}m`;
+}
+
+function formatCost(value: number | null | undefined, loading: boolean): string {
+  if (typeof value === 'number') return `$${value.toFixed(6)}`;
+  return loading ? 'Loading...' : '--';
+}
+
+function itemDetailKey(batchId: string, itemId: string): string {
+  return `${batchId}:${itemId}`;
 }
 
 function ProgressRing({ total, completed, failed, inProgress, cancelled }: {
@@ -125,16 +136,41 @@ function ProgressRing({ total, completed, failed, inProgress, cancelled }: {
 export default function BatchJobDetail() {
   const { batchId } = useParams<{ batchId: string }>();
   const navigate = useNavigate();
-  const [itemsOffset, setItemsOffset] = useState(0);
+  const activeBatchIdRef = useRef(batchId);
+  const [itemsPage, setItemsPage] = useState<{ offset: number; afterLineNumber: number | null }>({ offset: 0, afterLineNumber: null });
+  const [itemPageCursors, setItemPageCursors] = useState<Array<number | null>>([null]);
   const [expandedItem, setExpandedItem] = useState<string | null>(null);
+  const [itemDetails, setItemDetails] = useState<Record<string, BatchJobItemDetail>>({});
+  const [itemDetailLoading, setItemDetailLoading] = useState<Record<string, boolean>>({});
+  const [itemDetailErrors, setItemDetailErrors] = useState<Record<string, string>>({});
+  const [costs, setCosts] = useState<BatchJobCosts | null>(null);
+  const [costsLoading, setCostsLoading] = useState(false);
+  const [costsError, setCostsError] = useState<string | null>(null);
   const [cancelling, setCancelling] = useState(false);
 
   const { data: job, loading, refetch } = useApi<BatchJobDetail | null>(
-    () => batches.get(batchId!, { items_limit: 50, items_offset: itemsOffset }),
-    [batchId, itemsOffset],
+    () => batches.get(batchId!, {
+      items_limit: ITEMS_PAGE_SIZE,
+      items_offset: itemsPage.offset,
+      after_line_number: itemsPage.afterLineNumber,
+    }),
+    [batchId, itemsPage.offset, itemsPage.afterLineNumber],
   );
 
-  if (loading || !job) {
+  useEffect(() => {
+    activeBatchIdRef.current = batchId;
+    setItemsPage({ offset: 0, afterLineNumber: null });
+    setItemPageCursors([null]);
+    setExpandedItem(null);
+    setItemDetails({});
+    setItemDetailLoading({});
+    setItemDetailErrors({});
+    setCosts(null);
+    setCostsLoading(false);
+    setCostsError(null);
+  }, [batchId]);
+
+  if (!job || job.batch_id !== batchId) {
     return (
       <div className="flex items-center justify-center py-24">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
@@ -155,6 +191,77 @@ export default function BatchJobDetail() {
     } finally {
       setCancelling(false);
     }
+  }
+
+  async function handleExpandItem(itemId: string) {
+    if (!batchId) return;
+    const detailKey = itemDetailKey(batchId, itemId);
+    if (expandedItem === itemId) {
+      setExpandedItem(null);
+      return;
+    }
+    setExpandedItem(itemId);
+    if (itemDetails[detailKey] || itemDetailLoading[detailKey]) return;
+
+    setItemDetailErrors((current) => {
+      const next = { ...current };
+      delete next[detailKey];
+      return next;
+    });
+    setItemDetailLoading((current) => ({ ...current, [detailKey]: true }));
+    try {
+      const detail = await batches.getItem(batchId, itemId);
+      if (activeBatchIdRef.current !== batchId) return;
+      setItemDetails((current) => ({ ...current, [detailKey]: detail }));
+    } catch (e: any) {
+      if (activeBatchIdRef.current !== batchId) return;
+      setItemDetailErrors((current) => ({
+        ...current,
+        [detailKey]: e?.message || 'Failed to load item payload',
+      }));
+    } finally {
+      if (activeBatchIdRef.current !== batchId) return;
+      setItemDetailLoading((current) => ({ ...current, [detailKey]: false }));
+    }
+  }
+
+  async function handleLoadCosts() {
+    if (!batchId || costsLoading) return;
+    setCostsLoading(true);
+    setCostsError(null);
+    try {
+      const result = await batches.costs(batchId);
+      if (activeBatchIdRef.current !== batchId) return;
+      setCosts(result);
+    } catch (e: any) {
+      if (activeBatchIdRef.current !== batchId) return;
+      setCostsError(e?.message || 'Failed to load costs');
+    } finally {
+      if (activeBatchIdRef.current !== batchId) return;
+      setCostsLoading(false);
+    }
+  }
+
+  function handleItemsNextPage() {
+    const nextAfterLineNumber = itemsPagination?.next_after_line_number;
+    if (nextAfterLineNumber == null) return;
+    const nextOffset = itemsPage.offset + ITEMS_PAGE_SIZE;
+    const nextIndex = Math.floor(nextOffset / ITEMS_PAGE_SIZE);
+    setExpandedItem(null);
+    setItemPageCursors((current) => {
+      const next = current.slice(0, nextIndex + 1);
+      next[nextIndex] = nextAfterLineNumber;
+      return next;
+    });
+    setItemsPage({ offset: nextOffset, afterLineNumber: nextAfterLineNumber });
+  }
+
+  function handleItemsPreviousPage() {
+    const previousOffset = Math.max(0, itemsPage.offset - ITEMS_PAGE_SIZE);
+    const previousIndex = Math.floor(previousOffset / ITEMS_PAGE_SIZE);
+    const previousAfterLineNumber = itemPageCursors[previousIndex] ?? null;
+    setExpandedItem(null);
+    setItemsPage({ offset: previousOffset, afterLineNumber: previousAfterLineNumber });
   }
 
   const itemsData = job.items?.data || [];
@@ -198,14 +305,19 @@ export default function BatchJobDetail() {
       header: '',
       render: (row: BatchJobItem) => (
         <button
-          onClick={(e) => { e.stopPropagation(); setExpandedItem(expandedItem === row.item_id ? null : row.item_id); }}
+          onClick={(e) => { e.stopPropagation(); handleExpandItem(row.item_id); }}
           className="p-1 hover:bg-gray-100 rounded"
+          title="View item payload"
         >
           {expandedItem === row.item_id ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
         </button>
       ),
     },
   ];
+
+  const expandedRow = expandedItem ? itemsData.find((item: BatchJobItem) => item.item_id === expandedItem) : null;
+  const expandedDetailKey = batchId && expandedItem ? itemDetailKey(batchId, expandedItem) : null;
+  const expandedDetail = expandedDetailKey ? itemDetails[expandedDetailKey] : null;
 
   return (
     <RecordDetailShell
@@ -271,7 +383,19 @@ export default function BatchJobDetail() {
 
         <Card>
           <div className="p-5 space-y-4">
-            <h3 className="text-sm font-semibold text-gray-900 mb-4">Timing & Cost</h3>
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold text-gray-900">Timing & Cost</h3>
+              {!costs && (
+                <button
+                  onClick={handleLoadCosts}
+                  disabled={costsLoading}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-gray-50 px-2.5 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:opacity-50"
+                >
+                  <RefreshCw className={clsx('h-3.5 w-3.5', costsLoading && 'animate-spin')} />
+                  {costsError ? 'Retry' : 'Load costs'}
+                </button>
+              )}
+            </div>
             <div className="space-y-3">
               <div className="flex items-center gap-3">
                 <div className="p-2 bg-blue-50 rounded-lg">
@@ -288,7 +412,7 @@ export default function BatchJobDetail() {
                 </div>
                 <div>
                   <p className="text-xs text-gray-500">Billed Cost</p>
-                  <p className="text-sm font-semibold text-gray-900">${(job.total_billed_cost || 0).toFixed(6)}</p>
+                  <p className="text-sm font-semibold text-gray-900">{formatCost(costs?.total_billed_cost ?? job.total_billed_cost, costsLoading)}</p>
                 </div>
               </div>
               <div className="flex items-center gap-3">
@@ -297,9 +421,10 @@ export default function BatchJobDetail() {
                 </div>
                 <div>
                   <p className="text-xs text-gray-500">Provider Cost</p>
-                  <p className="text-sm font-semibold text-gray-900">${(job.total_provider_cost || 0).toFixed(6)}</p>
+                  <p className="text-sm font-semibold text-gray-900">{formatCost(costs?.total_provider_cost ?? job.total_provider_cost, costsLoading)}</p>
                 </div>
               </div>
+              {costsError && <p className="text-xs text-red-600">{costsError}</p>}
             </div>
             <div className="pt-3 border-t border-gray-100 space-y-1.5 text-xs text-gray-500">
               <div className="flex justify-between">
@@ -333,19 +458,60 @@ export default function BatchJobDetail() {
         <DataTable
           columns={itemColumns}
           data={itemsData}
+          loading={loading}
           emptyMessage="No items found"
           pagination={itemsPagination}
-          onPageChange={setItemsOffset}
+          onPreviousPage={handleItemsPreviousPage}
+          onNextPage={handleItemsNextPage}
         />
-        {expandedItem && itemsData.find((item: any) => item.item_id === expandedItem) && (
-          <ExpandedItemView item={itemsData.find((item: any) => item.item_id === expandedItem)!} />
+        {expandedItem && expandedRow && (
+          <ExpandedItemView
+            item={expandedDetail || expandedRow}
+            loading={Boolean(expandedDetailKey && itemDetailLoading[expandedDetailKey])}
+            error={expandedDetailKey ? itemDetailErrors[expandedDetailKey] : undefined}
+          />
         )}
       </Card>
     </RecordDetailShell>
   );
 }
 
-function ExpandedItemView({ item }: { item: any }) {
+function ExpandedItemView({
+  item,
+  loading,
+  error,
+}: {
+  item: BatchJobItem | BatchJobItemDetail;
+  loading?: boolean;
+  error?: string | null;
+}) {
+  if (loading) {
+    return (
+      <div className="border-t border-gray-100 bg-gray-50 p-4">
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-blue-600" />
+          Loading item payload...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="border-t border-gray-100 bg-red-50 p-4 text-sm text-red-700">
+        {error}
+      </div>
+    );
+  }
+
+  if (!item.request_body && !item.response_body && !item.error_body && !item.usage) {
+    return (
+      <div className="border-t border-gray-100 bg-gray-50 p-4 text-sm text-gray-500">
+        No item payload available.
+      </div>
+    );
+  }
+
   return (
     <div className="border-t border-gray-100 bg-gray-50 p-4 space-y-3">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
## What changed

- Slimmed the batch detail response to job summary fields plus paginated item metadata.
- Moved large item request/response/error/usage bodies behind an on-demand item endpoint.
- Moved batch cost aggregation behind an explicit "Load costs" action.
- Added cursor pagination for batch item rows using `after_line_number`.
- Added tests for the skinny payload, cursor pagination, on-demand item payloads, and on-demand costs.

## Why

Large batches were slow to open because the detail page fetched per-item JSON bodies and full item aggregates during initial render. The page now loads useful metadata first and defers heavier data until the user asks for it.

## Validation

- `uv run pytest tests/test_ui_authorization.py -q`
- `uv run ruff check src/api/admin/endpoints/batches.py tests/test_ui_authorization.py`
- `npm run build`
