### PR TITLE
Add batch webhook admission and atomic enqueue

### DIFF
--- a/src/api/v1/endpoints/batches.py
+++ b/src/api/v1/endpoints/batches.py
@@ -27,10 +27,16 @@ async def create_batch(request: Request, payload: dict[str, Any]):
     endpoint = str(payload.get("endpoint") or "").strip()
     completion_window = payload.get("completion_window")
     metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else None
+    webhook = payload.get("webhook")
+    webhook_configured = webhook is not None
     idempotency_key = str(request.headers.get("Idempotency-Key") or "").strip() or None
     try:
         service = _batch_service_or_404(request)
-        audit_metadata = {"route": request.url.path, "idempotency_key_present": bool(idempotency_key)}
+        audit_metadata = {
+            "route": request.url.path,
+            "idempotency_key_present": bool(idempotency_key),
+            "webhook_configured": webhook_configured,
+        }
         create_batch_result = getattr(service, "create_batch_result", None) or service.create_embeddings_batch_result
         result = await create_batch_result(
             auth=auth,
@@ -39,6 +45,7 @@ async def create_batch(request: Request, payload: dict[str, Any]):
             metadata=metadata,
             completion_window=completion_window,
             idempotency_key=idempotency_key,
+            webhook=webhook,
         )
         created = result.response
         audit_metadata.update(result.audit_metadata)
@@ -59,6 +66,7 @@ async def create_batch(request: Request, payload: dict[str, Any]):
                 "completion_window": completion_window,
                 "metadata": metadata,
                 "idempotency_key_present": bool(idempotency_key),
+                "webhook_configured": webhook_configured,
             },
             response_payload=created if isinstance(created, dict) else None,
             metadata=audit_metadata,
@@ -81,9 +89,14 @@ async def create_batch(request: Request, payload: dict[str, Any]):
                 "completion_window": completion_window,
                 "metadata": metadata,
                 "idempotency_key_present": bool(idempotency_key),
+                "webhook_configured": webhook_configured,
             },
             error=exc,
-            metadata={"route": request.url.path, "idempotency_key_present": bool(idempotency_key)},
+            metadata={
+                "route": request.url.path,
+                "idempotency_key_present": bool(idempotency_key),
+                "webhook_configured": webhook_configured,
+            },
         )
         raise
 

--- a/src/api/v1/endpoints/batches.py
+++ b/src/api/v1/endpoints/batches.py
@@ -19,6 +19,45 @@ def _batch_service_or_404(request: Request):
     return service
 
 
+def _batch_create_audit_request_payload(
+    *,
+    input_file_id: str,
+    endpoint: str,
+    completion_window: object,
+    metadata: dict[str, Any] | None,
+    idempotency_key_present: bool,
+    webhook_configured: bool,
+) -> dict[str, Any]:
+    return {
+        "input_file_id": input_file_id,
+        "endpoint": endpoint,
+        "completion_window": completion_window,
+        "metadata_present": bool(metadata),
+        "idempotency_key_present": idempotency_key_present,
+        "webhook_configured": webhook_configured,
+    }
+
+
+def _batch_audit_response_payload(batch: object) -> dict[str, Any] | None:
+    if not isinstance(batch, dict):
+        return None
+    webhook = batch.get("webhook")
+    return {
+        "id": batch.get("id"),
+        "object": batch.get("object"),
+        "endpoint": batch.get("endpoint"),
+        "status": batch.get("status"),
+        "input_file_id": batch.get("input_file_id"),
+        "output_file_id": batch.get("output_file_id"),
+        "error_file_id": batch.get("error_file_id"),
+        "request_counts": batch.get("request_counts"),
+        "metadata_present": bool(batch.get("metadata")),
+        "webhook_configured": bool(
+            isinstance(webhook, dict) and webhook.get("configured") is True
+        ),
+    }
+
+
 @router.post("/batches", dependencies=[Depends(require_api_key)])
 async def create_batch(request: Request, payload: dict[str, Any]):
     request_start = perf_counter()
@@ -30,6 +69,14 @@ async def create_batch(request: Request, payload: dict[str, Any]):
     webhook = payload.get("webhook")
     webhook_configured = webhook is not None
     idempotency_key = str(request.headers.get("Idempotency-Key") or "").strip() or None
+    audit_request_payload = _batch_create_audit_request_payload(
+        input_file_id=input_file_id,
+        endpoint=endpoint,
+        completion_window=completion_window,
+        metadata=metadata,
+        idempotency_key_present=bool(idempotency_key),
+        webhook_configured=webhook_configured,
+    )
     try:
         service = _batch_service_or_404(request)
         audit_metadata = {
@@ -60,15 +107,8 @@ async def create_batch(request: Request, payload: dict[str, Any]):
             api_key=auth.api_key,
             resource_type="batch",
             resource_id=created.get("id") if isinstance(created, dict) else None,
-            request_payload={
-                "input_file_id": input_file_id,
-                "endpoint": endpoint,
-                "completion_window": completion_window,
-                "metadata": metadata,
-                "idempotency_key_present": bool(idempotency_key),
-                "webhook_configured": webhook_configured,
-            },
-            response_payload=created if isinstance(created, dict) else None,
+            request_payload=audit_request_payload,
+            response_payload=_batch_audit_response_payload(created),
             metadata=audit_metadata,
         )
         return created
@@ -83,14 +123,7 @@ async def create_batch(request: Request, payload: dict[str, Any]):
             organization_id=getattr(auth, "organization_id", None),
             api_key=auth.api_key,
             resource_type="batch",
-            request_payload={
-                "input_file_id": input_file_id,
-                "endpoint": endpoint,
-                "completion_window": completion_window,
-                "metadata": metadata,
-                "idempotency_key_present": bool(idempotency_key),
-                "webhook_configured": webhook_configured,
-            },
+            request_payload=audit_request_payload,
             error=exc,
             metadata={
                 "route": request.url.path,
@@ -120,7 +153,7 @@ async def get_batch(request: Request, batch_id: str):
             resource_type="batch",
             resource_id=batch_id,
             request_payload={"batch_id": batch_id},
-            response_payload=batch if isinstance(batch, dict) else None,
+            response_payload=_batch_audit_response_payload(batch),
             metadata={"route": request.url.path},
         )
         return batch
@@ -202,7 +235,7 @@ async def cancel_batch(request: Request, batch_id: str):
             resource_type="batch",
             resource_id=batch_id,
             request_payload={"batch_id": batch_id},
-            response_payload=result if isinstance(result, dict) else None,
+            response_payload=_batch_audit_response_payload(result),
             metadata={"route": request.url.path},
         )
         return result

--- a/src/batch/create/promoter.py
+++ b/src/batch/create/promoter.py
@@ -366,6 +366,33 @@ class BatchCreateSessionPromoter:
                 )
 
             if existing_job is not None:
+                session_webhook = (
+                    session.webhook_config_ciphertext,
+                    session.webhook_config_fingerprint,
+                )
+                job_webhook = (
+                    existing_job.webhook_config_ciphertext,
+                    existing_job.webhook_config_fingerprint,
+                )
+                if job_webhook != session_webhook:
+                    if (
+                        job_webhook == (None, None)
+                        and session.webhook_config_ciphertext is not None
+                        and session.webhook_config_fingerprint is not None
+                    ):
+                        existing_job = await tx_repository.set_job_webhook_config_if_unset(
+                            batch_id=existing_job.batch_id,
+                            webhook_config_ciphertext=session.webhook_config_ciphertext,
+                            webhook_config_fingerprint=session.webhook_config_fingerprint,
+                        )
+                    else:
+                        existing_job = None
+                    if existing_job is None:
+                        raise BatchCreatePromotionError(
+                            f"Existing batch '{session.target_batch_id}' has inconsistent webhook configuration",
+                            code="webhook_config_mismatch",
+                            retryable=False,
+                        )
                 completed = await tx_repository.create_sessions.mark_session_completed(
                     session.session_id,
                     completed_at=datetime.now(tz=UTC),
@@ -434,6 +461,8 @@ class BatchCreateSessionPromoter:
                     "mixed_model": scheduling_summary.mixed_model,
                     "strict_model_homogeneity_enabled": self.strict_model_homogeneity_enabled,
                 },
+                webhook_config_ciphertext=session.webhook_config_ciphertext,
+                webhook_config_fingerprint=session.webhook_config_fingerprint,
                 tenant_scope_preference=self.tenant_scope_preference,
             )
             if job is None:

--- a/src/batch/create/promoter.py
+++ b/src/batch/create/promoter.py
@@ -19,7 +19,12 @@ from src.batch.create.models import (
 )
 from src.batch.scopes import batch_pending_scope_target_for_session
 from src.batch.create.staging import BatchCreateStagingBackend, staged_artifact_from_session
-from src.batch.models import BatchItemCreate, BatchJobRecord, BatchJobStatus
+from src.batch.models import (
+    BatchItemCreate,
+    BatchJobRecord,
+    BatchJobStatus,
+    BatchWebhookConfigurationConflictError,
+)
 from src.batch.scheduling import (
     ESTIMATOR_VERSION,
     MIXED_MODEL_GROUP,
@@ -201,12 +206,48 @@ class BatchCreateSessionPromoter:
                 code="completed_session_missing_batch",
                 retryable=False,
             )
+        job = await self._reconcile_existing_job_webhook(
+            repository=self.repository,
+            session=session,
+        )
         return BatchCreatePromotionResult(
             session_id=session.session_id,
             batch_id=job.batch_id,
             promoted=False,
             job=job,
         )
+
+    async def _reconcile_existing_job_webhook(
+        self,
+        *,
+        repository: BatchRepository,
+        session: BatchCreateSessionRecord,
+    ) -> BatchJobRecord:
+        try:
+            job = await repository.reconcile_job_webhook_config(
+                batch_id=session.target_batch_id,
+                webhook_config_ciphertext=session.webhook_config_ciphertext,
+                webhook_config_fingerprint=session.webhook_config_fingerprint,
+            )
+        except BatchWebhookConfigurationConflictError:
+            raise BatchCreatePromotionError(
+                f"Existing batch '{session.target_batch_id}' has inconsistent webhook configuration",
+                code="webhook_config_mismatch",
+                retryable=False,
+            ) from None
+        except Exception:
+            raise BatchCreatePromotionError(
+                f"Failed to reconcile webhook configuration for existing batch '{session.target_batch_id}'",
+                code="webhook_reconciliation_failed",
+                retryable=True,
+            ) from None
+        if job is None:
+            raise BatchCreatePromotionError(
+                f"Existing batch '{session.target_batch_id}' has inconsistent webhook configuration",
+                code="webhook_config_mismatch",
+                retryable=False,
+            )
+        return job
 
     async def _spool_staged_items(
         self,
@@ -358,6 +399,10 @@ class BatchCreateSessionPromoter:
                         code="completed_session_missing_batch",
                         retryable=False,
                     )
+                existing_job = await self._reconcile_existing_job_webhook(
+                    repository=tx_repository,
+                    session=session,
+                )
                 return BatchCreatePromotionResult(
                     session_id=session.session_id,
                     batch_id=existing_job.batch_id,
@@ -366,33 +411,10 @@ class BatchCreateSessionPromoter:
                 )
 
             if existing_job is not None:
-                session_webhook = (
-                    session.webhook_config_ciphertext,
-                    session.webhook_config_fingerprint,
+                existing_job = await self._reconcile_existing_job_webhook(
+                    repository=tx_repository,
+                    session=session,
                 )
-                job_webhook = (
-                    existing_job.webhook_config_ciphertext,
-                    existing_job.webhook_config_fingerprint,
-                )
-                if job_webhook != session_webhook:
-                    if (
-                        job_webhook == (None, None)
-                        and session.webhook_config_ciphertext is not None
-                        and session.webhook_config_fingerprint is not None
-                    ):
-                        existing_job = await tx_repository.set_job_webhook_config_if_unset(
-                            batch_id=existing_job.batch_id,
-                            webhook_config_ciphertext=session.webhook_config_ciphertext,
-                            webhook_config_fingerprint=session.webhook_config_fingerprint,
-                        )
-                    else:
-                        existing_job = None
-                    if existing_job is None:
-                        raise BatchCreatePromotionError(
-                            f"Existing batch '{session.target_batch_id}' has inconsistent webhook configuration",
-                            code="webhook_config_mismatch",
-                            retryable=False,
-                        )
                 completed = await tx_repository.create_sessions.mark_session_completed(
                     session.session_id,
                     completed_at=datetime.now(tz=UTC),

--- a/src/batch/create/service.py
+++ b/src/batch/create/service.py
@@ -28,6 +28,14 @@ from src.batch.scopes import (
     batch_pending_scope_target_for_auth,
 )
 from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorage
+from src.batch.webhooks import (
+    BatchWebhookCipher,
+    BatchWebhookCryptoError,
+    BatchWebhookRequest,
+    BatchWebhookValidationError,
+    batch_webhook_config_fingerprint,
+    parse_batch_webhook_request,
+)
 from src.models.responses import UserAPIKeyAuth
 from src.services.callable_target_grants import CallableTargetGrantService
 from src.services.model_visibility import CallableTargetPolicyMode, ensure_batch_model_allowed
@@ -40,6 +48,12 @@ logger = logging.getLogger(__name__)
 class BatchCreateSessionServiceResult:
     job: BatchJobRecord
     audit_metadata: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _ValidatedBatchWebhook:
+    config: BatchWebhookRequest
+    fingerprint: str
 
 
 class BatchCreateSessionService:
@@ -64,6 +78,10 @@ class BatchCreateSessionService:
         scheduler_shadow_enabled: bool = False,
         strict_model_homogeneity_enabled: bool = False,
         default_service_tier: str = "standard",
+        webhook_enabled: bool = False,
+        webhook_cipher: BatchWebhookCipher | None = None,
+        webhook_allow_http: bool = False,
+        webhook_allowed_ports: tuple[int, ...] | list[int] | None = (443,),
     ) -> None:
         self.repository = repository
         self.create_sessions = create_session_repository
@@ -86,6 +104,14 @@ class BatchCreateSessionService:
         self.scheduler_shadow_enabled = bool(scheduler_shadow_enabled)
         self.strict_model_homogeneity_enabled = bool(strict_model_homogeneity_enabled)
         self.default_service_tier = str(default_service_tier or "standard").strip() or "standard"
+        self.webhook_enabled = bool(webhook_enabled)
+        self.webhook_cipher = webhook_cipher
+        self.webhook_allow_http = bool(webhook_allow_http)
+        self.webhook_allowed_ports = (
+            tuple(int(port) for port in webhook_allowed_ports)
+            if webhook_allowed_ports is not None
+            else None
+        )
 
     def configure_scheduler(
         self,
@@ -109,6 +135,7 @@ class BatchCreateSessionService:
         metadata: dict[str, Any] | None,
         completion_window: str | None,
         idempotency_key: str | None = None,
+        webhook: object | None = None,
     ) -> BatchCreateSessionServiceResult:
         return await self.create_batch(
             auth=auth,
@@ -117,6 +144,7 @@ class BatchCreateSessionService:
             metadata=metadata,
             completion_window=completion_window,
             idempotency_key=idempotency_key,
+            webhook=webhook,
         )
 
     async def create_batch(
@@ -128,6 +156,7 @@ class BatchCreateSessionService:
         metadata: dict[str, Any] | None,
         completion_window: str | None,
         idempotency_key: str | None = None,
+        webhook: object | None = None,
     ) -> BatchCreateSessionServiceResult:
         endpoint = str(endpoint or "").strip()
         if endpoint not in SUPPORTED_BATCH_ENDPOINT_SET:
@@ -138,6 +167,8 @@ class BatchCreateSessionService:
         self._validate_completion_window(completion_window)
 
         normalized_metadata = self._normalize_metadata(metadata)
+        validated_webhook = self._validate_webhook(webhook)
+        webhook_fingerprint = validated_webhook.fingerprint if validated_webhook is not None else None
         idem_scope_key, idem_key = self._idempotency_pair(auth=auth, idempotency_key=idempotency_key)
 
         if idem_scope_key is not None and idem_key is not None:
@@ -152,12 +183,15 @@ class BatchCreateSessionService:
                     input_file_id=input_file_id,
                     endpoint=endpoint,
                     metadata=normalized_metadata,
+                    webhook_config_fingerprint=webhook_fingerprint,
                     resolution="existing",
                     idempotency_key_present=True,
                 )
 
         file_record = await self._load_authorized_input_file(auth=auth, input_file_id=input_file_id)
         await self._precheck_pending_batch_capacity(auth=auth)
+        webhook_ciphertext = self._encrypt_webhook(validated_webhook)
+        validated_webhook = None
 
         try:
             created_session = await self._stage_new_session(
@@ -165,6 +199,8 @@ class BatchCreateSessionService:
                 file_record=file_record,
                 endpoint=endpoint,
                 metadata=normalized_metadata,
+                webhook_config_ciphertext=webhook_ciphertext,
+                webhook_config_fingerprint=webhook_fingerprint,
                 idempotency_scope_key=idem_scope_key,
                 idempotency_key=idem_key,
             )
@@ -181,6 +217,7 @@ class BatchCreateSessionService:
                         input_file_id=input_file_id,
                         endpoint=endpoint,
                         metadata=normalized_metadata,
+                        webhook_config_fingerprint=webhook_fingerprint,
                         resolution="race_resolved",
                         idempotency_key_present=True,
                     )
@@ -199,6 +236,8 @@ class BatchCreateSessionService:
         file_record: Any,
         endpoint: str,
         metadata: dict[str, Any] | None,
+        webhook_config_ciphertext: str | None,
+        webhook_config_fingerprint: str | None,
         idempotency_scope_key: str | None,
         idempotency_key: str | None,
     ) -> BatchCreateSessionRecord:
@@ -264,6 +303,8 @@ class BatchCreateSessionService:
                 expected_item_count=expected_item_count,
                 inferred_model=inferred_model,
                 metadata=metadata,
+                webhook_config_ciphertext=webhook_config_ciphertext,
+                webhook_config_fingerprint=webhook_config_fingerprint,
                 effective_service_tier=self.default_service_tier,
                 scheduling_scope_key=self._session_scope_key(auth),
                 priority_quota_scope_key=self._session_scope_key(auth),
@@ -289,6 +330,7 @@ class BatchCreateSessionService:
         input_file_id: str,
         endpoint: str,
         metadata: dict[str, Any] | None,
+        webhook_config_fingerprint: str | None,
         resolution: str,
         idempotency_key_present: bool,
     ) -> BatchCreateSessionServiceResult:
@@ -307,6 +349,7 @@ class BatchCreateSessionService:
             input_file_id=input_file_id,
             endpoint=endpoint,
             metadata=metadata,
+            webhook_config_fingerprint=webhook_config_fingerprint,
         ):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -360,6 +403,7 @@ class BatchCreateSessionService:
                 "idempotency_key_present": idempotency_key_present,
                 "idempotency_resolution": resolution if idempotency_key_present else "not_requested",
                 "promotion_result": "promoted" if promotion.promoted else "existing_batch",
+                "webhook_configured": job.webhook_config_ciphertext is not None,
             },
         )
 
@@ -505,6 +549,73 @@ class BatchCreateSessionService:
             return None
         return dict(metadata) or None
 
+    def _validate_webhook(self, webhook: object | None) -> _ValidatedBatchWebhook | None:
+        if webhook is None:
+            return None
+        if not self.webhook_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": "batch_webhook_disabled",
+                    "message": "Batch webhooks are not enabled",
+                },
+            )
+        if self.webhook_cipher is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "code": "batch_webhook_unavailable",
+                    "message": "Batch webhook encryption is unavailable",
+                },
+            )
+        if not isinstance(webhook, (dict, BatchWebhookRequest)):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": "invalid_config",
+                    "message": "webhook configuration must be an object or null",
+                    "field": "webhook",
+                },
+            )
+        try:
+            config = parse_batch_webhook_request(
+                webhook,
+                allow_http=self.webhook_allow_http,
+                allowed_ports=self.webhook_allowed_ports,
+            )
+        except BatchWebhookValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=exc.as_detail(),
+            ) from None
+        return _ValidatedBatchWebhook(
+            config=config,
+            fingerprint=batch_webhook_config_fingerprint(config),
+        )
+
+    def _encrypt_webhook(self, webhook: _ValidatedBatchWebhook | None) -> str | None:
+        if webhook is None:
+            return None
+        cipher = self.webhook_cipher
+        if cipher is None:  # pragma: no cover - guarded during validation
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "code": "batch_webhook_unavailable",
+                    "message": "Batch webhook encryption is unavailable",
+                },
+            )
+        try:
+            return cipher.encrypt(webhook.config)
+        except BatchWebhookCryptoError:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "code": "batch_webhook_unavailable",
+                    "message": "Batch webhook encryption is unavailable",
+                },
+            ) from None
+
     def _request_matches_session(
         self,
         session: BatchCreateSessionRecord,
@@ -512,11 +623,21 @@ class BatchCreateSessionService:
         input_file_id: str,
         endpoint: str,
         metadata: dict[str, Any] | None,
+        webhook_config_fingerprint: str | None,
     ) -> bool:
+        session_webhook_pair_is_valid = (
+            session.webhook_config_ciphertext is None
+            and session.webhook_config_fingerprint is None
+        ) or (
+            session.webhook_config_ciphertext is not None
+            and session.webhook_config_fingerprint is not None
+        )
         return (
-            session.input_file_id == input_file_id
+            session_webhook_pair_is_valid
+            and session.input_file_id == input_file_id
             and session.endpoint == endpoint
             and self._normalize_metadata(session.metadata) == self._normalize_metadata(metadata)
+            and session.webhook_config_fingerprint == webhook_config_fingerprint
         )
 
     def _http_exception_for_promotion_error(self, exc: BatchCreatePromotionError) -> HTTPException:

--- a/src/batch/models.py
+++ b/src/batch/models.py
@@ -77,6 +77,10 @@ class BatchWebhookDeliveryStatus(StrEnum):
     FAILED = "failed"
 
 
+class BatchWebhookConfigurationConflictError(RuntimeError):
+    """Stored webhook state does not match the staged creation contract."""
+
+
 BATCH_WEBHOOK_EVENT_TYPES = tuple(BatchWebhookEventType)
 BATCH_WEBHOOK_EVENT_TYPE_VALUES = tuple(event_type.value for event_type in BatchWebhookEventType)
 BATCH_WEBHOOK_DELIVERY_STATUSES = tuple(BatchWebhookDeliveryStatus)

--- a/src/batch/models.py
+++ b/src/batch/models.py
@@ -393,6 +393,7 @@ class BatchWebhookOutboxRecord:
 
 @dataclass
 class BatchWebhookOutboxCreate:
+    event_id: str
     batch_id: str
     event_type: BatchWebhookEventType
     target_config_ciphertext: str

--- a/src/batch/repositories/__init__.py
+++ b/src/batch/repositories/__init__.py
@@ -3,6 +3,7 @@ from src.batch.repositories.file_repository import BatchFileRepository
 from src.batch.repositories.item_repository import BatchItemRepository
 from src.batch.repositories.job_repository import BatchJobRepository
 from src.batch.repositories.maintenance_repository import BatchMaintenanceRepository
+from src.batch.repositories.webhook_outbox_repository import BatchWebhookOutboxRepository
 
 __all__ = [
     "BatchFileRepository",
@@ -10,4 +11,5 @@ __all__ = [
     "BatchItemRepository",
     "BatchJobRepository",
     "BatchMaintenanceRepository",
+    "BatchWebhookOutboxRepository",
 ]

--- a/src/batch/repositories/job_repository.py
+++ b/src/batch/repositories/job_repository.py
@@ -4572,6 +4572,7 @@ class BatchJobRepository:
         error_file_id: str | None,
         final_status: str | BatchJobStatus,
         worker_id: str | None = None,
+        terminal_provider_error: str | None = None,
     ) -> BatchJobRecord | None:
         if self.prisma is None:
             return None
