### PR TITLE
Fix Bedrock sampling parameter intent

### DIFF
--- a/src/batch/chat_worker_execution.py
+++ b/src/batch/chat_worker_execution.py
@@ -35,6 +35,7 @@ from src.metrics import (
     set_batch_worker_saturation,
 )
 from src.models.errors import InvalidRequestError, ServiceUnavailableError
+from src.models.request_serialization import dump_request_for_preflight
 from src.models.requests import ChatCompletionRequest, MCPToolDefinition
 from src.providers.resolution import resolve_provider
 from src.router.health_policy import affects_deployment_health
@@ -65,7 +66,7 @@ class ChatWorkerExecutionMixin:
             app=self.app,
             job=job,
             payload=chat_request,
-            request_data=chat_request.model_dump(exclude_none=True),
+            request_data=dump_request_for_preflight(chat_request),
             call_type="completion",
         )
         chat_request = preflight.payload

--- a/src/batch/request_validation.py
+++ b/src/batch/request_validation.py
@@ -14,6 +14,7 @@ from src.batch.endpoints import (
     SUPPORTED_BATCH_ENDPOINT_SET,
     supported_batch_endpoints_display,
 )
+from src.models.request_serialization import dump_request_for_preflight
 from src.models.requests import ChatCompletionRequest, EmbeddingRequest, MCPToolDefinition
 from src.models.responses import UserAPIKeyAuth
 from src.services.callable_target_grants import CallableTargetGrantService
