### PR TITLE
Fix model group member deletion for slash IDs

### DIFF
--- a/src/api/admin/endpoints/route_groups.py
+++ b/src/api/admin/endpoints/route_groups.py
@@ -674,7 +674,7 @@ async def upsert_route_group_member(request: Request, group_key: str, payload: d
     return response
 
 
-@router.delete("/ui/api/route-groups/{group_key}/members/{deployment_id}", dependencies=[Depends(require_admin_permission(Permission.CONFIG_UPDATE))])
+@router.delete("/ui/api/route-groups/{group_key}/members/{deployment_id:path}", dependencies=[Depends(require_admin_permission(Permission.CONFIG_UPDATE))])
 async def delete_route_group_member(request: Request, group_key: str, deployment_id: str) -> dict[str, bool]:
     request_start = perf_counter()
     repository = _repository_or_503(request)

--- a/tests/test_ui_route_groups.py
+++ b/tests/test_ui_route_groups.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from typing import Any
+from urllib.parse import quote
 
 import pytest
 
@@ -409,6 +410,45 @@ async def test_route_group_admin_crud_and_policy_publish(client, test_app):
 
     assert test_app.state.model_hot_reload_manager.calls == 3
     assert runtime_cache.invalidate_calls == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("deployment_id", ["dep-a", "openai/gpt-4o"])
+async def test_route_group_member_delete_supports_encoded_deployment_ids(
+    client,
+    test_app,
+    deployment_id: str,
+):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.model_hot_reload_manager = _FakeHotReload()
+    test_app.state.route_group_runtime_cache = _FakeRouteGroupRuntimeCache()
+    headers = {"Authorization": "Bearer mk-test"}
+
+    create_response = await client.post(
+        "/ui/api/route-groups",
+        headers=headers,
+        json={"group_key": "support-route", "mode": "chat"},
+    )
+    assert create_response.status_code == 200
+
+    member_response = await client.post(
+        "/ui/api/route-groups/support-route/members",
+        headers=headers,
+        json={"deployment_id": deployment_id},
+    )
+    assert member_response.status_code == 200
+
+    delete_response = await client.delete(
+        f"/ui/api/route-groups/support-route/members/{quote(deployment_id, safe='')}",
+        headers=headers,
+    )
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {"deleted": True}
+
+    detail_response = await client.get("/ui/api/route-groups/support-route", headers=headers)
+    assert detail_response.status_code == 200
+    assert detail_response.json()["members"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Allow model-group member deletion routes to capture deployment IDs containing `/`.
- Add regression coverage for ordinary and URL-encoded slash-containing deployment IDs.

## Root cause

The UI URL-encodes deployment IDs, but FastAPI decodes `%2F` before route matching. The member deletion endpoint used a single-segment path parameter, so IDs such as `openai/gpt-4o` failed route matching with `405 Method Not Allowed` before the repository was called.

## Impact

Administrators can now remove model deployments with provider-style slash-containing IDs from model groups.

## Validation

- `uv run pytest tests/test_ui_route_groups.py -q` — 13 passed
- `uv run ruff check src/api/admin/endpoints/route_groups.py tests/test_ui_route_groups.py`
- `git diff --check`