@@ -4594,6 +4595,7 @@ class BatchJobRepository:
                 SET output_file_id = $2,
                     error_file_id = $3,
                     status = $4::"DeltaLLM_BatchJobStatus",
+                    provider_error = COALESCE($5, j.provider_error),
                     total_items = stats.total_items,
                     in_progress_items = stats.in_progress_items,
                     completed_items = stats.completed_items,
@@ -4615,6 +4617,7 @@ class BatchJobRepository:
                 output_file_id,
                 error_file_id,
                 normalized_final_status.value,
+                terminal_provider_error,
             )
         else:
             rows = await self.prisma.query_raw(
@@ -4634,6 +4637,7 @@ class BatchJobRepository:
                 SET output_file_id = $3,
                     error_file_id = $4,
                     status = $5::"DeltaLLM_BatchJobStatus",
+                    provider_error = COALESCE($6, j.provider_error),
                     total_items = stats.total_items,
                     in_progress_items = stats.in_progress_items,
                     completed_items = stats.completed_items,
@@ -4657,6 +4661,7 @@ class BatchJobRepository:
                 output_file_id,
                 error_file_id,
                 normalized_final_status.value,
+                terminal_provider_error,
             )
         if not rows:
             return None

--- a/src/batch/repositories/job_repository.py
+++ b/src/batch/repositories/job_repository.py
@@ -429,6 +429,8 @@ class BatchJobRepository:
         size_class: str | None = None,
         queue_entered_at: datetime | None = None,
         scheduler_debug: dict[str, Any] | None = None,
+        webhook_config_ciphertext: str | None = None,
+        webhook_config_fingerprint: str | None = None,
         tenant_scope_preference: tuple[str, ...] | list[str] | None = None,
     ) -> BatchJobRecord | None:
         if self.prisma is None:
@@ -474,7 +476,8 @@ class BatchJobRepository:
                 scheduling_endpoint, tenant_scope_type, tenant_scope_id, service_tier,
                 estimated_work_units, remaining_work_units, size_class, queue_entered_at,
                 scheduler_debug, created_by_api_key, created_by_user_id, created_by_team_id,
-                created_by_organization_id, expires_at
+                created_by_organization_id, expires_at, webhook_config_ciphertext,
+                webhook_config_fingerprint
             )
             VALUES (
                 $1,
@@ -501,7 +504,9 @@ class BatchJobRepository:
                 $22,
                 $23,
                 $24,
-                $25::timestamp
+                $25::timestamp,
+                $26,
+                $27
             )
             RETURNING *
             """,
@@ -530,6 +535,8 @@ class BatchJobRepository:
             created_by_team_id,
             created_by_organization_id,
             expires_at,
+            webhook_config_ciphertext,
+            webhook_config_fingerprint,
         )
         if not rows:
             return None
@@ -550,6 +557,33 @@ class BatchJobRepository:
             LIMIT 1
             """,
             batch_id,
+        )
+        if not rows:
+            return None
+        return job_from_row(rows[0])
+
+    async def set_webhook_config_if_unset(
+        self,
+        *,
+        batch_id: str,
+        webhook_config_ciphertext: str,
+        webhook_config_fingerprint: str,
+    ) -> BatchJobRecord | None:
+        if self.prisma is None:
+            return None
+        rows = await self.prisma.query_raw(
+            """
+            UPDATE deltallm_batch_job
+            SET webhook_config_ciphertext = $2,
+                webhook_config_fingerprint = $3
+            WHERE batch_id = $1
+              AND webhook_config_ciphertext IS NULL
+              AND webhook_config_fingerprint IS NULL
+            RETURNING *
+            """,
+            batch_id,
+            webhook_config_ciphertext,
+            webhook_config_fingerprint,
         )
         if not rows:
             return None
