### PR TITLE
Finalize Railway template publishing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Last Commit](https://img.shields.io/github/last-commit/deltawi/deltallm.svg)](https://github.com/deltawi/deltallm/commits/main)
 [![Stars](https://img.shields.io/github/stars/deltawi/deltallm.svg?style=social)](https://github.com/deltawi/deltallm/stargazers)
 
-
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/deltallm?utm_medium=integration&utm_source=template&utm_campaign=deltallm)
 
 ## What is DeltaLLM?
 

--- a/deploy/railway/template.md
+++ b/deploy/railway/template.md
@@ -1,4 +1,6 @@
-# Deploy DeltaLLM on Railway
+# Deploy and Host DeltaLLM on Railway
+
+## About Hosting
 
 DeltaLLM is a self-hosted AI gateway with an OpenAI-compatible API, model routing, virtual API keys, spend tracking, guardrails, and an Admin UI.
 
@@ -10,7 +12,24 @@ This Railway template provisions:
 - public HTTP networking for the Admin UI and gateway API
 - a `/health/readiness` healthcheck
 
-## Required Variables
+## Why Deploy
+
+Use this template when you want a managed DeltaLLM evaluation deployment without operating your own database, Redis instance, or container host. Railway provisions the app and backing services together, wires internal service URLs through reference variables, and keeps PostgreSQL and Redis data on managed volumes.
+
+## Common Use Cases
+
+- Evaluate DeltaLLM with the Admin UI and OpenAI-compatible API.
+- Route requests through virtual API keys and model deployments.
+- Test spend tracking, guardrails, and provider credential management.
+- Run a small managed gateway before moving to a production Kubernetes or dedicated-worker deployment.
+
+## Dependencies for DeltaLLM Hosting
+
+### Deployment Dependencies
+
+This template deploys the public `deltallm/deltallm:latest` image with managed PostgreSQL and Redis services.
+
+PostgreSQL and Redis variables are preconfigured with Railway's standard defaults. Change them only if you intentionally want custom database or cache settings.
 
 Set these when deploying the template:
 
@@ -20,14 +39,14 @@ Set these when deploying the template:
 | `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` | Initial Admin UI login email |
 | `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD` | Initial Admin UI password |
 
-`DELTALLM_MASTER_KEY` must be at least 32 characters and include letters and digits. The template generates `DELTALLM_SALT_KEY` per deployment. `OPENAI_API_KEY` is optional; when provided, the starter `gpt-4o-mini` deployment can be used immediately.
+`DELTALLM_MASTER_KEY` must be at least 32 characters and include letters and digits. The template generates `DELTALLM_SALT_KEY` per deployment and sets `DELTALLM_CONFIG_PATH=/app/config.example.yaml` so DeltaLLM loads the bundled Railway-safe config file.
 
 ## After Deployment
 
 1. Wait for the `deltallm` service healthcheck to pass.
 2. Open the generated Railway domain.
 3. Log in with `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` and `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD`.
-4. Add provider credentials and model deployments in the Admin UI if you did not set `OPENAI_API_KEY`.
+4. Add provider credentials and model deployments in the Admin UI.
 
 Read the full deployment guide in the DeltaLLM docs:
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -2,18 +2,16 @@
 
 Use Railway when you want a managed evaluation deployment with DeltaLLM, PostgreSQL, and Redis created from one template.
 
-The durable deployment artifact is a Railway Template. After the template is published, the repository README should link to the published template URL with Railway's deploy button.
+The durable deployment artifact is a Railway Template. The repository README links to the published template URL with Railway's deploy button.
 
 ```md
-[![Deploy on Railway](https://railway.com/button.svg)](<RAILWAY_TEMPLATE_URL>)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/deltallm?utm_medium=integration&utm_source=template&utm_campaign=deltallm)
 ```
-
-Do not merge a README button with a placeholder URL.
 
 Railway's deploy button uses the published template code:
 
 ```html
-<a href="https://railway.com/deploy/<template-code>?utm_medium=integration&utm_source=template&utm_campaign=deltallm">
+<a href="https://railway.com/deploy/deltallm?utm_medium=integration&utm_source=template&utm_campaign=deltallm">
   <img src="https://railway.com/button.svg" alt="Deploy on Railway" height="40">
 </a>
 ```
@@ -24,11 +22,11 @@ Create the template with three services:
 
 | Service | Source | Notes |
 |---------|--------|-------|
-| `deltallm` | GitHub repo or published `deltallm/deltallm:<release>` image | Uses `deploy/railway/Dockerfile`, public HTTP networking, and `/health/readiness` |
+| `deltallm` | GitHub repo or published `deltallm/deltallm:<release>` image | Uses public HTTP networking and `/health/readiness` |
 | `Postgres` | Railway PostgreSQL service | Referenced by the app through `DATABASE_URL` |
 | `Redis` | Railway Redis service | Referenced by the app through `REDIS_URL` and `DELTALLM_REDIS_URL` |
 
-Prefer the GitHub repo source for the first template so Railway can track template updates from the repository. Pin a released branch or tag when publishing a stable template.
+Use the published Docker image for a fully CLI-driven template setup. Use a GitHub repo source only when Railway's GitHub integration can fetch the repository; otherwise `templates create` can reject the source during generation.
 
 ## App Service Settings
 
@@ -48,17 +46,19 @@ restartPolicyMaxRetries = 10
 
 Do not hard-code `PORT`. Railway provides `PORT` at runtime, and `deploy/railway/Dockerfile` starts `uvicorn` with that value.
 
-The Docker image default config path is intended for Docker Compose bind mounts. Railway must set:
+`DELTALLM_CONFIG_PATH` tells DeltaLLM which YAML config file to load at startup. The Docker image default is intended for Docker Compose bind mounts. Railway sets:
 
 ```env
 DELTALLM_CONFIG_PATH=/app/config.example.yaml
 ```
 
-`config.example.yaml` is included in the image and is safe for a first-run Railway deployment because its secrets are environment-backed.
+`/app/config.example.yaml` is included in the image and is safe for a first-run Railway deployment because secrets and service URLs come from Railway environment variables.
 
 ## Template Variables
 
-Configure these variables on the `deltallm` service:
+The template preconfigures the PostgreSQL and Redis service variables with Railway's standard defaults. Users should only change those database/cache variables when they intentionally want custom ports, usernames, database names, or connection behavior.
+
+Configure or review these variables on the `deltallm` service:
 
 ```env
 DELTALLM_CONFIG_PATH=/app/config.example.yaml
@@ -69,7 +69,6 @@ DELTALLM_MASTER_KEY=<user input, 32+ characters with letters and digits>
 DELTALLM_SALT_KEY=${{secret(64)}}
 PLATFORM_BOOTSTRAP_ADMIN_EMAIL=<user input>
 PLATFORM_BOOTSTRAP_ADMIN_PASSWORD=<user input, 12+ characters>
-OPENAI_API_KEY=<optional user input>
 ```
 
 Variable notes:
@@ -77,18 +76,18 @@ Variable notes:
 - `DELTALLM_MASTER_KEY` must be supplied by the deployer, must be at least 32 characters, and must include letters and digits. This is the initial gateway credential for API calls.
 - `DELTALLM_SALT_KEY` must be unique and must not be `change-me`.
 - `PLATFORM_BOOTSTRAP_ADMIN_EMAIL` and `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD` create the initial browser-login admin account.
+- `DELTALLM_CONFIG_PATH` should stay `/app/config.example.yaml` on Railway unless you build a custom image with a different bundled config file.
 - Use an initial admin password with at least 12 characters so the first-login password-change flow can complete cleanly.
-- `OPENAI_API_KEY` is optional. Supplying it makes the starter `gpt-4o-mini` deployment usable immediately.
+- Do not include `OPENAI_API_KEY` as a blank template variable unless you want Railway to require it during every template deploy. Add provider credentials through the Admin UI after deployment, or add `OPENAI_API_KEY` to the service variables later if you want the starter `gpt-4o-mini` deployment to be usable immediately.
 
 ## First Deploy
 
 1. Open the published Railway Template URL.
 2. Review the `deltallm`, `Postgres`, and `Redis` services.
-3. Fill in the required admin variables.
-4. Optionally set `OPENAI_API_KEY`.
-5. Deploy the template.
-6. Wait for the `deltallm` service healthcheck to pass.
-7. Open the generated public domain for the `deltallm` service.
+3. Fill in `DELTALLM_MASTER_KEY`, `PLATFORM_BOOTSTRAP_ADMIN_EMAIL`, and `PLATFORM_BOOTSTRAP_ADMIN_PASSWORD`.
+4. Deploy the template.
+5. Wait for the `deltallm` service healthcheck to pass.
+6. Open the generated public domain for the `deltallm` service.
 
 The first boot runs Prisma migrations before starting the API:
 
@@ -131,7 +130,7 @@ Log in to the Admin UI at `APP_URL` with:
 
 The bootstrap account may require a password change before you can use the rest of the Admin UI.
 
-If `OPENAI_API_KEY` was supplied, verify the starter model:
+After adding provider credentials and model deployments, verify the gateway:
 
 ```bash
 export DELTALLM_MASTER_KEY="<the value you entered during template deploy>"
@@ -153,7 +152,7 @@ curl "$APP_URL/v1/chat/completions" \
   }'
 ```
 
-If `OPENAI_API_KEY` was omitted, the app should still boot. Use the Admin UI to add a provider credential and update or create model deployments before sending gateway requests.
+The app should boot before provider credentials are configured. Use the Admin UI to add a provider credential and update or create model deployments before sending gateway requests.
 
 ## Redeploy Behavior
 
@@ -182,12 +181,12 @@ For production-oriented deployments with dedicated batch workers, shared artifac
 
 The release workflow can publish or update the Railway template marketplace metadata after a GitHub Release is published.
 
-Configure these repository settings before enabling the README deploy button:
+Configure these repository settings so release automation can keep the published template metadata updated:
 
 | Setting | Type | Required | Notes |
 |---------|------|----------|-------|
 | `RAILWAY_API_TOKEN` | GitHub Actions secret | Yes | Railway account or workspace token with template publishing access |
-| `RAILWAY_TEMPLATE_ID` | GitHub Actions variable | Yes | Stable template ID returned by the initial Railway template creation |
+| `RAILWAY_TEMPLATE_ID` | GitHub Actions variable | Yes | `eb49f726-e90c-4a26-9e2c-b5a2ac431e0a` |
 | `RAILWAY_TEMPLATE_WORKSPACE` | GitHub Actions variable | Optional | Workspace ID or name, useful when the token can access multiple workspaces |
 | `RAILWAY_TEMPLATE_DEMO_PROJECT` | GitHub Actions variable | Optional | Public demo project ID to show on the template page |
 
@@ -195,9 +194,9 @@ The release workflow intentionally updates an existing reviewed template. It doe
 
 Before the first automated publish:
 
-1. Create the Railway template from a clean project whose `deltallm` service is connected to the public GitHub repository.
+1. Create the Railway template from a clean project whose `deltallm` service is connected to a template-compatible public source, such as `deltallm/deltallm:latest`.
 2. Confirm the template has the service graph and variables documented above.
 3. Store the returned template ID in `RAILWAY_TEMPLATE_ID`.
 4. Add `RAILWAY_API_TOKEN` as a GitHub Actions secret.
 5. Run the next release workflow.
-6. Copy the published template URL into the README button.
+6. Confirm the README button still points to `https://railway.com/deploy/deltallm`.


### PR DESCRIPTION
## Summary
- add the published Railway deploy button to the README
- update the Railway template overview to match Railway marketplace required sections
- document the final published template ID/URL and image-backed CLI template path

## Verification
- Published Railway template: https://railway.com/deploy/deltallm
- GitHub repo variables set: RAILWAY_TEMPLATE_ID, RAILWAY_TEMPLATE_WORKSPACE
- GitHub Actions secret set: RAILWAY_API_TOKEN
- git diff --check