@@ -106,7 +107,9 @@ def _validate_batch_request_body(
         if endpoint == BATCH_ENDPOINT_CHAT_COMPLETIONS:
             validated = ChatCompletionRequest.model_validate(body)
             _validate_batch_chat_request(validated, line_number=line_number)
-            return validated.model_dump(exclude_none=True), validated.model
+            request_body = dump_request_for_preflight(validated)
+            request_body.setdefault("stream", False)
+            return request_body, validated.model
     except ValidationError as exc:
         message = exc.errors()[0].get("msg") if exc.errors() else str(exc)
         raise HTTPException(

--- a/src/chat/preflight.py
+++ b/src/chat/preflight.py
@@ -8,6 +8,7 @@ from fastapi import Request
 from src.callbacks import CallbackManager
 from src.chat.audit import emit_prompt_resolution_audit_event
 from src.models.errors import InvalidRequestError
+from src.models.request_serialization import dump_request_for_preflight
 from src.models.requests import ChatCompletionRequest
 from src.routers.routing_decision import set_prompt_provenance
 from src.services.model_visibility import ensure_model_allowed, get_callable_target_policy_mode_from_app
@@ -35,7 +36,7 @@ async def run_text_preflight(
 
     guardrail_middleware = request.app.state.guardrail_middleware
     callback_manager: CallbackManager = getattr(request.app.state, "callback_manager", CallbackManager())
-    data = request_data or payload.model_dump(exclude_none=True)
+    data = dict(request_data) if request_data is not None else dump_request_for_preflight(payload)
     metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
     explicit_prompt_ref = parse_prompt_reference(metadata.get("prompt_ref")) if isinstance(metadata, dict) else None
     prompt_variables: dict[str, Any] = {}

--- a/src/models/request_serialization.py
+++ b/src/models/request_serialization.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def dump_request_for_preflight(payload: BaseModel) -> dict[str, Any]:
+    """Serialize request data without losing explicit nulls or adding defaults."""
+    return payload.model_dump(mode="python", exclude_unset=True)

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -17,6 +17,30 @@ from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 
 
+def provider_http_error_message(provider_error: httpx.HTTPStatusError, *, fallback: str) -> str:
+    response = provider_error.response
+    try:
+        payload = response.json()
+    except (AttributeError, ValueError):
+        payload = None
+
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            message = str(error.get("message") or "").strip()
+            if message:
+                return message
+        for key in ("message", "Message"):
+            message = str(payload.get(key) or "").strip()
+            if message:
+                return message
+
+    body = str(getattr(response, "text", "") or "").strip()
+    if body:
+        return body
+    return fallback
+
+
 def map_standard_provider_error(
     provider_error: Exception,
     *,

--- a/src/providers/bedrock.py
+++ b/src/providers/bedrock.py
@@ -9,7 +9,7 @@ import httpx
 from src.models.errors import InvalidRequestError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.base import ProviderAdapter, map_standard_provider_error, provider_http_error_message
 from src.providers.healthcheck import is_provider_healthy
 
 
@@ -46,9 +46,10 @@ class BedrockAdapter(ProviderAdapter):
         inference_config: dict[str, Any] = {}
         if canonical_request.max_tokens is not None:
             inference_config["maxTokens"] = canonical_request.max_tokens
-        if canonical_request.temperature is not None:
+        fields_set = getattr(canonical_request, "model_fields_set", set())
+        if "temperature" in fields_set and canonical_request.temperature is not None:
             inference_config["temperature"] = canonical_request.temperature
-        if canonical_request.top_p is not None:
+        if "top_p" in fields_set and canonical_request.top_p is not None:
             inference_config["topP"] = canonical_request.top_p
         if canonical_request.stop:
             inference_config["stopSequences"] = canonical_request.stop if isinstance(canonical_request.stop, list) else [canonical_request.stop]
@@ -105,10 +106,15 @@ class BedrockAdapter(ProviderAdapter):
 
     def map_error(self, provider_error: Exception) -> Exception:
         status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
+        invalid_request_message = (
+            provider_http_error_message(provider_error, fallback=f"Provider rejected request: {status}")
+            if isinstance(provider_error, httpx.HTTPStatusError)
+            else f"Provider rejected request: {status}"
+        )
         return map_standard_provider_error(
             provider_error,
-            invalid_request_message=f"Provider rejected request: {status}",
-            rate_limit_message=f"Provider rate limited request: {status}",
+            invalid_request_message=invalid_request_message,
+            rate_limit_message=invalid_request_message if status == 429 else f"Provider rate limited request: {status}",
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:

--- a/src/routers/completions.py
+++ b/src/routers/completions.py
@@ -18,11 +18,9 @@ router = APIRouter(prefix="/v1", tags=["completions"])
 @router.post("/completions", dependencies=[Depends(require_api_key), Depends(enforce_rate_limits)])
 async def completions(request: Request, payload: CompletionsRequest):
     canonical = completions_to_chat_request(payload)
-    request_data = canonical.model_dump(exclude_none=True)
     return await handle_chat_like_request(
         request,
         canonical,
-        request_data=request_data,
         response_transform=chat_response_to_completions_response,
         stream_line_transform=stream_chat_to_completions_line,
         stream_response_object="text_completion",

--- a/src/routers/responses.py
+++ b/src/routers/responses.py
@@ -18,11 +18,9 @@ router = APIRouter(prefix="/v1", tags=["responses"])
 @router.post("/responses", dependencies=[Depends(require_api_key), Depends(enforce_rate_limits)])
 async def responses(request: Request, payload: ResponsesRequest):
     canonical = responses_to_chat_request(payload)
-    request_data = canonical.model_dump(exclude_none=True)
     return await handle_chat_like_request(
         request,
         canonical,
-        request_data=request_data,
         response_transform=chat_response_to_responses_response,
         stream_line_transform=stream_chat_to_responses_line,
         stream_response_object="response.output_text.delta",

--- a/src/routers/text_adapters.py
+++ b/src/routers/text_adapters.py
@@ -7,6 +7,13 @@ from src.models.errors import InvalidRequestError
 from src.models.requests import ChatCompletionRequest, CompletionsRequest, ResponsesRequest
 
 
+def _copy_explicit_fields(source: CompletionsRequest | ResponsesRequest, target: dict[str, Any], field_map: dict[str, str]) -> None:
+    fields_set = getattr(source, "model_fields_set", set())
+    for source_field, target_field in field_map.items():
+        if source_field in fields_set:
+            target[target_field] = getattr(source, source_field)
+
+
 def completions_to_chat_request(payload: CompletionsRequest) -> ChatCompletionRequest:
     if payload.echo:
         raise InvalidRequestError(message="`echo=true` is not supported on this gateway")
@@ -22,20 +29,27 @@ def completions_to_chat_request(payload: CompletionsRequest) -> ChatCompletionRe
     else:
         prompt_text = payload.prompt
 
-    return ChatCompletionRequest(
-        model=payload.model,
-        messages=[{"role": "user", "content": prompt_text}],
-        temperature=payload.temperature,
-        max_tokens=payload.max_tokens,
-        top_p=payload.top_p,
-        n=payload.n,
-        stream=payload.stream,
-        stop=payload.stop,
-        presence_penalty=payload.presence_penalty,
-        frequency_penalty=payload.frequency_penalty,
-        user=payload.user,
-        metadata=payload.metadata,
+    data: dict[str, Any] = {
+        "model": payload.model,
+        "messages": [{"role": "user", "content": prompt_text}],
+    }
+    _copy_explicit_fields(
+        payload,
+        data,
+        {
+            "temperature": "temperature",
+            "max_tokens": "max_tokens",
+            "top_p": "top_p",
+            "n": "n",
+            "stream": "stream",
+            "stop": "stop",
+            "presence_penalty": "presence_penalty",
+            "frequency_penalty": "frequency_penalty",
+            "user": "user",
+            "metadata": "metadata",
+        },
     )
+    return ChatCompletionRequest.model_validate(data)
 
 
 def responses_to_chat_request(payload: ResponsesRequest) -> ChatCompletionRequest:
@@ -67,18 +81,25 @@ def responses_to_chat_request(payload: ResponsesRequest) -> ChatCompletionReques
     if not messages:
         raise InvalidRequestError(message="Responses `input` could not be translated into chat messages")
 
-    return ChatCompletionRequest(
-        model=payload.model,
-        messages=messages,
-        temperature=payload.temperature,
-        max_tokens=payload.max_output_tokens,
-        top_p=payload.top_p,
-        stream=payload.stream,
-        tools=payload.tools,
-        tool_choice=payload.tool_choice,
-        user=payload.user,
-        metadata=payload.metadata,
+    data: dict[str, Any] = {
+        "model": payload.model,
+        "messages": messages,
+    }
+    _copy_explicit_fields(
+        payload,
+        data,
+        {
+            "temperature": "temperature",
+            "max_output_tokens": "max_tokens",
+            "top_p": "top_p",
+            "stream": "stream",
+            "tools": "tools",
+            "tool_choice": "tool_choice",
+            "user": "user",
+            "metadata": "metadata",
+        },
     )
+    return ChatCompletionRequest.model_validate(data)
 
 
 def chat_response_to_completions_response(chat_payload: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1197,3 +1197,76 @@ async def test_chat_completion_uses_bedrock_sigv4_headers(client, test_app):
     response = await client.post("/v1/chat/completions", headers=headers, json=body)
     assert response.status_code == 200
     assert response.json()["choices"][0]["message"]["content"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_bedrock_omits_implicit_sampling_defaults(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = "bedrock"
+    deployment.deltallm_params["model"] = "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"
+    deployment.deltallm_params["region"] = "us-east-1"
+    deployment.deltallm_params["aws_access_key_id"] = "AKIDEXAMPLE"
+    deployment.deltallm_params["aws_secret_access_key"] = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+    captured: dict[str, object] = {}
+
+    async def post(url, headers, json=None, content=None, timeout=0):  # noqa: ANN001, ANN201
+        del url, headers, json, timeout
+        assert content is not None
+        captured["payload"] = jsonlib.loads(content.decode("utf-8"))
+        payload = {
+            "requestId": "req_123",
+            "output": {"message": {"content": [{"text": "ok"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
+        }
+        return httpx.Response(200, json=payload)
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False},
+    )
+
+    assert response.status_code == 200
+    assert "inferenceConfig" not in captured["payload"]
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_bedrock_preserves_explicit_null_sampling_params(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = "bedrock"
+    deployment.deltallm_params["model"] = "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"
+    deployment.deltallm_params["region"] = "us-east-1"
+    deployment.deltallm_params["aws_access_key_id"] = "AKIDEXAMPLE"
+    deployment.deltallm_params["aws_secret_access_key"] = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+    captured: dict[str, object] = {}
+
+    async def post(url, headers, json=None, content=None, timeout=0):  # noqa: ANN001, ANN201
+        del url, headers, json, timeout
+        assert content is not None
+        captured["payload"] = jsonlib.loads(content.decode("utf-8"))
+        payload = {
+            "requestId": "req_123",
+            "output": {"message": {"content": [{"text": "ok"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
+        }
+        return httpx.Response(200, json=payload)
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+            "top_p": None,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "inferenceConfig" not in captured["payload"]

--- a/tests/test_provider_compat.py
+++ b/tests/test_provider_compat.py
@@ -379,3 +379,58 @@ async def test_bedrock_adapter_translate_request_and_response() -> None:
         assert payload["usage"]["total_tokens"] == 6
     finally:
         await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_adapter_only_sends_explicit_sampling_params() -> None:
+    adapter = BedrockAdapter(httpx.AsyncClient())
+    try:
+        base = {
+            "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "messages": [{"role": "user", "content": "Say hi"}],
+        }
+
+        omitted = await adapter.translate_request(ChatCompletionRequest.model_validate(base), {})
+        assert "inferenceConfig" not in omitted
+
+        temperature = await adapter.translate_request(
+            ChatCompletionRequest.model_validate({**base, "temperature": 0.7}),
+            {},
+        )
+        assert temperature["inferenceConfig"] == {"temperature": 0.7}
+
+        top_p = await adapter.translate_request(
+            ChatCompletionRequest.model_validate({**base, "top_p": 0.8}),
+            {},
+        )
+        assert top_p["inferenceConfig"] == {"topP": 0.8}
+
+        top_p_null = await adapter.translate_request(
+            ChatCompletionRequest.model_validate({**base, "top_p": None}),
+            {},
+        )
+        assert "inferenceConfig" not in top_p_null
+
+        both_explicit = await adapter.translate_request(
+            ChatCompletionRequest.model_validate({**base, "temperature": 0.5, "top_p": 0.8}),
+            {},
+        )
+        assert both_explicit["inferenceConfig"] == {"temperature": 0.5, "topP": 0.8}
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_adapter_surfaces_provider_error_message() -> None:
+    adapter = BedrockAdapter(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            400,
+            json={"message": "`temperature` and `top_p` cannot both be specified"},
+            request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/model/claude/converse"),
+        )
+        exc = httpx.HTTPStatusError("bad request", request=response.request, response=response)
+        mapped = adapter.map_error(exc)
+        assert str(mapped) == "`temperature` and `top_p` cannot both be specified"
+    finally:
+        await adapter.http_client.aclose()


### PR DESCRIPTION
## Summary

Fixes #224.

This PR preserves caller intent for chat request generation parameters so explicit `null` values are not stripped before callbacks, guardrails, or provider translation. It also updates the native Bedrock adapter so implicit Pydantic defaults for `temperature` and `top_p` are not forwarded as Bedrock `inferenceConfig` sampling parameters.

## Root Cause

`ChatCompletionRequest.temperature` and `top_p` default to `1.0`, but preflight serialized requests with `exclude_none=True` and then revalidated that stripped dict. A request such as `"top_p": null` lost the explicit null and revalidated back to `top_p=1.0`, causing Bedrock to receive both `temperature` and `topP` for models that reject that combination.

## Changes

- Add a shared preflight serializer that preserves explicit nulls while avoiding unset defaults.
- Use caller intent through `model_fields_set` when translating Bedrock sampling params.
- Preserve explicit field intent through `/v1/completions`, `/v1/responses`, and chat batch preflight paths.
- Surface Bedrock provider validation messages instead of collapsing them to only the HTTP status.
- Add regression coverage for omitted sampling defaults, explicit `top_p: null`, and Bedrock error messages.

## Validation

- `uv run prisma generate --schema=./prisma/schema.prisma`
- `uv run --extra dev pytest tests/test_provider_compat.py tests/test_chat.py tests/test_text_endpoints.py tests/test_batch_worker.py -q`
- `uv run --extra dev ruff check src tests`
- `uv run --extra dev pytest -q`

Full suite result: `1829 passed, 77 skipped`.