@@ -4545,16 +4579,37 @@ class BatchJobRepository:
         if worker_id is None:
             rows = await self.prisma.query_raw(
                 """
-                UPDATE deltallm_batch_job
+                WITH stats AS (
+                    SELECT
+                        COUNT(*)::int AS total_items,
+                        COUNT(*) FILTER (WHERE status = 'pending')::int AS pending_items,
+                        COUNT(*) FILTER (WHERE status = 'in_progress')::int AS in_progress_items,
+                        COUNT(*) FILTER (WHERE status = 'completed')::int AS completed_items,
+                        COUNT(*) FILTER (WHERE status = 'failed')::int AS failed_items,
+                        COUNT(*) FILTER (WHERE status = 'cancelled')::int AS cancelled_items
+                    FROM deltallm_batch_item
+                    WHERE batch_id = $1
+                )
+                UPDATE deltallm_batch_job j
                 SET output_file_id = $2,
                     error_file_id = $3,
                     status = $4::"DeltaLLM_BatchJobStatus",
+                    total_items = stats.total_items,
+                    in_progress_items = stats.in_progress_items,
+                    completed_items = stats.completed_items,
+                    failed_items = stats.failed_items,
+                    cancelled_items = stats.cancelled_items,
+                    remaining_work_units = 0,
                     completed_at = COALESCE(completed_at, NOW()),
                     lease_expires_at = NULL,
                     locked_by = NULL,
                     status_last_updated_at = NOW()
-                WHERE batch_id = $1
-                RETURNING *
+                FROM stats
+                WHERE j.batch_id = $1
+                  AND j.status = 'finalizing'
+                  AND stats.pending_items = 0
+                  AND stats.in_progress_items = 0
+                RETURNING j.*
                 """,
                 batch_id,
                 output_file_id,
@@ -4564,18 +4619,38 @@ class BatchJobRepository:
         else:
             rows = await self.prisma.query_raw(
                 """
-                UPDATE deltallm_batch_job
+                WITH stats AS (
+                    SELECT
+                        COUNT(*)::int AS total_items,
+                        COUNT(*) FILTER (WHERE status = 'pending')::int AS pending_items,
+                        COUNT(*) FILTER (WHERE status = 'in_progress')::int AS in_progress_items,
+                        COUNT(*) FILTER (WHERE status = 'completed')::int AS completed_items,
+                        COUNT(*) FILTER (WHERE status = 'failed')::int AS failed_items,
+                        COUNT(*) FILTER (WHERE status = 'cancelled')::int AS cancelled_items
+                    FROM deltallm_batch_item
+                    WHERE batch_id = $1
+                )
+                UPDATE deltallm_batch_job j
                 SET output_file_id = $3,
                     error_file_id = $4,
                     status = $5::"DeltaLLM_BatchJobStatus",
+                    total_items = stats.total_items,
+                    in_progress_items = stats.in_progress_items,
+                    completed_items = stats.completed_items,
+                    failed_items = stats.failed_items,
+                    cancelled_items = stats.cancelled_items,
+                    remaining_work_units = 0,
                     completed_at = COALESCE(completed_at, NOW()),
                     lease_expires_at = NULL,
                     locked_by = NULL,
                     status_last_updated_at = NOW()
-                WHERE batch_id = $1
-                  AND locked_by = $2
-                  AND status = 'finalizing'
-                RETURNING *
+                FROM stats
+                WHERE j.batch_id = $1
+                  AND j.locked_by = $2
+                  AND j.status = 'finalizing'
+                  AND stats.pending_items = 0
+                  AND stats.in_progress_items = 0
+                RETURNING j.*
                 """,
                 batch_id,
                 worker_id,
@@ -4585,7 +4660,9 @@ class BatchJobRepository:
             )
         if not rows:
             return None
-        record = job_from_row(rows[0])
+        return job_from_row(rows[0])
+
+    def observe_finalization(self, record: BatchJobRecord) -> None:
         latency_start = record.queue_entered_at or record.created_at
         latency_end = record.completed_at or datetime.now(tz=UTC)
         observe_batch_completion_latency(
@@ -4595,7 +4672,6 @@ class BatchJobRepository:
             size_class=record.size_class,
             latency_seconds=max(0.0, (latency_end - latency_start).total_seconds()),
         )
-        return record
 
     async def retry_finalization_now(self, batch_id: str) -> BatchJobRecord | None:
         if self.prisma is None:

--- a/src/batch/repositories/job_repository.py
+++ b/src/batch/repositories/job_repository.py
@@ -19,6 +19,7 @@ from src.batch.models import (
     BatchSchedulerFlowRecord,
     BatchWorkClaim,
     BatchWorkRecommendation,
+    OPERATOR_FAILED_PREFIX,
     normalize_batch_job_status,
 )
 from src.batch.repositories.mappers import job_from_row, parse_datetime
@@ -555,6 +556,22 @@ class BatchJobRepository:
             FROM deltallm_batch_job
             WHERE batch_id = $1
             LIMIT 1
+            """,
+            batch_id,
+        )
+        if not rows:
+            return None
+        return job_from_row(rows[0])
+
+    async def get_job_for_update(self, batch_id: str) -> BatchJobRecord | None:
+        if self.prisma is None:
+            return None
+        rows = await self.prisma.query_raw(
+            """
+            SELECT *
+            FROM deltallm_batch_job
+            WHERE batch_id = $1
+            FOR UPDATE
             """,
             batch_id,
         )
@@ -4594,7 +4611,20 @@ class BatchJobRepository:
                 UPDATE deltallm_batch_job j
                 SET output_file_id = $2,
                     error_file_id = $3,
-                    status = $4::"DeltaLLM_BatchJobStatus",
+                    status = (
+                        CASE
+                        WHEN j.cancel_requested_at IS NOT NULL OR $4 = 'cancelled'
+                            THEN 'cancelled'
+                        WHEN $4 = 'expired'
+                            THEN 'expired'
+                        WHEN $4 = 'failed'
+                          OR $5 IS NOT NULL
+                          OR LEFT(COALESCE(j.provider_error, ''), LENGTH($6)) = $6
+                          OR (stats.completed_items = 0 AND stats.failed_items > 0)
+                            THEN 'failed'
+                        ELSE 'completed'
+                        END
+                    )::"DeltaLLM_BatchJobStatus",
                     provider_error = COALESCE($5, j.provider_error),
                     total_items = stats.total_items,
                     in_progress_items = stats.in_progress_items,
@@ -4618,6 +4648,7 @@ class BatchJobRepository:
                 error_file_id,
                 normalized_final_status.value,
                 terminal_provider_error,
+                OPERATOR_FAILED_PREFIX,
             )
         else:
             rows = await self.prisma.query_raw(
@@ -4636,7 +4667,20 @@ class BatchJobRepository:
                 UPDATE deltallm_batch_job j
                 SET output_file_id = $3,
                     error_file_id = $4,
-                    status = $5::"DeltaLLM_BatchJobStatus",
+                    status = (
+                        CASE
+                        WHEN j.cancel_requested_at IS NOT NULL OR $5 = 'cancelled'
+                            THEN 'cancelled'
+                        WHEN $5 = 'expired'
+                            THEN 'expired'
+                        WHEN $5 = 'failed'
+                          OR $6 IS NOT NULL
+                          OR LEFT(COALESCE(j.provider_error, ''), LENGTH($7)) = $7
+                          OR (stats.completed_items = 0 AND stats.failed_items > 0)
+                            THEN 'failed'
+                        ELSE 'completed'
+                        END
+                    )::"DeltaLLM_BatchJobStatus",
                     provider_error = COALESCE($6, j.provider_error),
                     total_items = stats.total_items,
                     in_progress_items = stats.in_progress_items,
@@ -4662,6 +4706,7 @@ class BatchJobRepository:
                 error_file_id,
                 normalized_final_status.value,
                 terminal_provider_error,
+                OPERATOR_FAILED_PREFIX,
             )
         if not rows:
             return None

--- a/src/batch/repositories/webhook_outbox_repository.py
+++ b/src/batch/repositories/webhook_outbox_repository.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.batch.models import (
+    BatchWebhookEventType,
+    BatchWebhookOutboxCreate,
+    BatchWebhookOutboxRecord,
+    normalize_batch_webhook_event_type,
+)
+from src.batch.repositories.mappers import webhook_outbox_from_row
+from src.batch.webhooks.events import canonical_batch_webhook_event_bytes
+
+
+class BatchWebhookOutboxRepository:
+    def __init__(self, prisma_client: Any | None = None) -> None:
+        self.prisma = prisma_client
+
+    async def insert_event(
+        self,
+        event: BatchWebhookOutboxCreate,
+    ) -> BatchWebhookOutboxRecord | None:
+        if self.prisma is None:
+            return None
+        rows = await self.prisma.query_raw(
+            """
+            INSERT INTO deltallm_batch_webhook_outbox (
+                event_id,
+                batch_id,
+                event_type,
+                target_config_ciphertext,
+                payload_json,
+                payload_sha256,
+                status,
+                attempt_count,
+                max_attempts,
+                next_attempt_at,
+                last_status_code,
+                last_error,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                $1,
+                $2,
+                $3,
+                $4,
+                $5::jsonb,
+                $6,
+                $7,
+                $8,
+                $9,
+                COALESCE($10::timestamp, NOW()),
+                $11,
+                $12,
+                NOW(),
+                NOW()
+            )
+            ON CONFLICT (batch_id, event_type) DO NOTHING
+            RETURNING *
+            """,
+            event.event_id,
+            event.batch_id,
+            event.event_type.value,
+            event.target_config_ciphertext,
+            canonical_batch_webhook_event_bytes(event.payload_json).decode("utf-8"),
+            event.payload_sha256,
+            event.status.value,
+            event.attempt_count,
+            event.max_attempts,
+            event.next_attempt_at,
+            event.last_status_code,
+            event.last_error,
+        )
+        if not rows:
+            return None
+        return webhook_outbox_from_row(dict(rows[0]))
+
+    async def get_by_batch_and_event_type(
+        self,
+        *,
+        batch_id: str,
+        event_type: str | BatchWebhookEventType,
+    ) -> BatchWebhookOutboxRecord | None:
+        if self.prisma is None:
+            return None
+        normalized_event_type = normalize_batch_webhook_event_type(event_type)
+        rows = await self.prisma.query_raw(
+            """
+            SELECT *
+            FROM deltallm_batch_webhook_outbox
+            WHERE batch_id = $1
+              AND event_type = $2
+            LIMIT 1
+            """,
+            batch_id,
+            normalized_event_type.value,
+        )
+        if not rows:
+            return None
+        return webhook_outbox_from_row(dict(rows[0]))

--- a/src/batch/repository.py
+++ b/src/batch/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 from datetime import datetime
 from typing import Any, Literal
 
@@ -18,8 +19,12 @@ from src.batch.models import (
     BatchModelBacklogRecord,
     BatchModelInFlightRecord,
     BatchSchedulerFlowRecord,
+    BatchWebhookOutboxCreate,
+    BatchWebhookOutboxRecord,
+    BatchWebhookEventType,
     BatchWorkClaim,
     BatchWorkRecommendation,
+    normalize_batch_job_status,
 )
 from src.batch.repositories import (
     BatchCompletionOutboxRepository,
@@ -27,9 +32,42 @@ from src.batch.repositories import (
     BatchItemRepository,
     BatchJobRepository,
     BatchMaintenanceRepository,
+    BatchWebhookOutboxRepository,
 )
 from src.batch.scheduling import parse_tenant_scope_preference
+from src.batch.serialization import serialize_public_batch
+from src.batch.webhooks.events import (
+    batch_webhook_event_payload_sha256,
+    batch_webhook_event_type_for_status,
+    build_batch_webhook_event,
+)
 from src.metrics import increment_batch_duplicate_completion_rejection
+
+
+def _webhook_outbox_matches_terminal_job(
+    record: BatchWebhookOutboxRecord,
+    *,
+    job: BatchJobRecord,
+    event_type: BatchWebhookEventType,
+) -> bool:
+    payload = record.payload_json
+    data = payload.get("data") if isinstance(payload, dict) else None
+    batch = data.get("batch") if isinstance(data, dict) else None
+    return bool(
+        record.batch_id == job.batch_id
+        and record.event_type == event_type
+        and record.target_config_ciphertext == job.webhook_config_ciphertext
+        and isinstance(payload, dict)
+        and payload.get("id") == record.event_id
+        and payload.get("object") == "event"
+        and payload.get("type") == event_type.value
+        and isinstance(batch, dict)
+        and batch == serialize_public_batch(job)
+        and hmac.compare_digest(
+            record.payload_sha256,
+            batch_webhook_event_payload_sha256(payload),
+        )
+    )
 
 
 class BatchRepository:
@@ -41,15 +79,18 @@ class BatchRepository:
         *,
         model_group_resolver: Any | None = None,
         tenant_scope_preference: tuple[str, ...] | list[str] | str | None = None,
+        webhook_max_attempts: int = 8,
     ) -> None:
         self.prisma = prisma_client
         self.model_group_resolver = model_group_resolver
         self.tenant_scope_preference = parse_tenant_scope_preference(tenant_scope_preference)
+        self.webhook_max_attempts = max(1, int(webhook_max_attempts))
         self.create_sessions = BatchCreateSessionRepository(prisma_client)
         self.files = BatchFileRepository(prisma_client)
         self.jobs = BatchJobRepository(prisma_client, model_group_resolver=model_group_resolver)
         self.items = BatchItemRepository(prisma_client)
         self.completion_outbox = BatchCompletionOutboxRepository(prisma_client)
+        self.webhook_outbox = BatchWebhookOutboxRepository(prisma_client)
         self.maintenance = BatchMaintenanceRepository(
             prisma_client,
             model_group_resolver=model_group_resolver,
@@ -61,6 +102,7 @@ class BatchRepository:
             prisma_client,
             model_group_resolver=self.model_group_resolver,
             tenant_scope_preference=self.tenant_scope_preference,
+            webhook_max_attempts=self.webhook_max_attempts,
         )
 
     def set_model_group_resolver(self, model_group_resolver: Any | None) -> None:
@@ -135,6 +177,8 @@ class BatchRepository:
         size_class: str | None = None,
         queue_entered_at: datetime | None = None,
         scheduler_debug: dict[str, Any] | None = None,
+        webhook_config_ciphertext: str | None = None,
+        webhook_config_fingerprint: str | None = None,
         tenant_scope_preference: tuple[str, ...] | list[str] | None = None,
     ) -> BatchJobRecord | None:
         effective_tenant_scope_preference = (
@@ -168,11 +212,26 @@ class BatchRepository:
             size_class=size_class,
             queue_entered_at=queue_entered_at,
             scheduler_debug=scheduler_debug,
+            webhook_config_ciphertext=webhook_config_ciphertext,
+            webhook_config_fingerprint=webhook_config_fingerprint,
             tenant_scope_preference=effective_tenant_scope_preference,
         )
 
     async def get_job(self, batch_id: str) -> BatchJobRecord | None:
         return await self.jobs.get_job(batch_id)
+
+    async def set_job_webhook_config_if_unset(
+        self,
+        *,
+        batch_id: str,
+        webhook_config_ciphertext: str,
+        webhook_config_fingerprint: str,
+    ) -> BatchJobRecord | None:
+        return await self.jobs.set_webhook_config_if_unset(
+            batch_id=batch_id,
+            webhook_config_ciphertext=webhook_config_ciphertext,
+            webhook_config_fingerprint=webhook_config_fingerprint,
+        )
 
     async def acquire_scope_advisory_lock(self, *, scope_type: str, scope_id: str) -> None:
         await self.jobs.acquire_scope_advisory_lock(scope_type=scope_type, scope_id=scope_id)
@@ -751,13 +810,67 @@ class BatchRepository:
         final_status: str | BatchJobStatus,
         worker_id: str | None = None,
     ) -> BatchJobRecord | None:
-        return await self.jobs.attach_artifacts_and_finalize(
-            batch_id=batch_id,
-            output_file_id=output_file_id,
-            error_file_id=error_file_id,
-            final_status=final_status,
-            worker_id=worker_id,
-        )
+        normalized_final_status = normalize_batch_job_status(final_status)
+        event_type = batch_webhook_event_type_for_status(normalized_final_status)
+
+        async def _run_in_current_repo(repo: BatchRepository) -> BatchJobRecord | None:
+            finalized = await repo.jobs.attach_artifacts_and_finalize(
+                batch_id=batch_id,
+                output_file_id=output_file_id,
+                error_file_id=error_file_id,
+                final_status=normalized_final_status,
+                worker_id=worker_id,
+            )
+            if finalized is None:
+                return None
+
+            ciphertext = finalized.webhook_config_ciphertext
+            fingerprint = finalized.webhook_config_fingerprint
+            if ciphertext is None and fingerprint is None:
+                return finalized
+            if ciphertext is None or fingerprint is None:
+                raise RuntimeError("batch webhook configuration is incomplete")
+
+            event = build_batch_webhook_event(finalized)
+            inserted = await repo.webhook_outbox.insert_event(
+                BatchWebhookOutboxCreate(
+                    event_id=event.event_id,
+                    batch_id=finalized.batch_id,
+                    event_type=event.event_type,
+                    target_config_ciphertext=ciphertext,
+                    payload_json=event.payload_json,
+                    payload_sha256=event.payload_sha256,
+                    max_attempts=repo.webhook_max_attempts,
+                )
+            )
+            if inserted is None:
+                inserted = await repo.webhook_outbox.get_by_batch_and_event_type(
+                    batch_id=finalized.batch_id,
+                    event_type=event_type,
+                )
+                if inserted is None or not _webhook_outbox_matches_terminal_job(
+                    inserted,
+                    job=finalized,
+                    event_type=event_type,
+                ):
+                    raise RuntimeError("batch webhook event conflicts with terminal outcome")
+            return finalized
+
+        if self.prisma is not None and hasattr(self.prisma, "tx"):
+            async with self.prisma.tx() as tx:
+                finalized = await _run_in_current_repo(self.with_prisma(tx))
+        else:
+            existing = await self.get_job(batch_id)
+            if existing is not None and (
+                existing.webhook_config_ciphertext is not None
+                or existing.webhook_config_fingerprint is not None
+            ):
+                raise RuntimeError("batch webhook finalization requires transaction support")
+            finalized = await _run_in_current_repo(self)
+
+        if finalized is not None:
+            self.jobs.observe_finalization(finalized)
+        return finalized
 
     async def retry_finalization_now(self, batch_id: str) -> BatchJobRecord | None:
         return await self.jobs.retry_finalization_now(batch_id)

--- a/src/batch/repository.py
+++ b/src/batch/repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hmac
+import logging
 from datetime import datetime
 from typing import Any, Literal
 
@@ -42,6 +43,8 @@ from src.batch.webhooks.events import (
     build_batch_webhook_event,
 )
 from src.metrics import increment_batch_duplicate_completion_rejection
+
+logger = logging.getLogger(__name__)
 
 
 def _webhook_outbox_matches_terminal_job(
@@ -809,6 +812,7 @@ class BatchRepository:
         error_file_id: str | None,
         final_status: str | BatchJobStatus,
         worker_id: str | None = None,
+        terminal_provider_error: str | None = None,
     ) -> BatchJobRecord | None:
         normalized_final_status = normalize_batch_job_status(final_status)
         event_type = batch_webhook_event_type_for_status(normalized_final_status)
@@ -820,6 +824,7 @@ class BatchRepository:
                 error_file_id=error_file_id,
                 final_status=normalized_final_status,
                 worker_id=worker_id,
+                terminal_provider_error=terminal_provider_error,
             )
             if finalized is None:
                 return None
@@ -869,7 +874,14 @@ class BatchRepository:
             finalized = await _run_in_current_repo(self)
 
         if finalized is not None:
-            self.jobs.observe_finalization(finalized)
+            try:
+                self.jobs.observe_finalization(finalized)
+            except Exception:
+                logger.warning(
+                    "batch finalization metric publish failed batch_id=%s",
+                    finalized.batch_id,
+                    exc_info=True,
+                )
         return finalized
 
     async def retry_finalization_now(self, batch_id: str) -> BatchJobRecord | None:

--- a/src/batch/repository.py
+++ b/src/batch/repository.py
@@ -23,6 +23,7 @@ from src.batch.models import (
     BatchWebhookOutboxCreate,
     BatchWebhookOutboxRecord,
     BatchWebhookEventType,
+    BatchWebhookConfigurationConflictError,
     BatchWorkClaim,
     BatchWorkRecommendation,
     normalize_batch_job_status,
@@ -36,7 +37,6 @@ from src.batch.repositories import (
     BatchWebhookOutboxRepository,
 )
 from src.batch.scheduling import parse_tenant_scope_preference
-from src.batch.serialization import serialize_public_batch
 from src.batch.webhooks.events import (
     batch_webhook_event_payload_sha256,
     batch_webhook_event_type_for_status,
@@ -47,15 +47,22 @@ from src.metrics import increment_batch_duplicate_completion_rejection
 logger = logging.getLogger(__name__)
 
 
+def _prisma_client_is_transaction(client: object | None) -> bool:
+    detector = getattr(client, "is_transaction", None)
+    return bool(detector()) if callable(detector) else False
+
+
 def _webhook_outbox_matches_terminal_job(
     record: BatchWebhookOutboxRecord,
     *,
     job: BatchJobRecord,
     event_type: BatchWebhookEventType,
 ) -> bool:
+    """Verify the stored snapshot without comparing mutable post-terminal fields."""
     payload = record.payload_json
     data = payload.get("data") if isinstance(payload, dict) else None
     batch = data.get("batch") if isinstance(data, dict) else None
+    webhook = batch.get("webhook") if isinstance(batch, dict) else None
     return bool(
         record.batch_id == job.batch_id
         and record.event_type == event_type
@@ -64,8 +71,13 @@ def _webhook_outbox_matches_terminal_job(
         and payload.get("id") == record.event_id
         and payload.get("object") == "event"
         and payload.get("type") == event_type.value
+        and type(payload.get("created_at")) is int
         and isinstance(batch, dict)
-        and batch == serialize_public_batch(job)
+        and batch.get("id") == job.batch_id
+        and batch.get("object") == "batch"
+        and batch.get("status") == job.status.value
+        and isinstance(webhook, dict)
+        and webhook.get("configured") is True
         and hmac.compare_digest(
             record.payload_sha256,
             batch_webhook_event_payload_sha256(payload),
@@ -222,6 +234,9 @@ class BatchRepository:
 
     async def get_job(self, batch_id: str) -> BatchJobRecord | None:
         return await self.jobs.get_job(batch_id)
+
+    async def get_job_for_update(self, batch_id: str) -> BatchJobRecord | None:
+        return await self.jobs.get_job_for_update(batch_id)
 
     async def set_job_webhook_config_if_unset(
         self,
@@ -804,6 +819,172 @@ class BatchRepository:
     async def fail_nonterminal_items(self, *, batch_id: str, reason: str) -> int:
         return await self.items.fail_nonterminal_items(batch_id=batch_id, reason=reason)
 
+    async def _enqueue_webhook_for_terminal_job_in_current_transaction(
+        self,
+        job: BatchJobRecord,
+    ) -> None:
+        ciphertext = job.webhook_config_ciphertext
+        fingerprint = job.webhook_config_fingerprint
+        if ciphertext is None and fingerprint is None:
+            return
+        if ciphertext is None or fingerprint is None:
+            raise BatchWebhookConfigurationConflictError(
+                "batch webhook configuration is incomplete"
+            )
+
+        event_type = batch_webhook_event_type_for_status(job.status)
+        event = build_batch_webhook_event(job)
+        inserted = await self.webhook_outbox.insert_event(
+            BatchWebhookOutboxCreate(
+                event_id=event.event_id,
+                batch_id=job.batch_id,
+                event_type=event.event_type,
+                target_config_ciphertext=ciphertext,
+                payload_json=event.payload_json,
+                payload_sha256=event.payload_sha256,
+                max_attempts=self.webhook_max_attempts,
+            )
+        )
+        if inserted is None:
+            inserted = await self.webhook_outbox.get_by_batch_and_event_type(
+                batch_id=job.batch_id,
+                event_type=event_type,
+            )
+            if inserted is None or not _webhook_outbox_matches_terminal_job(
+                inserted,
+                job=job,
+                event_type=event_type,
+            ):
+                raise BatchWebhookConfigurationConflictError(
+                    "batch webhook event conflicts with terminal outcome"
+                )
+
+    async def _attach_artifacts_and_enqueue_webhook_in_current_transaction(
+        self,
+        *,
+        batch_id: str,
+        output_file_id: str | None,
+        error_file_id: str | None,
+        final_status: BatchJobStatus,
+        worker_id: str | None,
+        terminal_provider_error: str | None,
+    ) -> BatchJobRecord | None:
+        finalized = await self.jobs.attach_artifacts_and_finalize(
+            batch_id=batch_id,
+            output_file_id=output_file_id,
+            error_file_id=error_file_id,
+            final_status=final_status,
+            worker_id=worker_id,
+            terminal_provider_error=terminal_provider_error,
+        )
+        if finalized is None:
+            return None
+        await self._enqueue_webhook_for_terminal_job_in_current_transaction(finalized)
+        return finalized
+
+    async def _reconcile_job_webhook_config_in_current_transaction(
+        self,
+        *,
+        batch_id: str,
+        webhook_config_ciphertext: str | None,
+        webhook_config_fingerprint: str | None,
+    ) -> BatchJobRecord | None:
+        expected = (webhook_config_ciphertext, webhook_config_fingerprint)
+        if (webhook_config_ciphertext is None) != (webhook_config_fingerprint is None):
+            raise BatchWebhookConfigurationConflictError(
+                "batch webhook configuration is incomplete"
+            )
+
+        job = await self.get_job_for_update(batch_id)
+        if job is None:
+            return None
+        current = (
+            job.webhook_config_ciphertext,
+            job.webhook_config_fingerprint,
+        )
+        if current != expected:
+            if current != (None, None) or expected == (None, None):
+                raise BatchWebhookConfigurationConflictError(
+                    "batch webhook configuration conflicts with existing job"
+                )
+            updated = await self.set_job_webhook_config_if_unset(
+                batch_id=batch_id,
+                webhook_config_ciphertext=str(webhook_config_ciphertext),
+                webhook_config_fingerprint=str(webhook_config_fingerprint),
+            )
+            if updated is None:
+                raise BatchWebhookConfigurationConflictError(
+                    "batch webhook configuration conflicts with existing job"
+                )
+            job = updated
+
+        if job.status in {
+            BatchJobStatus.COMPLETED,
+            BatchJobStatus.FAILED,
+            BatchJobStatus.CANCELLED,
+            BatchJobStatus.EXPIRED,
+        }:
+            await self._enqueue_webhook_for_terminal_job_in_current_transaction(job)
+        return job
+
+    async def reconcile_job_webhook_config(
+        self,
+        *,
+        batch_id: str,
+        webhook_config_ciphertext: str | None,
+        webhook_config_fingerprint: str | None,
+    ) -> BatchJobRecord | None:
+        """Reconcile staged webhook state and heal a missing terminal event."""
+        if _prisma_client_is_transaction(self.prisma):
+            return await self._reconcile_job_webhook_config_in_current_transaction(
+                batch_id=batch_id,
+                webhook_config_ciphertext=webhook_config_ciphertext,
+                webhook_config_fingerprint=webhook_config_fingerprint,
+            )
+        if self.prisma is not None and hasattr(self.prisma, "tx"):
+            async with self.prisma.tx() as tx:
+                transactional_repository = self.with_prisma(tx)
+                return await (
+                    transactional_repository._reconcile_job_webhook_config_in_current_transaction(
+                        batch_id=batch_id,
+                        webhook_config_ciphertext=webhook_config_ciphertext,
+                        webhook_config_fingerprint=webhook_config_fingerprint,
+                    )
+                )
+
+        existing = await self.get_job(batch_id)
+        expected = (webhook_config_ciphertext, webhook_config_fingerprint)
+        if existing is None:
+            return None
+        current = (
+            existing.webhook_config_ciphertext,
+            existing.webhook_config_fingerprint,
+        )
+        if current != expected:
+            raise RuntimeError("batch webhook reconciliation requires transaction support")
+        if (
+            existing.status
+            in {
+                BatchJobStatus.COMPLETED,
+                BatchJobStatus.FAILED,
+                BatchJobStatus.CANCELLED,
+                BatchJobStatus.EXPIRED,
+            }
+            and existing.webhook_config_ciphertext is not None
+        ):
+            raise RuntimeError("batch webhook reconciliation requires transaction support")
+        return existing
+
+    def publish_finalization_metric_after_commit(self, finalized: BatchJobRecord) -> None:
+        try:
+            self.jobs.observe_finalization(finalized)
+        except Exception:
+            logger.warning(
+                "batch finalization metric publish failed batch_id=%s",
+                finalized.batch_id,
+                exc_info=True,
+            )
+
     async def attach_artifacts_and_finalize(
         self,
         *,
@@ -814,11 +995,17 @@ class BatchRepository:
         worker_id: str | None = None,
         terminal_provider_error: str | None = None,
     ) -> BatchJobRecord | None:
-        normalized_final_status = normalize_batch_job_status(final_status)
-        event_type = batch_webhook_event_type_for_status(normalized_final_status)
+        """Commit terminal state and its webhook event as one aggregate operation.
 
-        async def _run_in_current_repo(repo: BatchRepository) -> BatchJobRecord | None:
-            finalized = await repo.jobs.attach_artifacts_and_finalize(
+        When this repository already wraps a transaction client, the caller owns
+        the outer commit and must publish the returned record's metric afterward.
+        """
+        normalized_final_status = normalize_batch_job_status(final_status)
+        batch_webhook_event_type_for_status(normalized_final_status)
+        reusing_transaction = _prisma_client_is_transaction(self.prisma)
+
+        if reusing_transaction:
+            finalized = await self._attach_artifacts_and_enqueue_webhook_in_current_transaction(
                 batch_id=batch_id,
                 output_file_id=output_file_id,
                 error_file_id=error_file_id,
@@ -826,44 +1013,19 @@ class BatchRepository:
                 worker_id=worker_id,
                 terminal_provider_error=terminal_provider_error,
             )
-            if finalized is None:
-                return None
-
-            ciphertext = finalized.webhook_config_ciphertext
-            fingerprint = finalized.webhook_config_fingerprint
-            if ciphertext is None and fingerprint is None:
-                return finalized
-            if ciphertext is None or fingerprint is None:
-                raise RuntimeError("batch webhook configuration is incomplete")
-
-            event = build_batch_webhook_event(finalized)
-            inserted = await repo.webhook_outbox.insert_event(
-                BatchWebhookOutboxCreate(
-                    event_id=event.event_id,
-                    batch_id=finalized.batch_id,
-                    event_type=event.event_type,
-                    target_config_ciphertext=ciphertext,
-                    payload_json=event.payload_json,
-                    payload_sha256=event.payload_sha256,
-                    max_attempts=repo.webhook_max_attempts,
-                )
-            )
-            if inserted is None:
-                inserted = await repo.webhook_outbox.get_by_batch_and_event_type(
-                    batch_id=finalized.batch_id,
-                    event_type=event_type,
-                )
-                if inserted is None or not _webhook_outbox_matches_terminal_job(
-                    inserted,
-                    job=finalized,
-                    event_type=event_type,
-                ):
-                    raise RuntimeError("batch webhook event conflicts with terminal outcome")
-            return finalized
-
-        if self.prisma is not None and hasattr(self.prisma, "tx"):
+        elif self.prisma is not None and hasattr(self.prisma, "tx"):
             async with self.prisma.tx() as tx:
-                finalized = await _run_in_current_repo(self.with_prisma(tx))
+                transactional_repository = self.with_prisma(tx)
+                finalized = (
+                    await transactional_repository._attach_artifacts_and_enqueue_webhook_in_current_transaction(
+                        batch_id=batch_id,
+                        output_file_id=output_file_id,
+                        error_file_id=error_file_id,
+                        final_status=normalized_final_status,
+                        worker_id=worker_id,
+                        terminal_provider_error=terminal_provider_error,
+                    )
+                )
         else:
             existing = await self.get_job(batch_id)
             if existing is not None and (
@@ -871,17 +1033,19 @@ class BatchRepository:
                 or existing.webhook_config_fingerprint is not None
             ):
                 raise RuntimeError("batch webhook finalization requires transaction support")
-            finalized = await _run_in_current_repo(self)
+            finalized = await self._attach_artifacts_and_enqueue_webhook_in_current_transaction(
+                batch_id=batch_id,
+                output_file_id=output_file_id,
+                error_file_id=error_file_id,
+                final_status=normalized_final_status,
+                worker_id=worker_id,
+                terminal_provider_error=terminal_provider_error,
+            )
 
-        if finalized is not None:
-            try:
-                self.jobs.observe_finalization(finalized)
-            except Exception:
-                logger.warning(
-                    "batch finalization metric publish failed batch_id=%s",
-                    finalized.batch_id,
-                    exc_info=True,
-                )
+        # An outer transaction owns the commit when this repository already wraps
+        # a transaction client. Its caller must publish after that commit succeeds.
+        if finalized is not None and not reusing_transaction:
+            self.publish_finalization_metric_after_commit(finalized)
         return finalized
 
     async def retry_finalization_now(self, batch_id: str) -> BatchJobRecord | None:

--- a/src/batch/serialization.py
+++ b/src/batch/serialization.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from src.batch.models import BatchJobRecord, BatchJobStatus, OPENAI_BATCH_COMPLETION_WINDOW
+
+
+def _timestamp_or_none(value: datetime | None) -> int | None:
+    return int(value.timestamp()) if value else None
+
+
+def _public_batch_status(job: BatchJobRecord) -> str:
+    status_value = str(job.status or "")
+    if status_value == BatchJobStatus.QUEUED.value:
+        return "validating"
+    if status_value == BatchJobStatus.IN_PROGRESS.value and job.cancel_requested_at is not None:
+        return "cancelling"
+    return status_value
+
+
+def _terminal_status_timestamp(
+    job: BatchJobRecord,
+    terminal_status: BatchJobStatus,
+) -> int | None:
+    if str(job.status or "") != terminal_status.value:
+        return None
+    return _timestamp_or_none(job.status_last_updated_at)
+
+
+def serialize_public_batch(job: BatchJobRecord) -> dict[str, Any]:
+    response: dict[str, Any] = {
+        "id": job.batch_id,
+        "object": "batch",
+        "endpoint": job.endpoint,
+        "completion_window": OPENAI_BATCH_COMPLETION_WINDOW,
+        "status": _public_batch_status(job),
+        "input_file_id": job.input_file_id,
+        "output_file_id": job.output_file_id,
+        "error_file_id": job.error_file_id,
+        "created_at": int(job.created_at.timestamp()),
+        "expires_at": _timestamp_or_none(job.expires_at),
+        "in_progress_at": int(job.started_at.timestamp()) if job.started_at else None,
+        "completed_at": int(job.completed_at.timestamp()) if job.completed_at else None,
+        "failed_at": _terminal_status_timestamp(job, BatchJobStatus.FAILED),
+        "expired_at": _terminal_status_timestamp(job, BatchJobStatus.EXPIRED),
+        "errors": None,
+        "request_counts": {
+            "total": job.total_items,
+            "completed": job.completed_items,
+            "failed": job.failed_items,
+            "cancelled": job.cancelled_items,
+            "in_progress": job.in_progress_items,
+        },
+        "metadata": job.metadata or {},
+    }
+    if job.webhook_config_ciphertext is not None:
+        response["webhook"] = {"configured": True}
+    return response

--- a/src/batch/service.py
+++ b/src/batch/service.py
@@ -8,10 +8,11 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 from fastapi import HTTPException, UploadFile, status
 
 from src.batch.access import can_access_owned_resource
-from src.batch.models import BatchItemCreate, BatchJobStatus, OPENAI_BATCH_COMPLETION_WINDOW
+from src.batch.models import BatchItemCreate
 from src.batch.request_validation import parse_batch_input_line
 from src.batch.repository import BatchRepository
 from src.batch.scheduling import estimate_request_work_units, resolve_model_group
+from src.batch.serialization import serialize_public_batch
 from src.batch.storage import BatchArtifactLineTooLongError, BatchArtifactStorage
 from src.metrics import (
     increment_batch_artifact_failure,
@@ -261,6 +262,7 @@ class BatchService:
         metadata: dict[str, Any] | None,
         completion_window: str | None,
         idempotency_key: str | None = None,
+        webhook: object | None = None,
     ) -> dict[str, Any]:
         return await self.create_batch(
             auth=auth,
@@ -269,6 +271,7 @@ class BatchService:
             metadata=metadata,
             completion_window=completion_window,
             idempotency_key=idempotency_key,
+            webhook=webhook,
         )
 
     async def create_batch(
@@ -280,6 +283,7 @@ class BatchService:
         metadata: dict[str, Any] | None,
         completion_window: str | None,
         idempotency_key: str | None = None,
+        webhook: object | None = None,
     ) -> dict[str, Any]:
         result = await self.create_batch_result(
             auth=auth,
@@ -288,6 +292,7 @@ class BatchService:
             metadata=metadata,
             completion_window=completion_window,
             idempotency_key=idempotency_key,
+            webhook=webhook,
         )
         return result.response
 
@@ -300,6 +305,7 @@ class BatchService:
         metadata: dict[str, Any] | None,
         completion_window: str | None,
         idempotency_key: str | None = None,
+        webhook: object | None = None,
     ) -> BatchCreateResponseResult:
         return await self.create_batch_result(
             auth=auth,
@@ -308,6 +314,7 @@ class BatchService:
             metadata=metadata,
             completion_window=completion_window,
             idempotency_key=idempotency_key,
+            webhook=webhook,
         )
 
     async def create_batch_result(
@@ -319,6 +326,7 @@ class BatchService:
         metadata: dict[str, Any] | None,
         completion_window: str | None,
         idempotency_key: str | None = None,
+        webhook: object | None = None,
     ) -> BatchCreateResponseResult:
         if self.create_session_service is None:
             raise HTTPException(
@@ -333,6 +341,7 @@ class BatchService:
                 metadata=metadata,
                 completion_window=completion_window,
                 idempotency_key=idempotency_key,
+                webhook=webhook,
             )
         else:
             result = await self.create_session_service.create_embeddings_batch(
@@ -342,6 +351,7 @@ class BatchService:
                 metadata=metadata,
                 completion_window=completion_window,
                 idempotency_key=idempotency_key,
+                webhook=webhook,
             )
         return BatchCreateResponseResult(
             response=self.job_to_response(result.job),
@@ -398,50 +408,7 @@ class BatchService:
         }
 
     def job_to_response(self, job) -> dict[str, Any]:
-        return {
-            "id": job.batch_id,
-            "object": "batch",
-            "endpoint": job.endpoint,
-            "completion_window": OPENAI_BATCH_COMPLETION_WINDOW,
-            "status": self._public_batch_status(job),
-            "input_file_id": job.input_file_id,
-            "output_file_id": job.output_file_id,
-            "error_file_id": job.error_file_id,
-            "created_at": int(job.created_at.timestamp()),
-            "expires_at": self._timestamp_or_none(getattr(job, "expires_at", None)),
-            "in_progress_at": int(job.started_at.timestamp()) if job.started_at else None,
-            "completed_at": int(job.completed_at.timestamp()) if job.completed_at else None,
-            "failed_at": self._terminal_status_timestamp(job, BatchJobStatus.FAILED),
-            "expired_at": self._terminal_status_timestamp(job, BatchJobStatus.EXPIRED),
-            "errors": None,
-            "request_counts": {
-                "total": job.total_items,
-                "completed": job.completed_items,
-                "failed": job.failed_items,
-                "cancelled": job.cancelled_items,
-                "in_progress": job.in_progress_items,
-            },
-            "metadata": job.metadata or {},
-        }
-
-    def _public_batch_status(self, job) -> str:
-        status_value = str(getattr(job, "status", "") or "")
-        if status_value == BatchJobStatus.QUEUED.value:
-            return "validating"
-        if (
-            status_value == BatchJobStatus.IN_PROGRESS.value
-            and getattr(job, "cancel_requested_at", None) is not None
-        ):
-            return "cancelling"
-        return status_value
-
-    def _terminal_status_timestamp(self, job, terminal_status: BatchJobStatus) -> int | None:
-        if str(getattr(job, "status", "") or "") != terminal_status.value:
-            return None
-        return self._timestamp_or_none(getattr(job, "status_last_updated_at", None))
-
-    def _timestamp_or_none(self, value: datetime | None) -> int | None:
-        return int(value.timestamp()) if value else None
+        return serialize_public_batch(job)
 
     def _parse_input_jsonl(
         self,

--- a/src/batch/webhooks/__init__.py
+++ b/src/batch/webhooks/__init__.py
@@ -3,6 +3,13 @@ from src.batch.webhooks.crypto import (
     BatchWebhookCryptoError,
     decode_batch_webhook_encryption_key,
 )
+from src.batch.webhooks.events import (
+    BatchWebhookEvent,
+    batch_webhook_event_payload_sha256,
+    batch_webhook_event_type_for_status,
+    build_batch_webhook_event,
+    canonical_batch_webhook_event_bytes,
+)
 from src.batch.webhooks.models import (
     BATCH_WEBHOOK_MAX_SECRET_BYTES,
     BATCH_WEBHOOK_MAX_URL_LENGTH,
@@ -21,9 +28,14 @@ __all__ = [
     "BATCH_WEBHOOK_MIN_SECRET_BYTES",
     "BatchWebhookCipher",
     "BatchWebhookCryptoError",
+    "BatchWebhookEvent",
     "BatchWebhookRequest",
     "BatchWebhookValidationError",
     "batch_webhook_config_fingerprint",
+    "batch_webhook_event_payload_sha256",
+    "batch_webhook_event_type_for_status",
+    "build_batch_webhook_event",
+    "canonical_batch_webhook_event_bytes",
     "canonical_batch_webhook_config_bytes",
     "decode_batch_webhook_encryption_key",
     "parse_batch_webhook_request",

--- a/src/batch/webhooks/events.py
+++ b/src/batch/webhooks/events.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from src.batch.models import BatchJobRecord, BatchJobStatus, BatchWebhookEventType
+from src.batch.serialization import serialize_public_batch
+
+
+_EVENT_TYPE_BY_TERMINAL_STATUS = {
+    BatchJobStatus.COMPLETED: BatchWebhookEventType.COMPLETED,
+    BatchJobStatus.FAILED: BatchWebhookEventType.FAILED,
+    BatchJobStatus.CANCELLED: BatchWebhookEventType.CANCELLED,
+    BatchJobStatus.EXPIRED: BatchWebhookEventType.EXPIRED,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class BatchWebhookEvent:
+    event_id: str
+    event_type: BatchWebhookEventType
+    payload_json: dict[str, Any]
+    payload_sha256: str
+
+
+def canonical_batch_webhook_event_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def batch_webhook_event_payload_sha256(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_batch_webhook_event_bytes(payload)).hexdigest()
+
+
+def batch_webhook_event_type_for_status(
+    status: str | BatchJobStatus,
+) -> BatchWebhookEventType:
+    normalized = status if isinstance(status, BatchJobStatus) else BatchJobStatus(str(status or ""))
+    try:
+        return _EVENT_TYPE_BY_TERMINAL_STATUS[normalized]
+    except KeyError as exc:
+        raise ValueError(f"batch status '{normalized.value}' is not terminal") from exc
+
+
+def build_batch_webhook_event(
+    job: BatchJobRecord,
+    *,
+    event_id: str | None = None,
+    created_at: datetime | None = None,
+) -> BatchWebhookEvent:
+    event_type = batch_webhook_event_type_for_status(job.status)
+    stable_event_id = str(event_id or f"evt_{uuid4().hex}")
+    event_created_at = created_at or datetime.now(tz=UTC)
+    payload = {
+        "id": stable_event_id,
+        "object": "event",
+        "type": event_type.value,
+        "created_at": int(event_created_at.timestamp()),
+        "data": {"batch": serialize_public_batch(job)},
+    }
+    return BatchWebhookEvent(
+        event_id=stable_event_id,
+        event_type=event_type,
+        payload_json=payload,
+        payload_sha256=batch_webhook_event_payload_sha256(payload),
+    )

--- a/src/batch/webhooks/models.py
+++ b/src/batch/webhooks/models.py
@@ -33,6 +33,10 @@ def _normalize_webhook_url(value: str) -> str:
     normalized = str(value or "").strip()
     if not normalized:
         raise ValueError("webhook url is required")
+    try:
+        normalized.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError("webhook url must contain valid UTF-8 text") from exc
     if len(normalized) > BATCH_WEBHOOK_MAX_URL_LENGTH:
         raise ValueError(f"webhook url must be at most {BATCH_WEBHOOK_MAX_URL_LENGTH} characters")
     if any(ord(character) <= 0x20 or ord(character) == 0x7F for character in normalized):

--- a/src/batch/worker_artifacts.py
+++ b/src/batch/worker_artifacts.py
@@ -310,27 +310,16 @@ class BatchArtifactFinalizer:
         return BatchJobStatus.COMPLETED
 
     async def _persist_permanent_finalization_failure(self, job, *, reason: str) -> bool:
+        provider_error = f"artifact_validation_failed: {reason}"
         finalized = await self.repository.attach_artifacts_and_finalize(
             batch_id=job.batch_id,
             output_file_id=None,
             error_file_id=None,
             final_status=BatchJobStatus.FAILED,
             worker_id=self.config.worker_id,
+            terminal_provider_error=provider_error,
         )
-        if finalized is None:
-            return False
-        try:
-            await self.repository.set_provider_error(
-                batch_id=job.batch_id,
-                provider_error=f"artifact_validation_failed: {reason}",
-            )
-        except Exception:
-            logger.warning(
-                "batch finalization failed to persist permanent failure reason batch_id=%s",
-                job.batch_id,
-                exc_info=True,
-            )
-        return True
+        return finalized is not None
 
     async def _schedule_finalization_retry(self, job) -> None:
         rescheduled = await self.repository.reschedule_finalization(

--- a/src/batch/worker_artifacts.py
+++ b/src/batch/worker_artifacts.py
@@ -17,7 +17,11 @@ from src.metrics import (
     observe_batch_finalize_latency,
 )
 
-from src.batch.worker_types import BatchArtifactValidationError, BatchWorkerConfig
+from src.batch.worker_types import (
+    BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
+    BatchArtifactValidationError,
+    BatchWorkerConfig,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -97,11 +101,12 @@ class BatchArtifactFinalizer:
             token_value = normalized_usage.get(token_field)
             if type(token_value) is not int:
                 raise BatchArtifactValidationError(
-                    f"completed batch item embedding response usage has invalid {token_field}={token_value!r}"
+                    "completed batch item embedding response usage has invalid "
+                    f"{token_field} type={type(token_value).__name__}"
                 )
             if token_value < 0:
                 raise BatchArtifactValidationError(
-                    f"completed batch item embedding response usage has negative {token_field}={token_value!r}"
+                    f"completed batch item embedding response usage has negative {token_field}"
                 )
 
         return normalized_usage
@@ -128,9 +133,7 @@ class BatchArtifactFinalizer:
         if object_type is None:
             sanitized["object"] = "list"
         elif object_type != "list":
-            raise BatchArtifactValidationError(
-                f"completed batch item has invalid embedding response object={object_type!r}"
-            )
+            raise BatchArtifactValidationError("completed batch item has invalid embedding response object")
 
         data_rows = sanitized.get("data")
         if not isinstance(data_rows, list):
@@ -155,7 +158,7 @@ class BatchArtifactFinalizer:
                 normalized_row["object"] = "embedding"
             elif row_object != "embedding":
                 raise BatchArtifactValidationError(
-                    f"completed batch item embedding response row {row_number} has invalid object={row_object!r}"
+                    f"completed batch item embedding response row {row_number} has invalid object"
                 )
 
             response_index = normalized_row.get("index")
@@ -163,7 +166,8 @@ class BatchArtifactFinalizer:
                 normalized_row["index"] = row_number
             elif type(response_index) is not int:
                 raise BatchArtifactValidationError(
-                    f"completed batch item embedding response row {row_number} has invalid index={response_index!r}"
+                    "completed batch item embedding response row "
+                    f"{row_number} has invalid index type={type(response_index).__name__}"
                 )
             normalized_rows.append(normalized_row)
 
@@ -211,11 +215,12 @@ class BatchArtifactFinalizer:
                 continue
             if type(token_value) is not int:
                 raise BatchArtifactValidationError(
-                    f"completed batch item chat response usage has invalid {token_field}={token_value!r}"
+                    "completed batch item chat response usage has invalid "
+                    f"{token_field} type={type(token_value).__name__}"
                 )
             if token_value < 0:
                 raise BatchArtifactValidationError(
-                    f"completed batch item chat response usage has negative {token_field}={token_value!r}"
+                    f"completed batch item chat response usage has negative {token_field}"
                 )
         return normalized_usage
 
@@ -229,9 +234,7 @@ class BatchArtifactFinalizer:
         if object_type is None:
             sanitized["object"] = "chat.completion"
         elif object_type != "chat.completion":
-            raise BatchArtifactValidationError(
-                f"completed batch item has invalid chat response object={object_type!r}"
-            )
+            raise BatchArtifactValidationError("completed batch item has invalid chat response object")
 
         choices = sanitized.get("choices")
         if not isinstance(choices, list):
@@ -309,15 +312,14 @@ class BatchArtifactFinalizer:
             return BatchJobStatus.FAILED
         return BatchJobStatus.COMPLETED
 
-    async def _persist_permanent_finalization_failure(self, job, *, reason: str) -> bool:
-        provider_error = f"artifact_validation_failed: {reason}"
+    async def _persist_permanent_finalization_failure(self, job) -> bool:  # noqa: ANN001
         finalized = await self.repository.attach_artifacts_and_finalize(
             batch_id=job.batch_id,
             output_file_id=None,
             error_file_id=None,
             final_status=BatchJobStatus.FAILED,
             worker_id=self.config.worker_id,
-            terminal_provider_error=provider_error,
+            terminal_provider_error=BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
         )
         return finalized is not None
 
@@ -353,13 +355,13 @@ class BatchArtifactFinalizer:
             return
         except BatchArtifactValidationError as exc:
             logger.warning(
-                "batch finalization permanently failed batch_id=%s error=%s",
+                "batch finalization permanently failed batch_id=%s error_code=%s reason=%s",
                 job.batch_id,
+                BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
                 exc,
-                exc_info=True,
             )
             try:
-                persisted = await self._persist_permanent_finalization_failure(job, reason=str(exc))
+                persisted = await self._persist_permanent_finalization_failure(job)
             except Exception:
                 logger.warning(
                     "batch finalization permanent-failure persistence failed batch_id=%s",
@@ -522,7 +524,7 @@ class BatchArtifactFinalizer:
         logger.info(
             "batch finalized id=%s status=%s completed=%s failed=%s",
             job.batch_id,
-            final_status,
+            finalized.status,
             job.completed_items,
             job.failed_items,
         )

--- a/src/batch/worker_types.py
+++ b/src/batch/worker_types.py
@@ -7,6 +7,9 @@ from src.batch.embedding_microbatch import _ExecutionSignature
 from src.models.requests import ChatCompletionRequest, EmbeddingRequest
 
 
+BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR = "artifact_validation_failed"
+
+
 class BatchArtifactValidationError(ValueError):
     """Raised when a completed batch artifact payload cannot be safely exposed."""
 

--- a/src/bootstrap/batch.py
+++ b/src/bootstrap/batch.py
@@ -44,6 +44,7 @@ from src.batch.scheduling import (
 )
 from src.batch.storage import LocalBatchArtifactStorage, S3BatchArtifactStorage
 from src.batch.worker import BatchExecutorWorker, BatchWorkerConfig
+from src.batch.webhooks import BatchWebhookCipher
 from src.bootstrap.status import BootstrapStatus
 from src.metrics import increment_batch_scheduler_rollback
 from src.services.model_visibility import normalize_callable_target_policy_mode
@@ -827,6 +828,11 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
     )
     app.state.batch_create_session_admin_service = runtime.create_session_admin_service
 
+    batch_webhook_encryption_key = getattr(
+        cfg.general_settings,
+        "batch_webhook_encryption_key",
+        None,
+    )
     app.state.batch_create_session_service = BatchCreateSessionService(
         repository=repository,
         create_session_repository=session_repository,
@@ -855,6 +861,14 @@ async def init_batch_runtime(app: Any, cfg: Any, repository: BatchRepository) ->
             False,
         ),
         default_service_tier=getattr(cfg.general_settings, "embeddings_batch_scheduler_default_service_tier", "standard"),
+        webhook_enabled=getattr(cfg.general_settings, "batch_webhook_enabled", False),
+        webhook_cipher=(
+            BatchWebhookCipher.from_config(batch_webhook_encryption_key)
+            if batch_webhook_encryption_key is not None
+            else None
+        ),
+        webhook_allow_http=getattr(cfg.general_settings, "batch_webhook_allow_http", False),
+        webhook_allowed_ports=getattr(cfg.general_settings, "batch_webhook_allowed_ports", [443]),
     )
     app.state.batch_service.bind_create_session_service(app.state.batch_create_session_service)
 

--- a/src/bootstrap/infrastructure.py
+++ b/src/bootstrap/infrastructure.py
@@ -102,7 +102,10 @@ async def init_infrastructure_runtime(app: Any) -> InfrastructureRuntime:
     app.state.prompt_registry_repository = PromptRegistryRepository(prisma_manager.client)
     app.state.mcp_repository = MCPRepository(prisma_manager.client)
     app.state.mcp_scope_policy_repository = MCPScopePolicyRepository(prisma_manager.client)
-    app.state.batch_repository = BatchRepository(prisma_manager.client)
+    app.state.batch_repository = BatchRepository(
+        prisma_manager.client,
+        webhook_max_attempts=getattr(cfg.general_settings, "batch_webhook_max_attempts", 8),
+    )
     app.state.email_outbox_repository = EmailOutboxRepository(prisma_manager.client)
     app.state.email_token_repository = EmailTokenRepository(prisma_manager.client)
     app.state.invitation_repository = InvitationRepository(prisma_manager.client)

--- a/tests/bootstrap/test_infrastructure_bootstrap.py
+++ b/tests/bootstrap/test_infrastructure_bootstrap.py
@@ -120,7 +120,10 @@ async def test_init_and_shutdown_infrastructure_runtime(monkeypatch: pytest.Monk
     monkeypatch.setattr("src.bootstrap.infrastructure.RouteGroupRepository", lambda client: ("route-group-repo", client))
     monkeypatch.setattr("src.bootstrap.infrastructure.PromptRegistryRepository", lambda client: ("prompt-repo", client))
     monkeypatch.setattr("src.bootstrap.infrastructure.MCPRepository", lambda client: ("mcp-repo", client))
-    monkeypatch.setattr("src.bootstrap.infrastructure.BatchRepository", lambda client: ("batch-repo", client))
+    monkeypatch.setattr(
+        "src.bootstrap.infrastructure.BatchRepository",
+        lambda client, **kwargs: ("batch-repo", client, kwargs),
+    )
 
     app = SimpleNamespace(state=SimpleNamespace())
 
@@ -156,7 +159,11 @@ async def test_init_and_shutdown_infrastructure_runtime(monkeypatch: pytest.Monk
     assert runtime.control_http_client.limits.max_keepalive_connections == 20
     assert runtime.control_http_client.limits.keepalive_expiry == 30
     assert app.state.openai_adapter[0] == "openai"
-    assert app.state.batch_repository == ("batch-repo", "db-client")
+    assert app.state.batch_repository == (
+        "batch-repo",
+        "db-client",
+        {"webhook_max_attempts": 8},
+    )
 
     await shutdown_infrastructure_runtime(runtime)
 

--- a/tests/test_batch_create_promoter.py
+++ b/tests/test_batch_create_promoter.py
@@ -5,7 +5,11 @@ import pytest
 
 from src.batch.create.models import BatchCreateSessionRecord, BatchCreateSessionStatus, BatchCreateStagedRequest
 from src.batch.create.promoter import BatchCreatePromotionError, BatchCreateSessionPromoter
-from src.batch.models import BatchJobRecord
+from src.batch.models import (
+    BatchJobRecord,
+    BatchJobStatus,
+    BatchWebhookConfigurationConflictError,
+)
 
 
 def _session(
@@ -153,6 +157,8 @@ class _FakeRepository:
         self._tenant_queued_work_units = tenant_queued_work_units
         self.lock_calls: list[tuple[str, str]] = []
         self.webhook_repair_calls: list[dict[str, str]] = []
+        self.webhook_reconcile_calls: list[dict[str, str | None]] = []
+        self.terminal_webhook_event_jobs: list[str] = []
         self.prisma = _FakePrisma(object()) if tx_repository is None else None
         if tx_repository is not None:
             self.prisma = _FakePrisma(tx_repository)
@@ -186,6 +192,46 @@ class _FakeRepository:
             return None
         self._job.webhook_config_ciphertext = webhook_config_ciphertext
         self._job.webhook_config_fingerprint = webhook_config_fingerprint
+        return self._job
+
+    async def reconcile_job_webhook_config(
+        self,
+        *,
+        batch_id: str,
+        webhook_config_ciphertext: str | None,
+        webhook_config_fingerprint: str | None,
+    ) -> BatchJobRecord | None:
+        self.webhook_reconcile_calls.append(
+            {
+                "batch_id": batch_id,
+                "webhook_config_ciphertext": webhook_config_ciphertext,
+                "webhook_config_fingerprint": webhook_config_fingerprint,
+            }
+        )
+        if self._job is None or self._job.batch_id != batch_id:
+            return None
+        expected = (webhook_config_ciphertext, webhook_config_fingerprint)
+        current = (
+            self._job.webhook_config_ciphertext,
+            self._job.webhook_config_fingerprint,
+        )
+        if current != expected:
+            if current != (None, None) or expected == (None, None):
+                raise BatchWebhookConfigurationConflictError(
+                    "webhook configuration conflict"
+                )
+            await self.set_job_webhook_config_if_unset(
+                batch_id=batch_id,
+                webhook_config_ciphertext=str(webhook_config_ciphertext),
+                webhook_config_fingerprint=str(webhook_config_fingerprint),
+            )
+        if self._job.status in {
+            BatchJobStatus.COMPLETED,
+            BatchJobStatus.FAILED,
+            BatchJobStatus.CANCELLED,
+            BatchJobStatus.EXPIRED,
+        } and self._job.webhook_config_ciphertext is not None:
+            self.terminal_webhook_event_jobs.append(batch_id)
         return self._job
 
     async def count_active_jobs_for_scope(self, *, created_by_api_key=None, created_by_team_id=None) -> int:  # noqa: ANN001
@@ -485,6 +531,88 @@ async def test_promote_session_repairs_missing_job_webhook_config_during_recover
             "webhook_config_fingerprint": "a" * 64,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_promote_completed_session_repairs_webhook_and_heals_terminal_event() -> None:
+    session = _session(
+        status=BatchCreateSessionStatus.COMPLETED,
+        webhook_config_ciphertext="v1.key.ciphertext",
+        webhook_config_fingerprint="a" * 64,
+    )
+    existing_job = _job()
+    existing_job.status = BatchJobStatus.COMPLETED
+    repository = _FakeRepository(
+        session_repo=_SessionRepo(session),
+        job=existing_job,
+    )
+    staging = _FakeStaging()
+
+    result = await BatchCreateSessionPromoter(
+        repository=repository,
+        staging=staging,
+    ).promote_session(session.session_id)
+
+    assert result.promoted is False
+    assert result.job is existing_job
+    assert existing_job.webhook_config_ciphertext == "v1.key.ciphertext"
+    assert existing_job.webhook_config_fingerprint == "a" * 64
+    assert repository.terminal_webhook_event_jobs == [existing_job.batch_id]
+    assert staging.read_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_promote_completed_session_rejects_webhook_configuration_conflict() -> None:
+    session = _session(
+        status=BatchCreateSessionStatus.COMPLETED,
+        webhook_config_ciphertext="v1.key.expected",
+        webhook_config_fingerprint="a" * 64,
+    )
+    existing_job = _job()
+    existing_job.webhook_config_ciphertext = "v1.key.different"
+    existing_job.webhook_config_fingerprint = "b" * 64
+    repository = _FakeRepository(
+        session_repo=_SessionRepo(session),
+        job=existing_job,
+    )
+
+    with pytest.raises(BatchCreatePromotionError) as exc:
+        await BatchCreateSessionPromoter(
+            repository=repository,
+            staging=_FakeStaging(),
+        ).promote_session(session.session_id)
+
+    assert exc.value.code == "webhook_config_mismatch"
+    assert exc.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_promote_completed_session_treats_reconciliation_failure_as_retryable() -> None:
+    session = _session(
+        status=BatchCreateSessionStatus.COMPLETED,
+        webhook_config_ciphertext="v1.key.expected",
+        webhook_config_fingerprint="a" * 64,
+    )
+    existing_job = _job()
+
+    class _UnavailableRepository(_FakeRepository):
+        async def reconcile_job_webhook_config(self, **kwargs):  # noqa: ANN003, ANN201
+            del kwargs
+            raise RuntimeError("database unavailable")
+
+    repository = _UnavailableRepository(
+        session_repo=_SessionRepo(session),
+        job=existing_job,
+    )
+
+    with pytest.raises(BatchCreatePromotionError) as exc:
+        await BatchCreateSessionPromoter(
+            repository=repository,
+            staging=_FakeStaging(),
+        ).promote_session(session.session_id)
+
+    assert exc.value.code == "webhook_reconciliation_failed"
+    assert exc.value.retryable is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_create_promoter.py
+++ b/tests/test_batch_create_promoter.py
@@ -8,7 +8,13 @@ from src.batch.create.promoter import BatchCreatePromotionError, BatchCreateSess
 from src.batch.models import BatchJobRecord
 
 
-def _session(*, status: str, expected_item_count: int = 1) -> BatchCreateSessionRecord:
+def _session(
+    *,
+    status: str,
+    expected_item_count: int = 1,
+    webhook_config_ciphertext: str | None = None,
+    webhook_config_fingerprint: str | None = None,
+) -> BatchCreateSessionRecord:
     now = datetime.now(tz=UTC)
     return BatchCreateSessionRecord(
         session_id="session-1",
@@ -41,6 +47,8 @@ def _session(*, status: str, expected_item_count: int = 1) -> BatchCreateSession
         completed_at=now if status == BatchCreateSessionStatus.COMPLETED else None,
         last_attempt_at=None,
         expires_at=None,
+        webhook_config_ciphertext=webhook_config_ciphertext,
+        webhook_config_fingerprint=webhook_config_fingerprint,
     )
 
 
@@ -144,6 +152,7 @@ class _FakeRepository:
         self._active_jobs = active_jobs
         self._tenant_queued_work_units = tenant_queued_work_units
         self.lock_calls: list[tuple[str, str]] = []
+        self.webhook_repair_calls: list[dict[str, str]] = []
         self.prisma = _FakePrisma(object()) if tx_repository is None else None
         if tx_repository is not None:
             self.prisma = _FakePrisma(tx_repository)
@@ -158,6 +167,26 @@ class _FakeRepository:
 
     async def acquire_scope_advisory_lock(self, *, scope_type: str, scope_id: str) -> None:
         self.lock_calls.append((scope_type, scope_id))
+
+    async def set_job_webhook_config_if_unset(
+        self,
+        *,
+        batch_id: str,
+        webhook_config_ciphertext: str,
+        webhook_config_fingerprint: str,
+    ) -> BatchJobRecord | None:
+        self.webhook_repair_calls.append(
+            {
+                "batch_id": batch_id,
+                "webhook_config_ciphertext": webhook_config_ciphertext,
+                "webhook_config_fingerprint": webhook_config_fingerprint,
+            }
+        )
+        if self._job is None:
+            return None
+        self._job.webhook_config_ciphertext = webhook_config_ciphertext
+        self._job.webhook_config_fingerprint = webhook_config_fingerprint
+        return self._job
 
     async def count_active_jobs_for_scope(self, *, created_by_api_key=None, created_by_team_id=None) -> int:  # noqa: ANN001
         del created_by_api_key, created_by_team_id
@@ -325,7 +354,11 @@ async def test_promote_session_short_circuits_before_staging_when_soft_precheck_
 
 @pytest.mark.asyncio
 async def test_promote_session_uses_configured_tx_timings_and_locked_recheck() -> None:
-    session = _session(status=BatchCreateSessionStatus.STAGED)
+    session = _session(
+        status=BatchCreateSessionStatus.STAGED,
+        webhook_config_ciphertext="v1.key.ciphertext",
+        webhook_config_fingerprint="a" * 64,
+    )
     tx_repository = _SuccessfulTxRepository(session_repo=_TxSessionRepo(session), active_jobs=0)
     repository = _FakeRepository(
         session_repo=_SessionRepo(session),
@@ -368,6 +401,8 @@ async def test_promote_session_uses_configured_tx_timings_and_locked_recheck() -
     assert tx_repository.created_jobs[0]["estimated_work_units"] == 1
     assert tx_repository.created_jobs[0]["remaining_work_units"] == 1
     assert tx_repository.created_jobs[0]["size_class"] == "xs"
+    assert tx_repository.created_jobs[0]["webhook_config_ciphertext"] == "v1.key.ciphertext"
+    assert tx_repository.created_jobs[0]["webhook_config_fingerprint"] == "a" * 64
 
 
 @pytest.mark.asyncio
@@ -408,6 +443,48 @@ async def test_promote_session_locks_configured_tenant_scope_before_queued_work_
         "api_key",
         "user",
     )
+
+
+@pytest.mark.asyncio
+async def test_promote_session_repairs_missing_job_webhook_config_during_recovery() -> None:
+    session = _session(
+        status=BatchCreateSessionStatus.STAGED,
+        webhook_config_ciphertext="v1.key.ciphertext",
+        webhook_config_fingerprint="a" * 64,
+    )
+    existing_job = _job()
+    tx_repository = _FakeRepository(
+        session_repo=_TxSessionRepo(session),
+        job=existing_job,
+    )
+    repository = _FakeRepository(
+        session_repo=_SessionRepo(session),
+        tx_repository=tx_repository,
+    )
+    staging = _FakeStaging(
+        records=[
+            BatchCreateStagedRequest(
+                line_number=1,
+                custom_id="req-1",
+                request_body={"model": "m1", "input": "hello"},
+            )
+        ]
+    )
+
+    result = await BatchCreateSessionPromoter(
+        repository=repository,
+        staging=staging,
+    ).promote_session(session.session_id)
+
+    assert result.promoted is False
+    assert result.job is existing_job
+    assert tx_repository.webhook_repair_calls == [
+        {
+            "batch_id": "batch-1",
+            "webhook_config_ciphertext": "v1.key.ciphertext",
+            "webhook_config_fingerprint": "a" * 64,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_create_service.py
+++ b/tests/test_batch_create_service.py
@@ -15,6 +15,7 @@ from src.batch.create import (
 from src.batch.create.service import BatchCreateSessionService, BatchCreateSessionServiceResult
 from src.batch.models import BatchJobRecord, BatchJobStatus
 from src.batch.service import BatchService
+from src.batch.webhooks import BatchWebhookCipher, batch_webhook_config_fingerprint
 from src.models.responses import UserAPIKeyAuth
 
 
@@ -59,6 +60,8 @@ def _session(
     status: str = BatchCreateSessionStatus.COMPLETED,
     input_file_id: str = "file-1",
     metadata: dict | None = None,
+    webhook_config_ciphertext: str | None = None,
+    webhook_config_fingerprint: str | None = None,
 ) -> BatchCreateSessionRecord:
     now = datetime.now(tz=UTC)
     return BatchCreateSessionRecord(
@@ -92,6 +95,8 @@ def _session(
         completed_at=now if status == BatchCreateSessionStatus.COMPLETED else None,
         last_attempt_at=now,
         expires_at=None,
+        webhook_config_ciphertext=webhook_config_ciphertext,
+        webhook_config_fingerprint=webhook_config_fingerprint,
     )
 
 
@@ -246,6 +251,227 @@ async def test_create_session_service_rejects_mismatched_existing_idempotent_req
     assert exc.value.status_code == 409
 
 
+def test_create_session_service_rejects_webhook_before_staging_when_disabled() -> None:
+    service = _create_session_service_for_validation()
+
+    with pytest.raises(HTTPException) as exc:
+        service._validate_webhook(  # noqa: SLF001
+            {
+                "url": "https://customer.example/webhooks",
+                "signing_secret": "s" * 32,
+            }
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {
+        "code": "batch_webhook_disabled",
+        "message": "Batch webhooks are not enabled",
+    }
+
+
+def test_create_session_service_rejects_webhook_when_encryption_is_unavailable() -> None:
+    service = _create_session_service_for_validation()
+    service.webhook_enabled = True
+
+    with pytest.raises(HTTPException) as exc:
+        service._validate_webhook(  # noqa: SLF001
+            {
+                "url": "https://customer.example/webhooks",
+                "signing_secret": "s" * 32,
+            }
+        )
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == {
+        "code": "batch_webhook_unavailable",
+        "message": "Batch webhook encryption is unavailable",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_session_service_matches_idempotency_by_webhook_fingerprint() -> None:
+    cipher = BatchWebhookCipher(bytes(range(32)))
+    webhook = {
+        "url": "https://customer.example/webhooks",
+        "signing_secret": "s" * 32,
+    }
+    validation_service = BatchCreateSessionService(
+        repository=SimpleNamespace(),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(),  # type: ignore[arg-type]
+        stager=SimpleNamespace(),  # type: ignore[arg-type]
+        promoter=SimpleNamespace(),  # type: ignore[arg-type]
+        storage_registry={},
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+        webhook_enabled=True,
+        webhook_cipher=cipher,
+    )
+    validated = validation_service._validate_webhook(webhook)  # noqa: SLF001
+    assert validated is not None
+    existing_session = _session(
+        webhook_config_ciphertext=cipher.encrypt(validated.config),
+        webhook_config_fingerprint=batch_webhook_config_fingerprint(validated.config),
+    )
+    job = _job(batch_id=existing_session.target_batch_id)
+    job.webhook_config_ciphertext = existing_session.webhook_config_ciphertext
+    job.webhook_config_fingerprint = existing_session.webhook_config_fingerprint
+
+    async def _get_session_by_idempotency_key(**kwargs):  # noqa: ANN003, ANN201
+        del kwargs
+        return existing_session
+
+    promoter = _PromoterStub(
+        result=BatchCreatePromotionResult(
+            session_id=existing_session.session_id,
+            batch_id=job.batch_id,
+            promoted=False,
+            job=job,
+        )
+    )
+    service = BatchCreateSessionService(
+        repository=_FailIfLoadedRepo(job=job),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(
+            get_session_by_idempotency_key=_get_session_by_idempotency_key
+        ),  # type: ignore[arg-type]
+        stager=SimpleNamespace(),  # type: ignore[arg-type]
+        promoter=promoter,  # type: ignore[arg-type]
+        storage_registry={},
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+        idempotency_enabled=True,
+        webhook_enabled=True,
+        webhook_cipher=cipher,
+    )
+
+    result = await service.create_batch(
+        auth=UserAPIKeyAuth(api_key="key-a"),
+        input_file_id="file-1",
+        endpoint="/v1/embeddings",
+        metadata=None,
+        completion_window=None,
+        idempotency_key="idem-1",
+        webhook=webhook,
+    )
+
+    assert result.job.batch_id == "batch-1"
+    assert result.audit_metadata["webhook_configured"] is True
+
+    changed_webhook = dict(webhook, signing_secret="x" * 32)
+    with pytest.raises(HTTPException) as exc:
+        await service.create_batch(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            input_file_id="file-1",
+            endpoint="/v1/embeddings",
+            metadata=None,
+            completion_window=None,
+            idempotency_key="idem-1",
+            webhook=changed_webhook,
+        )
+
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_session_service_encrypts_webhook_into_staged_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("src.batch.create.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+    cipher = BatchWebhookCipher(bytes(range(32)))
+    secret = "s" * 32
+    url = "https://customer.example/webhooks"
+    file_record = SimpleNamespace(
+        file_id="file-1",
+        filename="batch.jsonl",
+        bytes=128,
+        storage_backend="local",
+        storage_key="input/file-1.jsonl",
+        created_by_api_key="key-a",
+        created_by_team_id=None,
+        created_by_organization_id=None,
+    )
+
+    class _Storage:
+        async def iter_lines(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+            del args, kwargs
+            yield '{"custom_id":"req-1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}'
+
+    class _Stager:
+        created = None
+
+        async def stage_session(self, *, records, filename, build_session):  # noqa: ANN001, ANN201
+            del filename
+            staged = [record async for record in records]
+            assert len(staged) == 1
+            self.created = build_session(
+                SimpleNamespace(
+                    storage_backend="local",
+                    storage_key="batch-create-stage/session-1.jsonl",
+                    checksum="checksum",
+                    bytes_size=128,
+                )
+            )
+            return _session(
+                status=BatchCreateSessionStatus.STAGED,
+                webhook_config_ciphertext=self.created.webhook_config_ciphertext,
+                webhook_config_fingerprint=self.created.webhook_config_fingerprint,
+            )
+
+    async def _get_file(file_id: str):  # noqa: ANN201
+        assert file_id == "file-1"
+        return file_record
+
+    async def _count_active_jobs_for_scope(**kwargs):  # noqa: ANN003, ANN201
+        del kwargs
+        return 0
+
+    job = _job()
+    promoter = _PromoterStub(
+        result=BatchCreatePromotionResult(
+            session_id="session-1",
+            batch_id=job.batch_id,
+            promoted=True,
+            job=job,
+        )
+    )
+    stager = _Stager()
+    service = BatchCreateSessionService(
+        repository=SimpleNamespace(
+            get_file=_get_file,
+            count_active_jobs_for_scope=_count_active_jobs_for_scope,
+        ),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(),  # type: ignore[arg-type]
+        stager=stager,  # type: ignore[arg-type]
+        promoter=promoter,  # type: ignore[arg-type]
+        storage_registry={"local": _Storage()},  # type: ignore[dict-item]
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+        webhook_enabled=True,
+        webhook_cipher=cipher,
+    )
+
+    await service.create_batch(
+        auth=UserAPIKeyAuth(api_key="key-a"),
+        input_file_id="file-1",
+        endpoint="/v1/embeddings",
+        metadata=None,
+        completion_window=None,
+        webhook={"url": url, "signing_secret": secret},
+    )
+
+    assert stager.created is not None
+    assert stager.created.webhook_config_ciphertext not in {None, "", url, secret}
+    decrypted = cipher.decrypt(stager.created.webhook_config_ciphertext)
+    assert decrypted.url == "https://customer.example/webhooks"
+    assert decrypted.signing_secret.get_secret_value() == secret
+    assert len(stager.created.webhook_config_fingerprint) == 64
+
+
 @pytest.mark.asyncio
 async def test_batch_service_create_result_delegates_to_bound_create_session_service() -> None:
     class _CreateSessionServiceStub:
@@ -273,6 +499,7 @@ async def test_batch_service_create_result_delegates_to_bound_create_session_ser
         metadata=None,
         completion_window=None,
         idempotency_key="idem-1",
+        webhook={"configured": "raw-placeholder"},
     )
 
     assert result.response["id"] == "batch-delegated"
@@ -281,6 +508,7 @@ async def test_batch_service_create_result_delegates_to_bound_create_session_ser
     assert result.response["errors"] is None
     assert result.audit_metadata["create_path"] == "create_session"
     assert create_session_service.calls[0]["idempotency_key"] == "idem-1"
+    assert create_session_service.calls[0]["webhook"] == {"configured": "raw-placeholder"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_create_service.py
+++ b/tests/test_batch_create_service.py
@@ -289,6 +289,46 @@ def test_create_session_service_rejects_webhook_when_encryption_is_unavailable()
 
 
 @pytest.mark.asyncio
+async def test_create_session_service_rejects_non_utf8_webhook_url_before_loading_file() -> None:
+    async def _fail_get_file(file_id: str):  # noqa: ANN201
+        raise AssertionError(f"get_file must not be called for invalid webhook URL: {file_id}")
+
+    service = BatchCreateSessionService(
+        repository=SimpleNamespace(get_file=_fail_get_file),  # type: ignore[arg-type]
+        create_session_repository=SimpleNamespace(),  # type: ignore[arg-type]
+        stager=_NeverCalledStager(),  # type: ignore[arg-type]
+        promoter=SimpleNamespace(),  # type: ignore[arg-type]
+        storage_registry={},
+        max_file_bytes=1024,
+        max_items_per_batch=100,
+        max_line_bytes=1024,
+        storage_chunk_size=128,
+        webhook_enabled=True,
+        webhook_cipher=BatchWebhookCipher(bytes(range(32))),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_batch(
+            auth=UserAPIKeyAuth(api_key="key-a"),
+            input_file_id="file-1",
+            endpoint="/v1/embeddings",
+            metadata=None,
+            completion_window=None,
+            webhook={
+                "url": "https://customer.example/\ud800",
+                "signing_secret": "s" * 32,
+            },
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {
+        "code": "invalid_url",
+        "message": "webhook url is invalid",
+        "field": "url",
+    }
+
+
+@pytest.mark.asyncio
 async def test_create_session_service_matches_idempotency_by_webhook_fingerprint() -> None:
     cipher = BatchWebhookCipher(bytes(range(32)))
     webhook = {

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -26,7 +26,13 @@ from src.batch.create import (
 )
 from src.batch.create.service import BatchCreateSessionService
 from src.batch.cleanup import BatchCleanupConfig, BatchRetentionCleanupWorker
-from src.batch.models import BATCH_JOB_STATUS_VALUES, BatchCompletionOutboxCreate, BatchItemCreate
+from src.batch.models import (
+    BATCH_JOB_STATUS_VALUES,
+    BatchCompletionOutboxCreate,
+    BatchItemCreate,
+    BatchJobStatus,
+    BatchWebhookEventType,
+)
 from src.batch.models import encode_operator_failed_reason
 from src.batch.repository import BatchRepository
 from src.batch.scheduling import (
@@ -37,6 +43,8 @@ from src.batch.scheduling import (
 from src.batch.service import BatchService
 from src.batch.storage import LocalBatchArtifactStorage, S3BatchArtifactStorage
 from src.batch.worker import BatchExecutorWorker, BatchWorkerConfig
+from src.batch.webhooks import BatchWebhookCipher
+from src.batch.webhooks.events import batch_webhook_event_payload_sha256
 from src.auth.roles import Permission
 from src.models.responses import UserAPIKeyAuth
 
@@ -149,6 +157,7 @@ async def _connect_prisma() -> Any:
 async def _reset_batch_tables(db: Any) -> None:
     await db.execute_raw("DELETE FROM deltallm_batch_scheduler_flow")
     await db.execute_raw("DELETE FROM deltallm_batch_create_session")
+    await db.execute_raw("DELETE FROM deltallm_batch_webhook_outbox")
     await db.execute_raw("DELETE FROM deltallm_batch_completion_outbox")
     await db.execute_raw("DELETE FROM deltallm_batch_item")
     await db.execute_raw("DELETE FROM deltallm_batch_job")
@@ -242,11 +251,16 @@ async def batch_db():
             """
             SELECT
                 to_regclass('public.deltallm_batch_job')::text AS batch_job,
-                to_regclass('public.deltallm_batch_completion_outbox')::text AS batch_completion_outbox
+                to_regclass('public.deltallm_batch_completion_outbox')::text AS batch_completion_outbox,
+                to_regclass('public.deltallm_batch_webhook_outbox')::text AS batch_webhook_outbox
             """
         )
         row = dict(rows[0]) if rows else {}
-        if row.get("batch_job") is None or row.get("batch_completion_outbox") is None:
+        if (
+            row.get("batch_job") is None
+            or row.get("batch_completion_outbox") is None
+            or row.get("batch_webhook_outbox") is None
+        ):
             pytest.skip("Batch tables are missing; run prisma migrate deploy before DB-backed batch tests")
         await _reset_batch_tables(db)
         yield db
@@ -936,6 +950,8 @@ def _build_cutover_batch_service(
     storage_registry: dict[str, Any] | None = None,
     idempotency_enabled: bool = False,
     max_pending_batches_per_scope: int = 20,
+    webhook_enabled: bool = False,
+    webhook_cipher: BatchWebhookCipher | None = None,
 ) -> BatchService:
     active_storage_registry = {"local": storage}
     if storage_registry:
@@ -963,6 +979,8 @@ def _build_cutover_batch_service(
         storage_chunk_size=65_536,
         max_pending_batches_per_scope=max_pending_batches_per_scope,
         idempotency_enabled=idempotency_enabled,
+        webhook_enabled=webhook_enabled,
+        webhook_cipher=webhook_cipher,
     )
     return BatchService(
         repository=repository,
@@ -1286,6 +1304,261 @@ async def test_db_backed_batch_create_cutover_rejects_idempotency_payload_mismat
     job_rows = await batch_db.query_raw("SELECT batch_id FROM deltallm_batch_job")
     assert len(session_rows) == 1
     assert len(job_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_db_backed_batch_create_persists_encrypted_webhook_and_matches_idempotency(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("src.batch.create.service.ensure_batch_model_allowed", lambda *args, **kwargs: None)
+    cipher = BatchWebhookCipher(bytes(range(32)))
+    repository = BatchRepository(batch_db)
+    storage = LocalBatchArtifactStorage(str(tmp_path / "cutover-webhook-artifacts"))
+    service = _build_cutover_batch_service(
+        repository=repository,
+        storage=storage,
+        idempotency_enabled=True,
+        webhook_enabled=True,
+        webhook_cipher=cipher,
+    )
+    auth = UserAPIKeyAuth(api_key="key-a")
+    input_file_id = await _create_input_file(
+        service,
+        auth=auth,
+        payload=b'{"custom_id":"c1","url":"/v1/embeddings","body":{"model":"m1","input":"hello"}}\n',
+    )
+    webhook = {
+        "url": "https://customer.example/webhooks/deltallm",
+        "signing_secret": "s" * 32,
+    }
+
+    first = await service.create_batch_result(
+        auth=auth,
+        input_file_id=input_file_id,
+        endpoint="/v1/embeddings",
+        metadata={"customer_job_id": "job-1"},
+        completion_window=None,
+        idempotency_key="idem-webhook",
+        webhook=webhook,
+    )
+    second = await service.create_batch_result(
+        auth=auth,
+        input_file_id=input_file_id,
+        endpoint="/v1/embeddings",
+        metadata={"customer_job_id": "job-1"},
+        completion_window=None,
+        idempotency_key="idem-webhook",
+        webhook=webhook,
+    )
+
+    assert first.response["id"] == second.response["id"]
+    assert first.response["webhook"] == {"configured": True}
+    assert second.audit_metadata["idempotency_resolution"] == "existing"
+    rows = await batch_db.query_raw(
+        """
+        SELECT
+            s.webhook_config_ciphertext AS session_ciphertext,
+            s.webhook_config_fingerprint AS session_fingerprint,
+            j.webhook_config_ciphertext AS job_ciphertext,
+            j.webhook_config_fingerprint AS job_fingerprint
+        FROM deltallm_batch_create_session s
+        JOIN deltallm_batch_job j ON j.batch_id = s.target_batch_id
+        WHERE j.batch_id = $1
+        """,
+        str(first.response["id"]),
+    )
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["session_ciphertext"] == row["job_ciphertext"]
+    assert row["session_fingerprint"] == row["job_fingerprint"]
+    assert webhook["url"] not in str(row)
+    assert webhook["signing_secret"] not in str(row)
+    decrypted = cipher.decrypt(str(row["job_ciphertext"]))
+    assert decrypted.url == webhook["url"]
+    assert decrypted.signing_secret.get_secret_value() == webhook["signing_secret"]
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_batch_result(
+            auth=auth,
+            input_file_id=input_file_id,
+            endpoint="/v1/embeddings",
+            metadata={"customer_job_id": "job-1"},
+            completion_window=None,
+            idempotency_key="idem-webhook",
+            webhook={**webhook, "signing_secret": "x" * 32},
+        )
+
+    assert exc.value.status_code == 409
+
+
+async def _seed_finalizing_webhook_job(
+    batch_db,
+    *,
+    final_status: BatchJobStatus,
+) -> tuple[BatchRepository, str, str]:
+    repository = BatchRepository(batch_db, webhook_max_attempts=7)
+    input_file_id = await _seed_batch_file(repository)
+    job = await repository.create_job(
+        endpoint="/v1/embeddings",
+        input_file_id=input_file_id,
+        model="m1",
+        metadata={"customer_job_id": "job-1"},
+        created_by_api_key="key-a",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        expires_at=None,
+        webhook_config_ciphertext="v1.key.ciphertext",
+        webhook_config_fingerprint="a" * 64,
+    )
+    assert job is not None
+    inserted = await repository.create_items(
+        job.batch_id,
+        [BatchItemCreate(line_number=1, custom_id="c1", request_body={"model": "m1", "input": "a"})],
+    )
+    assert inserted == 1
+    item_status = {
+        BatchJobStatus.COMPLETED: "completed",
+        BatchJobStatus.FAILED: "failed",
+        BatchJobStatus.CANCELLED: "cancelled",
+        BatchJobStatus.EXPIRED: "failed",
+    }[final_status]
+    await batch_db.execute_raw(
+        """
+        UPDATE deltallm_batch_item
+        SET status = $2,
+            completed_at = NOW()
+        WHERE batch_id = $1
+        """,
+        job.batch_id,
+        item_status,
+    )
+    await batch_db.execute_raw(
+        """
+        UPDATE deltallm_batch_job
+        SET status = 'finalizing',
+            locked_by = 'worker-1',
+            lease_expires_at = NOW() + INTERVAL '2 minutes',
+            started_at = NOW()
+        WHERE batch_id = $1
+        """,
+        job.batch_id,
+    )
+    return repository, job.batch_id, "worker-1"
+
+
+@pytest.mark.parametrize(
+    ("final_status", "event_type"),
+    [
+        (BatchJobStatus.COMPLETED, BatchWebhookEventType.COMPLETED),
+        (BatchJobStatus.FAILED, BatchWebhookEventType.FAILED),
+        (BatchJobStatus.CANCELLED, BatchWebhookEventType.CANCELLED),
+        (BatchJobStatus.EXPIRED, BatchWebhookEventType.EXPIRED),
+    ],
+)
+@pytest.mark.asyncio
+async def test_db_backed_terminal_transition_atomically_enqueues_one_webhook_event(
+    batch_db,
+    final_status: BatchJobStatus,
+    event_type: BatchWebhookEventType,
+) -> None:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=final_status,
+    )
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id=batch_id,
+        output_file_id=None,
+        error_file_id=None,
+        final_status=final_status,
+        worker_id=worker_id,
+    )
+    duplicate = await repository.attach_artifacts_and_finalize(
+        batch_id=batch_id,
+        output_file_id=None,
+        error_file_id=None,
+        final_status=final_status,
+        worker_id=worker_id,
+    )
+
+    assert finalized is not None
+    assert finalized.status is final_status
+    assert finalized.total_items == 1
+    assert finalized.in_progress_items == 0
+    assert duplicate is None
+    rows = await batch_db.query_raw(
+        """
+        SELECT *
+        FROM deltallm_batch_webhook_outbox
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["event_type"] == event_type.value
+    assert row["target_config_ciphertext"] == "v1.key.ciphertext"
+    assert row["status"] == "queued"
+    assert int(row["max_attempts"]) == 7
+    payload = row["payload_json"]
+    assert isinstance(payload, dict)
+    assert payload["id"] == row["event_id"]
+    assert payload["type"] == event_type.value
+    assert payload["data"]["batch"]["status"] == final_status.value
+    assert payload["data"]["batch"]["metadata"] == {"customer_job_id": "job-1"}
+    assert row["payload_sha256"] == batch_webhook_event_payload_sha256(payload)
+
+
+@pytest.mark.asyncio
+async def test_db_backed_webhook_outbox_failure_rolls_back_terminal_transition(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=BatchJobStatus.COMPLETED,
+    )
+
+    async def _fail_insert(*args, **kwargs):  # noqa: ANN002, ANN003
+        del args, kwargs
+        raise RuntimeError("simulated webhook outbox failure")
+
+    monkeypatch.setattr(
+        "src.batch.repositories.webhook_outbox_repository.BatchWebhookOutboxRepository.insert_event",
+        _fail_insert,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated webhook outbox failure"):
+        await repository.attach_artifacts_and_finalize(
+            batch_id=batch_id,
+            output_file_id="file-output",
+            error_file_id=None,
+            final_status=BatchJobStatus.COMPLETED,
+            worker_id=worker_id,
+        )
+
+    job_rows = await batch_db.query_raw(
+        """
+        SELECT status, output_file_id, locked_by
+        FROM deltallm_batch_job
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert [dict(row) for row in job_rows] == [
+        {
+            "status": "finalizing",
+            "output_file_id": None,
+            "locked_by": worker_id,
+        }
+    ]
+    outbox_rows = await batch_db.query_raw(
+        "SELECT event_id FROM deltallm_batch_webhook_outbox WHERE batch_id = $1",
+        batch_id,
+    )
+    assert outbox_rows == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -41,6 +41,7 @@ from src.batch.scheduling import (
     stable_tenant_scope_id,
 )
 from src.batch.service import BatchService
+from src.batch.serialization import serialize_public_batch
 from src.batch.storage import LocalBatchArtifactStorage, S3BatchArtifactStorage
 from src.batch.worker import BatchExecutorWorker, BatchWorkerConfig
 from src.batch.webhooks import BatchWebhookCipher
@@ -1512,6 +1513,44 @@ async def test_db_backed_terminal_transition_atomically_enqueues_one_webhook_eve
 
 
 @pytest.mark.asyncio
+async def test_db_backed_permanent_finalization_failure_snapshots_final_public_batch(
+    batch_db,
+) -> None:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=BatchJobStatus.FAILED,
+    )
+    provider_error = "artifact_validation_failed: invalid output artifact"
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id=batch_id,
+        output_file_id=None,
+        error_file_id=None,
+        final_status=BatchJobStatus.FAILED,
+        worker_id=worker_id,
+        terminal_provider_error=provider_error,
+    )
+
+    assert finalized is not None
+    assert finalized.provider_error == provider_error
+    reloaded = await repository.get_job(batch_id)
+    assert reloaded is not None
+    assert reloaded.provider_error == provider_error
+    rows = await batch_db.query_raw(
+        """
+        SELECT payload_json
+        FROM deltallm_batch_webhook_outbox
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert len(rows) == 1
+    payload = dict(rows[0])["payload_json"]
+    assert payload["type"] == BatchWebhookEventType.FAILED.value
+    assert payload["data"]["batch"] == serialize_public_batch(reloaded)
+
+
+@pytest.mark.asyncio
 async def test_db_backed_webhook_outbox_failure_rolls_back_terminal_transition(
     batch_db,
     monkeypatch: pytest.MonkeyPatch,
@@ -1537,11 +1576,12 @@ async def test_db_backed_webhook_outbox_failure_rolls_back_terminal_transition(
             error_file_id=None,
             final_status=BatchJobStatus.COMPLETED,
             worker_id=worker_id,
+            terminal_provider_error="artifact_validation_failed: invalid output artifact",
         )
 
     job_rows = await batch_db.query_raw(
         """
-        SELECT status, output_file_id, locked_by
+        SELECT status, output_file_id, locked_by, provider_error
         FROM deltallm_batch_job
         WHERE batch_id = $1
         """,
@@ -1552,6 +1592,7 @@ async def test_db_backed_webhook_outbox_failure_rolls_back_terminal_transition(
             "status": "finalizing",
             "output_file_id": None,
             "locked_by": worker_id,
+            "provider_error": None,
         }
     ]
     outbox_rows = await batch_db.query_raw(

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime, timedelta
 import json
+import logging
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -44,6 +45,8 @@ from src.batch.service import BatchService
 from src.batch.serialization import serialize_public_batch
 from src.batch.storage import LocalBatchArtifactStorage, S3BatchArtifactStorage
 from src.batch.worker import BatchExecutorWorker, BatchWorkerConfig
+from src.batch.worker_artifacts import BatchArtifactFinalizer
+from src.batch.worker_types import BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR
 from src.batch.webhooks import BatchWebhookCipher
 from src.batch.webhooks.events import batch_webhook_event_payload_sha256
 from src.auth.roles import Permission
@@ -1449,6 +1452,58 @@ async def _seed_finalizing_webhook_job(
     return repository, job.batch_id, "worker-1"
 
 
+async def _reset_finalizing_webhook_job_item_to_pending(batch_db, *, batch_id: str) -> None:
+    await batch_db.execute_raw(
+        """
+        UPDATE deltallm_batch_item
+        SET status = 'pending',
+            completed_at = NULL
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    await batch_db.execute_raw(
+        """
+        UPDATE deltallm_batch_job
+        SET total_items = 1,
+            completed_items = 0,
+            failed_items = 0,
+            in_progress_items = 0,
+            cancelled_items = 0
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+
+
+async def _seed_terminal_job_without_webhook(
+    batch_db,
+) -> tuple[BatchRepository, str]:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=BatchJobStatus.COMPLETED,
+    )
+    await batch_db.execute_raw(
+        """
+        UPDATE deltallm_batch_job
+        SET webhook_config_ciphertext = NULL,
+            webhook_config_fingerprint = NULL
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id=batch_id,
+        output_file_id=None,
+        error_file_id=None,
+        final_status=BatchJobStatus.COMPLETED,
+        worker_id=worker_id,
+    )
+    assert finalized is not None
+    assert finalized.status is BatchJobStatus.COMPLETED
+    return repository, batch_id
+
+
 @pytest.mark.parametrize(
     ("final_status", "event_type"),
     [
@@ -1513,6 +1568,354 @@ async def test_db_backed_terminal_transition_atomically_enqueues_one_webhook_eve
 
 
 @pytest.mark.asyncio
+async def test_db_backed_terminal_webhook_reconciliation_preserves_snapshot_after_timestamp_drift(
+    batch_db,
+) -> None:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=BatchJobStatus.FAILED,
+    )
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id=batch_id,
+        output_file_id=None,
+        error_file_id=None,
+        final_status=BatchJobStatus.FAILED,
+        worker_id=worker_id,
+    )
+    assert finalized is not None
+    before_rows = await batch_db.query_raw(
+        """
+        SELECT event_id, payload_json, payload_sha256
+        FROM deltallm_batch_webhook_outbox
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert len(before_rows) == 1
+    before = dict(before_rows[0])
+
+    await batch_db.execute_raw(
+        """
+        UPDATE deltallm_batch_job
+        SET status_last_updated_at = status_last_updated_at + INTERVAL '1 hour'
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    drifted = await repository.get_job(batch_id)
+    assert drifted is not None
+    assert before["payload_json"]["data"]["batch"]["failed_at"] != serialize_public_batch(
+        drifted
+    )["failed_at"]
+
+    reconciled = await repository.reconcile_job_webhook_config(
+        batch_id=batch_id,
+        webhook_config_ciphertext="v1.key.ciphertext",
+        webhook_config_fingerprint="a" * 64,
+    )
+
+    assert reconciled is not None
+    assert reconciled.status is BatchJobStatus.FAILED
+    after_rows = await batch_db.query_raw(
+        """
+        SELECT event_id, payload_json, payload_sha256
+        FROM deltallm_batch_webhook_outbox
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert [dict(row) for row in after_rows] == [before]
+    assert before["payload_sha256"] == batch_webhook_event_payload_sha256(
+        before["payload_json"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_db_backed_late_cancellation_controls_terminal_status_and_webhook_event(
+    batch_db,
+) -> None:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=BatchJobStatus.COMPLETED,
+    )
+    cancellation = await repository.request_cancel(batch_id)
+    assert cancellation is not None
+    assert cancellation.status is BatchJobStatus.FINALIZING
+    assert cancellation.cancel_requested_at is not None
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id=batch_id,
+        output_file_id=None,
+        error_file_id=None,
+        final_status=BatchJobStatus.COMPLETED,
+        worker_id=worker_id,
+    )
+
+    assert finalized is not None
+    assert finalized.status is BatchJobStatus.CANCELLED
+    rows = await batch_db.query_raw(
+        """
+        SELECT event_type, payload_json
+        FROM deltallm_batch_webhook_outbox
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert len(rows) == 1
+    event = dict(rows[0])
+    assert event["event_type"] == BatchWebhookEventType.CANCELLED.value
+    assert event["payload_json"]["data"]["batch"] == serialize_public_batch(finalized)
+
+
+@pytest.mark.asyncio
+async def test_db_backed_late_operator_failure_controls_terminal_status_and_webhook_event(
+    batch_db,
+) -> None:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=BatchJobStatus.COMPLETED,
+    )
+    updated = await repository.set_provider_error(
+        batch_id=batch_id,
+        provider_error=encode_operator_failed_reason("manual stop"),
+    )
+    assert updated is not None
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id=batch_id,
+        output_file_id=None,
+        error_file_id=None,
+        final_status=BatchJobStatus.COMPLETED,
+        worker_id=worker_id,
+    )
+
+    assert finalized is not None
+    assert finalized.status is BatchJobStatus.FAILED
+    rows = await batch_db.query_raw(
+        """
+        SELECT event_type, payload_json
+        FROM deltallm_batch_webhook_outbox
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert len(rows) == 1
+    event = dict(rows[0])
+    assert event["event_type"] == BatchWebhookEventType.FAILED.value
+    assert event["payload_json"]["data"]["batch"] == serialize_public_batch(finalized)
+
+
+@pytest.mark.asyncio
+async def test_db_backed_terminal_webhook_reconciliation_repairs_config_and_event_once(
+    batch_db,
+) -> None:
+    repository, batch_id = await _seed_terminal_job_without_webhook(batch_db)
+
+    first = await repository.reconcile_job_webhook_config(
+        batch_id=batch_id,
+        webhook_config_ciphertext="v1.key.recovered",
+        webhook_config_fingerprint="b" * 64,
+    )
+    second = await repository.reconcile_job_webhook_config(
+        batch_id=batch_id,
+        webhook_config_ciphertext="v1.key.recovered",
+        webhook_config_fingerprint="b" * 64,
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first.webhook_config_ciphertext == "v1.key.recovered"
+    assert second.webhook_config_fingerprint == "b" * 64
+    rows = await batch_db.query_raw(
+        """
+        SELECT event_type, target_config_ciphertext, payload_json
+        FROM deltallm_batch_webhook_outbox
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert len(rows) == 1
+    event = dict(rows[0])
+    assert event["event_type"] == BatchWebhookEventType.COMPLETED.value
+    assert event["target_config_ciphertext"] == "v1.key.recovered"
+    assert event["payload_json"]["data"]["batch"] == serialize_public_batch(second)
+
+
+@pytest.mark.asyncio
+async def test_db_backed_terminal_webhook_reconciliation_rolls_back_config_on_outbox_failure(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository, batch_id = await _seed_terminal_job_without_webhook(batch_db)
+
+    async def _fail_insert(*args, **kwargs):  # noqa: ANN002, ANN003
+        del args, kwargs
+        raise RuntimeError("simulated recovery outbox failure")
+
+    monkeypatch.setattr(
+        "src.batch.repositories.webhook_outbox_repository.BatchWebhookOutboxRepository.insert_event",
+        _fail_insert,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated recovery outbox failure"):
+        await repository.reconcile_job_webhook_config(
+            batch_id=batch_id,
+            webhook_config_ciphertext="v1.key.recovered",
+            webhook_config_fingerprint="b" * 64,
+        )
+
+    reloaded = await repository.get_job(batch_id)
+    assert reloaded is not None
+    assert reloaded.webhook_config_ciphertext is None
+    assert reloaded.webhook_config_fingerprint is None
+    rows = await batch_db.query_raw(
+        "SELECT event_id FROM deltallm_batch_webhook_outbox WHERE batch_id = $1",
+        batch_id,
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_db_backed_finalization_reuses_outer_transaction_and_observes_uncommitted_items(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=BatchJobStatus.COMPLETED,
+    )
+    await _reset_finalizing_webhook_job_item_to_pending(batch_db, batch_id=batch_id)
+    observed: list[str] = []
+    monkeypatch.setattr(
+        repository.jobs,
+        "observe_finalization",
+        lambda job: observed.append(job.batch_id),
+    )
+
+    async with batch_db.tx() as tx:
+        await tx.execute_raw(
+            """
+            UPDATE deltallm_batch_item
+            SET status = 'completed',
+                completed_at = NOW()
+            WHERE batch_id = $1
+            """,
+            batch_id,
+        )
+        transactional_repository = repository.with_prisma(tx)
+        finalized = await transactional_repository.attach_artifacts_and_finalize(
+            batch_id=batch_id,
+            output_file_id=None,
+            error_file_id=None,
+            final_status=BatchJobStatus.COMPLETED,
+            worker_id=worker_id,
+        )
+
+        assert finalized is not None
+        assert finalized.status is BatchJobStatus.COMPLETED
+        assert finalized.completed_items == 1
+        assert observed == []
+
+    repository.publish_finalization_metric_after_commit(finalized)
+
+    assert observed == [batch_id]
+    reloaded = await repository.get_job(batch_id)
+    assert reloaded is not None
+    assert reloaded.status is BatchJobStatus.COMPLETED
+    assert reloaded.completed_items == 1
+    rows = await batch_db.query_raw(
+        """
+        SELECT event_type, payload_json
+        FROM deltallm_batch_webhook_outbox
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["event_type"] == BatchWebhookEventType.COMPLETED.value
+    assert row["payload_json"]["data"]["batch"] == serialize_public_batch(reloaded)
+
+
+@pytest.mark.asyncio
+async def test_db_backed_outer_transaction_rollback_removes_terminal_transition_and_webhook(
+    batch_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=BatchJobStatus.COMPLETED,
+    )
+    await _reset_finalizing_webhook_job_item_to_pending(batch_db, batch_id=batch_id)
+    observed: list[str] = []
+    monkeypatch.setattr(
+        repository.jobs,
+        "observe_finalization",
+        lambda job: observed.append(job.batch_id),
+    )
+
+    with pytest.raises(RuntimeError, match="force outer rollback"):
+        async with batch_db.tx() as tx:
+            await tx.execute_raw(
+                """
+                UPDATE deltallm_batch_item
+                SET status = 'completed',
+                    completed_at = NOW()
+                WHERE batch_id = $1
+                """,
+                batch_id,
+            )
+            transactional_repository = repository.with_prisma(tx)
+            finalized = await transactional_repository.attach_artifacts_and_finalize(
+                batch_id=batch_id,
+                output_file_id=None,
+                error_file_id=None,
+                final_status=BatchJobStatus.COMPLETED,
+                worker_id=worker_id,
+            )
+            assert finalized is not None
+            assert observed == []
+            raise RuntimeError("force outer rollback")
+
+    job_rows = await batch_db.query_raw(
+        """
+        SELECT status, output_file_id, locked_by, completed_items
+        FROM deltallm_batch_job
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert [dict(row) for row in job_rows] == [
+        {
+            "status": "finalizing",
+            "output_file_id": None,
+            "locked_by": worker_id,
+            "completed_items": 0,
+        }
+    ]
+    item_rows = await batch_db.query_raw(
+        """
+        SELECT status, completed_at
+        FROM deltallm_batch_item
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert [dict(row) for row in item_rows] == [
+        {
+            "status": "pending",
+            "completed_at": None,
+        }
+    ]
+    outbox_rows = await batch_db.query_raw(
+        "SELECT event_id FROM deltallm_batch_webhook_outbox WHERE batch_id = $1",
+        batch_id,
+    )
+    assert outbox_rows == []
+    assert observed == []
+
+
+@pytest.mark.asyncio
 async def test_db_backed_permanent_finalization_failure_snapshots_final_public_batch(
     batch_db,
 ) -> None:
@@ -1520,7 +1923,7 @@ async def test_db_backed_permanent_finalization_failure_snapshots_final_public_b
         batch_db,
         final_status=BatchJobStatus.FAILED,
     )
-    provider_error = "artifact_validation_failed: invalid output artifact"
+    provider_error = BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR
 
     finalized = await repository.attach_artifacts_and_finalize(
         batch_id=batch_id,
@@ -1551,6 +1954,97 @@ async def test_db_backed_permanent_finalization_failure_snapshots_final_public_b
 
 
 @pytest.mark.asyncio
+async def test_db_backed_oversized_artifact_validation_failure_still_enqueues_webhook(
+    batch_db,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    repository, batch_id, worker_id = await _seed_finalizing_webhook_job(
+        batch_db,
+        final_status=BatchJobStatus.FAILED,
+    )
+    provider_marker = "provider-controlled-marker"
+    provider_value = provider_marker + ("x" * 65_536)
+    await batch_db.execute_raw(
+        """
+        UPDATE deltallm_batch_item
+        SET response_body = $2::jsonb
+        WHERE batch_id = $1
+        """,
+        batch_id,
+        json.dumps(
+            {
+                "object": provider_value,
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+                "model": "m1",
+                "usage": {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1},
+            }
+        ),
+    )
+    await batch_db.execute_raw(
+        """
+        UPDATE deltallm_batch_job
+        SET total_items = 1,
+            completed_items = 1,
+            failed_items = 0,
+            in_progress_items = 0,
+            cancelled_items = 0
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    job = await repository.get_job(batch_id)
+    assert job is not None
+
+    finalizer = BatchArtifactFinalizer(
+        repository=repository,
+        storage=LocalBatchArtifactStorage(str(tmp_path)),
+        config=BatchWorkerConfig(worker_id=worker_id),
+    )
+    with caplog.at_level(logging.WARNING):
+        await finalizer.finalize_with_retry(job)
+
+    reloaded = await repository.get_job(batch_id)
+    assert reloaded is not None
+    assert reloaded.status is BatchJobStatus.FAILED
+    assert reloaded.provider_error == BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR
+    assert reloaded.completed_at is not None
+    assert reloaded.locked_by is None
+    assert reloaded.lease_expires_at is None
+    assert reloaded.total_items == 1
+    assert reloaded.completed_items == 1
+    assert reloaded.in_progress_items == 0
+    assert provider_marker not in caplog.text
+    assert list(tmp_path.rglob("*")) == []
+
+    duplicate = await repository.attach_artifacts_and_finalize(
+        batch_id=batch_id,
+        output_file_id=None,
+        error_file_id=None,
+        final_status=BatchJobStatus.FAILED,
+        worker_id=worker_id,
+        terminal_provider_error=BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
+    )
+    assert duplicate is None
+    rows = await batch_db.query_raw(
+        """
+        SELECT *
+        FROM deltallm_batch_webhook_outbox
+        WHERE batch_id = $1
+        """,
+        batch_id,
+    )
+    assert len(rows) == 1
+    row = dict(rows[0])
+    payload = row["payload_json"]
+    assert isinstance(payload, dict)
+    assert row["event_type"] == BatchWebhookEventType.FAILED.value
+    assert row["payload_sha256"] == batch_webhook_event_payload_sha256(payload)
+    assert payload["data"]["batch"] == serialize_public_batch(reloaded)
+    assert provider_marker not in json.dumps(payload)
+
+
+@pytest.mark.asyncio
 async def test_db_backed_webhook_outbox_failure_rolls_back_terminal_transition(
     batch_db,
     monkeypatch: pytest.MonkeyPatch,
@@ -1576,7 +2070,7 @@ async def test_db_backed_webhook_outbox_failure_rolls_back_terminal_transition(
             error_file_id=None,
             final_status=BatchJobStatus.COMPLETED,
             worker_id=worker_id,
-            terminal_provider_error="artifact_validation_failed: invalid output artifact",
+            terminal_provider_error=BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
         )
 
     job_rows = await batch_db.query_raw(

--- a/tests/test_batch_repository.py
+++ b/tests/test_batch_repository.py
@@ -15,6 +15,7 @@ from src.batch.models import (
     BatchJobStatus,
     BatchSchedulerFlowRecord,
     BatchWorkClaim,
+    OPERATOR_FAILED_PREFIX,
 )
 from src.batch.repository import BatchRepository
 from src.batch.repositories.item_repository import BatchItemRepository
@@ -22,6 +23,7 @@ from src.batch.repositories.job_repository import BatchJobRepository, flow_from_
 from src.batch.repositories.maintenance_repository import BatchMaintenanceRepository
 from src.batch.repositories.mappers import job_from_row
 from src.batch.repositories import job_repository as job_repository_module
+from src.batch.worker_types import BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR
 import src.batch.scheduling.advisory_locks as advisory_locks_module
 from src.batch.scheduling import (
     API_KEY_TENANT_SCOPE_PREFIX,
@@ -4521,14 +4523,17 @@ async def test_attach_artifacts_and_finalize_casts_status_parameter_to_enum() ->
         output_file_id="out-1",
         error_file_id="err-1",
         final_status="completed",
-        terminal_provider_error="artifact_validation_failed: invalid artifact",
+        terminal_provider_error=BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
     )
 
     assert finalized is None
-    assert 'status = $4::"DeltaLLM_BatchJobStatus"' in prisma.sql
+    assert 'status = (' in prisma.sql
+    assert "j.cancel_requested_at IS NOT NULL OR $4 = 'cancelled'" in prisma.sql
+    assert "LEFT(COALESCE(j.provider_error, ''), LENGTH($6)) = $6" in prisma.sql
     assert "provider_error = COALESCE($5, j.provider_error)" in prisma.sql
     assert prisma.params[3] == BatchJobStatus.COMPLETED.value
-    assert prisma.params[4] == "artifact_validation_failed: invalid artifact"
+    assert prisma.params[4] == BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR
+    assert prisma.params[5] == OPERATOR_FAILED_PREFIX
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_repository.py
+++ b/tests/test_batch_repository.py
@@ -4521,11 +4521,14 @@ async def test_attach_artifacts_and_finalize_casts_status_parameter_to_enum() ->
         output_file_id="out-1",
         error_file_id="err-1",
         final_status="completed",
+        terminal_provider_error="artifact_validation_failed: invalid artifact",
     )
 
     assert finalized is None
     assert 'status = $4::"DeltaLLM_BatchJobStatus"' in prisma.sql
+    assert "provider_error = COALESCE($5, j.provider_error)" in prisma.sql
     assert prisma.params[3] == BatchJobStatus.COMPLETED.value
+    assert prisma.params[4] == "artifact_validation_failed: invalid artifact"
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_repository.py
+++ b/tests/test_batch_repository.py
@@ -3559,7 +3559,8 @@ async def test_create_job_defaults_to_queued_status() -> None:
 
     assert '::"DeltaLLM_BatchJobStatus"' in prisma.sql
     assert prisma.params[2] == BatchJobStatus.QUEUED.value
-    assert len(prisma.params) == 25
+    assert len(prisma.params) == 27
+    assert prisma.params[-2:] == (None, None)
     assert "scheduler_version, scheduling_model, scheduling_model_group" in prisma.sql
 
 

--- a/tests/test_batch_service.py
+++ b/tests/test_batch_service.py
@@ -160,6 +160,19 @@ def test_job_to_response_sets_expired_at_for_expired_batches() -> None:
     assert response["failed_at"] is None
 
 
+def test_job_to_response_only_exposes_webhook_configured_indicator() -> None:
+    job = _batch_job(status=BatchJobStatus.QUEUED)
+    job.webhook_config_ciphertext = "v1.key.secret-ciphertext"
+    job.webhook_config_fingerprint = "a" * 64
+
+    response = _service().job_to_response(job)
+
+    assert response["webhook"] == {"configured": True}
+    rendered = str(response)
+    assert "secret-ciphertext" not in rendered
+    assert "a" * 64 not in rendered
+
+
 class _FakeCallableTargetBindingRepository:
     def __init__(self, bindings: list[CallableTargetBindingRecord]) -> None:
         self.bindings = list(bindings)

--- a/tests/test_batch_webhook_events.py
+++ b/tests/test_batch_webhook_events.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import pytest
+
+from src.batch.models import BatchJobRecord, BatchJobStatus, BatchWebhookEventType
+from src.batch.serialization import serialize_public_batch
+from src.batch.webhooks.events import (
+    batch_webhook_event_payload_sha256,
+    build_batch_webhook_event,
+    canonical_batch_webhook_event_bytes,
+)
+
+
+def _terminal_job(status: BatchJobStatus = BatchJobStatus.COMPLETED) -> BatchJobRecord:
+    now = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+    return BatchJobRecord(
+        batch_id="batch-1",
+        endpoint="/v1/embeddings",
+        status=status,
+        execution_mode="managed_internal",
+        input_file_id="file-input",
+        output_file_id="file-output",
+        error_file_id=None,
+        model="model-1",
+        metadata={"customer_job_id": "job-4821"},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=3,
+        in_progress_items=0,
+        completed_items=3,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="key-1",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_at=now,
+        started_at=now,
+        completed_at=now,
+        expires_at=None,
+        webhook_config_ciphertext="v1.key.ciphertext",
+        webhook_config_fingerprint="a" * 64,
+    )
+
+
+def test_public_batch_serializer_exposes_only_webhook_indicator() -> None:
+    configured = serialize_public_batch(_terminal_job())
+    legacy = serialize_public_batch(
+        replace(
+            _terminal_job(),
+            webhook_config_ciphertext=None,
+            webhook_config_fingerprint=None,
+        )
+    )
+
+    assert configured["webhook"] == {"configured": True}
+    assert "webhook" not in legacy
+    rendered = str(configured)
+    assert "ciphertext" not in rendered
+    assert "fingerprint" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("status", "event_type"),
+    [
+        (BatchJobStatus.COMPLETED, BatchWebhookEventType.COMPLETED),
+        (BatchJobStatus.FAILED, BatchWebhookEventType.FAILED),
+        (BatchJobStatus.CANCELLED, BatchWebhookEventType.CANCELLED),
+        (BatchJobStatus.EXPIRED, BatchWebhookEventType.EXPIRED),
+    ],
+)
+def test_terminal_event_snapshots_public_batch_with_stable_hash(
+    status: BatchJobStatus,
+    event_type: BatchWebhookEventType,
+) -> None:
+    created_at = datetime(2026, 8, 5, 12, 30, tzinfo=UTC)
+    event = build_batch_webhook_event(
+        replace(_terminal_job(), status=status),
+        event_id="evt-stable",
+        created_at=created_at,
+    )
+
+    assert event.event_id == "evt-stable"
+    assert event.event_type is event_type
+    assert event.payload_json["created_at"] == int(created_at.timestamp())
+    assert event.payload_json["data"]["batch"]["metadata"] == {"customer_job_id": "job-4821"}
+    assert event.payload_sha256 == batch_webhook_event_payload_sha256(event.payload_json)
+    assert canonical_batch_webhook_event_bytes(
+        event.payload_json
+    ) == canonical_batch_webhook_event_bytes(dict(reversed(list(event.payload_json.items()))))
+
+
+def test_event_builder_rejects_nonterminal_batch() -> None:
+    with pytest.raises(ValueError, match="not terminal"):
+        build_batch_webhook_event(replace(_terminal_job(), status=BatchJobStatus.FINALIZING))

--- a/tests/test_batch_webhook_models.py
+++ b/tests/test_batch_webhook_models.py
@@ -80,6 +80,27 @@ def test_webhook_request_rejects_invalid_urls(url: str, error: str) -> None:
         BatchWebhookRequest.model_validate({"url": url, "signing_secret": SIGNING_SECRET})
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/\ud800",
+        "https://example.com/hook?value=\udfff",
+    ],
+)
+def test_webhook_request_rejects_non_utf8_url_without_exposing_it(url: str) -> None:
+    with pytest.raises(BatchWebhookValidationError) as exc_info:
+        parse_batch_webhook_request({"url": url, "signing_secret": SIGNING_SECRET})
+
+    assert exc_info.value.as_detail() == {
+        "code": "invalid_url",
+        "message": "webhook url is invalid",
+        "field": "url",
+    }
+    rendered = f"{exc_info.value!s} {exc_info.value!r} {exc_info.value.as_detail()}"
+    assert repr(url) not in rendered
+    assert SIGNING_SECRET not in rendered
+
+
 def test_webhook_request_enforces_dns_hostname_total_length() -> None:
     maximum_hostname = ".".join(["a" * 63] * 3 + ["a" * 61])
     config = BatchWebhookRequest.model_validate(

--- a/tests/test_batch_webhook_models.py
+++ b/tests/test_batch_webhook_models.py
@@ -203,6 +203,7 @@ def test_webhook_last_error_is_normalized_and_bounded() -> None:
 def test_webhook_outbox_models_and_mapper_normalize_contract_values() -> None:
     now = datetime.now(tz=UTC)
     create = BatchWebhookOutboxCreate(
+        event_id="evt-1",
         batch_id="batch-1",
         event_type="batch.completed",  # type: ignore[arg-type]
         target_config_ciphertext="v1.key.ciphertext",
@@ -211,6 +212,7 @@ def test_webhook_outbox_models_and_mapper_normalize_contract_values() -> None:
     )
     assert create.event_type is BatchWebhookEventType.COMPLETED
     assert create.status is BatchWebhookDeliveryStatus.QUEUED
+    assert create.event_id == "evt-1"
 
     record = webhook_outbox_from_row(
         {
@@ -241,6 +243,7 @@ def test_webhook_outbox_models_and_mapper_normalize_contract_values() -> None:
 
     with pytest.raises(ValueError, match="event type"):
         BatchWebhookOutboxCreate(
+            event_id="evt-invalid",
             batch_id="batch-1",
             event_type="batch.unknown",  # type: ignore[arg-type]
             target_config_ciphertext="ciphertext",

--- a/tests/test_batch_webhook_outbox_repository.py
+++ b/tests/test_batch_webhook_outbox_repository.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from src.batch.models import (
+    BatchJobRecord,
+    BatchJobStatus,
+    BatchWebhookDeliveryStatus,
+    BatchWebhookOutboxCreate,
+    BatchWebhookOutboxRecord,
+)
+from src.batch.repositories.webhook_outbox_repository import BatchWebhookOutboxRepository
+from src.batch.repository import BatchRepository
+from src.batch.webhooks.events import build_batch_webhook_event
+
+
+def _job(*, configured: bool = True) -> BatchJobRecord:
+    now = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+    return BatchJobRecord(
+        batch_id="batch-1",
+        endpoint="/v1/embeddings",
+        status=BatchJobStatus.COMPLETED,
+        execution_mode="managed_internal",
+        input_file_id="file-input",
+        output_file_id="file-output",
+        error_file_id=None,
+        model="model-1",
+        metadata={"customer_job_id": "job-1"},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=1,
+        in_progress_items=0,
+        completed_items=1,
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=None,
+        status_last_updated_at=now,
+        created_by_api_key="key-1",
+        created_by_user_id=None,
+        created_by_team_id=None,
+        created_at=now,
+        started_at=now,
+        completed_at=now,
+        expires_at=None,
+        webhook_config_ciphertext="v1.key.ciphertext" if configured else None,
+        webhook_config_fingerprint="a" * 64 if configured else None,
+    )
+
+
+def _outbox_record(job: BatchJobRecord) -> BatchWebhookOutboxRecord:
+    now = datetime(2026, 8, 5, 12, 30, tzinfo=UTC)
+    event = build_batch_webhook_event(job, event_id="evt-existing", created_at=now)
+    return BatchWebhookOutboxRecord(
+        event_id=event.event_id,
+        batch_id=job.batch_id,
+        event_type=event.event_type,
+        target_config_ciphertext=str(job.webhook_config_ciphertext),
+        payload_json=event.payload_json,
+        payload_sha256=event.payload_sha256,
+        status=BatchWebhookDeliveryStatus.QUEUED,
+        attempt_count=0,
+        max_attempts=8,
+        next_attempt_at=now,
+        last_status_code=None,
+        last_error=None,
+        locked_by=None,
+        lease_expires_at=None,
+        created_at=now,
+        updated_at=now,
+        delivered_at=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_webhook_outbox_repository_inserts_explicit_stable_event_id() -> None:
+    now = datetime.now(tz=UTC)
+
+    class _Prisma:
+        async def query_raw(self, sql: str, *params):  # noqa: ANN201
+            assert "ON CONFLICT (batch_id, event_type) DO NOTHING" in sql
+            return [
+                {
+                    "event_id": params[0],
+                    "batch_id": params[1],
+                    "event_type": params[2],
+                    "target_config_ciphertext": params[3],
+                    "payload_json": params[4],
+                    "payload_sha256": params[5],
+                    "status": params[6],
+                    "attempt_count": params[7],
+                    "max_attempts": params[8],
+                    "next_attempt_at": now,
+                    "last_status_code": params[10],
+                    "last_error": params[11],
+                    "locked_by": None,
+                    "lease_expires_at": None,
+                    "created_at": now,
+                    "updated_at": now,
+                    "delivered_at": None,
+                }
+            ]
+
+    job = _job()
+    event = build_batch_webhook_event(job, event_id="evt-stable", created_at=now)
+    repository = BatchWebhookOutboxRepository(_Prisma())
+
+    inserted = await repository.insert_event(
+        BatchWebhookOutboxCreate(
+            event_id=event.event_id,
+            batch_id=job.batch_id,
+            event_type=event.event_type,
+            target_config_ciphertext=str(job.webhook_config_ciphertext),
+            payload_json=event.payload_json,
+            payload_sha256=event.payload_sha256,
+        )
+    )
+
+    assert inserted is not None
+    assert inserted.event_id == "evt-stable"
+    assert inserted.payload_json["id"] == "evt-stable"
+
+
+class _TransactionManager:
+    def __init__(self) -> None:
+        self.committed = False
+        self.rolled_back = False
+
+    @asynccontextmanager
+    async def tx(self):  # noqa: ANN201
+        try:
+            yield object()
+        except Exception:
+            self.rolled_back = True
+            raise
+        else:
+            self.committed = True
+
+
+class _JobRepository:
+    def __init__(self, job: BatchJobRecord | None) -> None:
+        self.job = job
+        self.calls: list[dict[str, object]] = []
+        self.observed: list[str] = []
+
+    async def attach_artifacts_and_finalize(self, **kwargs):  # noqa: ANN003, ANN201
+        self.calls.append(kwargs)
+        return self.job
+
+    def observe_finalization(self, job: BatchJobRecord) -> None:
+        self.observed.append(job.batch_id)
+
+
+class _OutboxRepository:
+    def __init__(
+        self,
+        *,
+        inserted: object | None = SimpleNamespace(),
+        existing: BatchWebhookOutboxRecord | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.inserted = inserted
+        self.existing = existing
+        self.error = error
+        self.events: list[BatchWebhookOutboxCreate] = []
+
+    async def insert_event(self, event: BatchWebhookOutboxCreate):  # noqa: ANN201
+        self.events.append(event)
+        if self.error is not None:
+            raise self.error
+        return self.inserted
+
+    async def get_by_batch_and_event_type(self, **kwargs):  # noqa: ANN003, ANN201
+        del kwargs
+        return self.existing
+
+
+def _aggregate_repository(
+    *,
+    job: BatchJobRecord | None,
+    outbox: _OutboxRepository,
+) -> tuple[BatchRepository, _TransactionManager, _JobRepository]:
+    transaction_manager = _TransactionManager()
+    transactional_jobs = _JobRepository(job)
+    transactional_repository = SimpleNamespace(
+        jobs=transactional_jobs,
+        webhook_outbox=outbox,
+        webhook_max_attempts=8,
+    )
+    repository = BatchRepository()
+    repository.prisma = transaction_manager
+    observed_jobs = _JobRepository(None)
+    repository.jobs = observed_jobs  # type: ignore[assignment]
+    repository.with_prisma = lambda _tx: transactional_repository  # type: ignore[method-assign]
+    return repository, transaction_manager, observed_jobs
+
+
+@pytest.mark.asyncio
+async def test_atomic_finalization_enqueues_configured_event_then_publishes_metric() -> None:
+    outbox = _OutboxRepository()
+    repository, transaction, observed_jobs = _aggregate_repository(job=_job(), outbox=outbox)
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id="batch-1",
+        output_file_id="file-output",
+        error_file_id=None,
+        final_status=BatchJobStatus.COMPLETED,
+        worker_id="worker-1",
+    )
+
+    assert finalized is not None
+    assert transaction.committed is True
+    assert transaction.rolled_back is False
+    assert len(outbox.events) == 1
+    assert outbox.events[0].payload_json["data"]["batch"]["metadata"] == {
+        "customer_job_id": "job-1"
+    }
+    assert observed_jobs.observed == ["batch-1"]
+
+
+@pytest.mark.asyncio
+async def test_atomic_finalization_rolls_back_when_outbox_insert_fails() -> None:
+    outbox = _OutboxRepository(error=RuntimeError("outbox unavailable"))
+    repository, transaction, observed_jobs = _aggregate_repository(job=_job(), outbox=outbox)
+
+    with pytest.raises(RuntimeError, match="outbox unavailable"):
+        await repository.attach_artifacts_and_finalize(
+            batch_id="batch-1",
+            output_file_id="file-output",
+            error_file_id=None,
+            final_status=BatchJobStatus.COMPLETED,
+            worker_id="worker-1",
+        )
+
+    assert transaction.committed is False
+    assert transaction.rolled_back is True
+    assert observed_jobs.observed == []
+
+
+@pytest.mark.asyncio
+async def test_atomic_finalization_skips_outbox_for_legacy_batch() -> None:
+    outbox = _OutboxRepository(error=AssertionError("outbox must not be called"))
+    repository, transaction, observed_jobs = _aggregate_repository(
+        job=_job(configured=False),
+        outbox=outbox,
+    )
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id="batch-1",
+        output_file_id="file-output",
+        error_file_id=None,
+        final_status=BatchJobStatus.COMPLETED,
+        worker_id="worker-1",
+    )
+
+    assert finalized is not None
+    assert transaction.committed is True
+    assert outbox.events == []
+    assert observed_jobs.observed == ["batch-1"]
+
+
+@pytest.mark.asyncio
+async def test_atomic_finalization_fence_loss_creates_no_event_or_metric() -> None:
+    outbox = _OutboxRepository(error=AssertionError("outbox must not be called"))
+    repository, transaction, observed_jobs = _aggregate_repository(job=None, outbox=outbox)
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id="batch-1",
+        output_file_id="file-output",
+        error_file_id=None,
+        final_status=BatchJobStatus.COMPLETED,
+        worker_id="stale-worker",
+    )
+
+    assert finalized is None
+    assert transaction.committed is True
+    assert outbox.events == []
+    assert observed_jobs.observed == []
+
+
+@pytest.mark.asyncio
+async def test_atomic_finalization_accepts_verified_existing_logical_event() -> None:
+    job = _job()
+    existing = _outbox_record(job)
+    outbox = _OutboxRepository(inserted=None, existing=existing)
+    repository, transaction, observed_jobs = _aggregate_repository(job=job, outbox=outbox)
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id="batch-1",
+        output_file_id="file-output",
+        error_file_id=None,
+        final_status=BatchJobStatus.COMPLETED,
+        worker_id="worker-1",
+    )
+
+    assert finalized is not None
+    assert transaction.committed is True
+    assert observed_jobs.observed == ["batch-1"]
+
+
+@pytest.mark.asyncio
+async def test_atomic_finalization_rejects_conflicting_existing_event() -> None:
+    job = _job()
+    existing = _outbox_record(job)
+    existing.payload_json["data"]["batch"]["status"] = "failed"
+    outbox = _OutboxRepository(inserted=None, existing=existing)
+    repository, transaction, observed_jobs = _aggregate_repository(job=job, outbox=outbox)
+
+    with pytest.raises(RuntimeError, match="conflicts with terminal outcome"):
+        await repository.attach_artifacts_and_finalize(
+            batch_id="batch-1",
+            output_file_id="file-output",
+            error_file_id=None,
+            final_status=BatchJobStatus.COMPLETED,
+            worker_id="worker-1",
+        )
+
+    assert transaction.rolled_back is True
+    assert observed_jobs.observed == []

--- a/tests/test_batch_webhook_outbox_repository.py
+++ b/tests/test_batch_webhook_outbox_repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -15,7 +15,11 @@ from src.batch.models import (
 )
 from src.batch.repositories.webhook_outbox_repository import BatchWebhookOutboxRepository
 from src.batch.repository import BatchRepository
-from src.batch.webhooks.events import build_batch_webhook_event
+from src.batch.webhooks.events import (
+    batch_webhook_event_payload_sha256,
+    build_batch_webhook_event,
+)
+from src.batch.worker_types import BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR
 
 
 def _job(*, configured: bool = True) -> BatchJobRecord:
@@ -144,6 +148,18 @@ class _TransactionManager:
             self.committed = True
 
 
+class _CurrentTransactionClient:
+    def __init__(self) -> None:
+        self.tx_called = False
+
+    def is_transaction(self) -> bool:
+        return True
+
+    def tx(self):  # noqa: ANN201
+        self.tx_called = True
+        raise AssertionError("an existing transaction must not open a nested transaction")
+
+
 class _JobRepository:
     def __init__(
         self,
@@ -155,9 +171,32 @@ class _JobRepository:
         self.observe_error = observe_error
         self.calls: list[dict[str, object]] = []
         self.observed: list[str] = []
+        self.locked: list[str] = []
 
     async def attach_artifacts_and_finalize(self, **kwargs):  # noqa: ANN003, ANN201
         self.calls.append(kwargs)
+        return self.job
+
+    async def get_job_for_update(self, batch_id: str) -> BatchJobRecord | None:
+        self.locked.append(batch_id)
+        return self.job if self.job is not None and self.job.batch_id == batch_id else None
+
+    async def set_webhook_config_if_unset(
+        self,
+        *,
+        batch_id: str,
+        webhook_config_ciphertext: str,
+        webhook_config_fingerprint: str,
+    ) -> BatchJobRecord | None:
+        if self.job is None or self.job.batch_id != batch_id:
+            return None
+        if (
+            self.job.webhook_config_ciphertext is not None
+            or self.job.webhook_config_fingerprint is not None
+        ):
+            return None
+        self.job.webhook_config_ciphertext = webhook_config_ciphertext
+        self.job.webhook_config_fingerprint = webhook_config_fingerprint
         return self.job
 
     def observe_finalization(self, job: BatchJobRecord) -> None:
@@ -198,11 +237,10 @@ def _aggregate_repository(
 ) -> tuple[BatchRepository, _TransactionManager, _JobRepository, _JobRepository]:
     transaction_manager = _TransactionManager()
     transactional_jobs = _JobRepository(job)
-    transactional_repository = SimpleNamespace(
-        jobs=transactional_jobs,
-        webhook_outbox=outbox,
-        webhook_max_attempts=8,
-    )
+    transactional_repository = BatchRepository()
+    transactional_repository.jobs = transactional_jobs  # type: ignore[assignment]
+    transactional_repository.webhook_outbox = outbox  # type: ignore[assignment]
+    transactional_repository.webhook_max_attempts = 8
     repository = BatchRepository()
     repository.prisma = transaction_manager
     observed_jobs = _JobRepository(None, observe_error=observe_error)
@@ -225,7 +263,7 @@ async def test_atomic_finalization_enqueues_configured_event_then_publishes_metr
         error_file_id=None,
         final_status=BatchJobStatus.COMPLETED,
         worker_id="worker-1",
-        terminal_provider_error="artifact_validation_failed: invalid artifact",
+        terminal_provider_error=BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
     )
 
     assert finalized is not None
@@ -243,9 +281,35 @@ async def test_atomic_finalization_enqueues_configured_event_then_publishes_metr
             "error_file_id": None,
             "final_status": BatchJobStatus.COMPLETED,
             "worker_id": "worker-1",
-            "terminal_provider_error": "artifact_validation_failed: invalid artifact",
+            "terminal_provider_error": BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_atomic_finalization_uses_authoritative_returned_status_for_event() -> None:
+    job = _job()
+    job.status = BatchJobStatus.CANCELLED
+    outbox = _OutboxRepository()
+    repository, transaction, observed_jobs, _ = _aggregate_repository(
+        job=job,
+        outbox=outbox,
+    )
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id=job.batch_id,
+        output_file_id=job.output_file_id,
+        error_file_id=job.error_file_id,
+        final_status=BatchJobStatus.COMPLETED,
+        worker_id="worker-1",
+    )
+
+    assert finalized is job
+    assert transaction.committed is True
+    assert observed_jobs.observed == [job.batch_id]
+    assert len(outbox.events) == 1
+    assert outbox.events[0].event_type.value == "batch.cancelled"
+    assert outbox.events[0].payload_json["data"]["batch"]["status"] == "cancelled"
 
 
 @pytest.mark.asyncio
@@ -273,6 +337,80 @@ async def test_atomic_finalization_ignores_metric_failure_after_commit(
     assert len(outbox.events) == 1
     assert observed_jobs.observed == ["batch-1"]
     assert "batch finalization metric publish failed batch_id=batch-1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_atomic_finalization_reuses_current_transaction_and_defers_metric() -> None:
+    job = _job()
+    outbox = _OutboxRepository()
+    jobs = _JobRepository(job)
+    transaction_client = _CurrentTransactionClient()
+    repository = BatchRepository()
+    repository.prisma = transaction_client
+    repository.jobs = jobs  # type: ignore[assignment]
+    repository.webhook_outbox = outbox  # type: ignore[assignment]
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id=job.batch_id,
+        output_file_id=job.output_file_id,
+        error_file_id=job.error_file_id,
+        final_status=job.status,
+        worker_id="worker-1",
+    )
+
+    assert finalized is job
+    assert transaction_client.tx_called is False
+    assert len(outbox.events) == 1
+    assert jobs.observed == []
+
+    repository.publish_finalization_metric_after_commit(finalized)
+
+    assert jobs.observed == [job.batch_id]
+
+
+@pytest.mark.asyncio
+async def test_webhook_reconciliation_repairs_terminal_job_and_enqueues_in_current_transaction() -> None:
+    job = _job(configured=False)
+    jobs = _JobRepository(job)
+    outbox = _OutboxRepository()
+    transaction_client = _CurrentTransactionClient()
+    repository = BatchRepository(transaction_client)
+    repository.jobs = jobs  # type: ignore[assignment]
+    repository.webhook_outbox = outbox  # type: ignore[assignment]
+
+    reconciled = await repository.reconcile_job_webhook_config(
+        batch_id=job.batch_id,
+        webhook_config_ciphertext="v1.key.recovered",
+        webhook_config_fingerprint="b" * 64,
+    )
+
+    assert reconciled is job
+    assert transaction_client.tx_called is False
+    assert jobs.locked == [job.batch_id]
+    assert job.webhook_config_ciphertext == "v1.key.recovered"
+    assert job.webhook_config_fingerprint == "b" * 64
+    assert len(outbox.events) == 1
+    assert outbox.events[0].event_type.value == "batch.completed"
+    assert outbox.events[0].target_config_ciphertext == "v1.key.recovered"
+
+
+@pytest.mark.asyncio
+async def test_webhook_reconciliation_rejects_conflicting_job_configuration() -> None:
+    job = _job()
+    jobs = _JobRepository(job)
+    outbox = _OutboxRepository(error=AssertionError("outbox must not be called"))
+    repository = BatchRepository(_CurrentTransactionClient())
+    repository.jobs = jobs  # type: ignore[assignment]
+    repository.webhook_outbox = outbox  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="conflicts with existing job"):
+        await repository.reconcile_job_webhook_config(
+            batch_id=job.batch_id,
+            webhook_config_ciphertext="v1.other.ciphertext",
+            webhook_config_fingerprint="c" * 64,
+        )
+
+    assert outbox.events == []
 
 
 @pytest.mark.asyncio
@@ -355,11 +493,46 @@ async def test_atomic_finalization_accepts_verified_existing_logical_event() -> 
     assert observed_jobs.observed == ["batch-1"]
 
 
+@pytest.mark.parametrize(
+    "terminal_status",
+    [BatchJobStatus.FAILED, BatchJobStatus.EXPIRED],
+)
+@pytest.mark.asyncio
+async def test_webhook_reconciliation_accepts_immutable_terminal_snapshot_after_timestamp_drift(
+    terminal_status: BatchJobStatus,
+) -> None:
+    job = _job()
+    job.status = terminal_status
+    job.completed_items = 0
+    job.failed_items = 1 if terminal_status is BatchJobStatus.FAILED else 0
+    existing = _outbox_record(job)
+    snapshot_timestamp = existing.payload_json["data"]["batch"][f"{terminal_status.value}_at"]
+    job.status_last_updated_at += timedelta(hours=1)
+    outbox = _OutboxRepository(inserted=None, existing=existing)
+    jobs = _JobRepository(job)
+    repository = BatchRepository(_CurrentTransactionClient())
+    repository.jobs = jobs  # type: ignore[assignment]
+    repository.webhook_outbox = outbox  # type: ignore[assignment]
+
+    reconciled = await repository.reconcile_job_webhook_config(
+        batch_id=job.batch_id,
+        webhook_config_ciphertext=str(job.webhook_config_ciphertext),
+        webhook_config_fingerprint=str(job.webhook_config_fingerprint),
+    )
+
+    assert reconciled is job
+    assert jobs.locked == [job.batch_id]
+    assert len(outbox.events) == 1
+    assert existing.payload_json["data"]["batch"][f"{terminal_status.value}_at"] == snapshot_timestamp
+    assert snapshot_timestamp != int(job.status_last_updated_at.timestamp())
+
+
 @pytest.mark.asyncio
 async def test_atomic_finalization_rejects_conflicting_existing_event() -> None:
     job = _job()
     existing = _outbox_record(job)
     existing.payload_json["data"]["batch"]["status"] = "failed"
+    existing.payload_sha256 = batch_webhook_event_payload_sha256(existing.payload_json)
     outbox = _OutboxRepository(inserted=None, existing=existing)
     repository, transaction, observed_jobs, _ = _aggregate_repository(job=job, outbox=outbox)
 
@@ -369,6 +542,39 @@ async def test_atomic_finalization_rejects_conflicting_existing_event() -> None:
             output_file_id="file-output",
             error_file_id=None,
             final_status=BatchJobStatus.COMPLETED,
+            worker_id="worker-1",
+        )
+
+    assert transaction.rolled_back is True
+    assert observed_jobs.observed == []
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    ["target", "batch_identity", "payload_hash"],
+)
+@pytest.mark.asyncio
+async def test_atomic_finalization_rejects_invalid_existing_event_identity_or_integrity(
+    conflict: str,
+) -> None:
+    job = _job()
+    existing = _outbox_record(job)
+    if conflict == "target":
+        existing.target_config_ciphertext = "v1.other.ciphertext"
+    elif conflict == "batch_identity":
+        existing.payload_json["data"]["batch"]["id"] = "batch-other"
+        existing.payload_sha256 = batch_webhook_event_payload_sha256(existing.payload_json)
+    else:
+        existing.payload_json["data"]["batch"]["metadata"] = {"tampered": True}
+    outbox = _OutboxRepository(inserted=None, existing=existing)
+    repository, transaction, observed_jobs, _ = _aggregate_repository(job=job, outbox=outbox)
+
+    with pytest.raises(RuntimeError, match="conflicts with terminal outcome"):
+        await repository.attach_artifacts_and_finalize(
+            batch_id=job.batch_id,
+            output_file_id=job.output_file_id,
+            error_file_id=job.error_file_id,
+            final_status=job.status,
             worker_id="worker-1",
         )
 

--- a/tests/test_batch_webhook_outbox_repository.py
+++ b/tests/test_batch_webhook_outbox_repository.py
@@ -145,8 +145,14 @@ class _TransactionManager:
 
 
 class _JobRepository:
-    def __init__(self, job: BatchJobRecord | None) -> None:
+    def __init__(
+        self,
+        job: BatchJobRecord | None,
+        *,
+        observe_error: Exception | None = None,
+    ) -> None:
         self.job = job
+        self.observe_error = observe_error
         self.calls: list[dict[str, object]] = []
         self.observed: list[str] = []
 
@@ -156,6 +162,8 @@ class _JobRepository:
 
     def observe_finalization(self, job: BatchJobRecord) -> None:
         self.observed.append(job.batch_id)
+        if self.observe_error is not None:
+            raise self.observe_error
 
 
 class _OutboxRepository:
@@ -186,7 +194,8 @@ def _aggregate_repository(
     *,
     job: BatchJobRecord | None,
     outbox: _OutboxRepository,
-) -> tuple[BatchRepository, _TransactionManager, _JobRepository]:
+    observe_error: Exception | None = None,
+) -> tuple[BatchRepository, _TransactionManager, _JobRepository, _JobRepository]:
     transaction_manager = _TransactionManager()
     transactional_jobs = _JobRepository(job)
     transactional_repository = SimpleNamespace(
@@ -196,16 +205,59 @@ def _aggregate_repository(
     )
     repository = BatchRepository()
     repository.prisma = transaction_manager
-    observed_jobs = _JobRepository(None)
+    observed_jobs = _JobRepository(None, observe_error=observe_error)
     repository.jobs = observed_jobs  # type: ignore[assignment]
     repository.with_prisma = lambda _tx: transactional_repository  # type: ignore[method-assign]
-    return repository, transaction_manager, observed_jobs
+    return repository, transaction_manager, observed_jobs, transactional_jobs
 
 
 @pytest.mark.asyncio
 async def test_atomic_finalization_enqueues_configured_event_then_publishes_metric() -> None:
     outbox = _OutboxRepository()
-    repository, transaction, observed_jobs = _aggregate_repository(job=_job(), outbox=outbox)
+    repository, transaction, observed_jobs, transactional_jobs = _aggregate_repository(
+        job=_job(),
+        outbox=outbox,
+    )
+
+    finalized = await repository.attach_artifacts_and_finalize(
+        batch_id="batch-1",
+        output_file_id="file-output",
+        error_file_id=None,
+        final_status=BatchJobStatus.COMPLETED,
+        worker_id="worker-1",
+        terminal_provider_error="artifact_validation_failed: invalid artifact",
+    )
+
+    assert finalized is not None
+    assert transaction.committed is True
+    assert transaction.rolled_back is False
+    assert len(outbox.events) == 1
+    assert outbox.events[0].payload_json["data"]["batch"]["metadata"] == {
+        "customer_job_id": "job-1"
+    }
+    assert observed_jobs.observed == ["batch-1"]
+    assert transactional_jobs.calls == [
+        {
+            "batch_id": "batch-1",
+            "output_file_id": "file-output",
+            "error_file_id": None,
+            "final_status": BatchJobStatus.COMPLETED,
+            "worker_id": "worker-1",
+            "terminal_provider_error": "artifact_validation_failed: invalid artifact",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_atomic_finalization_ignores_metric_failure_after_commit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    outbox = _OutboxRepository()
+    repository, transaction, observed_jobs, _ = _aggregate_repository(
+        job=_job(),
+        outbox=outbox,
+        observe_error=RuntimeError("metrics unavailable"),
+    )
 
     finalized = await repository.attach_artifacts_and_finalize(
         batch_id="batch-1",
@@ -219,16 +271,14 @@ async def test_atomic_finalization_enqueues_configured_event_then_publishes_metr
     assert transaction.committed is True
     assert transaction.rolled_back is False
     assert len(outbox.events) == 1
-    assert outbox.events[0].payload_json["data"]["batch"]["metadata"] == {
-        "customer_job_id": "job-1"
-    }
     assert observed_jobs.observed == ["batch-1"]
+    assert "batch finalization metric publish failed batch_id=batch-1" in caplog.text
 
 
 @pytest.mark.asyncio
 async def test_atomic_finalization_rolls_back_when_outbox_insert_fails() -> None:
     outbox = _OutboxRepository(error=RuntimeError("outbox unavailable"))
-    repository, transaction, observed_jobs = _aggregate_repository(job=_job(), outbox=outbox)
+    repository, transaction, observed_jobs, _ = _aggregate_repository(job=_job(), outbox=outbox)
 
     with pytest.raises(RuntimeError, match="outbox unavailable"):
         await repository.attach_artifacts_and_finalize(
@@ -247,7 +297,7 @@ async def test_atomic_finalization_rolls_back_when_outbox_insert_fails() -> None
 @pytest.mark.asyncio
 async def test_atomic_finalization_skips_outbox_for_legacy_batch() -> None:
     outbox = _OutboxRepository(error=AssertionError("outbox must not be called"))
-    repository, transaction, observed_jobs = _aggregate_repository(
+    repository, transaction, observed_jobs, _ = _aggregate_repository(
         job=_job(configured=False),
         outbox=outbox,
     )
@@ -269,7 +319,7 @@ async def test_atomic_finalization_skips_outbox_for_legacy_batch() -> None:
 @pytest.mark.asyncio
 async def test_atomic_finalization_fence_loss_creates_no_event_or_metric() -> None:
     outbox = _OutboxRepository(error=AssertionError("outbox must not be called"))
-    repository, transaction, observed_jobs = _aggregate_repository(job=None, outbox=outbox)
+    repository, transaction, observed_jobs, _ = _aggregate_repository(job=None, outbox=outbox)
 
     finalized = await repository.attach_artifacts_and_finalize(
         batch_id="batch-1",
@@ -290,7 +340,7 @@ async def test_atomic_finalization_accepts_verified_existing_logical_event() -> 
     job = _job()
     existing = _outbox_record(job)
     outbox = _OutboxRepository(inserted=None, existing=existing)
-    repository, transaction, observed_jobs = _aggregate_repository(job=job, outbox=outbox)
+    repository, transaction, observed_jobs, _ = _aggregate_repository(job=job, outbox=outbox)
 
     finalized = await repository.attach_artifacts_and_finalize(
         batch_id="batch-1",
@@ -311,7 +361,7 @@ async def test_atomic_finalization_rejects_conflicting_existing_event() -> None:
     existing = _outbox_record(job)
     existing.payload_json["data"]["batch"]["status"] = "failed"
     outbox = _OutboxRepository(inserted=None, existing=existing)
-    repository, transaction, observed_jobs = _aggregate_repository(job=job, outbox=outbox)
+    repository, transaction, observed_jobs, _ = _aggregate_repository(job=job, outbox=outbox)
 
     with pytest.raises(RuntimeError, match="conflicts with terminal outcome"):
         await repository.attach_artifacts_and_finalize(

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -4629,7 +4629,6 @@ async def test_batch_worker_marks_invalid_completed_artifacts_failed_without_ret
         def __init__(self) -> None:
             self.claim_count = 0
             self.attach_calls: list[dict] = []
-            self.provider_error_calls: list[dict] = []
             self.rescheduled: list[int] = []
             self.released = 0
             self.job = BatchJobRecord(
@@ -4703,10 +4702,6 @@ async def test_batch_worker_marks_invalid_completed_artifacts_failed_without_ret
             self.attach_calls.append(kwargs)
             return self.job
 
-        async def set_provider_error(self, **kwargs):
-            self.provider_error_calls.append(kwargs)
-            return self.job
-
         async def reschedule_finalization(self, *, batch_id: str, worker_id: str, retry_delay_seconds: int) -> bool:
             assert batch_id == "b-finalize"
             assert worker_id == "w1"
@@ -4746,12 +4741,10 @@ async def test_batch_worker_marks_invalid_completed_artifacts_failed_without_ret
             "error_file_id": None,
             "final_status": BatchJobStatus.FAILED,
             "worker_id": "w1",
-        }
-    ]
-    assert repo.provider_error_calls == [
-        {
-            "batch_id": "b-finalize",
-            "provider_error": "artifact_validation_failed: completed batch item embedding response is missing a valid model",
+            "terminal_provider_error": (
+                "artifact_validation_failed: completed batch item embedding response "
+                "is missing a valid model"
+            ),
         }
     ]
     assert repo.rescheduled == []

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -28,7 +28,10 @@ from src.batch.scheduling import (
 )
 from src.batch.service import BatchService
 from src.batch.worker import BatchArtifactValidationError, BatchExecutorWorker, BatchWorkerConfig
-from src.batch.worker_types import BatchItemLeaseLostError
+from src.batch.worker_types import (
+    BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
+    BatchItemLeaseLostError,
+)
 from src.config import GeneralSettings
 from src.db.repositories import KeyRecord
 from src.guardrails.exceptions import GuardrailViolationError
@@ -4624,6 +4627,7 @@ async def test_batch_worker_marks_invalid_completed_artifacts_failed_without_ret
     caplog: pytest.LogCaptureFixture,
 ):
     now = datetime.now(tz=UTC)
+    provider_value = "provider-controlled-marker-" + ("x" * 65_536)
 
     class _FinalizingRepo:
         def __init__(self) -> None:
@@ -4674,7 +4678,7 @@ async def test_batch_worker_marks_invalid_completed_artifacts_failed_without_ret
         async def list_items(self, batch_id: str):
             assert batch_id == "b-finalize"
             invalid_body = _valid_embedding_artifact_response_body()
-            invalid_body.pop("model")
+            invalid_body["object"] = provider_value
             return [
                 BatchItemRecord(
                     item_id="i1",
@@ -4741,19 +4745,21 @@ async def test_batch_worker_marks_invalid_completed_artifacts_failed_without_ret
             "error_file_id": None,
             "final_status": BatchJobStatus.FAILED,
             "worker_id": "w1",
-            "terminal_provider_error": (
-                "artifact_validation_failed: completed batch item embedding response "
-                "is missing a valid model"
-            ),
+            "terminal_provider_error": BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR,
         }
     ]
     assert repo.rescheduled == []
     assert repo.released == 1
     assert "batch finalization permanently failed batch_id=b-finalize" in caplog.text
+    assert f"error_code={BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR}" in caplog.text
+    assert "reason=completed batch item has invalid embedding response object" in caplog.text
+    assert "provider-controlled-marker" not in caplog.text
 
 
 @pytest.mark.asyncio
-async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows():
+async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows(
+    caplog: pytest.LogCaptureFixture,
+):
     now = datetime.now(tz=UTC)
 
     class _FinalizingRepo:
@@ -4813,7 +4819,10 @@ async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows():
 
         async def attach_artifacts_and_finalize(self, **kwargs):
             self.attach_calls.append(kwargs)
-            return SimpleNamespace(batch_id=kwargs["batch_id"])
+            return SimpleNamespace(
+                batch_id=kwargs["batch_id"],
+                status=BatchJobStatus.CANCELLED,
+            )
 
     class _CapturingStorage:
         backend_name = "local"
@@ -4868,7 +4877,8 @@ async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows():
         expires_at=None,
     )
 
-    await worker._finalize_artifacts(job)
+    with caplog.at_level(logging.INFO):
+        await worker._finalize_artifacts(job)
 
     output_rows = [json.loads(line) for line in storage.writes["batch_output"]["lines"]]
     error_rows = [json.loads(line) for line in storage.writes["batch_error"]["lines"]]
@@ -4907,6 +4917,7 @@ async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows():
             "worker_id": "w1",
         }
     ]
+    assert "batch finalized id=b-finalize status=cancelled" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_data_plane_audit_extended.py
+++ b/tests/test_data_plane_audit_extended.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import httpx
 import pytest
+from fastapi import HTTPException
 
 from src.services.prompt_registry import PromptProvenance, PromptRenderOutput
 
@@ -47,6 +48,9 @@ class _FakeBatchService:
         response: dict
         audit_metadata: dict
 
+    def __init__(self, *, default_metadata: dict | None = None) -> None:
+        self.default_metadata = default_metadata
+
     async def create_file(self, auth, upload, purpose):  # noqa: ANN001, ANN201
         del auth, upload, purpose
         return {"id": "file-1", "object": "file", "status": "processed"}
@@ -65,7 +69,11 @@ class _FakeBatchService:
     async def create_embeddings_batch_result(self, **kwargs):  # noqa: ANN003, ANN201
         idempotency_key = kwargs.get("idempotency_key")
         return self._CreateResult(
-            response=self._batch_response("validating"),
+            response=self._batch_response(
+                "validating",
+                metadata=kwargs.get("metadata"),
+                webhook_configured=kwargs.get("webhook") is not None,
+            ),
             audit_metadata={
                 "create_path": "create_session",
                 "idempotency_key_present": bool(idempotency_key),
@@ -75,18 +83,24 @@ class _FakeBatchService:
 
     async def get_batch(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
-        return self._batch_response("in_progress")
+        return self._batch_response("in_progress", metadata=self.default_metadata)
 
     async def list_batches(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
-        return [self._batch_response("in_progress")]
+        return [self._batch_response("in_progress", metadata=self.default_metadata)]
 
     async def cancel_batch(self, **kwargs):  # noqa: ANN003, ANN201
         del kwargs
-        return self._batch_response("cancelled")
+        return self._batch_response("cancelled", metadata=self.default_metadata)
 
-    def _batch_response(self, status: str) -> dict:
-        return {
+    def _batch_response(
+        self,
+        status: str,
+        *,
+        metadata: dict | None = None,
+        webhook_configured: bool = False,
+    ) -> dict:
+        response = {
             "id": "batch-1",
             "object": "batch",
             "endpoint": "/v1/embeddings",
@@ -103,8 +117,11 @@ class _FakeBatchService:
             "expired_at": None,
             "errors": None,
             "request_counts": {"total": 1, "completed": 0, "failed": 0, "cancelled": 0, "in_progress": 0},
-            "metadata": {},
+            "metadata": metadata or {},
         }
+        if webhook_configured:
+            response["webhook"] = {"configured": True}
+        return response
 
 
 class _SpendQueryDB:
@@ -331,6 +348,7 @@ async def test_batch_create_audit_redacts_webhook_configuration(client, test_app
     test_app.state.batch_repository = _FakeBatchRepository()
     secret = "customer-secret-that-must-not-appear"
     url = "https://customer.example/webhooks/deltallm"
+    metadata_marker = "customer-metadata-that-must-not-appear"
 
     response = await client.post(
         "/v1/batches",
@@ -339,11 +357,14 @@ async def test_batch_create_audit_redacts_webhook_configuration(client, test_app
             "input_file_id": "file-1",
             "endpoint": "/v1/embeddings",
             "completion_window": "24h",
+            "metadata": {"sensitive": metadata_marker},
             "webhook": {"url": url, "signing_secret": secret},
         },
     )
 
     assert response.status_code == 200
+    assert response.json()["metadata"] == {"sensitive": metadata_marker}
+    assert response.json()["webhook"] == {"configured": True}
     batch_create_records = [
         record for record in audit.records if record[0].action == "BATCH_CREATE_REQUEST"
     ]
@@ -353,8 +374,84 @@ async def test_batch_create_audit_redacts_webhook_configuration(client, test_app
     rendered = str((event, payloads))
     assert url not in rendered
     assert secret not in rendered
+    assert metadata_marker not in rendered
+    assert event.metadata["webhook_configured"] is True
     assert payloads[0].content_json["webhook_configured"] is True
+    assert payloads[0].content_json["metadata_present"] is True
+    assert payloads[1].content_json["webhook_configured"] is True
+    assert payloads[1].content_json["metadata_present"] is True
     assert "webhook" not in payloads[0].content_json
+    assert "metadata" not in payloads[0].content_json
+    assert "webhook" not in payloads[1].content_json
+    assert "metadata" not in payloads[1].content_json
+
+
+@pytest.mark.asyncio
+async def test_batch_create_error_audit_redacts_caller_metadata(client, test_app):
+    class _FailingBatchService(_FakeBatchService):
+        async def create_embeddings_batch_result(self, **kwargs):  # noqa: ANN003, ANN201
+            del kwargs
+            raise HTTPException(status_code=400, detail="simulated create failure")
+
+    audit = _RecordingAuditService()
+    test_app.state.audit_service = audit
+    test_app.state.batch_service = _FailingBatchService()
+    metadata_marker = "failed-request-metadata-that-must-not-appear"
+
+    response = await client.post(
+        "/v1/batches",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "input_file_id": "file-1",
+            "endpoint": "/v1/embeddings",
+            "completion_window": "24h",
+            "metadata": {"sensitive": metadata_marker},
+        },
+    )
+
+    assert response.status_code == 400
+    batch_create_records = [
+        record for record in audit.records if record[0].action == "BATCH_CREATE_REQUEST"
+    ]
+    assert len(batch_create_records) == 1
+    event, payloads, _critical = batch_create_records[0]
+    assert event.status == "error"
+    assert metadata_marker not in str((event, payloads))
+    assert payloads[0].content_json["metadata_present"] is True
+    assert "metadata" not in payloads[0].content_json
+
+
+@pytest.mark.asyncio
+async def test_batch_read_list_and_cancel_audits_redact_caller_metadata(client, test_app):
+    audit = _RecordingAuditService()
+    metadata_marker = "stored-batch-metadata-that-must-not-appear"
+    test_app.state.audit_service = audit
+    test_app.state.batch_service = _FakeBatchService(
+        default_metadata={"sensitive": metadata_marker}
+    )
+
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    read_response = await client.get("/v1/batches/batch-1", headers=headers)
+    list_response = await client.get("/v1/batches", headers=headers)
+    cancel_response = await client.post("/v1/batches/batch-1/cancel", headers=headers)
+
+    assert read_response.json()["metadata"] == {"sensitive": metadata_marker}
+    assert list_response.json()[0]["metadata"] == {"sensitive": metadata_marker}
+    assert cancel_response.json()["metadata"] == {"sensitive": metadata_marker}
+    batch_records = [
+        record
+        for record in audit.records
+        if record[0].action
+        in {"BATCH_READ_REQUEST", "BATCH_LIST_REQUEST", "BATCH_CANCEL_REQUEST"}
+    ]
+    assert len(batch_records) == 3
+    assert metadata_marker not in str(batch_records)
+    for event, payloads, _critical in batch_records:
+        if event.action == "BATCH_LIST_REQUEST":
+            assert payloads[1].content_json == {"count": 1}
+            continue
+        assert payloads[1].content_json["metadata_present"] is True
+        assert "metadata" not in payloads[1].content_json
 
 
 @pytest.mark.asyncio

--- a/tests/test_data_plane_audit_extended.py
+++ b/tests/test_data_plane_audit_extended.py
@@ -324,6 +324,40 @@ async def test_batch_create_audit_marks_idempotency_key_presence(client, test_ap
 
 
 @pytest.mark.asyncio
+async def test_batch_create_audit_redacts_webhook_configuration(client, test_app):
+    audit = _RecordingAuditService()
+    test_app.state.audit_service = audit
+    test_app.state.batch_service = _FakeBatchService()
+    test_app.state.batch_repository = _FakeBatchRepository()
+    secret = "customer-secret-that-must-not-appear"
+    url = "https://customer.example/webhooks/deltallm"
+
+    response = await client.post(
+        "/v1/batches",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "input_file_id": "file-1",
+            "endpoint": "/v1/embeddings",
+            "completion_window": "24h",
+            "webhook": {"url": url, "signing_secret": secret},
+        },
+    )
+
+    assert response.status_code == 200
+    batch_create_records = [
+        record for record in audit.records if record[0].action == "BATCH_CREATE_REQUEST"
+    ]
+    assert len(batch_create_records) == 1
+    event, payloads, _critical = batch_create_records[0]
+    assert event.metadata["webhook_configured"] is True
+    rendered = str((event, payloads))
+    assert url not in rendered
+    assert secret not in rendered
+    assert payloads[0].content_json["webhook_configured"] is True
+    assert "webhook" not in payloads[0].content_json
+
+
+@pytest.mark.asyncio
 async def test_spend_routes_emit_audit_success(client, test_app):
     audit = _RecordingAuditService()
     test_app.state.audit_service = audit


### PR DESCRIPTION
## Summary

- accept, validate, fingerprint, encrypt, and stage the optional per-batch webhook configuration
- preserve webhook state through idempotent create races, promotion, and recovery
- share one public batch serializer between API responses and webhook event snapshots
- atomically commit terminal job state and exactly one logical webhook outbox event
- keep webhook URLs, signing secrets, and caller metadata out of audit payloads and error text
- cover completion, failure, cancellation, expiry, fencing, rollback, recovery, and immutable event snapshots

## Why

This is PR 2 of issue #232. PR 1 established the configuration, crypto, and schema foundation. This PR connects that foundation to batch creation and terminal finalization while deliberately stopping before external HTTP delivery.

The finalization path now owns the job update and outbox insert in one transaction. If enqueueing fails, the terminal transition rolls back and can be retried safely. Duplicate or recovery paths verify the existing event's immutable identity, terminal outcome, encrypted target, and payload integrity without comparing it to mutable post-terminal job timestamps.

## Impact

Webhook-enabled batches durably enqueue a final public batch snapshot containing caller metadata. Batches without a webhook retain the existing response and persistence behavior. No customer HTTP request is made by this PR.

## Validation

- `python -m ruff check src tests`
- `python -m pytest -q` — 1939 passed, 92 skipped
- focused webhook outbox and create-promoter tests — 32 passed
- `git diff --check`

Database-backed tests are included, but are skipped locally when `DATABASE_URL` is unavailable.

Part of #232