### PR TITLE
Add configurable dashboard analytics ranges

### DIFF
--- a/src/api/admin/endpoints/spend.py
+++ b/src/api/admin/endpoints/spend.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, date, datetime, time
 from time import perf_counter
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, Header, Query, Request
 
@@ -281,6 +281,7 @@ async def spend_summary(
 async def spend_report(
     request: Request,
     group_by: str = Query(default="day", pattern="^(model|provider|day|user|team|organization|api_key)$"),
+    interval: Literal["day", "week", "month"] = Query(default="day"),
     start_date: date | None = Query(default=None),
     end_date: date | None = Query(default=None),
     search: str | None = Query(default=None),
@@ -294,6 +295,11 @@ async def spend_report(
     db = db_or_503(request)
     source = get_spend_read_source()
     if group_by == "day":
+        bucket_expr = {
+            "day": "DATE(start_time)",
+            "week": "DATE_TRUNC('week', start_time)::date",
+            "month": "DATE_TRUNC('month', start_time)::date",
+        }[interval]
         clauses: list[str] = []
         params: list[Any] = []
         if start_date is not None:
@@ -312,7 +318,7 @@ async def spend_report(
         rows = await db.query_raw(
             f"""
             SELECT
-                DATE(start_time) AS group_key,
+                {bucket_expr} AS group_key,
                 COALESCE(SUM(spend), 0) AS total_spend,
                 COUNT(*) AS request_count,
                 COALESCE(SUM(total_tokens), 0) AS total_tokens,
@@ -320,7 +326,7 @@ async def spend_report(
                 COUNT(*) FILTER (WHERE status = 'error') AS failed_requests
             FROM {source.table}
             {where_sql}
-            GROUP BY DATE(start_time)
+            GROUP BY {bucket_expr}
             ORDER BY group_key ASC
             """,
             *params,
@@ -328,12 +334,14 @@ async def spend_report(
         log_admin_query_timing(
             "spend_report_day",
             started_at,
+            interval=interval,
             start_date=start_date.isoformat() if start_date else None,
             end_date=end_date.isoformat() if end_date else None,
             scoped=not scope.is_platform_admin,
         )
         return {
             "group_by": group_by,
+            "interval": interval,
             "breakdown": [to_json_value(dict(row)) for row in rows],
         }
 

--- a/tests/test_ui_rbac_scoping.py
+++ b/tests/test_ui_rbac_scoping.py
@@ -162,6 +162,57 @@ async def test_spend_report_not_scoped_for_platform_admin(client, test_app, monk
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("interval", "bucket_expression"),
+    [
+        ("day", "DATE(start_time)"),
+        ("week", "DATE_TRUNC('week', start_time)::date"),
+        ("month", "DATE_TRUNC('month', start_time)::date"),
+    ],
+)
+async def test_daily_spend_report_supports_safe_time_intervals(
+    client, test_app, monkeypatch, interval, bucket_expression
+):
+    fake_db = FakeSpendDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.spend.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=True,
+            org_ids=[],
+            team_ids=[],
+        ),
+    )
+
+    response = await client.get(
+        f"/ui/api/spend/report?group_by=day&interval={interval}",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["interval"] == interval
+    query, _ = fake_db.calls[0]
+    assert f"{bucket_expression} AS group_key" in query
+    assert f"GROUP BY {bucket_expression}" in query
+    assert "successful_requests" in query
+    assert "failed_requests" in query
+
+
+@pytest.mark.asyncio
+async def test_daily_spend_report_rejects_unknown_time_interval(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.get(
+        "/ui/api/spend/report?group_by=day&interval=quarter",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_grouped_spend_report_applies_org_scope_for_non_platform(client, test_app, monkeypatch):
     fake_db = FakeSpendDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()

--- a/ui/scripts/run-unit-tests.mjs
+++ b/ui/scripts/run-unit-tests.mjs
@@ -10,6 +10,7 @@ const outputDir = path.join(uiRoot, 'node_modules', '.tmp', 'ui-unit-tests');
 const testSources = [
   'tests/modelFormShared.test.ts',
   'tests/batchDetailResource.test.ts',
+  'tests/dashboardRange.test.ts',
 ];
 
 await rm(outputDir, { recursive: true, force: true });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -135,6 +135,23 @@ export interface SpendSummary {
   failed_requests?: number;
 }
 
+export type SpendBucket = 'day' | 'week' | 'month';
+
+export interface SpendTimeSeriesRow {
+  group_key: string;
+  total_spend: number;
+  request_count: number;
+  total_tokens: number;
+  successful_requests: number;
+  failed_requests: number;
+}
+
+export interface SpendTimeSeriesReport {
+  group_by: 'day';
+  interval: SpendBucket;
+  breakdown: SpendTimeSeriesRow[];
+}
+
 export interface SpendGroupRow {
   group_key: string;
   display_name?: string | null;
@@ -758,6 +775,24 @@ export const spend = {
     if (end_date) qs.set('end_date', end_date);
     const suffix = qs.toString() ? `?${qs.toString()}` : '';
     return apiFetch<SpendSummary>(`/ui/api/spend/summary${suffix}`, opts);
+  },
+  timeSeries: (
+    params: { start_date?: string; end_date?: string; interval: SpendBucket },
+    opts?: RequestInit,
+  ) => {
+    const qs = new URLSearchParams({ group_by: 'day', interval: params.interval });
+    if (params.start_date) qs.set('start_date', params.start_date);
+    if (params.end_date) qs.set('end_date', params.end_date);
+    return apiFetch<SpendTimeSeriesReport>(`/ui/api/spend/report?${qs.toString()}`, opts);
+  },
+  providerReport: (
+    params?: { start_date?: string; end_date?: string; limit?: number },
+    opts?: RequestInit,
+  ) => {
+    const qs = new URLSearchParams({ group_by: 'provider', limit: String(params?.limit ?? 5) });
+    if (params?.start_date) qs.set('start_date', params.start_date);
+    if (params?.end_date) qs.set('end_date', params.end_date);
+    return apiFetch<SpendGroupReport>(`/ui/api/spend/report?${qs.toString()}`, opts);
   },
   report: (
     group_by: 'model' | 'provider' | 'day' | 'user' | 'team',

--- a/ui/src/lib/dashboardRange.ts
+++ b/ui/src/lib/dashboardRange.ts
@@ -1,0 +1,171 @@
+export type DashboardRangeKey = '7d' | '30d' | '3m' | '6m' | 'ytd' | 'all';
+export type SpendBucket = 'day' | 'week' | 'month';
+
+export interface DashboardRangeOption {
+  key: DashboardRangeKey;
+  label: string;
+  shortLabel: string;
+}
+
+export interface ResolvedDashboardRange extends DashboardRangeOption {
+  startDate?: string;
+  endDate?: string;
+  bucket: SpendBucket;
+}
+
+export interface RequestSeriesRow {
+  group_key: string;
+  request_count: number;
+  successful_requests: number;
+  failed_requests: number;
+  total_spend: number;
+  total_tokens: number;
+}
+
+export const DASHBOARD_RANGE_OPTIONS: readonly DashboardRangeOption[] = [
+  { key: '7d', label: 'Last 7 days', shortLabel: '7 days' },
+  { key: '30d', label: 'Last 30 days', shortLabel: '30 days' },
+  { key: '3m', label: 'Last 3 months', shortLabel: '3 months' },
+  { key: '6m', label: 'Last 6 months', shortLabel: '6 months' },
+  { key: 'ytd', label: 'Year to date', shortLabel: 'YTD' },
+  { key: 'all', label: 'All time', shortLabel: 'All time' },
+] as const;
+
+const RANGE_KEYS = new Set<DashboardRangeKey>(DASHBOARD_RANGE_OPTIONS.map((option) => option.key));
+
+function utcDate(year: number, month: number, day: number): Date {
+  return new Date(Date.UTC(year, month, day));
+}
+
+function utcDay(value: Date): Date {
+  return utcDate(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate());
+}
+
+function addUtcDays(value: Date, days: number): Date {
+  const result = new Date(value);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+function subtractUtcMonthsClamped(value: Date, months: number): Date {
+  const targetMonthIndex = value.getUTCFullYear() * 12 + value.getUTCMonth() - months;
+  const targetYear = Math.floor(targetMonthIndex / 12);
+  const targetMonth = targetMonthIndex - targetYear * 12;
+  const lastDay = utcDate(targetYear, targetMonth + 1, 0).getUTCDate();
+  return utcDate(targetYear, targetMonth, Math.min(value.getUTCDate(), lastDay));
+}
+
+function isoDate(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function parseIsoDate(value: string): Date {
+  return new Date(`${value.slice(0, 10)}T00:00:00Z`);
+}
+
+function startOfBucket(value: Date, bucket: SpendBucket): Date {
+  if (bucket === 'month') return utcDate(value.getUTCFullYear(), value.getUTCMonth(), 1);
+  if (bucket === 'week') {
+    const mondayOffset = (value.getUTCDay() + 6) % 7;
+    return addUtcDays(value, -mondayOffset);
+  }
+  return utcDay(value);
+}
+
+function nextBucket(value: Date, bucket: SpendBucket): Date {
+  if (bucket === 'month') return utcDate(value.getUTCFullYear(), value.getUTCMonth() + 1, 1);
+  return addUtcDays(value, bucket === 'week' ? 7 : 1);
+}
+
+export function parseDashboardRangeKey(value: string | null | undefined): DashboardRangeKey {
+  return value && RANGE_KEYS.has(value as DashboardRangeKey) ? (value as DashboardRangeKey) : '30d';
+}
+
+export function resolveDashboardRange(key: DashboardRangeKey, now = new Date()): ResolvedDashboardRange {
+  const option = DASHBOARD_RANGE_OPTIONS.find((candidate) => candidate.key === key) ?? DASHBOARD_RANGE_OPTIONS[1];
+  const today = utcDay(now);
+
+  if (key === 'all') return { ...option, bucket: 'month' };
+
+  let start: Date;
+  let bucket: SpendBucket;
+  if (key === '7d') {
+    start = addUtcDays(today, -6);
+    bucket = 'day';
+  } else if (key === '30d') {
+    start = addUtcDays(today, -29);
+    bucket = 'day';
+  } else if (key === '3m') {
+    start = subtractUtcMonthsClamped(today, 3);
+    bucket = 'week';
+  } else if (key === '6m') {
+    start = subtractUtcMonthsClamped(today, 6);
+    bucket = 'week';
+  } else {
+    start = utcDate(today.getUTCFullYear(), 0, 1);
+    bucket = 'month';
+  }
+
+  return {
+    ...option,
+    startDate: isoDate(start),
+    endDate: isoDate(today),
+    bucket,
+  };
+}
+
+export function normalizeRequestSeries(
+  rows: readonly RequestSeriesRow[],
+  range: Pick<ResolvedDashboardRange, 'startDate' | 'endDate' | 'bucket'>,
+): RequestSeriesRow[] {
+  if (rows.length === 0) return [];
+
+  const sortedRows = [...rows].sort((left, right) => left.group_key.localeCompare(right.group_key));
+  const normalizedRows = new Map(sortedRows.map((row) => [row.group_key.slice(0, 10), row]));
+  const firstKey = sortedRows[0].group_key.slice(0, 10);
+  const lastKey = sortedRows[sortedRows.length - 1].group_key.slice(0, 10);
+  const start = startOfBucket(parseIsoDate(range.startDate ?? firstKey), range.bucket);
+  const end = startOfBucket(parseIsoDate(range.endDate ?? lastKey), range.bucket);
+  const result: RequestSeriesRow[] = [];
+
+  for (let cursor = start; cursor <= end; cursor = nextBucket(cursor, range.bucket)) {
+    const key = isoDate(cursor);
+    result.push(
+      normalizedRows.get(key) ?? {
+        group_key: key,
+        request_count: 0,
+        successful_requests: 0,
+        failed_requests: 0,
+        total_spend: 0,
+        total_tokens: 0,
+      },
+    );
+  }
+
+  return result;
+}
+
+export function formatBucketTick(value: string, bucket: SpendBucket, includeYear = false): string {
+  const date = parseIsoDate(value);
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: bucket === 'month' ? undefined : 'numeric',
+    year: includeYear ? '2-digit' : undefined,
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+export function formatBucketLabel(value: string, bucket: SpendBucket): string {
+  const date = parseIsoDate(value);
+  const formatted = new Intl.DateTimeFormat(undefined, {
+    month: bucket === 'month' ? 'long' : 'short',
+    day: bucket === 'month' ? undefined : 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+  return bucket === 'week' ? `Week of ${formatted}` : formatted;
+}
+
+export function failureRate(failed: number, total: number): number {
+  return total > 0 ? (failed / total) * 100 : 0;
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,44 +1,71 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useApi } from '../lib/hooks';
-import { spend, models as modelsApi, keys as keysApi, health, type ProviderHealthStatus } from '../lib/api';
+import {
+  spend,
+  models as modelsApi,
+  keys as keysApi,
+  health,
+  type ProviderHealthStatus,
+  type SpendGroupReport,
+  type SpendSummary,
+  type SpendTimeSeriesReport,
+} from '../lib/api';
+import {
+  DASHBOARD_RANGE_OPTIONS,
+  failureRate,
+  formatBucketLabel,
+  formatBucketTick,
+  normalizeRequestSeries,
+  parseDashboardRangeKey,
+  resolveDashboardRange,
+  type DashboardRangeKey,
+  type ResolvedDashboardRange,
+} from '../lib/dashboardRange';
 import { fmtCompact } from '../lib/format';
 import { providerDisplayName } from '../lib/providers';
 import {
-  DollarSign,
-  Zap,
-  Key,
+  Activity,
+  AlertCircle,
   Box,
   Clock,
-  Server,
   Database,
-  TrendingUp,
-  Activity,
+  DollarSign,
+  Key,
+  LoaderCircle,
+  RefreshCw,
+  Server,
+  Zap,
 } from 'lucide-react';
 import {
-  AreaChart,
-  Area,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  CartesianGrid,
-  PieChart,
-  Pie,
-  Cell,
 } from 'recharts';
 
-const COLORS = ['#8b5cf6', '#3b82f6', '#06b6d4', '#10b981', '#f59e0b'];
+const COLORS = ['#8b5cf6', '#3b82f6', '#06b6d4', '#10b981', '#f59e0b', '#94a3b8'];
 
-type SpendReportRow = { group_key: string; total_spend: number; request_count?: number; total_tokens?: number; display_name?: string | null };
 type ProviderSpendDatum = { provider: string; label: string; spend: number };
+type RequestChartDatum = { date: string; success: number; failed: number; total: number };
 
-function fmtDollar(n: number | null | undefined): string {
-  if (n == null) return '$0.0000';
-  return `$${Number(n).toFixed(4)}`;
+interface DashboardAnalytics {
+  range: ResolvedDashboardRange;
+  summary: SpendSummary;
+  timeSeries: SpendTimeSeriesReport;
+  providerReport: SpendGroupReport;
 }
 
-function fmtDollarPrecise(n: number | null | undefined): string {
-  if (n == null) return '$0.0000';
-  return `$${Number(n).toFixed(4)}`;
+interface DashboardAnalyticsState {
+  requestKey: string | null;
+  data: DashboardAnalytics | null;
+  error: string | null;
 }
 
 interface ProviderAgg {
@@ -49,267 +76,436 @@ interface ProviderAgg {
   unhealthy_models: number;
 }
 
+interface RequestTooltipEntry {
+  payload?: RequestChartDatum;
+}
+
+interface RequestTooltipProps {
+  active?: boolean;
+  payload?: readonly RequestTooltipEntry[];
+  label?: string | number;
+  bucket: ResolvedDashboardRange['bucket'];
+}
+
 const statusConfig: Record<ProviderHealthStatus, { dot: string; text: string; bg: string; label: string }> = {
   healthy: { dot: 'bg-emerald-500', text: 'text-emerald-700', bg: 'bg-emerald-50', label: 'Healthy' },
   degraded: { dot: 'bg-amber-500', text: 'text-amber-700', bg: 'bg-amber-50', label: 'Degraded' },
   down: { dot: 'bg-rose-500', text: 'text-rose-700', bg: 'bg-rose-50', label: 'Down' },
 };
 
+function fmtDollar(n: number | null | undefined): string {
+  if (n == null) return '$0.0000';
+  return `$${Number(n).toFixed(4)}`;
+}
+
+function RequestVolumeTooltip({ active, payload, label, bucket }: RequestTooltipProps) {
+  const datum = payload?.[0]?.payload;
+  if (!active || !datum || typeof label !== 'string') return null;
+
+  return (
+    <div className="min-w-44 rounded-lg border border-gray-200 bg-white p-3 shadow-lg">
+      <p className="mb-2 text-xs font-semibold text-gray-700">{formatBucketLabel(label, bucket)}</p>
+      <div className="space-y-1.5 text-xs">
+        <div className="flex items-center justify-between gap-6 text-gray-600">
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-sm bg-violet-500" />Successful</span>
+          <span className="font-medium tabular-nums text-gray-900">{datum.success.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center justify-between gap-6 text-gray-600">
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-sm bg-rose-500" />Failed</span>
+          <span className="font-medium tabular-nums text-gray-900">{datum.failed.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center justify-between gap-6 border-t border-gray-100 pt-1.5 text-gray-600">
+          <span>Total</span>
+          <span className="font-semibold tabular-nums text-gray-900">{datum.total.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center justify-between gap-6 text-gray-500">
+          <span>Failure rate</span>
+          <span className="tabular-nums">{failureRate(datum.failed, datum.total).toFixed(1)}%</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MetricValue({ children, ready }: { children: ReactNode; ready: boolean }) {
+  if (!ready) return <span className="mt-2 block h-7 w-24 animate-pulse rounded bg-gray-100" />;
+  return <>{children}</>;
+}
+
 export default function Dashboard() {
-  const { data: summary } = useApi(() => spend.summary(), []);
-  const { data: dailyReport } = useApi(() => spend.report('day'), []);
-  const { data: providerReport } = useApi(() => spend.report('provider'), []);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedRangeKey = parseDashboardRangeKey(searchParams.get('range'));
+  const selectedRange = useMemo(() => resolveDashboardRange(selectedRangeKey), [selectedRangeKey]);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const requestKey = `${selectedRangeKey}:${selectedRange.startDate ?? ''}:${selectedRange.endDate ?? ''}:${refreshNonce}`;
+  const [analyticsState, setAnalyticsState] = useState<DashboardAnalyticsState>({
+    requestKey: null,
+    data: null,
+    error: null,
+  });
+
   const { data: providerHealthSummary } = useApi(() => modelsApi.providerHealthSummary(), []);
   const { data: keysResult } = useApi(() => keysApi.list(), []);
   const { data: healthData } = useApi(() => health.check(), []);
 
-  const daily = (dailyReport?.breakdown || dailyReport?.data || []).map((r: any) => ({
-    date: r.group_key,
-    success: r.successful_requests ?? r.request_count ?? 0,
-    failed: r.failed_requests ?? 0,
-  }));
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
 
-  const providerSpend: ProviderSpendDatum[] = ((providerReport?.breakdown || providerReport?.data || []) as SpendReportRow[]).map((r) => {
-    const provider = (r.group_key || 'unknown').trim().toLowerCase() || 'unknown';
-    return {
-      provider,
-      label: providerDisplayName(provider),
-      spend: r.total_spend,
+    Promise.all([
+      spend.summary(selectedRange.startDate, selectedRange.endDate, { signal: controller.signal }),
+      spend.timeSeries(
+        {
+          start_date: selectedRange.startDate,
+          end_date: selectedRange.endDate,
+          interval: selectedRange.bucket,
+        },
+        { signal: controller.signal },
+      ),
+      spend.providerReport(
+        { start_date: selectedRange.startDate, end_date: selectedRange.endDate },
+        { signal: controller.signal },
+      ),
+    ])
+      .then(([summary, timeSeries, providerReport]) => {
+        if (!active) return;
+        setAnalyticsState({
+          requestKey,
+          data: { range: selectedRange, summary, timeSeries, providerReport },
+          error: null,
+        });
+      })
+      .catch((error: unknown) => {
+        if (!active || (error instanceof Error && error.name === 'AbortError')) return;
+        setAnalyticsState((current) => ({
+          requestKey,
+          data: current.data,
+          error: error instanceof Error ? error.message : 'Unable to load dashboard analytics.',
+        }));
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
     };
-  });
+  }, [requestKey, selectedRange]);
+
+  const analytics = analyticsState.data;
+  const analyticsLoading = analyticsState.requestKey !== requestKey;
+  const analyticsError = analyticsState.requestKey === requestKey ? analyticsState.error : null;
+  const appliedRange = analytics?.range ?? selectedRange;
+  const summary = analytics?.summary;
+  const requestSeries = useMemo(
+    () => normalizeRequestSeries(analytics?.timeSeries.breakdown ?? [], appliedRange),
+    [analytics?.timeSeries.breakdown, appliedRange],
+  );
+  const requestData: RequestChartDatum[] = useMemo(
+    () => requestSeries.map((row) => ({
+      date: row.group_key,
+      success: row.successful_requests ?? Math.max(row.request_count - row.failed_requests, 0),
+      failed: row.failed_requests,
+      total: row.request_count,
+    })),
+    [requestSeries],
+  );
+  const providerSpend: ProviderSpendDatum[] = useMemo(
+    () => {
+      const providers = (analytics?.providerReport.data ?? [])
+        .map((row) => {
+          const provider = (row.group_key || 'unknown').trim().toLowerCase() || 'unknown';
+          return { provider, label: providerDisplayName(provider), spend: Number(row.total_spend) };
+        })
+        .filter((provider) => provider.spend > 0);
+      if (!analytics?.providerReport.pagination?.has_more) return providers;
+
+      const listedSpend = providers.reduce((total, provider) => total + provider.spend, 0);
+      const otherSpend = Math.max(Number(analytics.summary.total_spend) - listedSpend, 0);
+      return otherSpend > 0 ? [...providers, { provider: 'other', label: 'Other', spend: otherSpend }] : providers;
+    },
+    [analytics],
+  );
 
   const providerList = (providerHealthSummary?.providers || []) as ProviderAgg[];
   const totalModels = providerHealthSummary?.total_models ?? 0;
   const totalProviders = providerHealthSummary?.summary.total_providers ?? providerList.length;
-
   const healthStatus = healthData?.readiness?.status || healthData?.liveliness || 'unknown';
   const isHealthy = healthStatus === 'ok' || healthStatus === 'healthy';
   const activeProviders =
-    providerHealthSummary?.summary.active_providers ?? providerList.filter((p) => p.status !== 'down').length;
-
+    providerHealthSummary?.summary.active_providers ?? providerList.filter((provider) => provider.status !== 'down').length;
   const totalRequests = summary?.total_requests ?? 0;
   const failedRequests = summary?.failed_requests ?? 0;
+  const successfulRequests = summary?.successful_requests ?? Math.max(totalRequests - failedRequests, 0);
+  const summaryReady = summary !== undefined;
+  const isUpdating = analyticsLoading && analytics !== null;
+
+  function handleRangeChange(key: DashboardRangeKey) {
+    const next = new URLSearchParams(searchParams);
+    next.set('range', key);
+    setSearchParams(next);
+  }
 
   return (
     <div className="p-4 sm:p-6">
-      <div className="max-w-7xl mx-auto space-y-6">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-gray-900">Dashboard</h1>
+            <p className="mt-1 text-sm text-gray-500">Gateway overview · reporting dates use UTC</p>
+          </div>
 
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Dashboard</h1>
-          <p className="text-sm text-gray-500 mt-1">Gateway overview</p>
+          <div className="flex items-center gap-2">
+            {analyticsLoading && (
+              <span className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500" role="status">
+                <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                <span className="hidden sm:inline">Updating</span>
+                <span className="sr-only sm:hidden">Updating dashboard</span>
+              </span>
+            )}
+            <div className="hidden rounded-lg border border-gray-200 bg-gray-100 p-1 md:flex" role="group" aria-label="Dashboard period">
+              {DASHBOARD_RANGE_OPTIONS.map((option) => {
+                const selected = selectedRangeKey === option.key;
+                return (
+                  <button
+                    key={option.key}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => handleRangeChange(option.key)}
+                    className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                      selected ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-900'
+                    }`}
+                  >
+                    {option.shortLabel}
+                  </button>
+                );
+              })}
+            </div>
+            <label className="flex flex-1 items-center gap-2 md:hidden">
+              <span className="text-sm font-medium text-gray-600">Period</span>
+              <select
+                value={selectedRangeKey}
+                onChange={(event) => handleRangeChange(event.target.value as DashboardRangeKey)}
+                className="min-w-0 flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                {DASHBOARD_RANGE_OPTIONS.map((option) => (
+                  <option key={option.key} value={option.key}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+          </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+        {analyticsError && (
+          <div className="flex flex-col gap-3 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 sm:flex-row sm:items-center sm:justify-between" role="alert">
+            <div className="flex items-start gap-2">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                {analyticsError}
+                {analytics && ` Showing the last loaded period (${analytics.range.label}).`}
+              </span>
+            </div>
+            <button type="button" onClick={() => setRefreshNonce((value) => value + 1)} className="inline-flex items-center gap-1.5 self-start rounded font-semibold hover:text-rose-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500">
+              <RefreshCw className="h-3.5 w-3.5" /> Retry
+            </button>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5" aria-busy={analyticsLoading}>
+          <div className={`flex items-start gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-opacity ${isUpdating ? 'opacity-60' : ''}`}>
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-50">
               <DollarSign className="h-5 w-5 text-violet-600" />
             </div>
-            <div>
+            <div className="min-w-0">
               <p className="text-sm font-medium text-gray-500">Total Spend</p>
-              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtDollar(summary?.total_spend)}</p>
-              <p className="mt-1 text-xs text-gray-500">{fmtCompact(summary?.total_tokens)} tokens used</p>
+              <p className="mt-1 text-2xl font-bold tabular-nums text-gray-900">
+                <MetricValue ready={summaryReady}>{fmtDollar(summary?.total_spend)}</MetricValue>
+              </p>
+              <p className="mt-1 text-xs text-gray-500">{summaryReady ? `${fmtCompact(summary?.total_tokens)} tokens · ${appliedRange.label}` : 'Loading usage'}</p>
             </div>
           </div>
 
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+          <div className={`flex items-start gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-opacity ${isUpdating ? 'opacity-60' : ''}`}>
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50">
               <Zap className="h-5 w-5 text-blue-600" />
             </div>
-            <div>
+            <div className="min-w-0">
               <p className="text-sm font-medium text-gray-500">Total Requests</p>
-              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtCompact(totalRequests)}</p>
-              <p className={`mt-1 text-xs font-medium ${failedRequests > 0 ? 'text-red-500' : 'text-gray-400'}`}>{fmtCompact(failedRequests)} failed</p>
+              <p className="mt-1 text-2xl font-bold tabular-nums text-gray-900">
+                <MetricValue ready={summaryReady}>{fmtCompact(totalRequests)}</MetricValue>
+              </p>
+              <p className={`mt-1 text-xs font-medium ${failedRequests > 0 ? 'text-rose-600' : 'text-gray-400'}`}>
+                {summaryReady ? `${fmtCompact(failedRequests)} failed · ${failureRate(failedRequests, totalRequests).toFixed(1)}%` : 'Loading requests'}
+              </p>
             </div>
           </div>
 
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+          <div className="flex items-start gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-50">
               <Key className="h-5 w-5 text-emerald-600" />
             </div>
             <div>
               <p className="text-sm font-medium text-gray-500">Active Keys</p>
-              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtCompact(keysResult?.pagination?.total ?? keysResult?.data?.length)}</p>
+              <p className="mt-1 text-2xl font-bold tabular-nums text-gray-900">{fmtCompact(keysResult?.pagination?.total ?? keysResult?.data?.length)}</p>
+              <p className="mt-1 text-xs text-gray-400">Current</p>
             </div>
           </div>
 
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+          <div className="flex items-start gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-50">
               <Box className="h-5 w-5 text-amber-600" />
             </div>
             <div>
               <p className="text-sm font-medium text-gray-500">Models</p>
-              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{fmtCompact(totalModels)}</p>
+              <p className="mt-1 text-2xl font-bold tabular-nums text-gray-900">{fmtCompact(totalModels)}</p>
+              <p className="mt-1 text-xs text-gray-400">Current</p>
             </div>
           </div>
 
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 flex items-start gap-4">
+          <div className="flex items-start gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-cyan-50">
               <Clock className="h-5 w-5 text-cyan-600" />
             </div>
             <div>
               <p className="text-sm font-medium text-gray-500">Providers</p>
-              <p className="mt-1 text-2xl font-bold text-gray-900 tabular-nums">{totalProviders}</p>
-              <p className={`mt-1 text-xs font-medium ${activeProviders === totalProviders ? 'text-emerald-600' : 'text-amber-600'}`}>
-                {activeProviders} active
-              </p>
+              <p className="mt-1 text-2xl font-bold tabular-nums text-gray-900">{totalProviders}</p>
+              <p className={`mt-1 text-xs font-medium ${activeProviders === totalProviders ? 'text-emerald-600' : 'text-amber-600'}`}>{activeProviders} active · current</p>
             </div>
           </div>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
-            <h2 className="text-base font-semibold text-gray-900 mb-4">Request Volume</h2>
+        <div className={`grid grid-cols-1 gap-6 transition-opacity lg:grid-cols-2 ${isUpdating ? 'opacity-60' : ''}`} aria-busy={analyticsLoading}>
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-gray-900">Request Volume</h2>
+                <p className="mt-0.5 text-xs text-gray-400">{appliedRange.label} · {appliedRange.bucket === 'day' ? 'daily' : `${appliedRange.bucket}ly`} buckets</p>
+              </div>
+              {summaryReady && (
+                <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs">
+                  <span className="inline-flex items-center gap-1.5 text-gray-600"><span className="h-2 w-2 rounded-sm bg-violet-500" />{fmtCompact(successfulRequests)} successful</span>
+                  <span className="inline-flex items-center gap-1.5 text-gray-600"><span className="h-2 w-2 rounded-sm bg-rose-500" />{fmtCompact(failedRequests)} failed</span>
+                </div>
+              )}
+            </div>
             <div className="h-64">
-              {daily.length > 0 ? (
+              {!analytics && analyticsLoading ? (
+                <div className="h-full animate-pulse rounded-lg bg-gray-50" />
+              ) : requestData.length > 0 ? (
                 <ResponsiveContainer width="100%" height="100%">
-                  <AreaChart data={daily} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
-                    <defs>
-                      <linearGradient id="colorRequests" x1="0" y1="0" x2="0" y2="1">
-                        <stop offset="5%" stopColor="#8b5cf6" stopOpacity={0.3} />
-                        <stop offset="95%" stopColor="#8b5cf6" stopOpacity={0} />
-                      </linearGradient>
-                    </defs>
+                  <BarChart data={requestData} margin={{ top: 8, right: 8, left: 4, bottom: 4 }} accessibilityLayer>
                     <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
-                    <XAxis dataKey="date" axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#6b7280' }} dy={10} />
-                    <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#6b7280' }} />
-                    <Tooltip
-                      contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)' }}
-                      itemStyle={{ fontSize: '13px' }}
-                      labelStyle={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginBottom: '4px' }}
+                    <XAxis
+                      dataKey="date"
+                      axisLine={false}
+                      tickLine={false}
+                      tick={{ fontSize: 11, fill: '#6b7280' }}
+                      tickFormatter={(value: string) => formatBucketTick(value, appliedRange.bucket, appliedRange.key === 'all')}
+                      minTickGap={28}
+                      interval="preserveStartEnd"
+                      dy={8}
                     />
-                    <Area type="monotone" dataKey="success" stackId="1" stroke="#8b5cf6" strokeWidth={2} fillOpacity={1} fill="url(#colorRequests)" name="Successful" />
-                    <Area type="monotone" dataKey="failed" stackId="1" stroke="#f43f5e" strokeWidth={2} fill="#fecdd3" name="Failed" />
-                  </AreaChart>
+                    <YAxis
+                      axisLine={false}
+                      tickLine={false}
+                      tick={{ fontSize: 11, fill: '#6b7280' }}
+                      tickFormatter={(value: number) => fmtCompact(value)}
+                      allowDecimals={false}
+                      width={52}
+                    />
+                    <Tooltip content={<RequestVolumeTooltip bucket={appliedRange.bucket} />} cursor={{ fill: '#f3f4f6' }} />
+                    <Bar dataKey="success" name="Successful" stackId="requests" fill="#8b5cf6" radius={[2, 2, 0, 0]} />
+                    <Bar dataKey="failed" name="Failed" stackId="requests" fill="#f43f5e" radius={[2, 2, 0, 0]} />
+                  </BarChart>
                 </ResponsiveContainer>
               ) : (
-                <div className="flex items-center justify-center h-full text-gray-400 text-sm">
-                  <div className="text-center">
-                    <Activity className="w-8 h-8 mx-auto mb-2 opacity-50" />
-                    <p>No request data yet</p>
-                  </div>
+                <div className="flex h-full items-center justify-center text-sm text-gray-400">
+                  <div className="text-center"><Activity className="mx-auto mb-2 h-8 w-8 opacity-50" /><p>No requests in this period</p></div>
                 </div>
               )}
             </div>
           </div>
 
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
-            <h2 className="text-base font-semibold text-gray-900 mb-4">Cost by Provider</h2>
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <div className="mb-4">
+              <h2 className="text-base font-semibold text-gray-900">Cost by Provider</h2>
+              <p className="mt-0.5 text-xs text-gray-400">{appliedRange.label}</p>
+            </div>
             <div className="min-h-[256px]">
-              {providerSpend.length > 0 ? (
-                <div className="flex flex-col sm:flex-row items-center gap-4">
-                  <div className="w-full sm:w-1/2 h-48 sm:h-64">
+              {!analytics && analyticsLoading ? (
+                <div className="h-64 animate-pulse rounded-lg bg-gray-50" />
+              ) : providerSpend.length > 0 ? (
+                <div className="flex flex-col items-center gap-4 sm:flex-row">
+                  <div className="h-48 w-full sm:h-64 sm:w-1/2">
                     <ResponsiveContainer width="100%" height="100%">
-                      <PieChart>
-                        <Pie
-                          data={providerSpend}
-                          dataKey="spend"
-                          nameKey="label"
-                          cx="50%"
-                          cy="50%"
-                          outerRadius="70%"
-                          innerRadius="45%"
-                          paddingAngle={2}
-                        >
-                          {providerSpend.map((_, index) => (
-                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                          ))}
+                      <PieChart accessibilityLayer>
+                        <Pie data={providerSpend} dataKey="spend" nameKey="label" cx="50%" cy="50%" outerRadius="70%" innerRadius="45%" paddingAngle={2}>
+                          {providerSpend.map((provider, index) => <Cell key={provider.provider} fill={COLORS[index % COLORS.length]} />)}
                         </Pie>
                         <Tooltip
-                          formatter={(value: any) => [fmtDollarPrecise(value), 'Spend']}
+                          formatter={(value: number | string | undefined) => [fmtDollar(Number(value ?? 0)), 'Spend']}
                           contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)', fontSize: '13px' }}
                         />
                       </PieChart>
                     </ResponsiveContainer>
                   </div>
-                  <div className="w-full sm:w-1/2 sm:pl-2 overflow-y-auto max-h-48 sm:max-h-64">
+                  <div className="max-h-48 w-full overflow-y-auto sm:max-h-64 sm:w-1/2 sm:pl-2">
                     <div className="space-y-3">
-                      {providerSpend.map((p, idx) => (
-                        <div key={p.provider} className="flex items-center justify-between">
-                          <div className="flex items-center gap-2 overflow-hidden">
-                            <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: COLORS[idx % COLORS.length] }} />
-                            <span className="text-sm text-gray-600 truncate">{p.label}</span>
+                      {providerSpend.map((provider, index) => (
+                        <div key={provider.provider} className="flex items-center justify-between">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <div className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: COLORS[index % COLORS.length] }} />
+                            <span className="truncate text-sm text-gray-600">{provider.label}</span>
                           </div>
-                          <span className="text-sm font-medium text-gray-900 tabular-nums shrink-0 ml-2">{fmtDollarPrecise(p.spend)}</span>
+                          <span className="ml-2 shrink-0 text-sm font-medium tabular-nums text-gray-900">{fmtDollar(provider.spend)}</span>
                         </div>
                       ))}
                     </div>
                   </div>
                 </div>
               ) : (
-                <div className="flex items-center justify-center w-full h-64 text-gray-400 text-sm">
-                  <div className="text-center">
-                    <Box className="w-8 h-8 mx-auto mb-2 opacity-50" />
-                    <p>No provider data yet</p>
-                  </div>
+                <div className="flex h-64 w-full items-center justify-center text-sm text-gray-400">
+                  <div className="text-center"><Box className="mx-auto mb-2 h-8 w-8 opacity-50" /><p>No provider spend in this period</p></div>
                 </div>
               )}
             </div>
           </div>
         </div>
 
-        <div className="bg-gray-100/80 border border-gray-200/80 rounded-xl p-3 flex flex-wrap items-center gap-6 text-sm">
+        <div className="flex flex-wrap items-center gap-6 rounded-xl border border-gray-200/80 bg-gray-100/80 p-3 text-sm">
           <div className="flex items-center gap-2">
             <div className="relative flex h-2.5 w-2.5">
               {isHealthy ? (
-                <>
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-emerald-500"></span>
-                </>
-              ) : (
-                <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-amber-500"></span>
-              )}
+                <><span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" /><span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-500" /></>
+              ) : <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-amber-500" />}
             </div>
             <span className="font-medium text-gray-700">{isHealthy ? 'Healthy' : healthStatus}</span>
           </div>
-
-          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
-
-          <div className="flex items-center gap-1.5 text-gray-600">
-            <Server className="h-4 w-4 text-gray-400" />
-            <span>{activeProviders} Provider{activeProviders !== 1 ? 's' : ''} Active</span>
-          </div>
-
-          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
-
-          <div className="flex items-center gap-1.5 text-gray-600">
-            <Database className="h-4 w-4 text-gray-400" />
-            <span>{fmtCompact(totalModels)} Model{totalModels !== 1 ? 's' : ''} Deployed</span>
-          </div>
-
-          <div className="h-4 w-px bg-gray-300 hidden sm:block"></div>
-
-          <div className="flex items-center gap-1.5 text-gray-600">
-            <TrendingUp className="h-4 w-4 text-gray-400" />
-            <span>{fmtCompact(totalRequests)} Total Requests</span>
-          </div>
+          <div className="hidden h-4 w-px bg-gray-300 sm:block" />
+          <div className="flex items-center gap-1.5 text-gray-600"><Server className="h-4 w-4 text-gray-400" /><span>{activeProviders} Provider{activeProviders !== 1 ? 's' : ''} Active</span></div>
+          <div className="hidden h-4 w-px bg-gray-300 sm:block" />
+          <div className="flex items-center gap-1.5 text-gray-600"><Database className="h-4 w-4 text-gray-400" /><span>{fmtCompact(totalModels)} Model{totalModels !== 1 ? 's' : ''} Deployed</span></div>
         </div>
 
         {providerList.length > 0 && (
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-            <div className="px-5 py-4 border-b border-gray-100 flex items-center justify-between">
+          <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+            <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
               <h2 className="text-base font-semibold text-gray-900">Provider Health</h2>
               <span className="text-xs text-gray-400">{totalProviders} provider{totalProviders !== 1 ? 's' : ''} configured</span>
             </div>
             <div className="divide-y divide-gray-100">
-              {providerList.map((p) => {
-                const cfg = statusConfig[p.status];
+              {providerList.map((provider) => {
+                const config = statusConfig[provider.status];
                 return (
-                  <div key={p.provider} className="flex items-center justify-between px-5 py-3.5">
-                    <div className="flex items-center gap-3 min-w-0">
-                      <div className={`h-2.5 w-2.5 rounded-full shrink-0 ${cfg.dot}`} />
+                  <div key={provider.provider} className="flex items-center justify-between px-5 py-3.5">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className={`h-2.5 w-2.5 shrink-0 rounded-full ${config.dot}`} />
                       <div className="min-w-0">
-                        <p className="text-sm font-medium text-gray-900 truncate">{providerDisplayName(p.provider)}</p>
-                        <p className="text-xs text-gray-400">{p.models} model{p.models > 1 ? 's' : ''}</p>
+                        <p className="truncate text-sm font-medium text-gray-900">{providerDisplayName(provider.provider)}</p>
+                        <p className="text-xs text-gray-400">{provider.models} model{provider.models !== 1 ? 's' : ''}</p>
                       </div>
                     </div>
-                    <div className="flex items-center gap-5 shrink-0">
-                      <div className="text-right">
-                        <p className="text-sm tabular-nums text-gray-700">{p.healthy_models}/{p.models}</p>
-                        <p className="text-[11px] text-gray-400">healthy</p>
-                      </div>
-                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${cfg.bg} ${cfg.text}`}>
-                        {cfg.label}
-                      </span>
+                    <div className="flex shrink-0 items-center gap-5">
+                      <div className="text-right"><p className="text-sm tabular-nums text-gray-700">{provider.healthy_models}/{provider.models}</p><p className="text-[11px] text-gray-400">healthy</p></div>
+                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${config.bg} ${config.text}`}>{config.label}</span>
                     </div>
                   </div>
                 );
@@ -317,7 +513,6 @@ export default function Dashboard() {
             </div>
           </div>
         )}
-
       </div>
     </div>
   );

--- a/ui/tests/dashboardRange.test.ts
+++ b/ui/tests/dashboardRange.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  failureRate,
+  normalizeRequestSeries,
+  parseDashboardRangeKey,
+  resolveDashboardRange,
+  type RequestSeriesRow,
+} from '../src/lib/dashboardRange';
+
+const NOW = new Date('2026-08-08T16:00:00Z');
+
+test('dashboard ranges use inclusive UTC boundaries and adaptive buckets', () => {
+  assert.deepEqual(resolveDashboardRange('7d', NOW), {
+    key: '7d',
+    label: 'Last 7 days',
+    shortLabel: '7 days',
+    startDate: '2026-08-02',
+    endDate: '2026-08-08',
+    bucket: 'day',
+  });
+  assert.equal(resolveDashboardRange('30d', NOW).startDate, '2026-07-10');
+  assert.equal(resolveDashboardRange('3m', NOW).bucket, 'week');
+  assert.equal(resolveDashboardRange('6m', NOW).startDate, '2026-02-08');
+  assert.equal(resolveDashboardRange('ytd', NOW).startDate, '2026-01-01');
+  assert.deepEqual(resolveDashboardRange('all', NOW), {
+    key: 'all',
+    label: 'All time',
+    shortLabel: 'All time',
+    bucket: 'month',
+  });
+});
+
+test('calendar month ranges clamp safely at month end', () => {
+  const result = resolveDashboardRange('3m', new Date('2024-05-31T12:00:00Z'));
+  assert.equal(result.startDate, '2024-02-29');
+  assert.equal(result.endDate, '2024-05-31');
+});
+
+test('range parsing falls back to the 30 day default', () => {
+  assert.equal(parseDashboardRangeKey('ytd'), 'ytd');
+  assert.equal(parseDashboardRangeKey('unexpected'), '30d');
+  assert.equal(parseDashboardRangeKey(null), '30d');
+});
+
+test('request series fills missing daily buckets with zero values', () => {
+  const rows: RequestSeriesRow[] = [
+    {
+      group_key: '2026-08-02',
+      request_count: 8,
+      successful_requests: 7,
+      failed_requests: 1,
+      total_spend: 1,
+      total_tokens: 100,
+    },
+    {
+      group_key: '2026-08-04',
+      request_count: 4,
+      successful_requests: 4,
+      failed_requests: 0,
+      total_spend: 0.5,
+      total_tokens: 50,
+    },
+  ];
+
+  const result = normalizeRequestSeries(rows, {
+    startDate: '2026-08-02',
+    endDate: '2026-08-04',
+    bucket: 'day',
+  });
+
+  assert.equal(result.length, 3);
+  assert.equal(result[1].group_key, '2026-08-03');
+  assert.equal(result[1].request_count, 0);
+  assert.equal(result[2].request_count, 4);
+});
+
+test('weekly series aligns the requested range to Monday buckets', () => {
+  const rows: RequestSeriesRow[] = [
+    {
+      group_key: '2026-08-03',
+      request_count: 10,
+      successful_requests: 9,
+      failed_requests: 1,
+      total_spend: 1,
+      total_tokens: 100,
+    },
+  ];
+  const result = normalizeRequestSeries(rows, {
+    startDate: '2026-08-08',
+    endDate: '2026-08-17',
+    bucket: 'week',
+  });
+
+  assert.deepEqual(result.map((row) => row.group_key), ['2026-08-03', '2026-08-10', '2026-08-17']);
+});
+
+test('all-time monthly series fills gaps using the returned bounds', () => {
+  const row = (group_key: string): RequestSeriesRow => ({
+    group_key,
+    request_count: 1,
+    successful_requests: 1,
+    failed_requests: 0,
+    total_spend: 1,
+    total_tokens: 1,
+  });
+  const result = normalizeRequestSeries([row('2026-03-01'), row('2026-01-01')], { bucket: 'month' });
+
+  assert.deepEqual(result.map((item) => item.group_key), ['2026-01-01', '2026-02-01', '2026-03-01']);
+  assert.equal(result[1].request_count, 0);
+});
+
+test('failure rate is safe for empty periods', () => {
+  assert.equal(failureRate(1_399, 21_955).toFixed(1), '6.4');
+  assert.equal(failureRate(0, 0), 0);
+});


### PR DESCRIPTION
## Summary

- add Dashboard period presets for Last 7 days, Last 30 days, Last 3 months, Last 6 months, Year to date, and All time
- persist the selected period in the URL and use inclusive UTC reporting boundaries
- aggregate request analytics into adaptive daily, weekly, or monthly buckets
- replace the misleading request-volume area plot with a stacked bar chart that puts successful and failed requests on one shared Y-axis
- normalize missing time buckets to zero and improve chart labels, tooltips, axis visibility, loading, empty, and error states
- scope cost-by-provider and summary metrics to the same selected period

## Why

The previous request-volume chart could make successful and failed totals appear visually close despite materially different values, and its Y-axis was not consistently visible. Dashboard analytics also had no way to select a reporting period.

This change uses a stacked bar chart for discrete interval counts, ensuring both request statuses share the same scale while retaining their composition. It also makes the full Dashboard analytics surface respond coherently to one selected date range.

## API impact

The admin spend-report endpoint now accepts an optional, validated `interval` query parameter for day grouping:

- `day` (default; backward compatible)
- `week`
- `month`

The interval is mapped to fixed SQL expressions rather than interpolating arbitrary input.

## User impact

- Dashboard defaults to Last 30 days.
- Desktop users get a compact segmented range control; mobile users get a Period select.
- Longer ranges automatically use readable weekly or monthly buckets.
- Successful and failed request counts are directly comparable on one axis.
- All-time mode omits date filters and uses the returned data bounds.

## Validation

- `npm run test:unit` — 35 passed
- `npm run build` — passed
- focused ESLint for Dashboard, range helper/tests, and unit-test runner — passed
- `uv run pytest tests/test_ui_rbac_scoping.py -q` — 16 passed
- `uv run ruff check src/api/admin/endpoints/spend.py tests/test_ui_rbac_scoping.py` — passed
- `git diff --check origin/main...HEAD` — passed

## Lint baseline

Repository-wide `npm run lint` remains red with existing violations across unrelated UI files on current `main`. The focused files introduced by this PR pass ESLint.
