### PR TITLE
Fix platform admin Named Credentials access

### DIFF
--- a/src/models/platform_auth.py
+++ b/src/models/platform_auth.py
@@ -98,6 +98,7 @@ class UIAccessResponse(BaseModel):
     dashboard: bool = False
     models: bool = False
     model_admin: bool = False
+    named_credentials: bool = False
     route_groups: bool = False
     prompts: bool = False
     mcp_servers: bool = False

--- a/src/services/ui_authorization.py
+++ b/src/services/ui_authorization.py
@@ -50,6 +50,7 @@ def build_ui_access(
         "dashboard": can_view_dashboard,
         "models": authenticated,
         "model_admin": is_platform_admin,
+        "named_credentials": is_platform_admin,
         "route_groups": is_platform_admin,
         "prompts": is_platform_admin,
         "mcp_servers": authenticated and (is_platform_admin or Permission.KEY_READ in permissions),

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -248,8 +248,35 @@ async def test_auth_me_returns_ui_access(client, test_app):
     assert payload["ui_access"]["mcp_approvals"] is True
     assert payload["ui_access"]["audit"] is True
     assert payload["ui_access"]["playground"] is True
+    assert payload["ui_access"]["named_credentials"] is False
     assert payload["ui_access"]["people_access"] is False
     assert payload["ui_access"]["usage"] is False
+
+
+@pytest.mark.asyncio
+async def test_auth_me_allows_platform_admin_to_access_named_credentials(client, test_app):
+    class StubIdentityService:
+        async def get_context_for_session(self, token: str):
+            if token != "session-token":
+                return None
+            return PlatformAuthContext(
+                account_id="acct-admin",
+                email="admin@example.com",
+                role="platform_admin",
+                permissions=[],
+                organization_memberships=[],
+                team_memberships=[],
+                mfa_enabled=False,
+                mfa_verified=False,
+                force_password_change=False,
+            )
+
+    test_app.state.platform_identity_service = StubIdentityService()
+
+    response = await client.get("/auth/me", cookies={"deltallm_session": "session-token"})
+
+    assert response.status_code == 200
+    assert response.json()["ui_access"]["named_credentials"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- expose the `named_credentials` capability in the session UI-access response schema
- enable the capability for platform admins in the backend authorization builder
- cover both platform-admin access and scoped-user denial in authorization tests

## Why

Platform admins authenticated through a normal session could not see or open the Named Credentials page. The frontend already checked the `named_credentials` capability, but the backend omitted it from both the capability builder and response schema. The frontend therefore defaulted it to `false`.

Master-key login was unaffected because it uses the frontend's full-access path, and the Named Credentials API itself already authorized platform-admin sessions.

## Impact

Session-authenticated platform admins can now see and access the Named Credentials registration page. Access remains disabled for scoped non-platform users.

## Validation

- `uv run --extra dev pytest tests/test_ui_authorization.py -q` — 22 passed
- `uv run --extra dev ruff check src/models/platform_auth.py src/services/ui_authorization.py tests/test_ui_authorization.py` — passed
- `git diff --check` — passed

Fixes #243