### PR TITLE
Add Railway deployment template support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,77 @@
+# Git and local metadata
+.git/
+.github/
+.codex/
+.claude/
+.agents/
+.worktree/
+.worktrees/
+worktrees/
+
+# Local environment and secret-bearing config
+.env
+.env.*
+!.env.example
+config.yaml
+config/config.yaml
+config/*.local.yaml
+
+# Python environments and caches
+.venv/
+venv/
+env/
+ENV/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.pyre/
+.pytype/
+.cache/
+.coverage
+.coverage.*
+htmlcov/
+cover/
+*.egg-info/
+build/
+dist/
+
+# Node dependencies and generated frontend output
+node_modules/
+ui/node_modules/
+ui/dist/
+admin-dashboard/dist/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.npm/
+.yarn/
+
+# Documentation builds and local generated artifacts
+site/
+docs/_build/
+docs/internal/
+artifacts/
+logs/
+*.log
+tmp/
+temp/
+
+# Local database and generated engine files
+*.db
+*.sqlite
+*.sqlite3
+*.rdb
+prisma-query-engine-*
+
+# OS and editor files
+.DS_Store
+.AppleDouble
+.LSOverride
+Thumbs.db
+Desktop.ini
+*.code-workspace
+.idea/
+.vscode/

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -256,3 +256,60 @@ jobs:
           fi
           git commit -m "Publish Helm chart ${CHART_VERSION}"
           git push origin gh-pages
+
+  railway-template:
+    runs-on: ubuntu-latest
+    needs: [docker, helm-repo]
+    env:
+      RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+      RAILWAY_TEMPLATE_ID: ${{ vars.RAILWAY_TEMPLATE_ID }}
+      RAILWAY_TEMPLATE_WORKSPACE: ${{ vars.RAILWAY_TEMPLATE_WORKSPACE }}
+      RAILWAY_TEMPLATE_DEMO_PROJECT: ${{ vars.RAILWAY_TEMPLATE_DEMO_PROJECT }}
+      RAILWAY_TEMPLATE_README: deploy/railway/template.md
+
+    steps:
+      - name: Check Railway template publishing config
+        id: railway-template-config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${RAILWAY_API_TOKEN}" || -z "${RAILWAY_TEMPLATE_ID}" ]]; then
+            echo "::notice::Skipping Railway template publish. Configure secrets.RAILWAY_API_TOKEN and vars.RAILWAY_TEMPLATE_ID to enable it."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check out repository
+        if: steps.railway-template-config.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        if: steps.railway-template-config.outputs.enabled == 'true'
+        run: npm install -g @railway/cli
+
+      - name: Publish Railway template metadata
+        if: steps.railway-template-config.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          args=(
+            templates publish "${RAILWAY_TEMPLATE_ID}"
+            --category "AI/ML"
+            --description "Deploy DeltaLLM with managed PostgreSQL and Redis on Railway."
+            --readme-file "${RAILWAY_TEMPLATE_README}"
+            --json
+          )
+
+          if [[ -n "${RAILWAY_TEMPLATE_WORKSPACE}" ]]; then
+            args+=(--workspace "${RAILWAY_TEMPLATE_WORKSPACE}")
+          fi
+
+          if [[ -n "${RAILWAY_TEMPLATE_DEMO_PROJECT}" ]]; then
+            args+=(--demo-project "${RAILWAY_TEMPLATE_DEMO_PROJECT}")
+          fi
+
+          railway "${args[@]}"

--- a/deploy/railway/Dockerfile
+++ b/deploy/railway/Dockerfile
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1.7
+
+# Railway rejects portable BuildKit cache mounts unless their IDs use a
+# Railway-specific cache-key prefix, so this file mirrors the root Dockerfile
+# without the npm cache mount. Keep runtime behavior in sync with Dockerfile.
+
+# The UI output is static, so keep this stage on the native builder platform.
+FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend
+
+WORKDIR /app/ui
+
+COPY ui/package.json ui/package-lock.json* ./
+ENV NPM_CONFIG_AUDIT=false \
+    NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_FACTOR=2 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
+    NPM_CONFIG_FETCH_TIMEOUT=600000 \
+    NPM_CONFIG_FUND=false
+RUN if [ -f package-lock.json ]; then npm ci --prefer-offline; else npm install --prefer-offline; fi
+
+COPY ui/ ./
+RUN npm run build
+
+FROM python:3.11-slim AS builder
+
+WORKDIR /app
+ARG INSTALL_PRESIDIO=false
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libpq-dev curl libatomic1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --user -r requirements.txt
+
+RUN if [ "$INSTALL_PRESIDIO" = "true" ]; then \
+      pip install --no-cache-dir --user presidio-analyzer presidio-anonymizer; \
+    fi
+
+# `pip install --user` drops console scripts (like `prisma`) into /root/.local/bin,
+# which is not on PATH by default during the build stage.
+ENV PATH=/root/.local/bin:$PATH
+
+COPY pyproject.toml ./
+COPY src ./src
+COPY prisma ./prisma
+RUN prisma generate --schema=./prisma/schema.prisma
+RUN prisma py fetch
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq5 curl libatomic1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /root/.local /root/.local
+COPY --from=builder /root/.cache/prisma-python /root/.cache/prisma-python
+COPY --from=builder /app /app
+COPY --from=frontend /app/ui/dist ./ui/dist
+COPY config.example.yaml ./config.example.yaml
+
+ENV PATH=/root/.local/bin:$PATH
+ENV PYTHONUNBUFFERED=1
+ENV DELTALLM_CONFIG_PATH=/app/config/config.yaml
+ENV HOST=0.0.0.0
+ENV PORT=4000
+
+EXPOSE 4000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+  CMD curl -fsS "http://localhost:${PORT}/health/liveliness" || exit 1
+
+CMD ["sh", "-c", "python -m src.prisma_bootstrap --schema ./prisma/schema.prisma --max-attempts 30 --sleep-seconds 2 && exec uvicorn src.main:app --host ${HOST} --port ${PORT}"]

--- a/deploy/railway/template.md
+++ b/deploy/railway/template.md
@@ -1,0 +1,33 @@
+# Deploy DeltaLLM on Railway
+
+DeltaLLM is a self-hosted AI gateway with an OpenAI-compatible API, model routing, virtual API keys, spend tracking, guardrails, and an Admin UI.
+
+This Railway template provisions:
+
+- a `deltallm` web service
+- managed PostgreSQL
+- managed Redis
+- public HTTP networking for the Admin UI and gateway API
+- a `/health/readiness` healthcheck
+
+## Required Variables
+
+Set these when deploying the template:
+
+| Variable | Purpose |
+|----------|---------|
+| `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` | Initial Admin UI login email |
+| `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD` | Initial Admin UI password |
+
+The template generates `DELTALLM_MASTER_KEY` and `DELTALLM_SALT_KEY` per deployment. `OPENAI_API_KEY` is optional; when provided, the starter `gpt-4o-mini` deployment can be used immediately.
+
+## After Deployment
+
+1. Wait for the `deltallm` service healthcheck to pass.
+2. Open the generated Railway domain.
+3. Log in with `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` and `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD`.
+4. Add provider credentials and model deployments in the Admin UI if you did not set `OPENAI_API_KEY`.
+
+Read the full deployment guide in the DeltaLLM docs:
+
+https://deltallm.readthedocs.io/en/latest/deployment/railway/

--- a/deploy/railway/template.md
+++ b/deploy/railway/template.md
@@ -16,10 +16,11 @@ Set these when deploying the template:
 
 | Variable | Purpose |
 |----------|---------|
+| `DELTALLM_MASTER_KEY` | Initial gateway credential for API calls |
 | `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` | Initial Admin UI login email |
 | `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD` | Initial Admin UI password |
 
-The template generates `DELTALLM_MASTER_KEY` and `DELTALLM_SALT_KEY` per deployment. `OPENAI_API_KEY` is optional; when provided, the starter `gpt-4o-mini` deployment can be used immediately.
+`DELTALLM_MASTER_KEY` must be at least 32 characters and include letters and digits. The template generates `DELTALLM_SALT_KEY` per deployment. `OPENAI_API_KEY` is optional; when provided, the starter `gpt-4o-mini` deployment can be used immediately.
 
 ## After Deployment
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -103,4 +103,4 @@ docker compose pull
 docker compose up -d --build
 ```
 
-The application container runs the shared database bootstrap script on startup before launching the API. It prefers `prisma migrate deploy` and falls back to `prisma db push` for legacy or unbaselined databases.
+The application container runs the shared database bootstrap script on startup before launching the API. The bootstrap runs strict `prisma migrate deploy` with database-connectivity retries; it does not run `prisma db push`.

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -6,6 +6,7 @@ Use this section when you are moving from local evaluation to a repeatable envir
 
 | Path | Best for | Start here |
 |------|----------|------------|
+| Railway | Managed one-click evaluation stack with hosted PostgreSQL and Redis | [Railway](railway.md) |
 | Docker Compose | Single instance, demos, small teams, simple self-hosting | [Docker](docker.md) |
 | Kubernetes | Multi-instance production, autoscaling, managed infrastructure | [Kubernetes](kubernetes.md) |
 | Batch production setup | Async embedding/chat workloads with dedicated workers and shared storage | [Batch API & Production Setup](../features/batching.md#recommended-production-setup) |
@@ -13,11 +14,12 @@ Use this section when you are moving from local evaluation to a repeatable envir
 
 ## Quick Path to Success
 
-1. Choose Docker if you want the fastest production-style setup
-2. Choose Kubernetes if you need replicas, ingress, and cluster-native operations
-3. Generate a valid `DELTALLM_MASTER_KEY` and `DELTALLM_SALT_KEY`
-4. Keep secrets in environment variables, not in `config.yaml`
-5. Verify `/health/liveliness` and `/health/readiness` after startup
+1. Choose Railway if you want the fastest managed evaluation deployment
+2. Choose Docker if you want a production-style setup on your own host
+3. Choose Kubernetes if you need replicas, ingress, and cluster-native operations
+4. Generate a valid `DELTALLM_MASTER_KEY` and `DELTALLM_SALT_KEY`
+5. Keep secrets in environment variables, not in `config.yaml`
+6. Verify `/health/liveliness` and `/health/readiness` after startup
 
 ## Shared Requirements
 
@@ -54,6 +56,7 @@ The application runs Prisma schema setup automatically during container startup.
 ## Next Steps
 
 - [Docker deployment guide](docker.md)
+- [Railway deployment guide](railway.md)
 - [Kubernetes deployment guide](kubernetes.md)
 - [Upstream HTTP tuning](upstream-http.md)
 - [Observability](../features/observability.md)

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -65,7 +65,7 @@ DELTALLM_CONFIG_PATH=/app/config.example.yaml
 DATABASE_URL=${{Postgres.DATABASE_URL}}
 REDIS_URL=${{Redis.REDIS_URL}}
 DELTALLM_REDIS_URL=${{Redis.REDIS_URL}}
-DELTALLM_MASTER_KEY=sk-${{secret(32)}}A1
+DELTALLM_MASTER_KEY=<user input, 32+ characters with letters and digits>
 DELTALLM_SALT_KEY=${{secret(64)}}
 PLATFORM_BOOTSTRAP_ADMIN_EMAIL=<user input>
 PLATFORM_BOOTSTRAP_ADMIN_PASSWORD=<user input, 12+ characters>
@@ -74,7 +74,7 @@ OPENAI_API_KEY=<optional user input>
 
 Variable notes:
 
-- `DELTALLM_MASTER_KEY` must be at least 32 characters and include letters and digits. The `sk-${{secret(32)}}A1` shape satisfies the validator while keeping the value generated per deployment.
+- `DELTALLM_MASTER_KEY` must be supplied by the deployer, must be at least 32 characters, and must include letters and digits. This is the initial gateway credential for API calls.
 - `DELTALLM_SALT_KEY` must be unique and must not be `change-me`.
 - `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` and `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD` create the initial browser-login admin account.
 - Use an initial admin password with at least 12 characters so the first-login password-change flow can complete cleanly.
@@ -134,7 +134,7 @@ The bootstrap account may require a password change before you can use the rest 
 If `OPENAI_API_KEY` was supplied, verify the starter model:
 
 ```bash
-export DELTALLM_MASTER_KEY="<copy from the deltallm service variables>"
+export DELTALLM_MASTER_KEY="<the value you entered during template deploy>"
 curl "$APP_URL/v1/models" \
   -H "Authorization: Bearer $DELTALLM_MASTER_KEY"
 ```

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -10,6 +10,14 @@ The durable deployment artifact is a Railway Template. After the template is pub
 
 Do not merge a README button with a placeholder URL.
 
+Railway's deploy button uses the published template code:
+
+```html
+<a href="https://railway.com/deploy/<template-code>?utm_medium=integration&utm_source=template&utm_campaign=deltallm">
+  <img src="https://railway.com/button.svg" alt="Deploy on Railway" height="40">
+</a>
+```
+
 ## Template Services
 
 Create the template with three services:
@@ -169,3 +177,27 @@ After the app is running:
 5. Re-run `/v1/models` and a chat completion check.
 
 For production-oriented deployments with dedicated batch workers, shared artifact storage, custom domains, and stricter operational controls, create a separate template rather than extending this evaluation template.
+
+## Release Automation
+
+The release workflow can publish or update the Railway template marketplace metadata after a GitHub Release is published.
+
+Configure these repository settings before enabling the README deploy button:
+
+| Setting | Type | Required | Notes |
+|---------|------|----------|-------|
+| `RAILWAY_API_TOKEN` | GitHub Actions secret | Yes | Railway account or workspace token with template publishing access |
+| `RAILWAY_TEMPLATE_ID` | GitHub Actions variable | Yes | Stable template ID returned by the initial Railway template creation |
+| `RAILWAY_TEMPLATE_WORKSPACE` | GitHub Actions variable | Optional | Workspace ID or name, useful when the token can access multiple workspaces |
+| `RAILWAY_TEMPLATE_DEMO_PROJECT` | GitHub Actions variable | Optional | Public demo project ID to show on the template page |
+
+The release workflow intentionally updates an existing reviewed template. It does not create a fresh template from a live smoke-test project on every release because that can accidentally copy test-only variables, source settings, or one-off infrastructure state.
+
+Before the first automated publish:
+
+1. Create the Railway template from a clean project whose `deltallm` service is connected to the public GitHub repository.
+2. Confirm the template has the service graph and variables documented above.
+3. Store the returned template ID in `RAILWAY_TEMPLATE_ID`.
+4. Add `RAILWAY_API_TOKEN` as a GitHub Actions secret.
+5. Run the next release workflow.
+6. Copy the published template URL into the README button.

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -1,0 +1,171 @@
+# Railway Deployment
+
+Use Railway when you want a managed evaluation deployment with DeltaLLM, PostgreSQL, and Redis created from one template.
+
+The durable deployment artifact is a Railway Template. After the template is published, the repository README should link to the published template URL with Railway's deploy button.
+
+```md
+[![Deploy on Railway](https://railway.com/button.svg)](<RAILWAY_TEMPLATE_URL>)
+```
+
+Do not merge a README button with a placeholder URL.
+
+## Template Services
+
+Create the template with three services:
+
+| Service | Source | Notes |
+|---------|--------|-------|
+| `deltallm` | GitHub repo or published `deltallm/deltallm:<release>` image | Uses `deploy/railway/Dockerfile`, public HTTP networking, and `/health/readiness` |
+| `Postgres` | Railway PostgreSQL service | Referenced by the app through `DATABASE_URL` |
+| `Redis` | Railway Redis service | Referenced by the app through `REDIS_URL` and `DELTALLM_REDIS_URL` |
+
+Prefer the GitHub repo source for the first template so Railway can track template updates from the repository. Pin a released branch or tag when publishing a stable template.
+
+## App Service Settings
+
+The repository includes `railway.toml` with the app service defaults:
+
+```toml
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "deploy/railway/Dockerfile"
+
+[deploy]
+healthcheckPath = "/health/readiness"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10
+```
+
+Do not hard-code `PORT`. Railway provides `PORT` at runtime, and `deploy/railway/Dockerfile` starts `uvicorn` with that value.
+
+The Docker image default config path is intended for Docker Compose bind mounts. Railway must set:
+
+```env
+DELTALLM_CONFIG_PATH=/app/config.example.yaml
+```
+
+`config.example.yaml` is included in the image and is safe for a first-run Railway deployment because its secrets are environment-backed.
+
+## Template Variables
+
+Configure these variables on the `deltallm` service:
+
+```env
+DELTALLM_CONFIG_PATH=/app/config.example.yaml
+DATABASE_URL=${{Postgres.DATABASE_URL}}
+REDIS_URL=${{Redis.REDIS_URL}}
+DELTALLM_REDIS_URL=${{Redis.REDIS_URL}}
+DELTALLM_MASTER_KEY=sk-${{secret(32)}}A1
+DELTALLM_SALT_KEY=${{secret(64)}}
+PLATFORM_BOOTSTRAP_ADMIN_EMAIL=<user input>
+PLATFORM_BOOTSTRAP_ADMIN_PASSWORD=<user input, 12+ characters>
+OPENAI_API_KEY=<optional user input>
+```
+
+Variable notes:
+
+- `DELTALLM_MASTER_KEY` must be at least 32 characters and include letters and digits. The `sk-${{secret(32)}}A1` shape satisfies the validator while keeping the value generated per deployment.
+- `DELTALLM_SALT_KEY` must be unique and must not be `change-me`.
+- `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` and `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD` create the initial browser-login admin account.
+- Use an initial admin password with at least 12 characters so the first-login password-change flow can complete cleanly.
+- `OPENAI_API_KEY` is optional. Supplying it makes the starter `gpt-4o-mini` deployment usable immediately.
+
+## First Deploy
+
+1. Open the published Railway Template URL.
+2. Review the `deltallm`, `Postgres`, and `Redis` services.
+3. Fill in the required admin variables.
+4. Optionally set `OPENAI_API_KEY`.
+5. Deploy the template.
+6. Wait for the `deltallm` service healthcheck to pass.
+7. Open the generated public domain for the `deltallm` service.
+
+The first boot runs Prisma migrations before starting the API:
+
+```bash
+python -m src.prisma_bootstrap --schema ./prisma/schema.prisma --max-attempts 30 --sleep-seconds 2
+```
+
+The bootstrap retries database connectivity and then runs strict `prisma migrate deploy`.
+
+## Post-Deploy Checks
+
+Set `APP_URL` to the public Railway domain:
+
+```bash
+export APP_URL="https://your-deltallm-service.up.railway.app"
+```
+
+Check readiness:
+
+```bash
+curl "$APP_URL/health/readiness"
+```
+
+Expected response:
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "redis": true,
+    "database": true
+  }
+}
+```
+
+Log in to the Admin UI at `APP_URL` with:
+
+- `PLATFORM_BOOTSTRAP_ADMIN_EMAIL`
+- `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD`
+
+The bootstrap account may require a password change before you can use the rest of the Admin UI.
+
+If `OPENAI_API_KEY` was supplied, verify the starter model:
+
+```bash
+export DELTALLM_MASTER_KEY="<copy from the deltallm service variables>"
+curl "$APP_URL/v1/models" \
+  -H "Authorization: Bearer $DELTALLM_MASTER_KEY"
+```
+
+Send a chat request:
+
+```bash
+curl "$APP_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $DELTALLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [
+      {"role": "user", "content": "Hello from Railway"}
+    ]
+  }'
+```
+
+If `OPENAI_API_KEY` was omitted, the app should still boot. Use the Admin UI to add a provider credential and update or create model deployments before sending gateway requests.
+
+## Redeploy Behavior
+
+Redeploys are designed to be idempotent:
+
+- Prisma runs `migrate deploy`, so already-applied migrations are skipped.
+- PostgreSQL data persists in the Railway PostgreSQL service.
+- Redis state is external to the app service.
+- Model bootstrap inserts the `config.example.yaml` model list only when the model deployment table is empty.
+
+If a redeploy fails at migration time, inspect the `deltallm` deploy logs first. Do not use `prisma db push` against a Railway database; resolve migration history and rerun the deployment.
+
+## Adding Providers And Models
+
+After the app is running:
+
+1. Open the Admin UI.
+2. Go to the model deployment area.
+3. Add or update provider credentials.
+4. Create model deployments or update the starter `gpt-4o-mini` deployment.
+5. Re-run `/v1/models` and a chat completion check.
+
+For production-oriented deployments with dedicated batch workers, shared artifact storage, custom domains, and stricter operational controls, create a separate template rather than extending this evaluation template.

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -53,10 +53,10 @@ INSTALL_PRESIDIO=true docker compose --profile single up -d --build
 
 Run the command from the repository root so Compose can read the project `.env` file automatically.
 
-On startup, the DeltaLLM container applies the Prisma schema with:
+On startup, the DeltaLLM container applies migrations with:
 
 ```bash
-prisma db push --schema=./prisma/schema.prisma --accept-data-loss
+prisma migrate deploy --schema=./prisma/schema.prisma
 ```
 
 Then it starts the API server.
@@ -80,7 +80,7 @@ Run two DeltaLLM instances behind an Nginx load balancer:
 docker compose --profile ha up -d --build
 ```
 
-Each DeltaLLM container applies the Prisma schema with `prisma db push --schema=./prisma/schema.prisma --accept-data-loss` before starting the API.
+Each DeltaLLM container runs `prisma migrate deploy --schema=./prisma/schema.prisma` before starting the API.
 
 This starts:
 - 2 DeltaLLM instances (load balanced)
@@ -184,7 +184,7 @@ To build an image with the full Presidio engine:
 docker build --build-arg INSTALL_PRESIDIO=true -t deltallm .
 ```
 
-The image runs `prisma db push --schema=./prisma/schema.prisma --accept-data-loss` before starting `uvicorn`, so the target database must be reachable when the container starts.
+The image runs `prisma migrate deploy --schema=./prisma/schema.prisma` before starting `uvicorn`, so the target database must be reachable when the container starts.
 
 ## Health Check
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - Health & Metrics: api/health.md
   - Deployment:
       - deployment/index.md
+      - Railway: deployment/railway.md
       - Docker: deployment/docker.md
       - Governance Rollout: deployment/governance.md
       - Kubernetes: deployment/kubernetes.md

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "deploy/railway/Dockerfile"
+
+[deploy]
+healthcheckPath = "/health/readiness"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary

Closes #207.

Adds the repo-side support needed for a Railway one-click deployment template:

- adds root `railway.toml` with Dockerfile builder settings, `/health/readiness` healthcheck, and restart policy
- adds a Railway-specific Dockerfile at `deploy/railway/Dockerfile` so Railway avoids its cache-mount ID restriction without changing the self-hosted root `Dockerfile`
- adds `.dockerignore` to keep Railway/Docker build contexts clean and avoid local secrets or generated artifacts
- adds `docs/deployment/railway.md` and wires it into the deployment docs nav
- corrects Docker docs to describe strict `prisma migrate deploy` startup behavior instead of the stale `prisma db push` wording

## Validation

- `git diff --check`
- `uv run --with mkdocs --with mkdocs-material --with pymdown-extensions mkdocs build`
  - passes with pre-existing internal-doc nav/missing-link warnings
- Live Railway smoke test against project `deltallm-issue-207-railway-test`
  - deployment `90085de2-91b9-4c5f-8e84-b5303514231d`
  - Railway manifest confirmed `dockerfilePath: deploy/railway/Dockerfile`
  - `/health/readiness` returned `200` with Redis and database checks green

## Notes

The shared root `Dockerfile` is intentionally unchanged so existing Docker/self-hosted users keep the current BuildKit cache mount behavior. The Railway-specific Dockerfile mirrors runtime behavior but removes the npm cache mount that Railway rejects unless the mount ID embeds the service-specific cache key prefix.