### PR TITLE
Enforce model-group eligibility throughout failover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,13 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/deltallm_test
         run: uv run prisma migrate deploy --schema=./prisma/schema.prisma
 
-      - name: Run tier admission against real Redis
+      - name: Run Redis integration tests
         env:
           DELTALLM_TEST_REDIS_URL: redis://localhost:6379/0
-        run: uv run pytest -v -rs tests/services/test_tier_fair_share_redis_integration.py
+        run: >-
+          uv run pytest -v -rs
+          tests/services/test_tier_fair_share_redis_integration.py
+          tests/test_router_redis_integration.py
 
       - name: Run tests
         env:

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -434,12 +434,12 @@ For new deployments, set `deltallm_params.provider`. Provider prefixes in `delta
 | Gemini | Y | N | N | N | N | N |
 | AWS Bedrock | Y | N | N | N | N | N |
 | ElevenLabs | N | N | N | Y | Y | N |
-| vLLM | Y | Y | Y | Y | Y | N |
+| vLLM | Y | Y | Y | Y | Y | Y |
 | LM Studio | Y | Y | N | N | N | N |
 | Ollama | Y | Y | N | N | N | N |
 
 !!! note
-    `rerank` exists as a DeltaLLM mode, but no provider is currently marked as rerank-capable in the backend capability matrix.
+    vLLM rerank deployments use the OpenAI-compatible `/rerank` endpoint. Providers not marked as rerank-capable are excluded before routing attempts.
 
 ## Related Pages
 

--- a/src/api/admin/endpoints/models.py
+++ b/src/api/admin/endpoints/models.py
@@ -22,11 +22,19 @@ from src.upstream_auth import (
 )
 from src.providers.healthcheck import probe_provider_health
 from src.providers.model_discovery import discover_provider_models
-from src.providers.resolution import provider_presets, resolve_provider, validate_provider_mode_compatibility
+from src.providers.resolution import (
+    provider_presets,
+    resolve_provider,
+    validate_provider_mode_compatibility,
+)
 from src.router import build_deployment_registry
 from src.services.asset_binding_mirror import reload_callable_target_grants_for_app
 from src.services.callable_targets import build_callable_target_catalog
-from src.services.model_deployments import DuplicateModelNameError, ensure_model_name_available, resolve_runtime_deltallm_params
+from src.services.model_deployments import (
+    DuplicateModelNameError,
+    ensure_model_name_available,
+    resolve_runtime_deltallm_params,
+)
 from src.services.named_credentials import (
     canonicalize_named_credential_provider,
     merge_named_credential_params,
@@ -85,7 +93,9 @@ class ProviderModelDiscoveryRequest(BaseModel):
         if self.auth_header_name is None and self.auth_header_format is None:
             return self
         if not supports_custom_openai_compatible_auth(self.provider):
-            raise ValueError(f"Custom auth headers are not supported for provider '{self.provider}'")
+            raise ValueError(
+                f"Custom auth headers are not supported for provider '{self.provider}'"
+            )
         return self
 
 
@@ -140,16 +150,22 @@ async def _load_named_credential_or_400(
         return None
     repository = _named_credential_repository(app)
     if repository is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Named credential repository unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Named credential repository unavailable",
+        )
     named_credential = await repository.get_by_id(normalized_id)
     if named_credential is None:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="named_credential_id is invalid")
-    if (
-        provider is not None
-        and canonicalize_named_credential_provider(named_credential.provider)
-        != canonicalize_named_credential_provider(provider)
-    ):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Named credential provider does not match deployment provider")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="named_credential_id is invalid"
+        )
+    if provider is not None and canonicalize_named_credential_provider(
+        named_credential.provider
+    ) != canonicalize_named_credential_provider(provider):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Named credential provider does not match deployment provider",
+        )
     return named_credential
 
 
@@ -164,7 +180,8 @@ async def _deployment_health_flags(app: Any, deployment_ids: list[str]) -> dict[
     health_by_deployment = await health_backend.get_health_batch(deployment_ids)
     cooldown_by_deployment = await health_backend.get_cooldown_batch(deployment_ids)
     return {
-        deployment_id: str(health_by_deployment.get(deployment_id, {}).get("healthy", "true")) != "false"
+        deployment_id: str(health_by_deployment.get(deployment_id, {}).get("healthy", "true"))
+        != "false"
         and not cooldown_by_deployment.get(deployment_id, False)
         for deployment_id in deployment_ids
     }
@@ -215,9 +232,9 @@ def _serialize_model_write_response(
             "provider": provider,
             "mode": model_info.get("mode", "chat"),
             "credential_source": credential_source,
-            "inline_credentials_present": credential_source == "inline" and any(
-                str(deltallm_params.get(field) or "").strip()
-                for field in _INLINE_SECRET_FIELDS
+            "inline_credentials_present": credential_source == "inline"
+            and any(
+                str(deltallm_params.get(field) or "").strip() for field in _INLINE_SECRET_FIELDS
             ),
             "connection_summary": build_connection_summary(
                 effective_summary_params,
@@ -245,7 +262,7 @@ def _rebuild_runtime_registry(app: Any) -> None:
         runtime_registry.clear()
         runtime_registry.update(rebuilt)
 
-    for attr in ("failover_manager", "router_health_handler", "background_health_checker"):
+    for attr in ("router_health_handler", "background_health_checker"):
         holder = getattr(app.state, attr, None)
         registry = getattr(holder, "registry", None)
         if isinstance(registry, dict) and registry is not runtime_registry:
@@ -263,7 +280,9 @@ async def _invalidate_route_group_runtime_cache(app: Any) -> None:
 async def _sync_auto_follow_org_bindings(app: Any) -> None:
     await sync_auto_follow_organization_bindings(
         db=getattr(getattr(app.state, "prisma_manager", None), "client", None),
-        callable_target_binding_repository=getattr(app.state, "callable_target_binding_repository", None),
+        callable_target_binding_repository=getattr(
+            app.state, "callable_target_binding_repository", None
+        ),
         route_group_repository=getattr(app.state, "route_group_repository", None),
         callable_target_catalog=getattr(app.state, "callable_target_catalog", None),
     )
@@ -284,7 +303,9 @@ def _normalize_model_info_or_400(model_info: dict[str, Any]) -> dict[str, Any]:
     if "access_groups" not in normalized:
         return normalized
     try:
-        normalized["access_groups"] = normalize_access_group_list(normalized.get("access_groups"), strict=True)
+        normalized["access_groups"] = normalize_access_group_list(
+            normalized.get("access_groups"), strict=True
+        )
     except InvalidAccessGroupError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     return normalized
@@ -300,7 +321,9 @@ def _normalized_model_payload_or_400(
 ) -> tuple[str, str | None, dict[str, Any], dict[str, Any]]:
     model_name = str(payload.get("model_name") or existing_model_name or "").strip()
     if not model_name:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="model_name is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="model_name is required"
+        )
 
     raw_named_credential_id = payload.get("named_credential_id", _MISSING)
     if raw_named_credential_id is _MISSING:
@@ -318,7 +341,9 @@ def _normalized_model_payload_or_400(
             named_credential_id=named_credential_id,
         )
     else:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="deltallm_params must be an object")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="deltallm_params must be an object"
+        )
 
     provider = str(params.get("provider") or "").strip().lower()
     model = str(params.get("model") or "").strip()
@@ -327,7 +352,9 @@ def _normalized_model_payload_or_400(
     if not provider:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="provider is required")
     if not model:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="deltallm_params.model is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="deltallm_params.model is required"
+        )
 
     params["provider"] = provider
     params["model"] = model
@@ -345,7 +372,9 @@ def _normalized_model_payload_or_400(
     elif isinstance(raw_model_info, dict):
         model_info = dict(raw_model_info)
     else:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="model_info must be an object")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="model_info must be an object"
+        )
 
     return model_name, named_credential_id, params, _normalize_model_info_or_400(model_info)
 
@@ -357,9 +386,15 @@ def _merged_model_params(
     named_credential_id: str | None,
 ) -> dict[str, Any]:
     merged = dict(existing_params or {})
-    existing_provider = str(merged.get("provider") or "").strip().lower() or resolve_provider(merged)
-    incoming_provider = str(incoming_params.get("provider") or existing_provider or "").strip().lower()
-    provider_changed = bool(existing_provider and incoming_provider and existing_provider != incoming_provider)
+    existing_provider = str(merged.get("provider") or "").strip().lower() or resolve_provider(
+        merged
+    )
+    incoming_provider = (
+        str(incoming_params.get("provider") or existing_provider or "").strip().lower()
+    )
+    provider_changed = bool(
+        existing_provider and incoming_provider and existing_provider != incoming_provider
+    )
 
     if named_credential_id is not None or provider_changed:
         for field in _CREDENTIAL_CONNECTION_FIELDS:
@@ -392,7 +427,13 @@ async def list_models(
 
     if search:
         q = search.lower()
-        entries = [e for e in entries if q in e["model_name"].lower() or q in e["deployment_id"].lower() or q in e.get("provider", "").lower()]
+        entries = [
+            e
+            for e in entries
+            if q in e["model_name"].lower()
+            or q in e["deployment_id"].lower()
+            or q in e.get("provider", "").lower()
+        ]
     if provider:
         p = provider.lower()
         entries = [e for e in entries if e.get("provider", "").lower() == p]
@@ -401,7 +442,7 @@ async def list_models(
         entries = [e for e in entries if (e.get("mode") or "chat").lower() == m]
 
     total = len(entries)
-    page = entries[offset: offset + limit]
+    page = entries[offset : offset + limit]
 
     for entry in page:
         healthy = True
@@ -412,7 +453,12 @@ async def list_models(
 
     return {
         "data": page,
-        "pagination": {"total": total, "limit": limit, "offset": offset, "has_more": offset + limit < total},
+        "pagination": {
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + limit < total,
+        },
     }
 
 
@@ -479,7 +525,9 @@ async def list_provider_presets() -> dict[str, Any]:
 
 
 @router.post("/ui/api/provider-models/discover", dependencies=[Depends(require_authenticated)])
-async def discover_models_for_provider(request: Request, payload: ProviderModelDiscoveryRequest) -> dict[str, Any]:
+async def discover_models_for_provider(
+    request: Request, payload: ProviderModelDiscoveryRequest
+) -> dict[str, Any]:
     raw_named_credential = await _load_named_credential_or_400(
         request.app,
         payload.named_credential_id,
@@ -509,7 +557,9 @@ async def discover_models_for_provider(request: Request, payload: ProviderModelD
         api_version=merged_params.get("api_version"),
         auth_header_name=merged_params.get("auth_header_name"),
         auth_header_format=merged_params.get("auth_header_format"),
-        default_openai_base_url=getattr(request.app.state.settings, "openai_base_url", "https://api.openai.com/v1"),
+        default_openai_base_url=getattr(
+            request.app.state.settings, "openai_base_url", "https://api.openai.com/v1"
+        ),
         general_settings=getattr(
             request.app.state,
             "upstream_http_settings",
@@ -530,7 +580,10 @@ async def get_model(request: Request, deployment_id: str) -> dict[str, Any]:
     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deployment not found")
 
 
-@router.post("/ui/api/models/{deployment_id:path}/health-check", dependencies=[Depends(require_authenticated)])
+@router.post(
+    "/ui/api/models/{deployment_id:path}/health-check",
+    dependencies=[Depends(require_authenticated)],
+)
 async def check_model_health(request: Request, deployment_id: str) -> dict[str, Any]:
     deployment = _find_runtime_deployment(request.app, deployment_id)
     if deployment is None:
@@ -557,7 +610,9 @@ async def check_model_health(request: Request, deployment_id: str) -> dict[str, 
         "deployment_id": deployment_id,
         "healthy": health["healthy"],
         "health": health,
-        "message": "Health check passed" if result.healthy else (result.error or "Health check failed"),
+        "message": "Health check passed"
+        if result.healthy
+        else (result.error or "Health check failed"),
         "status_code": result.status_code,
         "checked_at": result.checked_at,
     }
@@ -566,7 +621,9 @@ async def check_model_health(request: Request, deployment_id: str) -> dict[str, 
 @router.post("/ui/api/models", dependencies=[Depends(require_master_key)])
 async def create_model(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
     request_start = perf_counter()
-    model_name, named_credential_id, deltallm_params, model_info = _normalized_model_payload_or_400(payload)
+    model_name, named_credential_id, deltallm_params, model_info = _normalized_model_payload_or_400(
+        payload
+    )
     named_credential = await _load_named_credential_or_400(
         request.app,
         named_credential_id,
@@ -574,10 +631,14 @@ async def create_model(request: Request, payload: dict[str, Any]) -> dict[str, A
     )
     effective_params = merge_named_credential_params(deltallm_params, named_credential)
     if not str(effective_params.get("api_base") or "").strip():
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="deltallm_params.api_base is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="deltallm_params.api_base is required"
+        )
     deployment_id = str(payload.get("deployment_id") or f"{model_name}-{secrets.token_hex(4)}")
     try:
-        ensure_model_name_available(getattr(request.app.state, "model_registry", {}) or {}, model_name=model_name)
+        ensure_model_name_available(
+            getattr(request.app.state, "model_registry", {}) or {}, model_name=model_name
+        )
     except DuplicateModelNameError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
     model_config = {
@@ -589,7 +650,9 @@ async def create_model(request: Request, payload: dict[str, Any]) -> dict[str, A
     }
     _validate_model_config_or_400(model_config)
 
-    hot_reload: ModelHotReloadManager | None = getattr(request.app.state, "model_hot_reload_manager", None)
+    hot_reload: ModelHotReloadManager | None = getattr(
+        request.app.state, "model_hot_reload_manager", None
+    )
     if hot_reload is not None:
         deployment_id = await hot_reload.add_model(model_config, updated_by="admin_api")
     else:
@@ -597,7 +660,9 @@ async def create_model(request: Request, payload: dict[str, Any]) -> dict[str, A
             {
                 "deployment_id": deployment_id,
                 "named_credential_id": named_credential_id,
-                "named_credential_name": named_credential.name if named_credential is not None else None,
+                "named_credential_name": named_credential.name
+                if named_credential is not None
+                else None,
                 "deltallm_params": resolve_runtime_deltallm_params(
                     deltallm_params,
                     request.app.state.settings,
@@ -635,9 +700,13 @@ async def create_model(request: Request, payload: dict[str, Any]) -> dict[str, A
 
 
 @router.put("/ui/api/models/{deployment_id:path}", dependencies=[Depends(require_master_key)])
-async def update_model(request: Request, deployment_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+async def update_model(
+    request: Request, deployment_id: str, payload: dict[str, Any]
+) -> dict[str, Any]:
     request_start = perf_counter()
-    hot_reload: ModelHotReloadManager | None = getattr(request.app.state, "model_hot_reload_manager", None)
+    hot_reload: ModelHotReloadManager | None = getattr(
+        request.app.state, "model_hot_reload_manager", None
+    )
     registry: dict[str, list[dict[str, Any]]] = request.app.state.model_registry
     model_repository = getattr(request.app.state, "model_deployment_repository", None)
     get_by_deployment_id = getattr(model_repository, "get_by_deployment_id", None)
@@ -672,12 +741,14 @@ async def update_model(request: Request, deployment_id: str, payload: dict[str, 
     if found_deployment is None or found_model_name is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deployment not found")
 
-    new_model_name, named_credential_id, deltallm_params, model_info = _normalized_model_payload_or_400(
-        payload,
-        existing_model_name=found_model_name,
-        existing_named_credential_id=found_deployment.get("named_credential_id"),
-        existing_params=found_deployment.get("deltallm_params", {}),
-        existing_model_info=found_deployment.get("model_info", {}),
+    new_model_name, named_credential_id, deltallm_params, model_info = (
+        _normalized_model_payload_or_400(
+            payload,
+            existing_model_name=found_model_name,
+            existing_named_credential_id=found_deployment.get("named_credential_id"),
+            existing_params=found_deployment.get("deltallm_params", {}),
+            existing_model_info=found_deployment.get("model_info", {}),
+        )
     )
     named_credential = await _load_named_credential_or_400(
         request.app,
@@ -686,7 +757,9 @@ async def update_model(request: Request, deployment_id: str, payload: dict[str, 
     )
     effective_params = merge_named_credential_params(deltallm_params, named_credential)
     if not str(effective_params.get("api_base") or "").strip():
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="deltallm_params.api_base is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="deltallm_params.api_base is required"
+        )
     try:
         ensure_model_name_available(
             getattr(request.app.state, "model_registry", {}) or {},
@@ -711,7 +784,9 @@ async def update_model(request: Request, deployment_id: str, payload: dict[str, 
             updated_by="admin_api",
         )
         if not updated:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deployment not found")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Deployment not found"
+            )
     else:
         deployments = registry.get(found_model_name, [])
         for idx, deployment in enumerate(deployments):
@@ -724,7 +799,9 @@ async def update_model(request: Request, deployment_id: str, payload: dict[str, 
             {
                 "deployment_id": deployment_id,
                 "named_credential_id": named_credential_id,
-                "named_credential_name": named_credential.name if named_credential is not None else None,
+                "named_credential_name": named_credential.name
+                if named_credential is not None
+                else None,
                 "deltallm_params": resolve_runtime_deltallm_params(
                     deltallm_params,
                     request.app.state.settings,
@@ -764,12 +841,16 @@ async def update_model(request: Request, deployment_id: str, payload: dict[str, 
 @router.delete("/ui/api/models/{deployment_id:path}", dependencies=[Depends(require_master_key)])
 async def delete_model(request: Request, deployment_id: str) -> dict[str, bool]:
     request_start = perf_counter()
-    hot_reload: ModelHotReloadManager | None = getattr(request.app.state, "model_hot_reload_manager", None)
+    hot_reload: ModelHotReloadManager | None = getattr(
+        request.app.state, "model_hot_reload_manager", None
+    )
 
     if hot_reload is not None:
         removed = await hot_reload.remove_model(deployment_id, updated_by="admin_api")
         if not removed:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deployment not found")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Deployment not found"
+            )
         response = {"deleted": True}
         await emit_control_audit_event(
             request=request,

--- a/src/batch/chat_worker_execution.py
+++ b/src/batch/chat_worker_execution.py
@@ -37,6 +37,7 @@ from src.models.errors import InvalidRequestError, ServiceUnavailableError
 from src.models.request_serialization import dump_request_for_preflight
 from src.models.requests import ChatCompletionRequest, MCPToolDefinition
 from src.providers.resolution import resolve_provider
+from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.router.health_policy import affects_deployment_health
 from src.routers.routing_decision import route_failover_kwargs
 
@@ -74,6 +75,7 @@ class ChatWorkerExecutionMixin:
         request_context: dict[str, Any] = {
             "metadata": chat_request.metadata or {},
             "user_id": preflight.auth.user_id or preflight.auth.api_key or "batch-worker",
+            ROUTING_MODE_CONTEXT_KEY: "chat",
         }
         app_router = self.app.state.router
         model_group = app_router.resolve_model_group(chat_request.model)
@@ -98,7 +100,9 @@ class ChatWorkerExecutionMixin:
 
     def _validate_batch_chat_request(self, payload: ChatCompletionRequest) -> None:
         if payload.stream is True:
-            raise InvalidRequestError(message="Chat batch requests support non-streaming requests only; stream must be false")
+            raise InvalidRequestError(
+                message="Chat batch requests support non-streaming requests only; stream must be false"
+            )
         if any(isinstance(tool, MCPToolDefinition) for tool in payload.tools or []):
             raise InvalidRequestError(message="MCP tools are not supported in batch chat yet")
 
@@ -150,12 +154,8 @@ class ChatWorkerExecutionMixin:
                     provider_cost=provider_cost,
                     billing=customer_billing.billing,
                     provider_billing=provider_billing.billing,
-                    effective_pricing_sources=(
-                        customer_billing.pricing_sources_used
-                    ),
-                    missing_pricing_fields=(
-                        customer_billing.missing_pricing_fields
-                    ),
+                    effective_pricing_sources=(customer_billing.pricing_sources_used),
+                    missing_pricing_fields=(customer_billing.missing_pricing_fields),
                     pricing_tier="batch",
                 ),
                 batch_execution_mode=batch_execution_mode,
@@ -177,7 +177,9 @@ class ChatWorkerExecutionMixin:
         try:
             await self._acquire_prepared_policy_lease(prepared=prepared)
         except Exception as exc:
-            record_batch_policy_failure(endpoint=batch_call_type_for_endpoint(job.endpoint), exc=exc)
+            record_batch_policy_failure(
+                endpoint=batch_call_type_for_endpoint(job.endpoint), exc=exc
+            )
             await self._mark_item_failed(
                 job=job,
                 item=prepared.item,
@@ -201,9 +203,12 @@ class ChatWorkerExecutionMixin:
                 lease_lost_event=item_lease_lost,
             )
             (
-                response_body,
-                api_latency_ms,
-            ), served_deployment = await self._await_with_lease_loss_cancellation(
+                (
+                    response_body,
+                    api_latency_ms,
+                ),
+                served_deployment,
+            ) = await self._await_with_lease_loss_cancellation(
                 self.app.state.failover_manager.execute_with_failover(
                     primary_deployment=prepared.primary_deployment,
                     model_group=prepared.model_group,
@@ -214,6 +219,7 @@ class ChatWorkerExecutionMixin:
                         record_usage=False,
                     ),
                     return_deployment=True,
+                    routing_context=prepared.request_context,
                     **prepared.failover_kwargs,
                 ),
                 lease_lost_event=item_lease_lost,
@@ -294,7 +300,8 @@ class ChatWorkerExecutionMixin:
                 item=prepared.item,
                 model_name=prepared.model_name,
                 exc=exc,
-                deployment_id=str(getattr(prepared.primary_deployment, "deployment_id", None) or "") or None,
+                deployment_id=str(getattr(prepared.primary_deployment, "deployment_id", None) or "")
+                or None,
                 started_at_monotonic=prepared.started_at_monotonic,
             )
             increment_batch_chat_item_executed(mode=batch_execution_mode, status="error")
@@ -306,7 +313,10 @@ class ChatWorkerExecutionMixin:
 
     @staticmethod
     def _chat_deployment_key(prepared: _PreparedChatItem) -> str:
-        return str(getattr(prepared.primary_deployment, "deployment_id", None) or id(prepared.primary_deployment))
+        return str(
+            getattr(prepared.primary_deployment, "deployment_id", None)
+            or id(prepared.primary_deployment)
+        )
 
     def _resolve_chat_microbatch_executor(
         self,
@@ -322,7 +332,9 @@ class ChatWorkerExecutionMixin:
         try:
             from src.providers.registry import resolve_chat_upstream
 
-            upstream = resolve_chat_upstream(prepared.request_shim, target_deployment.deltallm_params)
+            upstream = resolve_chat_upstream(
+                prepared.request_shim, target_deployment.deltallm_params
+            )
         except Exception:
             return None
         adapter = upstream.adapter
@@ -331,7 +343,9 @@ class ChatWorkerExecutionMixin:
         return None
 
     @staticmethod
-    def _chat_microbatch_unsupported_error(deployment: Any, *, reason: str = "unsupported") -> ServiceUnavailableError:
+    def _chat_microbatch_unsupported_error(
+        deployment: Any, *, reason: str = "unsupported"
+    ) -> ServiceUnavailableError:
         deployment_id = str(getattr(deployment, "deployment_id", None) or "unknown")
         return ServiceUnavailableError(
             message=f"Deployment '{deployment_id}' does not support sync chat microbatch: {reason}",
@@ -361,13 +375,24 @@ class ChatWorkerExecutionMixin:
     ) -> ChatMicrobatchExecutor:
         settings = resolve_chat_batching_settings(getattr(deployment, "deltallm_params", None))
         if settings.mode != "sync_microbatch":
-            raise self._chat_microbatch_unsupported_error(deployment, reason=f"mode={settings.mode}")
+            raise self._chat_microbatch_unsupported_error(
+                deployment, reason=f"mode={settings.mode}"
+            )
         if settings.upstream_max_batch_size < chunk_size:
-            raise self._chat_microbatch_unsupported_error(deployment, reason="upstream_max_batch_size")
-        if settings.max_total_input_tokens is not None and input_tokens > settings.max_total_input_tokens:
-            raise self._chat_microbatch_unsupported_error(deployment, reason="max_total_input_tokens")
+            raise self._chat_microbatch_unsupported_error(
+                deployment, reason="upstream_max_batch_size"
+            )
+        if (
+            settings.max_total_input_tokens is not None
+            and input_tokens > settings.max_total_input_tokens
+        ):
+            raise self._chat_microbatch_unsupported_error(
+                deployment, reason="max_total_input_tokens"
+            )
 
-        deployment_executor = self._resolve_chat_microbatch_executor(prepared, deployment=deployment)
+        deployment_executor = self._resolve_chat_microbatch_executor(
+            prepared, deployment=deployment
+        )
         if deployment_executor is None:
             raise self._chat_microbatch_unsupported_error(deployment, reason="executor_unavailable")
         return deployment_executor
@@ -419,7 +444,11 @@ class ChatWorkerExecutionMixin:
                 continue
 
             exceeds_count = len(current_chunk) >= max_batch_size
-            exceeds_tokens = token_cap is not None and current_chunk and current_tokens + input_tokens > token_cap
+            exceeds_tokens = (
+                token_cap is not None
+                and current_chunk
+                and current_tokens + input_tokens > token_cap
+            )
             if exceeds_count or exceeds_tokens:
                 flush_current()
 
@@ -509,7 +538,9 @@ class ChatWorkerExecutionMixin:
             decision=decision,
             retry_delay_seconds=retry_delay,
         )
-        if not self._chat_microbatch_retry_fits_job_deadline(job=job, retry_delay_seconds=retry_delay):
+        if not self._chat_microbatch_retry_fits_job_deadline(
+            job=job, retry_delay_seconds=retry_delay
+        ):
             return False
 
         for prepared in prepared_items:
@@ -522,11 +553,17 @@ class ChatWorkerExecutionMixin:
                 return False
 
         chunk_size = len(prepared_items)
-        retry_count = max(
-            self._chat_microbatch_retry_count(prepared.item.error_body) for prepared in prepared_items
-        ) + 1
+        retry_count = (
+            max(
+                self._chat_microbatch_retry_count(prepared.item.error_body)
+                for prepared in prepared_items
+            )
+            + 1
+        )
         original_size = max(
-            self._chat_microbatch_original_size(error_body=prepared.item.error_body, fallback=chunk_size)
+            self._chat_microbatch_original_size(
+                error_body=prepared.item.error_body, fallback=chunk_size
+            )
             for prepared in prepared_items
         )
         item_ids = [prepared.item.item_id for prepared in prepared_items]
@@ -546,8 +583,7 @@ class ChatWorkerExecutionMixin:
                 error_body=error_body,
                 last_error=str(exc),
                 item_claim_epochs={
-                    prepared.item.item_id: prepared.item.claim_epoch
-                    for prepared in prepared_items
+                    prepared.item.item_id: prepared.item.claim_epoch for prepared in prepared_items
                 },
             )
         except Exception as release_exc:
@@ -608,19 +644,25 @@ class ChatWorkerExecutionMixin:
         if not prepared_items:
             return
         if len(prepared_items) <= 1:
-            await self._execute_prepared_chat_item(job, prepared_items[0], batch_execution_mode="sync_microbatch")
+            await self._execute_prepared_chat_item(
+                job, prepared_items[0], batch_execution_mode="sync_microbatch"
+            )
             return
 
         batch_id = job.batch_id
         chunk_size = len(prepared_items)
         first_item = prepared_items[0]
-        chat_settings = settings or resolve_chat_batching_settings(first_item.primary_deployment.deltallm_params)
+        chat_settings = settings or resolve_chat_batching_settings(
+            first_item.primary_deployment.deltallm_params
+        )
         item_ids = [prepared.item.item_id for prepared in prepared_items]
         item_heartbeats: dict[str, asyncio.Task[None]] = {}
         item_lease_lost = asyncio.Event()
         microbatch_id = f"{batch_id}:{item_ids[0]}:{chunk_size}"
         chunk_started_at = perf_counter()
-        chunk_input_tokens = sum(estimate_chat_input_tokens(prepared.payload) for prepared in prepared_items)
+        chunk_input_tokens = sum(
+            estimate_chat_input_tokens(prepared.payload) for prepared in prepared_items
+        )
         served_deployment: Any | None = None
         last_retryable_microbatch_exc: Exception | None = None
         last_retryable_microbatch_deployment_id: str | None = None
@@ -658,12 +700,13 @@ class ChatWorkerExecutionMixin:
         try:
             for prepared in prepared_items:
                 item_heartbeats[prepared.item.item_id] = self._start_heartbeat_fn(
-                    renew=lambda item_id=prepared.item.item_id,
-                    claim_epoch=prepared.item.claim_epoch: self.repository.renew_item_lease(
-                        item_id=item_id,
-                        worker_id=self.config.worker_id,
-                        lease_seconds=self.config.item_lease_seconds,
-                        claim_epoch=claim_epoch,
+                    renew=lambda item_id=prepared.item.item_id, claim_epoch=prepared.item.claim_epoch: (
+                        self.repository.renew_item_lease(
+                            item_id=item_id,
+                            worker_id=self.config.worker_id,
+                            lease_seconds=self.config.item_lease_seconds,
+                            claim_epoch=claim_epoch,
+                        )
                     ),
                     label=f"item:{prepared.item.item_id}",
                     lease_lost_event=item_lease_lost,
@@ -676,6 +719,7 @@ class ChatWorkerExecutionMixin:
                     model_group=first_item.model_group,
                     execute=_execute_for_deployment,
                     return_deployment=True,
+                    routing_context=first_item.request_context,
                     **first_item.failover_kwargs,
                 ),
                 lease_lost_event=item_lease_lost,
@@ -723,7 +767,9 @@ class ChatWorkerExecutionMixin:
                 failure_deployment_id = last_retryable_microbatch_deployment_id
             else:
                 failure_deployment = served_deployment or first_item.primary_deployment
-                failure_deployment_id = str(getattr(failure_deployment, "deployment_id", None) or "") or None
+                failure_deployment_id = (
+                    str(getattr(failure_deployment, "deployment_id", None) or "") or None
+                )
             await self._record_upstream_failure_runtime_hook(
                 batch_id=batch_id,
                 deployment_id=failure_deployment_id,
@@ -801,7 +847,9 @@ class ChatWorkerExecutionMixin:
 
             if result.response_body is None or result.usage is None:
                 failure_count += 1
-                exc = BatchResponseShapeError("chat microbatch result is missing response body or per-item usage")
+                exc = BatchResponseShapeError(
+                    "chat microbatch result is missing response body or per-item usage"
+                )
                 item_heartbeat = item_heartbeats.pop(prepared.item.item_id, None)
                 if item_heartbeat is not None:
                     await self._stop_heartbeat_fn(item_heartbeat)
@@ -898,7 +946,9 @@ class ChatWorkerExecutionMixin:
             try:
                 await self._acquire_prepared_policy_lease(prepared=prepared)
             except Exception as exc:
-                record_batch_policy_failure(endpoint=batch_call_type_for_endpoint(job.endpoint), exc=exc)
+                record_batch_policy_failure(
+                    endpoint=batch_call_type_for_endpoint(job.endpoint), exc=exc
+                )
                 await self._mark_item_failed(
                     job=job,
                     item=prepared.item,
@@ -920,7 +970,9 @@ class ChatWorkerExecutionMixin:
         max_in_flight: int | None = None,
     ) -> None:
         configured_limit = max_in_flight or self.config.worker_concurrency
-        fallback_limit = max(1, min(int(configured_limit), self.config.worker_concurrency, len(prepared_items)))
+        fallback_limit = max(
+            1, min(int(configured_limit), self.config.worker_concurrency, len(prepared_items))
+        )
         fallback_semaphore = asyncio.Semaphore(fallback_limit)
 
         async def _execute_single(prepared: _PreparedChatItem) -> None:
@@ -974,7 +1026,9 @@ class ChatWorkerExecutionMixin:
                 try:
                     prepared = await prepare_item(job, item)
                     if not isinstance(prepared, _PreparedChatItem):
-                        raise InvalidRequestError(message="Prepared batch chat item has an invalid execution shape")
+                        raise InvalidRequestError(
+                            message="Prepared batch chat item has an invalid execution shape"
+                        )
                     async with prepared_lock:
                         prepared_items.append(prepared)
                 except Exception as exc:
@@ -1004,7 +1058,9 @@ class ChatWorkerExecutionMixin:
         for prepared in prepared_items:
             by_deployment.setdefault(self._chat_deployment_key(prepared), []).append(prepared)
 
-        def _queue_single(prepared: _PreparedChatItem, settings: ChatBatchingSettings, *, mode: str) -> None:
+        def _queue_single(
+            prepared: _PreparedChatItem, settings: ChatBatchingSettings, *, mode: str
+        ) -> None:
             work_units.append(
                 (
                     self._chat_deployment_key(prepared),
@@ -1018,7 +1074,9 @@ class ChatWorkerExecutionMixin:
             )
 
         for deployment_key, deployment_items in by_deployment.items():
-            settings = resolve_chat_batching_settings(deployment_items[0].primary_deployment.deltallm_params)
+            settings = resolve_chat_batching_settings(
+                deployment_items[0].primary_deployment.deltallm_params
+            )
             if settings.mode in {"disabled", "concurrent"}:
                 for prepared in deployment_items:
                     _queue_single(prepared, settings, mode=settings.mode)
@@ -1043,10 +1101,14 @@ class ChatWorkerExecutionMixin:
                     failover_kwargs=prepared.failover_kwargs,
                 )
                 if not eligibility.eligible or eligibility.group_key is None:
-                    increment_batch_chat_microbatch_fallback(reason=eligibility.reason or "ineligible")
+                    increment_batch_chat_microbatch_fallback(
+                        reason=eligibility.reason or "ineligible"
+                    )
                     _queue_single(prepared, settings, mode="sync_microbatch_fallback")
                     continue
-                grouped_candidates.setdefault(eligibility.group_key, []).append((prepared, eligibility.input_tokens))
+                grouped_candidates.setdefault(eligibility.group_key, []).append(
+                    (prepared, eligibility.input_tokens)
+                )
 
             for candidates in grouped_candidates.values():
                 chunks, fallbacks = self._split_chat_microbatch_candidates(candidates, settings)

--- a/src/batch/embedding_worker_execution.py
+++ b/src/batch/embedding_worker_execution.py
@@ -18,7 +18,12 @@ from src.batch.embedding_microbatch import (
 )
 from src.batch.endpoints import batch_call_type_for_endpoint, router_usage_mode_for_batch_endpoint
 from src.batch.policy import record_batch_policy_failure, run_batch_request_preflight
-from src.batch.retry import BatchResponseShapeError, BatchRetryCategory, BatchRetryDecision, classify_batch_retry
+from src.batch.retry import (
+    BatchResponseShapeError,
+    BatchRetryCategory,
+    BatchRetryDecision,
+    classify_batch_retry,
+)
 from src.batch.worker_constants import COMPLETION_OUTBOX_MAX_ATTEMPTS
 from src.batch.worker_types import BatchItemLeaseLostError, _PreparedEmbeddingItem, _RequestShim
 from src.metrics import (
@@ -33,6 +38,7 @@ from src.metrics import (
 )
 from src.models.requests import EmbeddingRequest
 from src.providers.resolution import resolve_provider
+from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.routers.routing_decision import route_failover_kwargs
 
 logger = logging.getLogger(__name__)
@@ -51,7 +57,11 @@ class EmbeddingWorkerExecutionMixin:
         )
         embedding_request = preflight.payload
 
-        request_context: dict[str, Any] = {"metadata": {}, "user_id": preflight.auth.user_id or preflight.auth.api_key}
+        request_context: dict[str, Any] = {
+            "metadata": {},
+            "user_id": preflight.auth.user_id or preflight.auth.api_key,
+            ROUTING_MODE_CONTEXT_KEY: "embedding",
+        }
         app_router = self.app.state.router
         model_group = app_router.resolve_model_group(embedding_request.model)
         await self._raise_if_model_group_deferred(model_group)
@@ -60,8 +70,8 @@ class EmbeddingWorkerExecutionMixin:
             model_group=model_group,
             deployment=await app_router.select_deployment(model_group, request_context),
         )
-        input_kind, microbatch_eligible, microbatch_ineligible_reason = classify_embedding_microbatch_request(
-            embedding_request
+        input_kind, microbatch_eligible, microbatch_ineligible_reason = (
+            classify_embedding_microbatch_request(embedding_request)
         )
         primary_deployment_id = str(getattr(primary_deployment, "deployment_id", None) or "")
         effective_upstream_max_batch_inputs = resolve_effective_upstream_max_batch_inputs(
@@ -69,7 +79,9 @@ class EmbeddingWorkerExecutionMixin:
         )
         metadata_max_inputs = self._microbatch_next_max_inputs(item.error_body)
         if metadata_max_inputs is not None:
-            effective_upstream_max_batch_inputs = min(effective_upstream_max_batch_inputs, metadata_max_inputs)
+            effective_upstream_max_batch_inputs = min(
+                effective_upstream_max_batch_inputs, metadata_max_inputs
+            )
         return _PreparedEmbeddingItem(
             item=item,
             started_at_monotonic=started_at_monotonic,
@@ -83,7 +95,9 @@ class EmbeddingWorkerExecutionMixin:
             effective_upstream_max_batch_inputs=effective_upstream_max_batch_inputs,
             microbatch_eligible=microbatch_eligible,
             microbatch_ineligible_reason=microbatch_ineligible_reason,
-            microbatch_weight=estimate_embedding_microbatch_weight(embedding_request) if microbatch_eligible else None,
+            microbatch_weight=estimate_embedding_microbatch_weight(embedding_request)
+            if microbatch_eligible
+            else None,
             execution_signature=build_embedding_execution_signature(
                 payload=embedding_request,
                 model_group=model_group,
@@ -93,7 +107,9 @@ class EmbeddingWorkerExecutionMixin:
             policy_auth=preflight.auth,
         )
 
-    def _sanitize_embedding_response(self, data: dict[str, Any]) -> tuple[dict[str, Any], str | None, str | None]:
+    def _sanitize_embedding_response(
+        self, data: dict[str, Any]
+    ) -> tuple[dict[str, Any], str | None, str | None]:
         response_body = dict(data)
         response_body.pop("_api_latency_ms", None)
         api_base = response_body.pop("_api_base", None)
@@ -137,23 +153,33 @@ class EmbeddingWorkerExecutionMixin:
         normalized_rows: list[dict[str, Any] | None] = [None] * expected_count
         for row_number, row in enumerate(data_rows):
             if not isinstance(row, dict):
-                raise BatchResponseShapeError(f"microbatch response item {row_number} is not an object")
+                raise BatchResponseShapeError(
+                    f"microbatch response item {row_number} is not an object"
+                )
             if "embedding" not in row:
-                raise BatchResponseShapeError(f"microbatch response item {row_number} is missing embedding")
+                raise BatchResponseShapeError(
+                    f"microbatch response item {row_number} is missing embedding"
+                )
 
             response_index = row.get("index")
             if type(response_index) is not int:
-                raise BatchResponseShapeError(f"microbatch response item {row_number} has invalid index")
+                raise BatchResponseShapeError(
+                    f"microbatch response item {row_number} has invalid index"
+                )
             if response_index < 0 or response_index >= expected_count:
                 raise BatchResponseShapeError(
                     f"microbatch response item {row_number} index out of range index={response_index}"
                 )
             if normalized_rows[response_index] is not None:
-                raise BatchResponseShapeError(f"microbatch response contains duplicate index={response_index}")
+                raise BatchResponseShapeError(
+                    f"microbatch response contains duplicate index={response_index}"
+                )
             normalized_rows[response_index] = dict(row)
 
         if any(row is None for row in normalized_rows):
-            raise BatchResponseShapeError("microbatch response is missing one or more expected indexes")
+            raise BatchResponseShapeError(
+                "microbatch response is missing one or more expected indexes"
+            )
 
         return [row for row in normalized_rows if row is not None]
 
@@ -248,7 +274,9 @@ class EmbeddingWorkerExecutionMixin:
         try:
             increment_batch_microbatch_requeue(category=category_value, result=result)
             if retry_delay_seconds is not None and result in {"scheduled", "reduced"}:
-                observe_batch_microbatch_retry_delay(category=category_value, delay_seconds=retry_delay_seconds)
+                observe_batch_microbatch_retry_delay(
+                    category=category_value, delay_seconds=retry_delay_seconds
+                )
         except Exception as exc:
             logger.warning(
                 "batch embedding microbatch retry metric publish failed category=%s result=%s error=%s",
@@ -308,9 +336,13 @@ class EmbeddingWorkerExecutionMixin:
                 return False
 
         chunk_size = len(prepared_items)
-        retry_count = max(
-            self._microbatch_retry_count(prepared.item.error_body) for prepared in prepared_items
-        ) + 1
+        retry_count = (
+            max(
+                self._microbatch_retry_count(prepared.item.error_body)
+                for prepared in prepared_items
+            )
+            + 1
+        )
         original_size = max(
             self._microbatch_original_size(error_body=prepared.item.error_body, fallback=chunk_size)
             for prepared in prepared_items
@@ -345,8 +377,7 @@ class EmbeddingWorkerExecutionMixin:
                 error_body=error_body,
                 last_error=str(exc),
                 item_claim_epochs={
-                    prepared.item.item_id: prepared.item.claim_epoch
-                    for prepared in prepared_items
+                    prepared.item.item_id: prepared.item.claim_epoch for prepared in prepared_items
                 },
             )
         except Exception as release_exc:
@@ -402,7 +433,9 @@ class EmbeddingWorkerExecutionMixin:
         try:
             await self._acquire_prepared_policy_lease(prepared=prepared)
         except Exception as exc:
-            record_batch_policy_failure(endpoint=batch_call_type_for_endpoint(job.endpoint), exc=exc)
+            record_batch_policy_failure(
+                endpoint=batch_call_type_for_endpoint(job.endpoint), exc=exc
+            )
             await self._mark_item_failed(
                 job=job,
                 item=prepared.item,
@@ -428,19 +461,26 @@ class EmbeddingWorkerExecutionMixin:
                 self.app.state.failover_manager.execute_with_failover(
                     primary_deployment=prepared.primary_deployment,
                     model_group=prepared.model_group,
-                    execute=lambda dep: self._execute_embedding(prepared.request_shim, prepared.payload, dep),
+                    execute=lambda dep: self._execute_embedding(
+                        prepared.request_shim, prepared.payload, dep
+                    ),
                     return_deployment=True,
+                    routing_context=prepared.request_context,
                     **prepared.failover_kwargs,
                 ),
                 lease_lost_event=item_lease_lost,
                 label=f"item:{prepared.item.item_id}",
             )
             response_body, api_base, deployment_model = self._sanitize_embedding_response(data)
-            usage_allocations = allocate_embedding_usage(response_body.get("usage"), item_weights=[1])
+            usage_allocations = allocate_embedding_usage(
+                response_body.get("usage"), item_weights=[1]
+            )
             usage = dict(usage_allocations[0] if usage_allocations else {})
             api_provider = resolve_provider(served_deployment.deltallm_params)
             api_base = api_base or served_deployment.deltallm_params.get("api_base")
-            deployment_model = deployment_model or (str(served_deployment.deltallm_params.get("model") or "") or None)
+            deployment_model = deployment_model or (
+                str(served_deployment.deltallm_params.get("model") or "") or None
+            )
             response_body = self._normalize_persisted_embedding_response_body(
                 response_body=response_body,
                 usage=usage,
@@ -506,12 +546,8 @@ class EmbeddingWorkerExecutionMixin:
                                 provider_cost=provider_cost,
                                 billing=customer_billing.billing,
                                 provider_billing=provider_billing.billing,
-                                effective_pricing_sources=(
-                                    customer_billing.pricing_sources_used
-                                ),
-                                missing_pricing_fields=(
-                                    customer_billing.missing_pricing_fields
-                                ),
+                                effective_pricing_sources=(customer_billing.pricing_sources_used),
+                                missing_pricing_fields=(customer_billing.missing_pricing_fields),
                                 pricing_tier="batch",
                             ),
                         ),
@@ -542,7 +578,8 @@ class EmbeddingWorkerExecutionMixin:
                 item=prepared.item,
                 model_name=prepared.model_name,
                 exc=exc,
-                deployment_id=str(getattr(prepared.primary_deployment, "deployment_id", None) or "") or None,
+                deployment_id=str(getattr(prepared.primary_deployment, "deployment_id", None) or "")
+                or None,
                 started_at_monotonic=prepared.started_at_monotonic,
             )
             return
@@ -558,7 +595,9 @@ class EmbeddingWorkerExecutionMixin:
         *,
         process_item: Callable[[Any, Any], Awaitable[None]],
     ) -> None:
-        prepared_items = await self._acquire_embedding_policy_leases_for_chunk(job=job, prepared_items=prepared_items)
+        prepared_items = await self._acquire_embedding_policy_leases_for_chunk(
+            job=job, prepared_items=prepared_items
+        )
         if not prepared_items:
             return
         if len(prepared_items) <= 1:
@@ -576,12 +615,13 @@ class EmbeddingWorkerExecutionMixin:
         try:
             for prepared in prepared_items:
                 item_heartbeats[prepared.item.item_id] = self._start_heartbeat_fn(
-                    renew=lambda item_id=prepared.item.item_id,
-                    claim_epoch=prepared.item.claim_epoch: self.repository.renew_item_lease(
-                        item_id=item_id,
-                        worker_id=self.config.worker_id,
-                        lease_seconds=self.config.item_lease_seconds,
-                        claim_epoch=claim_epoch,
+                    renew=lambda item_id=prepared.item.item_id, claim_epoch=prepared.item.claim_epoch: (
+                        self.repository.renew_item_lease(
+                            item_id=item_id,
+                            worker_id=self.config.worker_id,
+                            lease_seconds=self.config.item_lease_seconds,
+                            claim_epoch=claim_epoch,
+                        )
                     ),
                     label=f"item:{prepared.item.item_id}",
                     lease_lost_event=item_lease_lost,
@@ -601,8 +641,11 @@ class EmbeddingWorkerExecutionMixin:
                 self.app.state.failover_manager.execute_with_failover(
                     primary_deployment=first_item.primary_deployment,
                     model_group=first_item.model_group,
-                    execute=lambda dep: self._execute_embedding(first_item.request_shim, chunk_payload, dep),
+                    execute=lambda dep: self._execute_embedding(
+                        first_item.request_shim, chunk_payload, dep
+                    ),
                     return_deployment=True,
+                    routing_context=first_item.request_context,
                     **first_item.failover_kwargs,
                 ),
                 lease_lost_event=item_lease_lost,
@@ -645,7 +688,9 @@ class EmbeddingWorkerExecutionMixin:
                 logger.warning(
                     "batch embedding microbatch response mismatch batch_id=%s deployment_id=%s size=%s error=%s",
                     batch_id,
-                    getattr(served_deployment or first_item.primary_deployment, "deployment_id", None),
+                    getattr(
+                        served_deployment or first_item.primary_deployment, "deployment_id", None
+                    ),
                     chunk_size,
                     exc,
                 )
@@ -681,7 +726,9 @@ class EmbeddingWorkerExecutionMixin:
         try:
             api_provider = resolve_provider(served_deployment.deltallm_params)
             api_base = api_base or served_deployment.deltallm_params.get("api_base")
-            deployment_model = deployment_model or (str(served_deployment.deltallm_params.get("model") or "") or None)
+            deployment_model = deployment_model or (
+                str(served_deployment.deltallm_params.get("model") or "") or None
+            )
             served_deployment_id = str(
                 getattr(served_deployment, "deployment_id", None)
                 or getattr(first_item.primary_deployment, "deployment_id", None)
@@ -695,7 +742,9 @@ class EmbeddingWorkerExecutionMixin:
                 reference=",".join(item_ids),
             )
             completion_rows: list[dict[str, Any]] = []
-            for prepared, item_response, usage in zip(prepared_items, item_responses, usage_allocations, strict=False):
+            for prepared, item_response, usage in zip(
+                prepared_items, item_responses, usage_allocations, strict=False
+            ):
                 normalized_response_body = self._build_single_item_embedding_response_body(
                     chunk_response=response_body,
                     item_response=item_response,
@@ -724,12 +773,8 @@ class EmbeddingWorkerExecutionMixin:
                             provider_cost=provider_cost,
                             billing=customer_billing.billing,
                             provider_billing=provider_billing.billing,
-                            effective_pricing_sources=(
-                                customer_billing.pricing_sources_used
-                            ),
-                            missing_pricing_fields=(
-                                customer_billing.missing_pricing_fields
-                            ),
+                            effective_pricing_sources=(customer_billing.pricing_sources_used),
+                            missing_pricing_fields=(customer_billing.missing_pricing_fields),
                             pricing_tier="batch",
                         ),
                     }
@@ -815,7 +860,9 @@ class EmbeddingWorkerExecutionMixin:
             try:
                 await self._acquire_prepared_policy_lease(prepared=prepared)
             except Exception as exc:
-                record_batch_policy_failure(endpoint=batch_call_type_for_endpoint(job.endpoint), exc=exc)
+                record_batch_policy_failure(
+                    endpoint=batch_call_type_for_endpoint(job.endpoint), exc=exc
+                )
                 await self._mark_item_failed(
                     job=job,
                     item=prepared.item,
@@ -865,22 +912,29 @@ class EmbeddingWorkerExecutionMixin:
             prepared_candidates: list[_PreparedEmbeddingItem] = []
             grouped_candidates: list[Any] = []
             for candidate in candidates:
-                if candidate.microbatch_eligible and candidate.effective_upstream_max_batch_inputs > 1:
+                if (
+                    candidate.microbatch_eligible
+                    and candidate.effective_upstream_max_batch_inputs > 1
+                ):
                     grouped_candidates.append(candidate.item)
                 else:
                     prepared_candidates.append(candidate)
             _requeue_prepared_candidates(prepared_candidates)
             _requeue_grouped_raw_items(grouped_candidates)
 
-        def _queue_preparation_failure(item, model_name: str, exc: Exception, started_at_monotonic: float) -> None:
+        def _queue_preparation_failure(
+            item, model_name: str, exc: Exception, started_at_monotonic: float
+        ) -> None:
             planned_work_units.append(
-                lambda item=item, model_name=model_name, exc=exc, started_at_monotonic=started_at_monotonic: self._mark_item_failed(
-                    job=job,
-                    item=item,
-                    model_name=model_name,
-                    exc=exc,
-                    deployment_id=None,
-                    started_at_monotonic=started_at_monotonic,
+                lambda item=item, model_name=model_name, exc=exc, started_at_monotonic=started_at_monotonic: (
+                    self._mark_item_failed(
+                        job=job,
+                        item=item,
+                        model_name=model_name,
+                        exc=exc,
+                        deployment_id=None,
+                        started_at_monotonic=started_at_monotonic,
+                    )
                 )
             )
 
@@ -894,7 +948,9 @@ class EmbeddingWorkerExecutionMixin:
                 _queue_preparation_failure(item, model_name, exc, started_at_monotonic)
                 return None
             if not prepared.microbatch_eligible:
-                increment_batch_microbatch_ineligible_item(reason=prepared.microbatch_ineligible_reason or "unknown")
+                increment_batch_microbatch_ineligible_item(
+                    reason=prepared.microbatch_ineligible_reason or "unknown"
+                )
             return prepared
 
         def _raw_item_looks_groupable(item) -> bool:  # noqa: ANN001
@@ -902,7 +958,9 @@ class EmbeddingWorkerExecutionMixin:
             _, microbatch_eligible, _ = classify_embedding_microbatch_request(payload)
             return microbatch_eligible
 
-        async def _pop_next_candidate(*, allow_grouped_chunks: bool) -> _PreparedEmbeddingItem | object | None:
+        async def _pop_next_candidate(
+            *, allow_grouped_chunks: bool
+        ) -> _PreparedEmbeddingItem | object | None:
             while True:
                 if allow_grouped_chunks and deferred_grouped_raw_items:
                     prepared = await _prepare_candidate_item(deferred_grouped_raw_items.popleft())
@@ -933,7 +991,10 @@ class EmbeddingWorkerExecutionMixin:
                 prepared = await _prepare_candidate_item(item)
                 if prepared is None:
                     continue
-                grouped_chunk_candidate = prepared.microbatch_eligible and prepared.effective_upstream_max_batch_inputs > 1
+                grouped_chunk_candidate = (
+                    prepared.microbatch_eligible
+                    and prepared.effective_upstream_max_batch_inputs > 1
+                )
                 if grouped_chunk_candidate and not allow_grouped_chunks:
                     deferred_grouped_raw_items.append(prepared.item)
                     continue
@@ -986,7 +1047,8 @@ class EmbeddingWorkerExecutionMixin:
                     candidate_matches_chunk = (
                         candidate.microbatch_eligible
                         and candidate.effective_upstream_max_batch_inputs > 1
-                        and candidate.effective_upstream_max_batch_inputs == seed.effective_upstream_max_batch_inputs
+                        and candidate.effective_upstream_max_batch_inputs
+                        == seed.effective_upstream_max_batch_inputs
                         and self._microbatch_group_key(candidate) == chunk_key
                     )
                     if candidate_matches_chunk:

--- a/src/bootstrap/routing.py
+++ b/src/bootstrap/routing.py
@@ -28,7 +28,10 @@ from src.router import (
     build_route_group_policies,
 )
 from src.services.callable_targets import build_callable_target_catalog
-from src.services.model_deployments import bootstrap_model_deployments_from_config, load_model_registry
+from src.services.model_deployments import (
+    bootstrap_model_deployments_from_config,
+    load_model_registry,
+)
 from src.services.route_groups import load_route_groups
 
 logger = logging.getLogger(__name__)
@@ -65,11 +68,7 @@ async def _load_model_registry_compat(
         "secret_resolver": secret_resolver,
     }
     signature = inspect.signature(loader)
-    supported_kwargs = {
-        key: value
-        for key, value in kwargs.items()
-        if key in signature.parameters
-    }
+    supported_kwargs = {key: value for key, value in kwargs.items() if key in signature.parameters}
     return await loader(repository, cfg, settings, **supported_kwargs)
 
 
@@ -83,7 +82,9 @@ async def init_routing_runtime(
     salt_key: str,
 ) -> RoutingRuntime:
     if cfg.general_settings.model_deployment_bootstrap_from_config:
-        did_bootstrap = await bootstrap_model_deployments_from_config(app.state.model_deployment_repository, cfg)
+        did_bootstrap = await bootstrap_model_deployments_from_config(
+            app.state.model_deployment_repository, cfg
+        )
         if did_bootstrap:
             logger.info("bootstrapped model deployments from config into database")
 
@@ -115,7 +116,9 @@ async def init_routing_runtime(
     )
     state_backend = RedisStateBackend(redis_client, degraded_mode=degraded_mode)
     route_groups = list(getattr(app.state, "route_groups", []))
-    deployment_registry = build_deployment_registry(app.state.model_registry, route_groups=route_groups)
+    deployment_registry = build_deployment_registry(
+        app.state.model_registry, route_groups=route_groups
+    )
     router_config = RouterConfig(
         num_retries=cfg.router_settings.num_retries,
         retry_after=cfg.router_settings.retry_after,
@@ -144,11 +147,15 @@ async def init_routing_runtime(
             retry_after=cfg.router_settings.retry_after,
             timeout=cfg.router_settings.timeout,
             fallbacks=_normalize_fallbacks(cfg.deltallm_settings.fallbacks),
-            context_window_fallbacks=_normalize_fallbacks(cfg.deltallm_settings.context_window_fallbacks),
-            content_policy_fallbacks=_normalize_fallbacks(cfg.deltallm_settings.content_policy_fallbacks),
+            context_window_fallbacks=_normalize_fallbacks(
+                cfg.deltallm_settings.context_window_fallbacks
+            ),
+            content_policy_fallbacks=_normalize_fallbacks(
+                cfg.deltallm_settings.content_policy_fallbacks
+            ),
             event_history_size=cfg.general_settings.failover_event_history_size,
         ),
-        deployment_registry=deployment_registry,
+        candidate_planner=app.state.router,
         state_backend=state_backend,
         cooldown_manager=app.state.cooldown_manager,
     )
@@ -208,7 +215,9 @@ async def init_routing_runtime(
                 "ready",
                 f"models={len(app.state.model_registry)} route_groups={len(app.state.route_groups)} callable_targets={len(app.state.callable_target_catalog)}",
             ),
-            BootstrapStatus("background_health_checks", "ready" if health_task is not None else "disabled"),
+            BootstrapStatus(
+                "background_health_checks", "ready" if health_task is not None else "disabled"
+            ),
         ),
     )
 

--- a/src/config_runtime/models.py
+++ b/src/config_runtime/models.py
@@ -183,7 +183,6 @@ class ModelHotReloadManager:
         app.state.route_groups = route_groups
         app.state.callable_target_catalog = callable_target_catalog
         app.state.router.deployment_registry = dict(new_deployments)
-        app.state.failover_manager.registry = dict(new_deployments)
         app.state.router_health_handler.registry = dict(new_deployments)
         app.state.background_health_checker.registry = dict(new_deployments)
 

--- a/src/providers/resolution.py
+++ b/src/providers/resolution.py
@@ -42,7 +42,13 @@ PROVIDER_CAPABILITIES: dict[str, set[ModelMode]] = {
     "openai": {"chat", "embedding", "image_generation", "audio_speech", "audio_transcription"},
     "anthropic": {"chat"},
     "azure": {"chat", "embedding", "image_generation", "audio_speech", "audio_transcription"},
-    "azure_openai": {"chat", "embedding", "image_generation", "audio_speech", "audio_transcription"},
+    "azure_openai": {
+        "chat",
+        "embedding",
+        "image_generation",
+        "audio_speech",
+        "audio_transcription",
+    },
     "openrouter": {"chat", "embedding", "image_generation"},
     "groq": {"chat", "embedding", "audio_speech", "audio_transcription"},
     "together": {"chat", "embedding", "image_generation"},
@@ -52,24 +58,71 @@ PROVIDER_CAPABILITIES: dict[str, set[ModelMode]] = {
     "gemini": {"chat", "audio_speech"},
     "bedrock": {"chat"},
     "elevenlabs": {"audio_speech", "audio_transcription"},
-    "vllm": {"chat", "embedding", "image_generation", "audio_speech", "audio_transcription"},
+    "vllm": {
+        "chat",
+        "embedding",
+        "image_generation",
+        "audio_speech",
+        "audio_transcription",
+        "rerank",
+    },
     "lmstudio": {"chat", "embedding"},
     "ollama": {"chat", "embedding"},
 }
 
 PROVIDER_PRESETS: dict[str, dict[str, str | None]] = {
     "openai": {"provider": "openai", "api_base": "https://api.openai.com/v1", "compat": "openai"},
-    "anthropic": {"provider": "anthropic", "api_base": "https://api.anthropic.com/v1", "compat": "anthropic"},
-    "azure_openai": {"provider": "azure_openai", "api_base": "https://{resource}.openai.azure.com/openai/v1", "compat": "openai"},
-    "openrouter": {"provider": "openrouter", "api_base": "https://openrouter.ai/api/v1", "compat": "openai"},
+    "anthropic": {
+        "provider": "anthropic",
+        "api_base": "https://api.anthropic.com/v1",
+        "compat": "anthropic",
+    },
+    "azure_openai": {
+        "provider": "azure_openai",
+        "api_base": "https://{resource}.openai.azure.com/openai/v1",
+        "compat": "openai",
+    },
+    "openrouter": {
+        "provider": "openrouter",
+        "api_base": "https://openrouter.ai/api/v1",
+        "compat": "openai",
+    },
     "groq": {"provider": "groq", "api_base": "https://api.groq.com/openai/v1", "compat": "openai"},
-    "together": {"provider": "together", "api_base": "https://api.together.xyz/v1", "compat": "openai"},
-    "fireworks": {"provider": "fireworks", "api_base": "https://api.fireworks.ai/inference/v1", "compat": "openai"},
-    "deepinfra": {"provider": "deepinfra", "api_base": "https://api.deepinfra.com/v1/openai", "compat": "openai"},
-    "perplexity": {"provider": "perplexity", "api_base": "https://api.perplexity.ai", "compat": "openai"},
-    "gemini": {"provider": "gemini", "api_base": "https://generativelanguage.googleapis.com/v1beta", "compat": "native"},
-    "bedrock": {"provider": "bedrock", "api_base": "https://bedrock-runtime.{region}.amazonaws.com", "compat": "native"},
-    "elevenlabs": {"provider": "elevenlabs", "api_base": "https://api.elevenlabs.io/v1", "compat": "native"},
+    "together": {
+        "provider": "together",
+        "api_base": "https://api.together.xyz/v1",
+        "compat": "openai",
+    },
+    "fireworks": {
+        "provider": "fireworks",
+        "api_base": "https://api.fireworks.ai/inference/v1",
+        "compat": "openai",
+    },
+    "deepinfra": {
+        "provider": "deepinfra",
+        "api_base": "https://api.deepinfra.com/v1/openai",
+        "compat": "openai",
+    },
+    "perplexity": {
+        "provider": "perplexity",
+        "api_base": "https://api.perplexity.ai",
+        "compat": "openai",
+    },
+    "gemini": {
+        "provider": "gemini",
+        "api_base": "https://generativelanguage.googleapis.com/v1beta",
+        "compat": "native",
+    },
+    "bedrock": {
+        "provider": "bedrock",
+        "api_base": "https://bedrock-runtime.{region}.amazonaws.com",
+        "compat": "native",
+    },
+    "elevenlabs": {
+        "provider": "elevenlabs",
+        "api_base": "https://api.elevenlabs.io/v1",
+        "compat": "native",
+    },
     "vllm": {"provider": "vllm", "api_base": None, "compat": "openai"},
     "lmstudio": {"provider": "lmstudio", "api_base": None, "compat": "openai"},
     "ollama": {"provider": "ollama", "api_base": None, "compat": "openai"},
@@ -94,7 +147,9 @@ def resolve_provider(params: Mapping[str, object] | None) -> str:
     return provider_from_model(str(params.get("model") or ""))
 
 
-def resolve_upstream_model(params: Mapping[str, object] | None, fallback_model: str | None = None) -> str:
+def resolve_upstream_model(
+    params: Mapping[str, object] | None, fallback_model: str | None = None
+) -> str:
     if not params:
         return (fallback_model or "").strip()
 
@@ -106,7 +161,7 @@ def resolve_upstream_model(params: Mapping[str, object] | None, fallback_model: 
     lowered = upstream_model.lower()
     for prefix in PROVIDER_MODEL_PREFIXES_TO_STRIP.get(provider, ()):
         if lowered.startswith(prefix):
-            return upstream_model[len(prefix):]
+            return upstream_model[len(prefix) :]
     return upstream_model
 
 

--- a/src/router/__init__.py
+++ b/src/router/__init__.py
@@ -1,6 +1,20 @@
 from src.router.cooldown import CooldownManager, CooldownRecoveryMonitor
+from src.router.candidates import (
+    ROUTING_MODE_CONTEXT_KEY,
+    AttemptCapacity,
+    AttemptCapacityLimit,
+    AttemptPermit,
+    AttemptRejectionReason,
+    RouteCandidatePlan,
+    RouteCandidatePlanner,
+)
 from src.router.failover import ErrorClassification, FallbackConfig, FailoverManager, RetryPolicy
-from src.router.health import BackgroundHealthChecker, HealthCheckConfig, HealthEndpointHandler, PassiveHealthTracker
+from src.router.health import (
+    BackgroundHealthChecker,
+    HealthCheckConfig,
+    HealthEndpointHandler,
+    PassiveHealthTracker,
+)
 from src.router.router import (
     Deployment,
     RouteGroupPolicy,
@@ -14,6 +28,10 @@ from src.router.state import DeploymentStateBackend, RedisStateBackend
 
 __all__ = [
     "BackgroundHealthChecker",
+    "AttemptCapacity",
+    "AttemptCapacityLimit",
+    "AttemptPermit",
+    "AttemptRejectionReason",
     "CooldownManager",
     "CooldownRecoveryMonitor",
     "Deployment",
@@ -24,6 +42,9 @@ __all__ = [
     "HealthEndpointHandler",
     "PassiveHealthTracker",
     "RedisStateBackend",
+    "ROUTING_MODE_CONTEXT_KEY",
+    "RouteCandidatePlan",
+    "RouteCandidatePlanner",
     "RouteGroupPolicy",
     "ErrorClassification",
     "RetryPolicy",

--- a/src/router/candidates.py
+++ b/src/router/candidates.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Literal, Protocol, Sequence
+
+if TYPE_CHECKING:
+    from src.router.router import Deployment
+
+
+ROUTING_MODE_CONTEXT_KEY = "routing_mode"
+_CANDIDATE_PLANS_CONTEXT_KEY = "_deltallm_candidate_plans"
+DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS = 630
+
+UsageCounterName = Literal[
+    "rpm",
+    "tpm",
+    "image_pm",
+    "audio_seconds_pm",
+    "char_pm",
+    "rerank_units_pm",
+]
+
+
+class AttemptRejectionReason(str, Enum):
+    STATIC_POLICY = "static_policy"
+    COOLDOWN = "cooldown"
+    UNHEALTHY = "unhealthy"
+    CAPACITY = "capacity"
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptCapacityLimit:
+    counter: UsageCounterName
+    limit: int
+
+    def __post_init__(self) -> None:
+        if self.limit <= 0:
+            raise ValueError("attempt capacity limit must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptCapacity:
+    limits: tuple[AttemptCapacityLimit, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptPermit:
+    deployment_id: str
+    acquired: bool
+    backend: Literal["redis", "local"] | None = None
+    owner_token: str | None = None
+    expires_at_ms: int | None = None
+    active_requests: int | None = None
+    rejection_reason: AttemptRejectionReason | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RouteCandidatePlan:
+    """Request-scoped, policy-ordered deployments eligible for failover attempts."""
+
+    model_group: str
+    strategy: str
+    deployments: tuple[Deployment, ...]
+    candidate_count: int
+    healthy_count: int
+    filtered_count: int
+
+
+class RouteCandidatePlanner(Protocol):
+    async def plan_deployments(
+        self,
+        model_groups: Sequence[str],
+        request_context: dict[str, Any],
+    ) -> dict[str, RouteCandidatePlan]: ...
+
+    async def acquire_attempt(
+        self,
+        deployment: Deployment,
+        request_context: dict[str, Any],
+        *,
+        lease_ttl_seconds: int = DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
+    ) -> AttemptPermit: ...
+
+    async def release_attempt(self, permit: AttemptPermit) -> int | None: ...
+
+
+def candidate_plan_cache(
+    request_context: dict[str, Any],
+) -> dict[str, RouteCandidatePlan]:
+    cached = request_context.get(_CANDIDATE_PLANS_CONTEXT_KEY)
+    if isinstance(cached, dict) and all(
+        isinstance(group, str) and isinstance(plan, RouteCandidatePlan)
+        for group, plan in cached.items()
+    ):
+        return cached
+
+    plans: dict[str, RouteCandidatePlan] = {}
+    request_context[_CANDIDATE_PLANS_CONTEXT_KEY] = plans
+    return plans

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import random
 import time
 from collections import deque
@@ -20,12 +21,14 @@ from src.models.errors import (
     TimeoutError,
     parse_retry_after_header,
 )
+from src.router.candidates import DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS, RouteCandidatePlanner
 from src.router.cooldown import CooldownManager
 from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
 from src.router.state import DeploymentStateBackend
 
 logger = logging.getLogger(__name__)
+_ATTEMPT_PERMIT_CLEANUP_MARGIN_SECONDS = 30
 
 TimeoutForDeployment = Callable[[Deployment], float | int | None]
 
@@ -159,12 +162,12 @@ class FailoverManager:
     def __init__(
         self,
         config: FallbackConfig,
-        deployment_registry: dict[str, list[Deployment]],
+        candidate_planner: RouteCandidatePlanner,
         state_backend: DeploymentStateBackend,
         cooldown_manager: CooldownManager,
     ):
         self.config = config
-        self.registry = deployment_registry
+        self.candidate_planner = candidate_planner
         self.state = state_backend
         self.cooldown = cooldown_manager
         self._fallback_events: deque[FallbackEvent] = deque(
@@ -215,24 +218,32 @@ class FailoverManager:
         if success:
             logger.info(
                 "Fallback succeeded: model_group=%s from=%s to=%s reason=%s",
-                model_group, from_id, to_id, reason,
+                model_group,
+                from_id,
+                to_id,
+                reason,
             )
         else:
             logger.warning(
                 "Fallback attempt failed: model_group=%s deployment=%s classification=%s error=%s",
-                model_group, from_id, classification, error_msg[:200],
+                model_group,
+                from_id,
+                classification,
+                error_msg[:200],
             )
 
     def _compute_backoff(self, attempt: int) -> float:
         base = self.config.retry_after or 1.0
-        delay = base * (self.config.backoff_multiplier ** attempt)
+        delay = base * (self.config.backoff_multiplier**attempt)
         delay = min(delay, self.config.backoff_max)
         if self.config.backoff_jitter:
             delay = delay * (0.5 + random.random() * 0.5)
         return delay
 
     @staticmethod
-    def _notify_attempt(on_attempt: Callable[[Deployment], None] | None, deployment: Deployment) -> None:
+    def _notify_attempt(
+        on_attempt: Callable[[Deployment], None] | None, deployment: Deployment
+    ) -> None:
         if on_attempt is None:
             return
         try:
@@ -335,37 +346,41 @@ class FailoverManager:
         timeout_for_deployment: TimeoutForDeployment | None = None,
         retry_max_attempts: int | None = None,
         retryable_error_classes: list[str] | set[str] | None = None,
+        routing_context: dict[str, Any] | None = None,
     ) -> Any:
-        chain = self._build_fallback_chain(primary_deployment, model_group, request_tokens)
+        routing_context = routing_context if routing_context is not None else {}
+        chain = await self._build_fallback_chain(
+            primary_deployment,
+            model_group,
+            request_tokens,
+            routing_context,
+        )
         effective_retries = self._effective_retry_count(retry_max_attempts)
         effective_retry_classes = self._normalize_retryable_error_classes(retryable_error_classes)
         last_error: Exception | None = None
         previous_deployment_id = primary_deployment.deployment_id
+        visited_ids: set[str] = set()
+        attempted_ids: set[str] = set()
 
         for chain_index, deployment in enumerate(chain):
-            if await self.state.is_cooled_down(deployment.deployment_id):
+            if deployment.deployment_id in visited_ids:
                 continue
-            health = await self.state.get_health(deployment.deployment_id)
-            if health.get("healthy", "true") == "false":
-                continue
-
+            visited_ids.add(deployment.deployment_id)
+            deployment_was_attempted = False
             for attempt in range(effective_retries + 1):
-                started = time.monotonic()
                 try:
-                    self._notify_attempt(on_attempt, deployment)
-                    await self.state.increment_active(deployment.deployment_id)
-                    attempt_timeout = self._effective_attempt_timeout(
+                    attempted, result = await self._execute_attempt(
                         deployment,
-                        timeout_seconds,
-                        timeout_for_deployment,
+                        execute,
+                        routing_context,
+                        attempted_ids,
+                        on_attempt=on_attempt,
+                        timeout_seconds=timeout_seconds,
+                        timeout_for_deployment=timeout_for_deployment,
                     )
-                    result = await asyncio.wait_for(
-                        execute(deployment),
-                        timeout=attempt_timeout,
-                    )
-                    latency_ms = (time.monotonic() - started) * 1000
-                    await self.state.record_latency(deployment.deployment_id, latency_ms)
-                    await self.cooldown.record_success(deployment.deployment_id)
+                    if not attempted:
+                        break
+                    deployment_was_attempted = True
 
                     if chain_index > 0:
                         self._record_fallback_event(
@@ -383,13 +398,20 @@ class FailoverManager:
                         return result, deployment
                     return result
                 except Exception as exc:
-                    last_error, classification, allow_classified_fallbacks = self._normalize_execution_error(
-                        exc,
-                        deployment,
+                    deployment_was_attempted = deployment.deployment_id in attempted_ids
+                    last_error, classification, allow_classified_fallbacks = (
+                        self._normalize_execution_error(
+                            exc,
+                            deployment,
+                        )
                     )
                     error_message = str(last_error)
-                    reason = "timeout" if classification == ErrorClassification.TIMEOUT else classification
-                    await self.cooldown.record_failure(
+                    reason = (
+                        "timeout"
+                        if classification == ErrorClassification.TIMEOUT
+                        else classification
+                    )
+                    entered_cooldown = await self.cooldown.record_failure(
                         deployment.deployment_id,
                         error_message,
                         exc=last_error,
@@ -407,7 +429,12 @@ class FailoverManager:
                     )
 
                     if allow_classified_fallbacks:
-                        extra_chain = self._get_classified_fallbacks(classification, model_group)
+                        extra_chain = await self._get_classified_fallbacks(
+                            classification,
+                            model_group,
+                            routing_context,
+                            excluded_ids=visited_ids | attempted_ids,
+                        )
                         if extra_chain:
                             extra_result = await self._try_classified_fallbacks(
                                 extra_chain,
@@ -415,6 +442,9 @@ class FailoverManager:
                                 execute,
                                 deployment.deployment_id,
                                 classification,
+                                routing_context,
+                                visited_ids,
+                                attempted_ids,
                                 on_attempt=on_attempt,
                                 timeout_seconds=timeout_seconds,
                                 timeout_for_deployment=timeout_for_deployment,
@@ -430,14 +460,21 @@ class FailoverManager:
                             raise
                         raise last_error from exc
 
-                    if self._should_retry(classification, last_error, effective_retry_classes) and attempt < effective_retries:
+                    if (
+                        not entered_cooldown
+                        and self._should_retry(
+                            classification,
+                            last_error,
+                            effective_retry_classes,
+                        )
+                        and attempt < effective_retries
+                    ):
                         await asyncio.sleep(self._compute_backoff(attempt))
                         continue
                     break
-                finally:
-                    await self.state.decrement_active(deployment.deployment_id)
 
-            previous_deployment_id = deployment.deployment_id
+            if deployment_was_attempted:
+                previous_deployment_id = deployment.deployment_id
 
         if isinstance(last_error, ProxyError):
             raise last_error
@@ -448,10 +485,13 @@ class FailoverManager:
             code=NO_HEALTHY_DEPLOYMENTS_CODE,
         )
 
-    def _get_classified_fallbacks(
+    async def _get_classified_fallbacks(
         self,
         classification: str,
         model_group: str,
+        routing_context: dict[str, Any],
+        *,
+        excluded_ids: set[str],
     ) -> list[Deployment]:
         if classification == ErrorClassification.CONTEXT_WINDOW:
             fallback_map = self.config.context_window_fallbacks
@@ -464,10 +504,17 @@ class FailoverManager:
         if not fallback_groups:
             return []
 
+        plans = await self.candidate_planner.plan_deployments(
+            fallback_groups,
+            routing_context,
+        )
         chain: list[Deployment] = []
-        seen: set[str] = set()
+        seen = set(excluded_ids)
         for group in fallback_groups:
-            for dep in self.registry.get(group, []):
+            plan = plans.get(group)
+            if plan is None:
+                continue
+            for dep in plan.deployments:
                 if dep.deployment_id not in seen:
                     chain.append(dep)
                     seen.add(dep.deployment_id)
@@ -480,35 +527,30 @@ class FailoverManager:
         execute: Callable[[Deployment], Awaitable[Any]],
         from_deployment_id: str,
         classification: str,
+        routing_context: dict[str, Any],
+        visited_ids: set[str],
+        attempted_ids: set[str],
         *,
         on_attempt: Callable[[Deployment], None] | None = None,
         timeout_seconds: float | None,
         timeout_for_deployment: TimeoutForDeployment | None = None,
     ) -> tuple[Any, Deployment] | None:
         for deployment in chain:
-            if await self.state.is_cooled_down(deployment.deployment_id):
+            if deployment.deployment_id in visited_ids:
                 continue
-            health = await self.state.get_health(deployment.deployment_id)
-            if health.get("healthy", "true") == "false":
-                continue
-
+            visited_ids.add(deployment.deployment_id)
             try:
-                self._notify_attempt(on_attempt, deployment)
-                await self.state.increment_active(deployment.deployment_id)
-                started = time.monotonic()
-                attempt_timeout = self._effective_attempt_timeout(
+                attempted, result = await self._execute_attempt(
                     deployment,
-                    timeout_seconds,
-                    timeout_for_deployment,
+                    execute,
+                    routing_context,
+                    attempted_ids,
+                    on_attempt=on_attempt,
+                    timeout_seconds=timeout_seconds,
+                    timeout_for_deployment=timeout_for_deployment,
                 )
-                result = await asyncio.wait_for(
-                    execute(deployment),
-                    timeout=attempt_timeout,
-                )
-                latency_ms = (time.monotonic() - started) * 1000
-                await self.state.record_latency(deployment.deployment_id, latency_ms)
-                await self.cooldown.record_success(deployment.deployment_id)
-
+                if not attempted:
+                    continue
                 self._record_fallback_event(
                     model_group=model_group,
                     from_id=from_deployment_id,
@@ -522,9 +564,11 @@ class FailoverManager:
 
                 return result, deployment
             except Exception as exc:
-                normalized_error, failure_classification, allow_classified_fallbacks = self._normalize_execution_error(
-                    exc,
-                    deployment,
+                normalized_error, failure_classification, allow_classified_fallbacks = (
+                    self._normalize_execution_error(
+                        exc,
+                        deployment,
+                    )
                 )
                 error_message = str(normalized_error)
                 await self.cooldown.record_failure(
@@ -544,17 +588,72 @@ class FailoverManager:
                 )
                 if not allow_classified_fallbacks:
                     raise normalized_error from exc
-                if not affects_deployment_health(normalized_error) and failure_classification not in {
+                if not affects_deployment_health(
+                    normalized_error
+                ) and failure_classification not in {
                     ErrorClassification.CONTEXT_WINDOW,
                     ErrorClassification.CONTENT_POLICY,
                 }:
                     if normalized_error is exc:
                         raise
                     raise normalized_error from exc
-            finally:
-                await self.state.decrement_active(deployment.deployment_id)
 
         return None
+
+    async def _execute_attempt(
+        self,
+        deployment: Deployment,
+        execute: Callable[[Deployment], Awaitable[Any]],
+        routing_context: dict[str, Any],
+        attempted_ids: set[str],
+        *,
+        on_attempt: Callable[[Deployment], None] | None,
+        timeout_seconds: float | None,
+        timeout_for_deployment: TimeoutForDeployment | None,
+    ) -> tuple[bool, Any]:
+        attempt_timeout = self._effective_attempt_timeout(
+            deployment,
+            timeout_seconds,
+            timeout_for_deployment,
+        )
+        permit = await self.candidate_planner.acquire_attempt(
+            deployment,
+            routing_context,
+            lease_ttl_seconds=self._attempt_permit_ttl_seconds(attempt_timeout),
+        )
+        if not permit.acquired:
+            return False, None
+
+        attempted_ids.add(deployment.deployment_id)
+        try:
+            self._notify_attempt(on_attempt, deployment)
+            started = time.monotonic()
+            result = await asyncio.wait_for(
+                execute(deployment),
+                timeout=attempt_timeout,
+            )
+            latency_ms = (time.monotonic() - started) * 1000
+            await self.state.record_latency(deployment.deployment_id, latency_ms)
+            await self.cooldown.record_success(deployment.deployment_id)
+            return True, result
+        finally:
+            try:
+                await self.candidate_planner.release_attempt(permit)
+            except Exception:
+                # Cleanup failure is local routing-state degradation. The expiring,
+                # owner-scoped permit bounds the stale count, and a provider result or
+                # provider error must never be replaced or retried because release failed.
+                logger.warning(
+                    "router attempt permit release failed deployment_id=%s",
+                    deployment.deployment_id,
+                    exc_info=True,
+                )
+
+    @staticmethod
+    def _attempt_permit_ttl_seconds(attempt_timeout: float) -> int:
+        if not math.isfinite(attempt_timeout):
+            return DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS
+        return max(1, math.ceil(attempt_timeout) + _ATTEMPT_PERMIT_CLEANUP_MARGIN_SECONDS)
 
     @staticmethod
     def _coerce_positive_timeout(timeout_seconds: Any) -> float | None:
@@ -588,7 +687,9 @@ class FailoverManager:
             return self._effective_timeout(timeout_seconds)
         if deployment_timeout is None:
             return self._effective_timeout(timeout_seconds)
-        return self._coerce_positive_timeout(deployment_timeout) or self._effective_timeout(timeout_seconds)
+        return self._coerce_positive_timeout(deployment_timeout) or self._effective_timeout(
+            timeout_seconds
+        )
 
     def _effective_retry_count(self, retry_max_attempts: int | None) -> int:
         if retry_max_attempts is None:
@@ -605,7 +706,9 @@ class FailoverManager:
     ) -> set[str] | None:
         if retryable_error_classes is None:
             return None
-        normalized = {str(item).strip().lower() for item in retryable_error_classes if str(item).strip()}
+        normalized = {
+            str(item).strip().lower() for item in retryable_error_classes if str(item).strip()
+        }
         return normalized or None
 
     @staticmethod
@@ -618,14 +721,18 @@ class FailoverManager:
             return RetryPolicy.is_retryable(error)
         return classification.lower() in retryable_error_classes
 
-    def _build_fallback_chain(
+    async def _build_fallback_chain(
         self,
         primary_deployment: Deployment,
         model_group: str,
         request_tokens: int,
+        routing_context: dict[str, Any],
     ) -> list[Deployment]:
         del request_tokens
 
+        fallback_groups = self.config.fallbacks.get(model_group, [])
+        groups = [model_group, *fallback_groups]
+        plans = await self.candidate_planner.plan_deployments(groups, routing_context)
         chain: list[Deployment] = []
         seen: set[str] = set()
 
@@ -636,10 +743,15 @@ class FailoverManager:
                 chain.append(deployment)
                 seen.add(deployment.deployment_id)
 
-        add([primary_deployment])
-        add(self.registry.get(model_group, []))
+        eligible_ids = {
+            deployment.deployment_id for plan in plans.values() for deployment in plan.deployments
+        }
+        if primary_deployment.deployment_id in eligible_ids:
+            add([primary_deployment])
 
-        for fallback_group in self.config.fallbacks.get(model_group, []):
-            add(self.registry.get(fallback_group, []))
+        for group in groups:
+            plan = plans.get(group)
+            if plan is not None:
+                add(list(plan.deployments))
 
         return chain

--- a/src/router/router.py
+++ b/src/router/router.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field, replace
 from enum import Enum
 import logging
-from typing import Any
+from typing import Any, Sequence, cast
 
-from src.models.errors import ModelNotFoundError, NO_HEALTHY_DEPLOYMENTS_CODE, ServiceUnavailableError
+from src.config import ModelMode
+from src.models.errors import (
+    ModelNotFoundError,
+    NO_HEALTHY_DEPLOYMENTS_CODE,
+    ServiceUnavailableError,
+)
+from src.providers.resolution import provider_supports_mode, resolve_provider
+from src.router.candidates import (
+    DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
+    ROUTING_MODE_CONTEXT_KEY,
+    AttemptCapacity,
+    AttemptCapacityLimit,
+    AttemptPermit,
+    AttemptRejectionReason,
+    RouteCandidatePlan,
+    candidate_plan_cache,
+)
 from src.router.state import DeploymentStateBackend
 from src.router.strategies import (
     CostBasedStrategy,
@@ -14,9 +31,11 @@ from src.router.strategies import (
     PriorityBasedStrategy,
     RateLimitAwareStrategy,
     SimpleShuffleStrategy,
+    StrategyStateSnapshot,
     TagBasedStrategy,
     UsageBasedStrategy,
     WeightedStrategy,
+    usage_limits_for_deployment,
     usage_within_limits,
 )
 
@@ -85,6 +104,14 @@ class RouteGroupPolicy:
         return overrides
 
 
+@dataclass(frozen=True, slots=True)
+class _CandidatePlanInput:
+    model_group: str
+    strategy: RoutingStrategy
+    strategy_impl: Any
+    candidates: tuple[Deployment, ...]
+
+
 class Router:
     def __init__(
         self,
@@ -108,49 +135,18 @@ class Router:
         model_group: str,
         request_context: dict[str, Any],
     ) -> Deployment | None:
-        candidates = await self._get_candidates(model_group)
-        strategy, strategy_impl, policy = self._resolve_strategy_for_group(model_group)
+        strategy, _, policy = self._resolve_strategy_for_group(model_group)
         self._attach_route_policy_context(request_context, policy)
-
-        if not candidates:
-            self._record_route_decision(
-                request_context,
-                model_group=model_group,
-                strategy=strategy.value,
-                policy_version=policy.policy_version if policy is not None else None,
-                timeout_seconds=policy.timeout_seconds if policy is not None else None,
-                retry_max_attempts=policy.retry_max_attempts if policy is not None else None,
-                candidate_count=0,
-                healthy_count=0,
-                filtered_count=0,
-                selected_deployment_id=None,
-                reason="no_candidates",
-            )
-            return None
-
-        healthy = await self._filter_healthy(candidates)
-        filtered = self._apply_filters(healthy, request_context)
-
-        if self.config.enable_pre_call_checks:
-            filtered = await self._apply_pre_call_checks(filtered)
-
-        if not filtered:
-            self._record_route_decision(
-                request_context,
-                model_group=model_group,
-                strategy=strategy.value,
-                policy_version=policy.policy_version if policy is not None else None,
-                timeout_seconds=policy.timeout_seconds if policy is not None else None,
-                retry_max_attempts=policy.retry_max_attempts if policy is not None else None,
-                candidate_count=len(candidates),
-                healthy_count=len(healthy),
-                filtered_count=0,
-                selected_deployment_id=None,
-                reason="no_eligible_candidates",
-            )
-            return None
-
-        selected = await strategy_impl.select(filtered, request_context)
+        plan = (await self.plan_deployments([model_group], request_context))[model_group]
+        selected = plan.deployments[0] if plan.deployments else None
+        if plan.candidate_count == 0:
+            reason = "no_candidates"
+        elif plan.filtered_count == 0:
+            reason = "no_eligible_candidates"
+        elif selected is None:
+            reason = "strategy_returned_none"
+        else:
+            reason = "selected"
         self._record_route_decision(
             request_context,
             model_group=model_group,
@@ -158,26 +154,156 @@ class Router:
             policy_version=policy.policy_version if policy is not None else None,
             timeout_seconds=policy.timeout_seconds if policy is not None else None,
             retry_max_attempts=policy.retry_max_attempts if policy is not None else None,
-            candidate_count=len(candidates),
-            healthy_count=len(healthy),
-            filtered_count=len(filtered),
+            candidate_count=plan.candidate_count,
+            healthy_count=plan.healthy_count,
+            filtered_count=plan.filtered_count,
             selected_deployment_id=selected.deployment_id if selected is not None else None,
-            reason="selected" if selected is not None else "strategy_returned_none",
+            reason=reason,
         )
         return selected
+
+    async def plan_deployments(
+        self,
+        model_groups: Sequence[str],
+        request_context: dict[str, Any],
+    ) -> dict[str, RouteCandidatePlan]:
+        groups = list(
+            dict.fromkeys(str(group).strip() for group in model_groups if str(group).strip())
+        )
+        cached = candidate_plan_cache(request_context)
+        missing_groups = [group for group in groups if group not in cached]
+        if not missing_groups:
+            return {group: cached[group] for group in groups}
+
+        pending: list[_CandidatePlanInput] = []
+        for group in missing_groups:
+            strategy, strategy_impl, _ = self._resolve_strategy_for_group(group)
+            pending.append(
+                _CandidatePlanInput(
+                    model_group=group,
+                    strategy=strategy,
+                    strategy_impl=strategy_impl,
+                    candidates=tuple(await self._get_candidates(group)),
+                )
+            )
+
+        deployment_ids = list(
+            dict.fromkeys(
+                deployment.deployment_id for group in pending for deployment in group.candidates
+            )
+        )
+        health, cooldowns, state_snapshot = await self._load_planning_state(
+            deployment_ids,
+            pending,
+        )
+
+        for group in pending:
+            healthy = self._filter_healthy(group.candidates, health, cooldowns)
+            filtered = self._apply_filters(healthy, request_context)
+            if self.config.enable_pre_call_checks:
+                filtered = self._apply_pre_call_checks(filtered, state_snapshot.usage or {})
+            ordered = await group.strategy_impl.order(
+                filtered,
+                request_context,
+                state_snapshot,
+            )
+            cached[group.model_group] = RouteCandidatePlan(
+                model_group=group.model_group,
+                strategy=group.strategy.value,
+                deployments=tuple(ordered),
+                candidate_count=len(group.candidates),
+                healthy_count=len(healthy),
+                filtered_count=len(filtered),
+            )
+
+        return {group: cached[group] for group in groups}
+
+    async def acquire_attempt(
+        self,
+        deployment: Deployment,
+        request_context: dict[str, Any],
+        *,
+        lease_ttl_seconds: int = DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
+    ) -> AttemptPermit:
+        if not self._apply_filters([deployment], request_context):
+            return AttemptPermit(
+                deployment_id=deployment.deployment_id,
+                acquired=False,
+                rejection_reason=AttemptRejectionReason.STATIC_POLICY,
+            )
+
+        capacity = (
+            self._attempt_capacity(deployment)
+            if self.config.enable_pre_call_checks
+            else AttemptCapacity()
+        )
+        return await self.state.acquire_attempt(
+            deployment.deployment_id,
+            capacity,
+            lease_ttl_seconds=lease_ttl_seconds,
+        )
+
+    async def release_attempt(self, permit: AttemptPermit) -> int | None:
+        return await self.state.release_attempt(permit)
 
     async def _get_candidates(self, model_group: str) -> list[Deployment]:
         return list(self.deployment_registry.get(model_group, []))
 
-    async def _filter_healthy(self, candidates: list[Deployment]) -> list[Deployment]:
-        if not candidates:
-            return []
+    async def _load_planning_state(
+        self,
+        deployment_ids: list[str],
+        groups: list[_CandidatePlanInput],
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, bool], StrategyStateSnapshot]:
+        if not deployment_ids:
+            return {}, {}, StrategyStateSnapshot()
 
-        ids = [d.deployment_id for d in candidates]
-        health = await self.state.get_health_batch(ids)
+        state_queries = [group.strategy_impl.state_query() for group in groups]
+        needs_active = any(query.active_requests for query in state_queries)
+        needs_usage = self.config.enable_pre_call_checks or any(
+            query.usage for query in state_queries
+        )
+        latency_windows = sorted(
+            {
+                query.latency_window_ms
+                for query in state_queries
+                if query.latency_window_ms is not None
+            }
+        )
+
+        calls: dict[str, Any] = {
+            "health": self.state.get_health_batch(deployment_ids),
+            "cooldowns": self.state.get_cooldown_batch(deployment_ids),
+        }
+        if needs_active:
+            calls["active"] = self.state.get_active_requests_batch(deployment_ids)
+        if needs_usage:
+            calls["usage"] = self.state.get_usage_batch(deployment_ids)
+        for window_ms in latency_windows:
+            calls[f"latency:{window_ms}"] = self.state.get_latency_windows_batch(
+                deployment_ids,
+                window_ms,
+            )
+
+        keys = list(calls)
+        values = await asyncio.gather(*(calls[key] for key in keys))
+        results = dict(zip(keys, values, strict=True))
+        latency = {window_ms: results[f"latency:{window_ms}"] for window_ms in latency_windows}
+        snapshot = StrategyStateSnapshot(
+            active_requests=results.get("active"),
+            usage=results.get("usage"),
+            latency_windows=latency or None,
+        )
+        return results["health"], results["cooldowns"], snapshot
+
+    @staticmethod
+    def _filter_healthy(
+        candidates: Sequence[Deployment],
+        health: dict[str, dict[str, Any]],
+        cooldowns: dict[str, bool],
+    ) -> list[Deployment]:
         filtered: list[Deployment] = []
         for deployment in candidates:
-            if await self.state.is_cooled_down(deployment.deployment_id):
+            if cooldowns.get(deployment.deployment_id, False):
                 continue
             dep_health = health.get(deployment.deployment_id, {})
             if dep_health.get("healthy", "true") == "false":
@@ -186,27 +312,51 @@ class Router:
 
         return filtered
 
-    def _apply_filters(self, deployments: list[Deployment], request_context: dict[str, Any]) -> list[Deployment]:
+    def _apply_filters(
+        self, deployments: list[Deployment], request_context: dict[str, Any]
+    ) -> list[Deployment]:
         if not deployments:
             return []
 
         metadata = request_context.get("metadata")
         request_tags = metadata.get("tags") if isinstance(metadata, dict) else None
-        normalized_tags = [tag.strip() for tag in request_tags if isinstance(tag, str) and tag.strip()] if isinstance(request_tags, list) else []
-        if not normalized_tags:
-            return list(deployments)
+        normalized_tags = (
+            [tag.strip() for tag in request_tags if isinstance(tag, str) and tag.strip()]
+            if isinstance(request_tags, list)
+            else []
+        )
+        request_mode = str(request_context.get(ROUTING_MODE_CONTEXT_KEY) or "").strip().lower()
 
         return [
             deployment
             for deployment in deployments
-            if deployment.tags and all(tag in deployment.tags for tag in normalized_tags)
+            if (
+                not normalized_tags
+                or (deployment.tags and all(tag in deployment.tags for tag in normalized_tags))
+            )
+            and self._supports_request_mode(deployment, request_mode)
         ]
 
-    async def _apply_pre_call_checks(self, deployments: list[Deployment]) -> list[Deployment]:
+    @staticmethod
+    def _supports_request_mode(deployment: Deployment, request_mode: str) -> bool:
+        if not request_mode:
+            return True
+        deployment_mode = str(deployment.model_info.get("mode") or "chat").strip().lower() or "chat"
+        if deployment_mode != request_mode:
+            return False
+        return provider_supports_mode(
+            resolve_provider(deployment.deltallm_params),
+            cast(ModelMode, request_mode),
+        )
+
+    @staticmethod
+    def _apply_pre_call_checks(
+        deployments: list[Deployment],
+        usage: dict[str, dict[str, int]],
+    ) -> list[Deployment]:
         if not deployments:
             return []
 
-        usage = await self.state.get_usage_batch([d.deployment_id for d in deployments])
         candidates: list[Deployment] = []
         for deployment in deployments:
             dep_usage = usage.get(deployment.deployment_id, {})
@@ -214,6 +364,15 @@ class Router:
                 candidates.append(deployment)
 
         return candidates
+
+    @staticmethod
+    def _attempt_capacity(deployment: Deployment) -> AttemptCapacity:
+        return AttemptCapacity(
+            limits=tuple(
+                AttemptCapacityLimit(counter=counter, limit=limit)
+                for counter, limit in usage_limits_for_deployment(deployment)
+            )
+        )
 
     def _build_strategy_map(self):
         return {
@@ -231,13 +390,19 @@ class Router:
     def _load_strategy(self, strategy: RoutingStrategy):
         return self._strategies[strategy]
 
-    def _resolve_strategy_for_group(self, model_group: str) -> tuple[RoutingStrategy, Any, RouteGroupPolicy | None]:
+    def _resolve_strategy_for_group(
+        self, model_group: str
+    ) -> tuple[RoutingStrategy, Any, RouteGroupPolicy | None]:
         policy = self.config.route_group_policies.get(model_group)
-        strategy = policy.strategy if policy is not None and policy.strategy is not None else self.strategy
+        strategy = (
+            policy.strategy if policy is not None and policy.strategy is not None else self.strategy
+        )
         return strategy, self._load_strategy(strategy), policy
 
     @staticmethod
-    def _attach_route_policy_context(request_context: dict[str, Any], policy: RouteGroupPolicy | None) -> None:
+    def _attach_route_policy_context(
+        request_context: dict[str, Any], policy: RouteGroupPolicy | None
+    ) -> None:
         if policy is None:
             request_context.pop("route_policy", None)
             return
@@ -293,7 +458,9 @@ class Router:
                     message=f"No healthy deployments available for model '{model_group}'",
                     code=NO_HEALTHY_DEPLOYMENTS_CODE,
                 )
-            raise ModelNotFoundError(message=f"Model '{model_group}' is not configured", code="model_not_found")
+            raise ModelNotFoundError(
+                message=f"Model '{model_group}' is not configured", code="model_not_found"
+            )
         return deployment
 
 
@@ -345,7 +512,9 @@ def build_deployment_registry_with_route_groups(
                 replace(
                     base,
                     weight=int(override_weight) if override_weight is not None else base.weight,
-                    priority=int(override_priority) if override_priority is not None else base.priority,
+                    priority=int(override_priority)
+                    if override_priority is not None
+                    else base.priority,
                 )
             )
 
@@ -355,7 +524,9 @@ def build_deployment_registry_with_route_groups(
     return registry
 
 
-def build_route_group_policies(route_groups: list[dict[str, Any]] | None) -> dict[str, RouteGroupPolicy]:
+def build_route_group_policies(
+    route_groups: list[dict[str, Any]] | None,
+) -> dict[str, RouteGroupPolicy]:
     policies: dict[str, RouteGroupPolicy] = {}
     if not route_groups:
         return policies
@@ -441,14 +612,34 @@ def _deployment_from_entry(model_name: str, entry: dict[str, Any], index: int) -
         tags=list(model_info.get("tags", []) or []),
         input_cost_per_token=float(model_info.get("input_cost_per_token", 0.0) or 0.0),
         output_cost_per_token=float(model_info.get("output_cost_per_token", 0.0) or 0.0),
-        rpm_limit=(int(model_info["rpm_limit"]) if model_info.get("rpm_limit") is not None else params.get("rpm")),
-        tpm_limit=(int(model_info["tpm_limit"]) if model_info.get("tpm_limit") is not None else params.get("tpm")),
-        image_pm_limit=(int(model_info["image_pm_limit"]) if model_info.get("image_pm_limit") is not None else None),
-        audio_seconds_pm_limit=(
-            int(model_info["audio_seconds_pm_limit"]) if model_info.get("audio_seconds_pm_limit") is not None else None
+        rpm_limit=(
+            int(model_info["rpm_limit"])
+            if model_info.get("rpm_limit") is not None
+            else params.get("rpm")
         ),
-        char_pm_limit=(int(model_info["char_pm_limit"]) if model_info.get("char_pm_limit") is not None else None),
+        tpm_limit=(
+            int(model_info["tpm_limit"])
+            if model_info.get("tpm_limit") is not None
+            else params.get("tpm")
+        ),
+        image_pm_limit=(
+            int(model_info["image_pm_limit"])
+            if model_info.get("image_pm_limit") is not None
+            else None
+        ),
+        audio_seconds_pm_limit=(
+            int(model_info["audio_seconds_pm_limit"])
+            if model_info.get("audio_seconds_pm_limit") is not None
+            else None
+        ),
+        char_pm_limit=(
+            int(model_info["char_pm_limit"])
+            if model_info.get("char_pm_limit") is not None
+            else None
+        ),
         rerank_units_pm_limit=(
-            int(model_info["rerank_units_pm_limit"]) if model_info.get("rerank_units_pm_limit") is not None else None
+            int(model_info["rerank_units_pm_limit"])
+            if model_info.get("rerank_units_pm_limit") is not None
+            else None
         ),
     )

--- a/src/router/state.py
+++ b/src/router/state.py
@@ -2,21 +2,157 @@ from __future__ import annotations
 
 import json
 import logging
+import secrets
 import time
 from datetime import UTC, datetime
 from typing import Any, Literal, Mapping, Protocol
 
 from src.models.errors import ServiceUnavailableError
+from src.router.candidates import (
+    DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
+    AttemptCapacity,
+    AttemptPermit,
+    AttemptRejectionReason,
+    UsageCounterName,
+)
 
 logger = logging.getLogger(__name__)
 
 USAGE_COUNTER_NAMES = ("rpm", "tpm", "image_pm", "audio_seconds_pm", "char_pm", "rerank_units_pm")
+_ATTEMPT_LEASE_CLEANUP_GRACE_MS = 1_000
+_ATTEMPT_LEGACY_COMPAT_TTL_SECONDS = 86_400
+
+_ATTEMPT_ADMISSION_SCRIPT = """
+-- router_attempt_admission_v2
+local redis_time = redis.call('TIME')
+local now_ms = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000)
+local capacity_count = tonumber(ARGV[1]) or 0
+local lease_ttl_ms = tonumber(ARGV[2]) or 1000
+local legacy_compat_ttl_ms = tonumber(ARGV[3]) or lease_ttl_ms
+local owner_token = ARGV[4]
+
+local expired = redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', now_ms)
+local current = tonumber(redis.call('GET', KEYS[1]) or '0') or 0
+current = math.max(0, current - expired)
+local owner_count = redis.call('ZCARD', KEYS[2])
+current = math.max(current, owner_count)
+
+local active_ttl_ms = redis.call('PTTL', KEYS[1])
+if current <= 0 then
+  redis.call('DEL', KEYS[1])
+elseif expired > 0 then
+  redis.call('SET', KEYS[1], current)
+  if active_ttl_ms > 0 then
+    redis.call('PEXPIRE', KEYS[1], active_ttl_ms)
+  end
+end
+
+if redis.call('EXISTS', KEYS[3]) == 1 then
+  return {0, 'cooldown', 0}
+end
+
+local healthy = redis.call('HGET', KEYS[4], 'healthy')
+if healthy == 'false' then
+  return {0, 'unhealthy', 0}
+end
+
+for index = 1, capacity_count do
+  local usage = tonumber(redis.call('GET', KEYS[4 + index]) or '0')
+  local limit = tonumber(ARGV[4 + index])
+  if usage >= limit then
+    return {0, 'capacity', 0}
+  end
+end
+
+local expires_at_ms = now_ms + lease_ttl_ms
+redis.call('ZADD', KEYS[2], expires_at_ms, owner_token)
+local active = current + 1
+redis.call('SET', KEYS[1], active)
+
+local latest = redis.call('ZREVRANGE', KEYS[2], 0, 0, 'WITHSCORES')
+local key_expires_at_ms = expires_at_ms
+if #latest >= 2 then
+  key_expires_at_ms = math.max(key_expires_at_ms, tonumber(latest[2]))
+end
+if current > owner_count then
+  key_expires_at_ms = math.max(key_expires_at_ms, now_ms + legacy_compat_ttl_ms)
+end
+key_expires_at_ms = key_expires_at_ms + tonumber(ARGV[5 + capacity_count])
+redis.call('PEXPIREAT', KEYS[1], key_expires_at_ms)
+redis.call('PEXPIREAT', KEYS[2], key_expires_at_ms)
+return {1, 'acquired', active, expires_at_ms}
+"""
+
+_ATTEMPT_RELEASE_SCRIPT = """
+-- router_attempt_release_v2
+local removed = redis.call('ZREM', KEYS[2], ARGV[1])
+local current = tonumber(redis.call('GET', KEYS[1]) or '0')
+local owner_count = redis.call('ZCARD', KEYS[2])
+if removed == 1 then
+  current = math.max(0, current - 1)
+end
+current = math.max(current, owner_count)
+
+if current <= 0 then
+  redis.call('DEL', KEYS[1])
+else
+  local active_ttl_ms = redis.call('PTTL', KEYS[1])
+  redis.call('SET', KEYS[1], current)
+  if active_ttl_ms > 0 then
+    redis.call('PEXPIRE', KEYS[1], active_ttl_ms)
+  end
+end
+if owner_count == 0 then
+  redis.call('DEL', KEYS[2])
+end
+return current
+"""
+
+_ATTEMPT_ACTIVE_BATCH_SCRIPT = """
+-- router_attempt_active_batch_v1
+local redis_time = redis.call('TIME')
+local now_ms = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000)
+local deployment_count = math.floor(#KEYS / 2)
+local results = {}
+
+for index = 1, deployment_count do
+  local active_key = KEYS[((index - 1) * 2) + 1]
+  local owners_key = KEYS[((index - 1) * 2) + 2]
+  local expired = redis.call('ZREMRANGEBYSCORE', owners_key, '-inf', now_ms)
+  local current = tonumber(redis.call('GET', active_key) or '0') or 0
+  current = math.max(0, current - expired)
+  local owner_count = redis.call('ZCARD', owners_key)
+  current = math.max(current, owner_count)
+
+  if current <= 0 then
+    redis.call('DEL', active_key)
+  elseif expired > 0 then
+    local active_ttl_ms = redis.call('PTTL', active_key)
+    redis.call('SET', active_key, current)
+    if active_ttl_ms > 0 then
+      redis.call('PEXPIRE', active_key, active_ttl_ms)
+    end
+  end
+  if owner_count == 0 then
+    redis.call('DEL', owners_key)
+  end
+  results[index] = current
+end
+
+return results
+"""
 
 
 class DeploymentStateBackend(Protocol):
-    async def increment_active(self, deployment_id: str) -> int: ...
+    async def acquire_attempt(
+        self,
+        deployment_id: str,
+        capacity: AttemptCapacity,
+        *,
+        lease_ttl_seconds: int = DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
+    ) -> AttemptPermit: ...
 
-    async def decrement_active(self, deployment_id: str) -> int: ...
+    async def release_attempt(self, permit: AttemptPermit) -> int | None: ...
 
     async def get_active_requests(self, deployment_id: str) -> int: ...
 
@@ -24,7 +160,9 @@ class DeploymentStateBackend(Protocol):
 
     async def record_latency(self, deployment_id: str, latency_ms: float) -> None: ...
 
-    async def get_latency_window(self, deployment_id: str, window_ms: int) -> list[tuple[int, float]]: ...
+    async def get_latency_window(
+        self, deployment_id: str, window_ms: int
+    ) -> list[tuple[int, float]]: ...
 
     async def get_latency_windows_batch(
         self,
@@ -32,7 +170,9 @@ class DeploymentStateBackend(Protocol):
         window_ms: int,
     ) -> dict[str, list[tuple[int, float]]]: ...
 
-    async def increment_usage(self, deployment_id: str, tokens: int, window: str | None = None) -> None: ...
+    async def increment_usage(
+        self, deployment_id: str, tokens: int, window: str | None = None
+    ) -> None: ...
 
     async def increment_usage_counters(
         self,
@@ -65,7 +205,11 @@ class DeploymentStateBackend(Protocol):
 
 
 class RedisStateBackend:
-    """Redis-backed runtime state for deployments with explicit degraded-mode behavior."""
+    """Runtime state for the standalone Redis topology constructed by bootstrap.
+
+    Multi-key attempt admission intentionally uses one Lua call and is not compatible
+    with Redis Cluster's cross-slot execution model.
+    """
 
     def __init__(
         self,
@@ -78,10 +222,13 @@ class RedisStateBackend:
     ):
         self.redis = redis
         self.latency_window_ms = latency_window_ms
-        self.degraded_mode = degraded_mode if degraded_mode in {"fail_open", "fail_closed"} else "fail_open"
+        self.degraded_mode = (
+            degraded_mode if degraded_mode in {"fail_open", "fail_closed"} else "fail_open"
+        )
         self.local_state_ttl_sec = max(1, int(local_state_ttl_sec))
         self.max_local_latency_samples = max(1, int(max_local_latency_samples))
         self._active: dict[str, int] = {}
+        self._active_permits: dict[str, dict[str, float]] = {}
         self._latency: dict[str, list[tuple[int, float]]] = {}
         self._usage: dict[str, dict[str, Any]] = {}
         self._cooldown_until: dict[str, float] = {}
@@ -117,7 +264,9 @@ class RedisStateBackend:
         self._last_redis_error = str(exc) or "redis unavailable"
         self._last_redis_error_at = int(time.time())
         if previous_mode != next_mode:
-            logger.warning("router state backend entered %s mode: %s", next_mode, self._last_redis_error)
+            logger.warning(
+                "router state backend entered %s mode: %s", next_mode, self._last_redis_error
+            )
 
     def _mark_backend_healthy(self) -> None:
         if self.redis is None:
@@ -137,6 +286,7 @@ class RedisStateBackend:
         self._local_last_seen[deployment_id] = now or time.time()
 
     def _drop_local_state_if_unused(self, deployment_id: str) -> None:
+        self._prune_local_attempt_permits(deployment_id)
         if self._active.get(deployment_id, 0) > 0:
             return
         cooldown_until = self._cooldown_until.get(deployment_id)
@@ -163,6 +313,7 @@ class RedisStateBackend:
         cutoff = current_time - self.local_state_ttl_sec
 
         for deployment_id, seen_at in list(self._local_last_seen.items()):
+            self._prune_local_attempt_permits(deployment_id, now=current_time)
             if seen_at >= cutoff:
                 continue
 
@@ -174,6 +325,7 @@ class RedisStateBackend:
                 continue
 
             self._active.pop(deployment_id, None)
+            self._active_permits.pop(deployment_id, None)
             self._latency.pop(deployment_id, None)
             self._usage.pop(deployment_id, None)
             self._cooldown_until.pop(deployment_id, None)
@@ -189,57 +341,216 @@ class RedisStateBackend:
         self._mark_backend_healthy()
         return result
 
-    async def increment_active(self, deployment_id: str) -> int:
-        key = f"active_requests:{deployment_id}"
+    async def acquire_attempt(
+        self,
+        deployment_id: str,
+        capacity: AttemptCapacity,
+        *,
+        lease_ttl_seconds: int = DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
+    ) -> AttemptPermit:
+        minute = self._minute_window()
+        normalized_ttl_seconds = max(1, int(lease_ttl_seconds))
+        owner_token = secrets.token_urlsafe(18)
+        capacity_keys = [
+            self._usage_key(deployment_id, item.counter, minute) for item in capacity.limits
+        ]
+        keys = [
+            f"active_requests:{deployment_id}",
+            self._attempt_owners_key(deployment_id),
+            f"cooldown:{deployment_id}",
+            f"health:{deployment_id}",
+            *capacity_keys,
+        ]
+        args = [
+            len(capacity.limits),
+            normalized_ttl_seconds * 1000,
+            _ATTEMPT_LEGACY_COMPAT_TTL_SECONDS * 1000,
+            owner_token,
+            *(item.limit for item in capacity.limits),
+            _ATTEMPT_LEASE_CLEANUP_GRACE_MS,
+        ]
         try:
-            return int(await self._redis_call("incr", key))
+            raw = await self._redis_call(
+                "eval",
+                _ATTEMPT_ADMISSION_SCRIPT,
+                len(keys),
+                *keys,
+                *args,
+            )
+            if not isinstance(raw, (list, tuple)) or len(raw) < 3:
+                raise RuntimeError("invalid router attempt admission response")
+            acquired = int(raw[0]) == 1
+            if acquired:
+                if len(raw) < 4:
+                    raise RuntimeError("invalid acquired router attempt response")
+                return AttemptPermit(
+                    deployment_id=deployment_id,
+                    acquired=True,
+                    backend="redis",
+                    owner_token=owner_token,
+                    expires_at_ms=int(raw[3]),
+                    active_requests=int(raw[2]),
+                )
+            return AttemptPermit(
+                deployment_id=deployment_id,
+                acquired=False,
+                rejection_reason=AttemptRejectionReason(self._decode_redis_text(raw[1])),
+            )
         except Exception as exc:
             self._handle_backend_failure(exc)
-            self._active[deployment_id] = self._active.get(deployment_id, 0) + 1
-            self._touch_local_state(deployment_id)
-            return self._active[deployment_id]
+            rejection_reason = self._local_attempt_rejection(deployment_id, capacity)
+            if rejection_reason is not None:
+                return AttemptPermit(
+                    deployment_id=deployment_id,
+                    acquired=False,
+                    rejection_reason=rejection_reason,
+                )
+            now = time.time()
+            active_requests = self._prune_local_attempt_permits(deployment_id, now=now) + 1
+            expires_at = now + normalized_ttl_seconds
+            self._active_permits.setdefault(deployment_id, {})[owner_token] = expires_at
+            self._active[deployment_id] = active_requests
+            self._touch_local_state(deployment_id, now=now)
+            return AttemptPermit(
+                deployment_id=deployment_id,
+                acquired=True,
+                backend="local",
+                owner_token=owner_token,
+                expires_at_ms=int(expires_at * 1000),
+                active_requests=active_requests,
+            )
 
-    async def decrement_active(self, deployment_id: str) -> int:
-        key = f"active_requests:{deployment_id}"
+    async def release_attempt(self, permit: AttemptPermit) -> int | None:
+        if not permit.acquired or permit.backend is None:
+            return 0
+        if permit.backend == "local":
+            return self._release_local_attempt(permit)
+        if not permit.owner_token:
+            return await self.get_active_requests(permit.deployment_id)
+
+        keys = [
+            f"active_requests:{permit.deployment_id}",
+            self._attempt_owners_key(permit.deployment_id),
+        ]
         try:
-            value = int(await self._redis_call("decr", key))
-            if value < 0:
-                await self._redis_call("set", key, "0")
-                return 0
-            return value
+            return int(
+                await self._redis_call(
+                    "eval",
+                    _ATTEMPT_RELEASE_SCRIPT,
+                    len(keys),
+                    *keys,
+                    permit.owner_token,
+                )
+            )
         except Exception as exc:
             self._handle_backend_failure(exc)
-            value = max(0, self._active.get(deployment_id, 0) - 1)
-            if value == 0:
-                self._active.pop(deployment_id, None)
-                self._drop_local_state_if_unused(deployment_id)
-            else:
-                self._active[deployment_id] = value
-                self._touch_local_state(deployment_id)
-            return value
+            return None
+
+    def _local_attempt_rejection(
+        self,
+        deployment_id: str,
+        capacity: AttemptCapacity,
+    ) -> AttemptRejectionReason | None:
+        now = time.time()
+        cooldown_until = self._cooldown_until.get(deployment_id)
+        if cooldown_until is not None:
+            if cooldown_until > now:
+                self._touch_local_state(deployment_id, now=now)
+                return AttemptRejectionReason.COOLDOWN
+            self._cooldown_until.pop(deployment_id, None)
+
+        if self._health.get(deployment_id, {}).get("healthy", "true") == "false":
+            self._touch_local_state(deployment_id, now=now)
+            return AttemptRejectionReason.UNHEALTHY
+
+        usage = self._usage.get(deployment_id, {})
+        if usage.get("window") != self._minute_window():
+            usage = {}
+        if any(int(usage.get(item.counter, 0) or 0) >= item.limit for item in capacity.limits):
+            self._touch_local_state(deployment_id, now=now)
+            return AttemptRejectionReason.CAPACITY
+        return None
+
+    def _release_local_attempt(self, permit: AttemptPermit) -> int:
+        permits = self._active_permits.get(permit.deployment_id)
+        if permits is not None and permit.owner_token:
+            permits.pop(permit.owner_token, None)
+        value = self._prune_local_attempt_permits(permit.deployment_id)
+        if value == 0:
+            self._drop_local_state_if_unused(permit.deployment_id)
+        return value
+
+    def _prune_local_attempt_permits(
+        self,
+        deployment_id: str,
+        *,
+        now: float | None = None,
+    ) -> int:
+        permits = self._active_permits.get(deployment_id)
+        if not permits:
+            self._active_permits.pop(deployment_id, None)
+            self._active.pop(deployment_id, None)
+            return 0
+
+        current_time = time.time() if now is None else now
+        for owner_token, expires_at in list(permits.items()):
+            if expires_at <= current_time:
+                permits.pop(owner_token, None)
+        if not permits:
+            self._active_permits.pop(deployment_id, None)
+            self._active.pop(deployment_id, None)
+            return 0
+
+        value = len(permits)
+        self._active[deployment_id] = value
+        return value
+
+    @staticmethod
+    def _attempt_owners_key(deployment_id: str) -> str:
+        return f"router_attempt_owners:v1:{deployment_id}"
+
+    @staticmethod
+    def _usage_key(deployment_id: str, counter: UsageCounterName, minute: str) -> str:
+        return f"usage_{counter}:{deployment_id}:{minute}"
+
+    @staticmethod
+    def _decode_redis_text(value: Any) -> str:
+        return value.decode("utf-8") if isinstance(value, bytes) else str(value)
 
     async def get_active_requests(self, deployment_id: str) -> int:
-        key = f"active_requests:{deployment_id}"
-        try:
-            value = await self._redis_call("get", key)
-            return int(value or 0)
-        except Exception as exc:
-            self._handle_backend_failure(exc)
-            self._prune_local_state()
-            return self._active.get(deployment_id, 0)
+        active = await self.get_active_requests_batch([deployment_id])
+        return active.get(deployment_id, 0)
 
     async def get_active_requests_batch(self, deployment_ids: list[str]) -> dict[str, int]:
         if not deployment_ids:
             return {}
 
-        keys = [f"active_requests:{deployment_id}" for deployment_id in deployment_ids]
+        keys = [
+            key
+            for deployment_id in deployment_ids
+            for key in (
+                f"active_requests:{deployment_id}",
+                self._attempt_owners_key(deployment_id),
+            )
+        ]
         try:
-            values = await self._redis_call("mget", keys)
-            return {deployment_id: int(value or 0) for deployment_id, value in zip(deployment_ids, values, strict=False)}
+            values = await self._redis_call(
+                "eval",
+                _ATTEMPT_ACTIVE_BATCH_SCRIPT,
+                len(keys),
+                *keys,
+            )
+            return {
+                deployment_id: int(value or 0)
+                for deployment_id, value in zip(deployment_ids, values, strict=False)
+            }
         except Exception as exc:
             self._handle_backend_failure(exc)
             self._prune_local_state()
-            return {deployment_id: self._active.get(deployment_id, 0) for deployment_id in deployment_ids}
+            return {
+                deployment_id: self._prune_local_attempt_permits(deployment_id)
+                for deployment_id in deployment_ids
+            }
 
     async def record_latency(self, deployment_id: str, latency_ms: float) -> None:
         timestamp_ms = int(time.time() * 1000)
@@ -264,40 +575,60 @@ class RedisStateBackend:
             self._latency[deployment_id] = trimmed
             self._touch_local_state(deployment_id, now=time.time())
 
-    async def get_latency_window(self, deployment_id: str, window_ms: int) -> list[tuple[int, float]]:
-        now_ms = int(time.time() * 1000)
-        min_score = now_ms - window_ms
-        key = f"latency:{deployment_id}"
-        try:
-            items = await self._redis_call("zrangebyscore", key, min_score, "+inf")
-            window: list[tuple[int, float]] = []
-            for item in items:
-                ts_str, latency_str = str(item).split(":", 1)
-                window.append((int(ts_str), float(latency_str)))
-            return window
-        except Exception as exc:
-            self._handle_backend_failure(exc)
-            self._prune_local_state()
-            window = [(ts, lat) for ts, lat in self._latency.get(deployment_id, []) if ts >= min_score]
-            if window:
-                self._latency[deployment_id] = window[-self.max_local_latency_samples :]
-                self._touch_local_state(deployment_id, now=time.time())
-            else:
-                self._latency.pop(deployment_id, None)
-                self._drop_local_state_if_unused(deployment_id)
-            return window
+    async def get_latency_window(
+        self, deployment_id: str, window_ms: int
+    ) -> list[tuple[int, float]]:
+        windows = await self.get_latency_windows_batch([deployment_id], window_ms)
+        return windows.get(deployment_id, [])
 
     async def get_latency_windows_batch(
         self,
         deployment_ids: list[str],
         window_ms: int,
     ) -> dict[str, list[tuple[int, float]]]:
-        windows: dict[str, list[tuple[int, float]]] = {}
-        for deployment_id in deployment_ids:
-            windows[deployment_id] = await self.get_latency_window(deployment_id, window_ms)
-        return windows
+        if not deployment_ids:
+            return {}
 
-    async def increment_usage(self, deployment_id: str, tokens: int, window: str | None = None) -> None:
+        now_ms = int(time.time() * 1000)
+        min_score = now_ms - window_ms
+        try:
+            pipe = self.redis.pipeline()
+            for deployment_id in deployment_ids:
+                pipe.zrangebyscore(f"latency:{deployment_id}", min_score, "+inf")
+            results = await pipe.execute()
+            self._mark_backend_healthy()
+            windows: dict[str, list[tuple[int, float]]] = {}
+            for deployment_id, items in zip(deployment_ids, results, strict=False):
+                window: list[tuple[int, float]] = []
+                for item in items:
+                    text = item.decode("utf-8") if isinstance(item, bytes) else str(item)
+                    timestamp, latency = text.split(":", 1)
+                    window.append((int(timestamp), float(latency)))
+                windows[deployment_id] = window
+            return windows
+        except Exception as exc:
+            self._handle_backend_failure(exc)
+            self._prune_local_state()
+            windows = {}
+            now = time.time()
+            for deployment_id in deployment_ids:
+                window = [
+                    (timestamp, latency)
+                    for timestamp, latency in self._latency.get(deployment_id, [])
+                    if timestamp >= min_score
+                ]
+                if window:
+                    self._latency[deployment_id] = window[-self.max_local_latency_samples :]
+                    self._touch_local_state(deployment_id, now=now)
+                else:
+                    self._latency.pop(deployment_id, None)
+                    self._drop_local_state_if_unused(deployment_id)
+                windows[deployment_id] = window
+            return windows
+
+    async def increment_usage(
+        self, deployment_id: str, tokens: int, window: str | None = None
+    ) -> None:
         await self.increment_usage_counters(
             deployment_id,
             {"rpm": 1, "tpm": max(0, int(tokens))},
@@ -348,29 +679,56 @@ class RedisStateBackend:
             self._touch_local_state(deployment_id, now=time.time())
 
     async def get_usage(self, deployment_id: str) -> dict[str, int]:
+        usage = await self.get_usage_batch([deployment_id])
+        return usage.get(deployment_id, {"rpm": 0, "tpm": 0})
+
+    async def get_usage_batch(self, deployment_ids: list[str]) -> dict[str, dict[str, int]]:
+        if not deployment_ids:
+            return {}
+
         minute = self._minute_window()
-        keys = [f"usage_{counter_name}:{deployment_id}:{minute}" for counter_name in USAGE_COUNTER_NAMES]
+        keys = [
+            f"usage_{counter_name}:{deployment_id}:{minute}"
+            for deployment_id in deployment_ids
+            for counter_name in USAGE_COUNTER_NAMES
+        ]
         try:
             values = await self._redis_call("mget", keys)
-            usage = {"rpm": int(values[0] or 0), "tpm": int(values[1] or 0)}
-            for counter_name, value in zip(USAGE_COUNTER_NAMES[2:], values[2:], strict=False):
-                parsed = int(value or 0)
-                if parsed > 0:
-                    usage[counter_name] = parsed
-            return usage
+            width = len(USAGE_COUNTER_NAMES)
+            snapshots: dict[str, dict[str, int]] = {}
+            for index, deployment_id in enumerate(deployment_ids):
+                offset = index * width
+                deployment_values = list(values[offset : offset + width])
+                deployment_values.extend([None] * (width - len(deployment_values)))
+                usage = {
+                    "rpm": int(deployment_values[0] or 0),
+                    "tpm": int(deployment_values[1] or 0),
+                }
+                for counter_name, value in zip(
+                    USAGE_COUNTER_NAMES[2:],
+                    deployment_values[2:],
+                    strict=False,
+                ):
+                    parsed = int(value or 0)
+                    if parsed > 0:
+                        usage[counter_name] = parsed
+                snapshots[deployment_id] = usage
+            return snapshots
         except Exception as exc:
             self._handle_backend_failure(exc)
             self._prune_local_state()
-            usage = self._usage.get(deployment_id, {})
-            if usage.get("window") != minute:
-                self._usage.pop(deployment_id, None)
-                self._drop_local_state_if_unused(deployment_id)
-                return {"rpm": 0, "tpm": 0}
-            self._touch_local_state(deployment_id, now=time.time())
-            return self._materialize_usage_snapshot(usage)
-
-    async def get_usage_batch(self, deployment_ids: list[str]) -> dict[str, dict[str, int]]:
-        return {deployment_id: await self.get_usage(deployment_id) for deployment_id in deployment_ids}
+            snapshots = {}
+            now = time.time()
+            for deployment_id in deployment_ids:
+                usage = self._usage.get(deployment_id, {})
+                if usage.get("window") != minute:
+                    self._usage.pop(deployment_id, None)
+                    self._drop_local_state_if_unused(deployment_id)
+                    snapshots[deployment_id] = {"rpm": 0, "tpm": 0}
+                    continue
+                self._touch_local_state(deployment_id, now=now)
+                snapshots[deployment_id] = self._materialize_usage_snapshot(usage)
+            return snapshots
 
     @staticmethod
     def _normalize_usage_counters(counters: Mapping[str, int]) -> dict[str, int]:
@@ -540,14 +898,27 @@ class RedisStateBackend:
             self._touch_local_state(deployment_id, now=time.time())
 
     async def get_health(self, deployment_id: str) -> dict[str, Any]:
-        health_key = f"health:{deployment_id}"
+        health = await self.get_health_batch([deployment_id])
+        return health.get(deployment_id, {})
+
+    async def get_health_batch(self, deployment_ids: list[str]) -> dict[str, dict[str, Any]]:
+        if not deployment_ids:
+            return {}
+
         try:
-            raw = await self._redis_call("hgetall", health_key)
-            return dict(raw or {})
+            pipe = self.redis.pipeline()
+            for deployment_id in deployment_ids:
+                pipe.hgetall(f"health:{deployment_id}")
+            results = await pipe.execute()
+            self._mark_backend_healthy()
+            return {
+                deployment_id: dict(raw or {})
+                for deployment_id, raw in zip(deployment_ids, results, strict=False)
+            }
         except Exception as exc:
             self._handle_backend_failure(exc)
             self._prune_local_state()
-            return dict(self._health.get(deployment_id, {}))
-
-    async def get_health_batch(self, deployment_ids: list[str]) -> dict[str, dict[str, Any]]:
-        return {deployment_id: await self.get_health(deployment_id) for deployment_id in deployment_ids}
+            return {
+                deployment_id: dict(self._health.get(deployment_id, {}))
+                for deployment_id in deployment_ids
+            }

--- a/src/router/strategies.py
+++ b/src/router/strategies.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import math
 import random
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol
 
 from src.billing.cost import compute_billing_result
+from src.router.candidates import UsageCounterName
 
 
 @dataclass
@@ -38,11 +40,35 @@ class StateBackendLike(Protocol):
     async def get_usage_batch(self, deployment_ids: list[str]) -> dict[str, dict[str, int]]: ...
 
 
+@dataclass(frozen=True, slots=True)
+class StrategyStateQuery:
+    active_requests: bool = False
+    usage: bool = False
+    latency_window_ms: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyStateSnapshot:
+    active_requests: Mapping[str, int] | None = None
+    usage: Mapping[str, dict[str, int]] | None = None
+    latency_windows: Mapping[int, Mapping[str, list[tuple[int, float]]]] | None = None
+
+
 class RoutingStrategyImpl(Protocol):
+    def state_query(self) -> StrategyStateQuery: ...
+
+    async def order(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]: ...
+
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
     ) -> DeploymentLike | None: ...
 
 
@@ -71,31 +97,94 @@ def weighted_random_choice(deployments: list[DeploymentLike]) -> DeploymentLike 
     return deployments[-1]
 
 
+def random_order(deployments: list[DeploymentLike]) -> list[DeploymentLike]:
+    remaining = list(deployments)
+    ordered: list[DeploymentLike] = []
+    while remaining:
+        selected = random_choice(remaining)
+        if selected is None:
+            break
+        ordered.append(selected)
+        remaining.remove(selected)
+    return ordered
+
+
+def weighted_random_order(deployments: list[DeploymentLike]) -> list[DeploymentLike]:
+    remaining = list(deployments)
+    ordered: list[DeploymentLike] = []
+    while remaining:
+        selected = weighted_random_choice(remaining)
+        if selected is None:
+            break
+        ordered.append(selected)
+        remaining.remove(selected)
+    return ordered
+
+
 class SimpleShuffleStrategy:
+    def state_query(self) -> StrategyStateQuery:
+        return StrategyStateQuery()
+
+    async def order(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]:
+        del context, state_snapshot
+        return random_order(deployments)
+
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
     ) -> DeploymentLike | None:
-        return random_choice(deployments)
+        ordered = await self.order(deployments, context, state_snapshot)
+        return ordered[0] if ordered else None
 
 
 class LeastBusyStrategy:
     def __init__(self, state_backend: StateBackendLike):
         self.state = state_backend
 
+    def state_query(self) -> StrategyStateQuery:
+        return StrategyStateQuery(active_requests=True)
+
+    async def order(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]:
+        del context
+        if not deployments:
+            return []
+
+        if state_snapshot is not None and state_snapshot.active_requests is not None:
+            counts = state_snapshot.active_requests
+        else:
+            counts = await self.state.get_active_requests_batch(
+                [deployment.deployment_id for deployment in deployments]
+            )
+
+        by_count: dict[int, list[DeploymentLike]] = {}
+        for deployment in deployments:
+            by_count.setdefault(int(counts.get(deployment.deployment_id, 0)), []).append(deployment)
+
+        ordered: list[DeploymentLike] = []
+        for count in sorted(by_count):
+            ordered.extend(weighted_random_order(by_count[count]))
+        return ordered
+
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
     ) -> DeploymentLike | None:
-        if not deployments:
-            return None
-
-        counts = await self.state.get_active_requests_batch([d.deployment_id for d in deployments])
-        min_count = min(counts.get(d.deployment_id, 0) for d in deployments)
-        candidates = [d for d in deployments if counts.get(d.deployment_id, 0) == min_count]
-        return weighted_random_choice(candidates)
+        ordered = await self.order(deployments, context, state_snapshot)
+        return ordered[0] if ordered else None
 
 
 class LatencyBasedStrategy:
@@ -103,35 +192,59 @@ class LatencyBasedStrategy:
         self.state = state_backend
         self.window_size_ms = window_size_ms
 
+    def state_query(self) -> StrategyStateQuery:
+        return StrategyStateQuery(latency_window_ms=self.window_size_ms)
+
+    async def order(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]:
+        del context
+        if not deployments:
+            return []
+
+        cached_windows = None
+        if state_snapshot is not None and state_snapshot.latency_windows is not None:
+            cached_windows = state_snapshot.latency_windows.get(self.window_size_ms)
+        windows = (
+            cached_windows
+            if cached_windows is not None
+            else await self.state.get_latency_windows_batch(
+                [deployment.deployment_id for deployment in deployments],
+                window_ms=self.window_size_ms,
+            )
+        )
+
+        by_latency: dict[float, list[DeploymentLike]] = {}
+        unsampled: list[DeploymentLike] = []
+        for deployment in deployments:
+            average = self._weighted_avg(windows.get(deployment.deployment_id, []))
+            if math.isfinite(average):
+                by_latency.setdefault(average, []).append(deployment)
+            else:
+                unsampled.append(deployment)
+
+        if not by_latency:
+            return weighted_random_order(deployments)
+
+        ordered: list[DeploymentLike] = []
+        latencies = sorted(by_latency)
+        first_pool = [*by_latency[latencies[0]], *unsampled]
+        ordered.extend(weighted_random_order(first_pool))
+        for latency in latencies[1:]:
+            ordered.extend(weighted_random_order(by_latency[latency]))
+        return ordered
+
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
     ) -> DeploymentLike | None:
-        if not deployments:
-            return None
-
-        windows = await self.state.get_latency_windows_batch(
-            [d.deployment_id for d in deployments],
-            window_ms=self.window_size_ms,
-        )
-        scored: list[tuple[DeploymentLike, float]] = []
-        unsampled: list[DeploymentLike] = []
-        for deployment in deployments:
-            avg = self._weighted_avg(windows.get(deployment.deployment_id, []))
-            if math.isfinite(avg):
-                scored.append((deployment, avg))
-            else:
-                unsampled.append(deployment)
-
-        if not scored:
-            return weighted_random_choice(deployments)
-
-        best_latency = min(score for _, score in scored)
-        candidates = [deployment for deployment, score in scored if score == best_latency]
-        if unsampled:
-            candidates.extend(unsampled)
-        return weighted_random_choice(candidates)
+        ordered = await self.order(deployments, context, state_snapshot)
+        return ordered[0] if ordered else None
 
     def _weighted_avg(self, window: list[tuple[int, float]]) -> float:
         if not window:
@@ -150,22 +263,29 @@ class LatencyBasedStrategy:
 
 
 class CostBasedStrategy:
+    def state_query(self) -> StrategyStateQuery:
+        return StrategyStateQuery()
+
+    async def order(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]:
+        del context, state_snapshot
+        costs = [(deployment, self._estimated_unit_cost(deployment)) for deployment in deployments]
+        if not any(math.isfinite(cost) for _, cost in costs):
+            return weighted_random_order(deployments)
+        return [deployment for deployment, _ in sorted(costs, key=lambda item: item[1])]
+
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
     ) -> DeploymentLike | None:
-        if not deployments:
-            return None
-
-        best_deployment: DeploymentLike | None = None
-        best_cost = float("inf")
-        for deployment in deployments:
-            estimated_cost = self._estimated_unit_cost(deployment)
-            if estimated_cost < best_cost:
-                best_cost = estimated_cost
-                best_deployment = deployment
-        return best_deployment or weighted_random_choice(deployments)
+        ordered = await self.order(deployments, context, state_snapshot)
+        return ordered[0] if ordered else None
 
     @staticmethod
     def _estimated_unit_cost(deployment: DeploymentLike) -> float:
@@ -213,73 +333,128 @@ class UsageBasedStrategy:
     def __init__(self, state_backend: StateBackendLike):
         self.state = state_backend
 
+    def state_query(self) -> StrategyStateQuery:
+        return StrategyStateQuery(usage=True)
+
+    async def order(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]:
+        del context
+        if not deployments:
+            return []
+
+        if state_snapshot is not None and state_snapshot.usage is not None:
+            usage = state_snapshot.usage
+        else:
+            usage = await self.state.get_usage_batch(
+                [deployment.deployment_id for deployment in deployments]
+            )
+        return sorted(
+            deployments,
+            key=lambda deployment: usage_utilization_for_deployment(
+                deployment,
+                usage.get(deployment.deployment_id, {}),
+            ),
+        )
+
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
     ) -> DeploymentLike | None:
-        if not deployments:
-            return None
+        ordered = await self.order(deployments, context, state_snapshot)
+        return ordered[0] if ordered else None
 
-        usage = await self.state.get_usage_batch([d.deployment_id for d in deployments])
-        best: DeploymentLike | None = None
-        best_utilization = float("inf")
-
-        for deployment in deployments:
-            dep_usage = usage.get(deployment.deployment_id, {})
-            utilization = usage_utilization_for_deployment(deployment, dep_usage)
-            if utilization < best_utilization:
-                best_utilization = utilization
-                best = deployment
-
-        return best or weighted_random_choice(deployments)
 
 class TagBasedStrategy:
     def __init__(self, fallback_strategy: RoutingStrategyImpl | None = None):
         self.fallback = fallback_strategy or WeightedStrategy()
 
+    def state_query(self) -> StrategyStateQuery:
+        return self.fallback.state_query()
+
+    async def order(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]:
+        # Request-tag eligibility is enforced by Router before strategy ordering.
+        return await self.fallback.order(deployments, context, state_snapshot)
+
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
     ) -> DeploymentLike | None:
-        # Request-tag eligibility is already enforced by the router before strategy
-        # selection, so tag-based routing is intentionally just weighted selection on
-        # the remaining tag-matched pool.
-        return await self.fallback.select(deployments, context)
+        ordered = await self.order(deployments, context, state_snapshot)
+        return ordered[0] if ordered else None
 
 
 class PriorityBasedStrategy:
     def __init__(self, fallback_strategy: RoutingStrategyImpl | None = None):
         self.fallback = fallback_strategy or WeightedStrategy()
 
-    async def select(
+    def state_query(self) -> StrategyStateQuery:
+        return self.fallback.state_query()
+
+    async def order(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
-    ) -> DeploymentLike | None:
-        if not deployments:
-            return None
-
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]:
         by_priority: dict[int, list[DeploymentLike]] = {}
         for deployment in deployments:
             by_priority.setdefault(int(deployment.priority), []).append(deployment)
 
+        ordered: list[DeploymentLike] = []
         for priority in sorted(by_priority):
-            selected = await self.fallback.select(by_priority[priority], context)
-            if selected:
-                return selected
+            ordered.extend(
+                await self.fallback.order(
+                    by_priority[priority],
+                    context,
+                    state_snapshot,
+                )
+            )
+        return ordered
 
-        return None
-
-
-class WeightedStrategy:
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
     ) -> DeploymentLike | None:
-        return weighted_random_choice(deployments)
+        ordered = await self.order(deployments, context, state_snapshot)
+        return ordered[0] if ordered else None
+
+
+class WeightedStrategy:
+    def state_query(self) -> StrategyStateQuery:
+        return StrategyStateQuery()
+
+    async def order(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]:
+        del context, state_snapshot
+        return weighted_random_order(deployments)
+
+    async def select(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> DeploymentLike | None:
+        ordered = await self.order(deployments, context, state_snapshot)
+        return ordered[0] if ordered else None
 
 
 class RateLimitAwareStrategy:
@@ -287,23 +462,44 @@ class RateLimitAwareStrategy:
         self.state = state_backend
         self.utilization_threshold = utilization_threshold
 
+    def state_query(self) -> StrategyStateQuery:
+        return StrategyStateQuery(usage=True)
+
+    async def order(
+        self,
+        deployments: list[DeploymentLike],
+        context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
+    ) -> list[DeploymentLike]:
+        del context
+        if not deployments:
+            return []
+
+        if state_snapshot is not None and state_snapshot.usage is not None:
+            usage = state_snapshot.usage
+        else:
+            usage = await self.state.get_usage_batch(
+                [deployment.deployment_id for deployment in deployments]
+            )
+        available = [
+            deployment
+            for deployment in deployments
+            if usage_utilization_for_deployment(
+                deployment,
+                usage.get(deployment.deployment_id, {}),
+            )
+            < self.utilization_threshold
+        ]
+        return weighted_random_order(available)
+
     async def select(
         self,
         deployments: list[DeploymentLike],
         context: dict[str, Any],
+        state_snapshot: StrategyStateSnapshot | None = None,
     ) -> DeploymentLike | None:
-        if not deployments:
-            return None
-
-        usage = await self.state.get_usage_batch([d.deployment_id for d in deployments])
-        available: list[DeploymentLike] = []
-        for deployment in deployments:
-            dep_usage = usage.get(deployment.deployment_id, {})
-            utilization = usage_utilization_for_deployment(deployment, dep_usage)
-            if utilization < self.utilization_threshold:
-                available.append(deployment)
-
-        return weighted_random_choice(available)
+        ordered = await self.order(deployments, context, state_snapshot)
+        return ordered[0] if ordered else None
 
 
 def usage_utilization_for_deployment(
@@ -311,35 +507,38 @@ def usage_utilization_for_deployment(
     usage: dict[str, int] | None,
 ) -> float:
     dep_usage = usage or {}
-    utilizations: list[float] = []
+    return max(
+        (
+            _calc_utilization(dep_usage.get(counter, 0), limit)
+            for counter, limit in usage_limits_for_deployment(deployment)
+        ),
+        default=0.0,
+    )
 
-    rpm_util = _calc_utilization(dep_usage.get("rpm", 0), deployment.rpm_limit)
-    if deployment.rpm_limit is not None:
-        utilizations.append(rpm_util)
 
+def usage_limits_for_deployment(
+    deployment: DeploymentLike,
+) -> tuple[tuple[UsageCounterName, int], ...]:
+    limits: list[tuple[UsageCounterName, int]] = []
+
+    def add(counter: UsageCounterName, limit: int | None) -> None:
+        if limit is not None and limit > 0:
+            limits.append((counter, limit))
+
+    add("rpm", deployment.rpm_limit)
     mode = str((deployment.model_info or {}).get("mode") or "chat").strip().lower() or "chat"
     if mode in {"chat", "embedding"}:
-        if deployment.tpm_limit is not None:
-            utilizations.append(_calc_utilization(dep_usage.get("tpm", 0), deployment.tpm_limit))
+        add("tpm", deployment.tpm_limit)
     elif mode == "image_generation":
-        if deployment.image_pm_limit is not None:
-            utilizations.append(_calc_utilization(dep_usage.get("image_pm", 0), deployment.image_pm_limit))
+        add("image_pm", deployment.image_pm_limit)
     elif mode in {"audio_speech", "audio_transcription"}:
-        if deployment.audio_seconds_pm_limit is not None:
-            utilizations.append(
-                _calc_utilization(dep_usage.get("audio_seconds_pm", 0), deployment.audio_seconds_pm_limit)
-            )
-        if deployment.char_pm_limit is not None:
-            utilizations.append(_calc_utilization(dep_usage.get("char_pm", 0), deployment.char_pm_limit))
+        add("audio_seconds_pm", deployment.audio_seconds_pm_limit)
+        add("char_pm", deployment.char_pm_limit)
     elif mode == "rerank":
-        if deployment.rerank_units_pm_limit is not None:
-            utilizations.append(
-                _calc_utilization(dep_usage.get("rerank_units_pm", 0), deployment.rerank_units_pm_limit)
-            )
-    elif deployment.tpm_limit is not None:
-        utilizations.append(_calc_utilization(dep_usage.get("tpm", 0), deployment.tpm_limit))
-
-    return max(utilizations, default=0.0)
+        add("rerank_units_pm", deployment.rerank_units_pm_limit)
+    else:
+        add("tpm", deployment.tpm_limit)
+    return tuple(limits)
 
 
 def usage_within_limits(

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -34,6 +34,7 @@ from src.metrics import (
 from src.models.errors import InvalidRequestError
 from src.models.requests import AudioSpeechRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
+from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.upstream_auth import build_openai_compatible_auth_headers
 from src.upstream_http import build_upstream_request_timeout_for_request, configured_timeout_seconds
 from src.router.router import Deployment
@@ -238,7 +239,11 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
 
     app_router = request.app.state.router
     model_group = app_router.resolve_model_group(payload.model)
-    request_context = {"metadata": {}, "user_id": auth.user_id or auth.api_key}
+    request_context = {
+        "metadata": {},
+        "user_id": auth.user_id or auth.api_key,
+        ROUTING_MODE_CONTEXT_KEY: "audio_speech",
+    }
     primary = app_router.require_deployment(
         model_group=model_group,
         deployment=await app_router.select_deployment(model_group, request_context),
@@ -261,6 +266,7 @@ async def audio_speech(request: Request, payload: AudioSpeechRequest):
             execute=lambda dep: _execute_tts(request, payload, dep),
             return_deployment=True,
             on_attempt=track_attempt,
+            routing_context=request_context,
             **failover_kwargs,
         )
         update_served_route_decision(

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -35,6 +35,7 @@ from src.providers.resolution import (
     resolve_provider,
     resolve_upstream_model,
 )
+from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.upstream_auth import build_openai_compatible_auth_headers
 from src.upstream_http import build_upstream_request_timeout_for_request, configured_timeout_seconds
 from src.router.router import Deployment
@@ -260,7 +261,11 @@ async def audio_transcriptions(
 
     app_router = request.app.state.router
     model_group = app_router.resolve_model_group(model)
-    request_context = {"metadata": {}, "user_id": auth.user_id or auth.api_key}
+    request_context = {
+        "metadata": {},
+        "user_id": auth.user_id or auth.api_key,
+        ROUTING_MODE_CONTEXT_KEY: "audio_transcription",
+    }
     primary = app_router.require_deployment(
         model_group=model_group,
         deployment=await app_router.select_deployment(model_group, request_context),
@@ -300,6 +305,7 @@ async def audio_transcriptions(
             ),
             return_deployment=True,
             on_attempt=track_attempt,
+            routing_context=request_context,
             **failover_kwargs,
         )
         update_served_route_decision(

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -27,6 +27,7 @@ from src.models.errors import InvalidRequestError, ServiceUnavailableError
 from src.models.requests import ChatCompletionRequest
 from src.providers.registry import resolve_chat_upstream
 from src.providers.resolution import resolve_provider
+from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.router.usage import record_router_usage
 from src.telemetry.request_failures import seed_request_failure_context
 from src.routers.routing_decision import (
@@ -74,7 +75,11 @@ async def handle_chat_like_request(
 
     router = request.app.state.router
     model_group = router.resolve_model_group(payload.model)
-    request_context = {"metadata": payload.metadata or {}, "user_id": auth.user_id or auth.api_key}
+    request_context = {
+        "metadata": payload.metadata or {},
+        "user_id": auth.user_id or auth.api_key,
+        ROUTING_MODE_CONTEXT_KEY: "chat",
+    }
     primary = router.require_deployment(
         model_group=model_group,
         deployment=await router.select_deployment(model_group, request_context),
@@ -123,6 +128,7 @@ async def handle_chat_like_request(
                         execute=lambda dep: open_stream_with_first_chunk(request, payload, dep),
                         return_deployment=True,
                         on_attempt=track_attempt,
+                        routing_context=request_context,
                         **failover_kwargs,
                     )
                     update_served_route_decision(
@@ -321,6 +327,7 @@ async def handle_chat_like_request(
             execute=_execute_for_deployment,
             return_deployment=True,
             on_attempt=track_attempt,
+            routing_context=request_context,
             **failover_kwargs,
         )
         update_served_route_decision(

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -29,6 +29,7 @@ from src.metrics import (
 from src.models.errors import InvalidRequestError
 from src.models.requests import EmbeddingRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
+from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.upstream_auth import build_openai_compatible_auth_headers
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
@@ -190,7 +191,11 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
 
     app_router = request.app.state.router
     model_group = app_router.resolve_model_group(payload.model)
-    request_context = {"metadata": {}, "user_id": auth.user_id or auth.api_key}
+    request_context = {
+        "metadata": {},
+        "user_id": auth.user_id or auth.api_key,
+        ROUTING_MODE_CONTEXT_KEY: "embedding",
+    }
     primary = app_router.require_deployment(
         model_group=model_group,
         deployment=await app_router.select_deployment(model_group, request_context),
@@ -213,6 +218,7 @@ async def embeddings(request: Request, payload: EmbeddingRequest):
             execute=lambda dep: _execute_embedding(request, payload, dep),
             return_deployment=True,
             on_attempt=track_attempt,
+            routing_context=request_context,
             **failover_kwargs,
         )
         update_served_route_decision(

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -31,6 +31,7 @@ from src.providers.resolution import (
     resolve_provider,
     resolve_upstream_model,
 )
+from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.upstream_auth import build_openai_compatible_auth_headers
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
@@ -164,7 +165,11 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
 
     app_router = request.app.state.router
     model_group = app_router.resolve_model_group(payload.model)
-    request_context = {"metadata": {}, "user_id": auth.user_id or auth.api_key}
+    request_context = {
+        "metadata": {},
+        "user_id": auth.user_id or auth.api_key,
+        ROUTING_MODE_CONTEXT_KEY: "image_generation",
+    }
     primary = app_router.require_deployment(
         model_group=model_group,
         deployment=await app_router.select_deployment(model_group, request_context),
@@ -187,6 +192,7 @@ async def image_generations(request: Request, payload: ImageGenerationRequest):
             execute=lambda dep: _execute_image_generation(request, payload, dep),
             return_deployment=True,
             on_attempt=track_attempt,
+            routing_context=request_context,
             **failover_kwargs,
         )
         update_served_route_decision(

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -30,6 +30,7 @@ from src.metrics import (
 from src.models.errors import InvalidRequestError
 from src.models.requests import RerankRequest
 from src.providers.resolution import resolve_provider, resolve_upstream_model
+from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.upstream_auth import build_openai_compatible_auth_headers
 from src.upstream_http import build_upstream_request_timeout_for_request, configured_timeout_seconds
 from src.router.router import Deployment
@@ -158,7 +159,11 @@ async def rerank(request: Request, payload: RerankRequest):
 
     app_router = request.app.state.router
     model_group = app_router.resolve_model_group(payload.model)
-    request_context = {"metadata": {}, "user_id": auth.user_id or auth.api_key}
+    request_context = {
+        "metadata": {},
+        "user_id": auth.user_id or auth.api_key,
+        ROUTING_MODE_CONTEXT_KEY: "rerank",
+    }
     primary = app_router.require_deployment(
         model_group=model_group,
         deployment=await app_router.select_deployment(model_group, request_context),
@@ -181,6 +186,7 @@ async def rerank(request: Request, payload: RerankRequest):
             execute=lambda dep: _execute_rerank(request, payload, dep),
             return_deployment=True,
             on_attempt=track_attempt,
+            routing_context=request_context,
             **failover_kwargs,
         )
         update_served_route_decision(

--- a/tests/config/test_dynamic.py
+++ b/tests/config/test_dynamic.py
@@ -703,7 +703,7 @@ async def test_model_hot_reload_manager_updates_runtime_registries():
     cooldown_manager = CooldownManager(state_backend=state_backend)
     failover_manager = FailoverManager(
         config=FallbackConfig(),
-        deployment_registry=deployment_registry,
+        candidate_planner=router,
         state_backend=state_backend,
         cooldown_manager=cooldown_manager,
     )
@@ -836,7 +836,7 @@ async def test_model_hot_reload_manager_model_crud_refreshes_runtime_registry():
     cooldown_manager = CooldownManager(state_backend=state_backend)
     failover_manager = FailoverManager(
         config=FallbackConfig(),
-        deployment_registry=deployment_registry,
+        candidate_planner=router,
         state_backend=state_backend,
         cooldown_manager=cooldown_manager,
     )
@@ -941,7 +941,7 @@ async def test_model_hot_reload_manager_reloads_runtime_on_model_updated_event()
     cooldown_manager = CooldownManager(state_backend=state_backend)
     failover_manager = FailoverManager(
         config=FallbackConfig(),
-        deployment_registry=deployment_registry,
+        candidate_planner=router,
         state_backend=state_backend,
         cooldown_manager=cooldown_manager,
     )
@@ -1039,7 +1039,7 @@ async def test_model_hot_reload_manager_invalidates_route_group_l1_cache_on_mode
     cooldown_manager = CooldownManager(state_backend=state_backend)
     failover_manager = FailoverManager(
         config=FallbackConfig(),
-        deployment_registry=deployment_registry,
+        candidate_planner=router,
         state_backend=state_backend,
         cooldown_manager=cooldown_manager,
     )
@@ -1150,7 +1150,7 @@ async def test_model_hot_reload_manager_rejects_duplicate_model_name() -> None:
     cooldown_manager = CooldownManager(state_backend=state_backend)
     failover_manager = FailoverManager(
         config=FallbackConfig(),
-        deployment_registry=deployment_registry,
+        candidate_planner=router,
         state_backend=state_backend,
         cooldown_manager=cooldown_manager,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from datetime import UTC, datetime, timedelta
+import time
 from typing import Any
 
 import httpx
@@ -98,6 +99,21 @@ class FakeRedis:
             self.ttl_store[key] = max(1, int(ttl) // 1000)
         return True
 
+    async def pexpireat(self, key: str, expires_at_ms: int):
+        if key in self.store or key in self.hash_store or key in self.zset_store:
+            remaining_ms = max(1, int(expires_at_ms) - int(time.time() * 1000))
+            self.ttl_store[key] = max(1, remaining_ms // 1000)
+        return True
+
+    async def ttl(self, key: str):
+        if key not in self.store and key not in self.hash_store and key not in self.zset_store:
+            return -2
+        return self.ttl_store.get(key, -1)
+
+    async def pttl(self, key: str):
+        ttl = await self.ttl(key)
+        return ttl * 1000 if ttl >= 0 else ttl
+
     async def mget(self, keys):
         return [self.store.get(key) for key in keys]
 
@@ -161,14 +177,18 @@ class FakeRedis:
     async def zrem(self, key: str, *members: str):
         values = self.zset_store.get(key, [])
         before = len(values)
-        self.zset_store[key] = [(score, member) for score, member in values if member not in set(members)]
+        self.zset_store[key] = [
+            (score, member) for score, member in values if member not in set(members)
+        ]
         if not self.zset_store[key]:
             self.zset_store.pop(key, None)
         return before - len(self.zset_store.get(key, []))
 
     async def zremrangebyscore(self, key: str, min_score: int, max_score: int):
         values = self.zset_store.get(key, [])
-        self.zset_store[key] = [(s, m) for s, m in values if not (int(min_score) <= s <= int(max_score))]
+        self.zset_store[key] = [
+            (s, m) for s, m in values if not (int(min_score) <= s <= int(max_score))
+        ]
 
     async def zrangebyscore(
         self,
@@ -200,10 +220,15 @@ class FakeRedis:
             if score >= int(min_score) and (max_value is None or score <= max_value)
         )
 
+    async def zcard(self, key: str):
+        return len(self.zset_store.get(key, []))
+
     async def zrevrange(self, key: str, start: int, end: int):
-        values = sorted(self.zset_store.get(key, []), key=lambda item: (item[0], item[1]), reverse=True)
+        values = sorted(
+            self.zset_store.get(key, []), key=lambda item: (item[0], item[1]), reverse=True
+        )
         if end < 0:
-            sliced = values[int(start):]
+            sliced = values[int(start) :]
         else:
             sliced = values[int(start) : int(end) + 1]
         return [member for _score, member in sliced]
@@ -256,6 +281,99 @@ class FakeRedis:
         keys = [str(item) for item in args[:numkeys]]
         argv = [str(item) for item in args[numkeys:]]
         n = len(keys)
+
+        if "router_attempt_release_v2" in script:
+            active_key, owners_key = keys
+            owner_token = argv[0]
+            owners = self.zset_store.get(owners_key, [])
+            removed = any(member == owner_token for _score, member in owners)
+            if removed:
+                self.zset_store[owners_key] = [
+                    (score, member) for score, member in owners if member != owner_token
+                ]
+                if not self.zset_store[owners_key]:
+                    self.zset_store.pop(owners_key, None)
+                    self.ttl_store.pop(owners_key, None)
+            current = int(self.store.get(active_key, 0) or 0)
+            if removed:
+                current = max(0, current - 1)
+            current = max(current, len(self.zset_store.get(owners_key, [])))
+            if current <= 0:
+                self.store.pop(active_key, None)
+                self.ttl_store.pop(active_key, None)
+                return 0
+            self.store[active_key] = current
+            return current
+
+        if "router_attempt_admission_v2" in script:
+            active_key, owners_key, cooldown_key, health_key = keys[:4]
+            now_ms = int(time.time() * 1000)
+            owners = self.zset_store.get(owners_key, [])
+            expired_count = sum(1 for score, _member in owners if score <= now_ms)
+            if expired_count:
+                self.zset_store[owners_key] = [
+                    (score, member) for score, member in owners if score > now_ms
+                ]
+                if not self.zset_store[owners_key]:
+                    self.zset_store.pop(owners_key, None)
+                    self.ttl_store.pop(owners_key, None)
+            current_active = max(
+                0,
+                int(self.store.get(active_key, 0) or 0) - expired_count,
+            )
+            current_active = max(current_active, len(self.zset_store.get(owners_key, [])))
+            if current_active:
+                self.store[active_key] = current_active
+            else:
+                self.store.pop(active_key, None)
+                self.ttl_store.pop(active_key, None)
+            if cooldown_key in self.store:
+                return [0, "cooldown", 0]
+            if self.hash_store.get(health_key, {}).get("healthy") == "false":
+                return [0, "unhealthy", 0]
+
+            capacity_count = int(argv[0])
+            for index in range(capacity_count):
+                current = int(self.store.get(keys[4 + index], 0) or 0)
+                limit = int(argv[4 + index])
+                if current >= limit:
+                    return [0, "capacity", 0]
+
+            lease_ttl_ms = int(argv[1])
+            owner_token = argv[3]
+            expires_at_ms = now_ms + lease_ttl_ms
+            await self.zadd(owners_key, {owner_token: expires_at_ms})
+            active = current_active + 1
+            self.store[active_key] = active
+            ttl_seconds = max(1, (lease_ttl_ms + int(argv[4 + capacity_count])) // 1000)
+            self.ttl_store[active_key] = ttl_seconds
+            self.ttl_store[owners_key] = ttl_seconds
+            return [1, "acquired", active, expires_at_ms]
+
+        if "router_attempt_active_batch_v1" in script:
+            now_ms = int(time.time() * 1000)
+            results: list[int] = []
+            for index in range(0, len(keys), 2):
+                active_key, owners_key = keys[index : index + 2]
+                owners = self.zset_store.get(owners_key, [])
+                expired_count = sum(1 for score, _member in owners if score <= now_ms)
+                if expired_count:
+                    self.zset_store[owners_key] = [
+                        (score, member) for score, member in owners if score > now_ms
+                    ]
+                    if not self.zset_store[owners_key]:
+                        self.zset_store.pop(owners_key, None)
+                        self.ttl_store.pop(owners_key, None)
+                current = max(0, int(self.store.get(active_key, 0) or 0) - expired_count)
+                current = max(current, len(self.zset_store.get(owners_key, [])))
+                if current:
+                    self.store[active_key] = current
+                else:
+                    self.store.pop(active_key, None)
+                    self.ttl_store.pop(active_key, None)
+                results.append(current)
+            return results
+
         staged_fair_counters: dict[str, int] = {}
         staged_active_states: dict[str, dict[str, Any]] = {}
         staged_active_order: list[dict[str, Any]] = []
@@ -294,7 +412,9 @@ class FakeRedis:
             total_weight = int(float(self.store.get(total_weight_key, 0) or 0))
             expired = [
                 member
-                for score, member in sorted(self.zset_store.get(active_key, []), key=lambda item: item[0])
+                for score, member in sorted(
+                    self.zset_store.get(active_key, []), key=lambda item: item[0]
+                )
                 if score <= now_ms
             ][:cleanup_limit]
             cleanup_lagged = cleanup_limit > 0 and len(expired) >= cleanup_limit
@@ -340,7 +460,9 @@ class FakeRedis:
             weights = state["weights"]
             if organization_id in weights:
                 return int(weights[organization_id])
-            return int(float(self.hash_store.get(state["weight_key"], {}).get(organization_id, 0) or 0))
+            return int(
+                float(self.hash_store.get(state["weight_key"], {}).get(organization_id, 0) or 0)
+            )
 
         def stage_active_organization(
             *,
@@ -369,7 +491,9 @@ class FakeRedis:
             previous_score = staged_active_score(state, organization_id)
             previous_weight = staged_active_weight(state, organization_id)
             if previous_score > now_ms:
-                state["total_weight"] = int(state["total_weight"]) - previous_weight + effective_weight
+                state["total_weight"] = (
+                    int(state["total_weight"]) - previous_weight + effective_weight
+                )
             else:
                 state["active_count"] = int(state["active_count"]) + 1
                 state["total_weight"] = int(state["total_weight"]) + effective_weight
@@ -435,7 +559,9 @@ class FakeRedis:
                 await self.expire(limit_hit_rank_key, window_seconds)
                 await self.expire(limit_hit_total_key, window_seconds)
 
-            def check_dimension(pool_key: str, org_key: str, capacity: int, amount: int, scope: str, dimension: str):
+            def check_dimension(
+                pool_key: str, org_key: str, capacity: int, amount: int, scope: str, dimension: str
+            ):
                 if capacity <= 0 or amount <= 0:
                     return [1, scope, "not_configured", 0, 0, capacity, 0, 0.0, dimension]
                 pool_current = fair_counter_value(pool_key)
@@ -443,21 +569,84 @@ class FakeRedis:
                 next_pool = pool_current + amount
                 saturation = next_pool / capacity
                 share_multiplier = burst_multiplier if strategy == "reserved_burst" else 1.0
-                share_limit = max(1, int((capacity * effective_weight * share_multiplier) // max(1.0, total_weight)))
+                share_limit = max(
+                    1,
+                    int((capacity * effective_weight * share_multiplier) // max(1.0, total_weight)),
+                )
                 share_limit = min(capacity, share_limit)
                 if next_pool > capacity:
-                    return [0, scope, "pool_capacity_exceeded", pool_current, org_current, capacity, share_limit, saturation, dimension]
+                    return [
+                        0,
+                        scope,
+                        "pool_capacity_exceeded",
+                        pool_current,
+                        org_current,
+                        capacity,
+                        share_limit,
+                        saturation,
+                        dimension,
+                    ]
                 if cleanup_lagged:
-                    return [1, scope, "cleanup_lagged", pool_current, org_current, capacity, share_limit, saturation, dimension]
+                    return [
+                        1,
+                        scope,
+                        "cleanup_lagged",
+                        pool_current,
+                        org_current,
+                        capacity,
+                        share_limit,
+                        saturation,
+                        dimension,
+                    ]
                 if saturation > saturation_threshold and org_current + amount > share_limit:
-                    return [0, scope, "weighted_share_exceeded", pool_current, org_current, capacity, share_limit, saturation, dimension]
-                return [1, scope, "allowed", pool_current, org_current, capacity, share_limit, saturation, dimension]
+                    return [
+                        0,
+                        scope,
+                        "weighted_share_exceeded",
+                        pool_current,
+                        org_current,
+                        capacity,
+                        share_limit,
+                        saturation,
+                        dimension,
+                    ]
+                return [
+                    1,
+                    scope,
+                    "allowed",
+                    pool_current,
+                    org_current,
+                    capacity,
+                    share_limit,
+                    saturation,
+                    dimension,
+                ]
 
-            rpm = check_dimension(rpm_pool_key, rpm_org_key, rpm_capacity, rpm_amount, "tier_pool_fair_share_rpm", "rpm")
+            rpm = check_dimension(
+                rpm_pool_key,
+                rpm_org_key,
+                rpm_capacity,
+                rpm_amount,
+                "tier_pool_fair_share_rpm",
+                "rpm",
+            )
             if rpm[0] == 0:
                 await record_limit_hit(str(rpm[1]))
                 return [
-                    [0, rpm[1], rpm[2], active_count, total_weight, effective_weight, rpm[3], rpm[4], rpm[5], rpm[6], int(rpm[7] * 1_000_000), rpm[8]],
+                    [
+                        0,
+                        rpm[1],
+                        rpm[2],
+                        active_count,
+                        total_weight,
+                        effective_weight,
+                        rpm[3],
+                        rpm[4],
+                        rpm[5],
+                        rpm[6],
+                        int(rpm[7] * 1_000_000),
+                        rpm[8],
+                    ],
                     None,
                 ]
             rpm_org_total = int(rpm[4])
@@ -465,11 +654,31 @@ class FakeRedis:
                 stage_fair_counter_increment(rpm_pool_key, rpm_amount)
                 rpm_org_total = stage_fair_counter_increment(rpm_org_key, rpm_amount)
 
-            tpm = check_dimension(tpm_pool_key, tpm_org_key, tpm_capacity, tpm_amount, "tier_pool_fair_share_tpm", "tpm")
+            tpm = check_dimension(
+                tpm_pool_key,
+                tpm_org_key,
+                tpm_capacity,
+                tpm_amount,
+                "tier_pool_fair_share_tpm",
+                "tpm",
+            )
             if tpm[0] == 0:
                 await record_limit_hit(str(tpm[1]))
                 return [
-                    [0, tpm[1], tpm[2], active_count, total_weight, effective_weight, tpm[3], tpm[4], tpm[5], tpm[6], int(tpm[7] * 1_000_000), tpm[8]],
+                    [
+                        0,
+                        tpm[1],
+                        tpm[2],
+                        active_count,
+                        total_weight,
+                        effective_weight,
+                        tpm[3],
+                        tpm[4],
+                        tpm[5],
+                        tpm[6],
+                        int(tpm[7] * 1_000_000),
+                        tpm[8],
+                    ],
                     None,
                 ]
             tpm_org_total = int(tpm[4])
@@ -492,7 +701,11 @@ class FakeRedis:
                 "rpm_org_current": rpm_org_total,
                 "tpm_org_current": tpm_org_total,
             }
-            reason = "cleanup_lagged" if rpm[2] == "cleanup_lagged" or tpm[2] == "cleanup_lagged" else "allowed"
+            reason = (
+                "cleanup_lagged"
+                if rpm[2] == "cleanup_lagged" or tpm[2] == "cleanup_lagged"
+                else "allowed"
+            )
             selected = tpm if float(tpm[7]) > float(rpm[7]) else rpm
             return [
                 [
@@ -518,8 +731,13 @@ class FakeRedis:
                     await self.zrem(state["active_key"], organization_id)
                     await self.hdel(state["weight_key"], organization_id)
                 for organization_id in state["touched_orgs"]:
-                    await self.zadd(state["active_key"], {organization_id: state["scores"][organization_id]})
-                    await self.hset(state["weight_key"], {organization_id: str(state["weights"][organization_id])})
+                    await self.zadd(
+                        state["active_key"], {organization_id: state["scores"][organization_id]}
+                    )
+                    await self.hset(
+                        state["weight_key"],
+                        {organization_id: str(state["weights"][organization_id])},
+                    )
                 self.store[state["active_count_key"]] = str(state["active_count"])
                 self.store[state["total_weight_key"]] = str(state["total_weight"])
                 ttl_seconds = int(state["active_ttl_seconds"])
@@ -574,11 +792,7 @@ class FakeRedis:
             parallel_tokens = argv[cursor : cursor + parallel_token_count]
             cursor += parallel_token_count
             capacity_arg_start = cursor + (fair_count * 15)
-            capacity_count = (
-                int(argv[capacity_arg_start])
-                if capacity_arg_start < len(argv)
-                else 0
-            )
+            capacity_count = int(argv[capacity_arg_start]) if capacity_arg_start < len(argv) else 0
             capacity_by_rate_index: dict[int, tuple[str, int]] = {}
             for idx in range(capacity_count):
                 arg_start = capacity_arg_start + 1 + (idx * 3)
@@ -587,10 +801,7 @@ class FakeRedis:
                     int(argv[arg_start + 2]),
                 )
             capacity_key_start = (
-                rate_count
-                + legacy_parallel_count
-                + parallel_count
-                + (fair_count * 14)
+                rate_count + legacy_parallel_count + parallel_count + (fair_count * 14)
             )
 
             async def record_capacity_limit_hit(rate_index: int) -> None:
@@ -598,9 +809,7 @@ class FakeRedis:
                 if metadata is None:
                     return
                 field, ttl = metadata
-                heatmap_key, rank_key, total_key = keys[
-                    capacity_key_start : capacity_key_start + 3
-                ]
+                heatmap_key, rank_key, total_key = keys[capacity_key_start : capacity_key_start + 3]
                 await self.hincrby(heatmap_key, field, 1)
                 await self.zincrby(rank_key, 1, field)
                 await self.incr(total_key)
@@ -628,7 +837,10 @@ class FakeRedis:
                     for score, member in self.zset_store.get(key, [])
                     if score > now_ms
                 ]
-                if len(self.zset_store.get(key, [])) + parallel_requested[idx] > parallel_limits[idx]:
+                if (
+                    len(self.zset_store.get(key, [])) + parallel_requested[idx]
+                    > parallel_limits[idx]
+                ):
                     return [0, "parallel", "lease", idx + 1]
             decisions = []
             commits = []
@@ -717,7 +929,9 @@ class FakeRedis:
                         if member != token
                     ]
                     self.zset_store.setdefault(key, []).append((expires_at_values[idx], token))
-                    self.ttl_store[key] = max(1, (expires_at_values[idx] - int(argv[(2 * n)])) // 1000)
+                    self.ttl_store[key] = max(
+                        1, (expires_at_values[idx] - int(argv[(2 * n)])) // 1000
+                    )
                 return [1, 0]
 
             if len(argv) == n:
@@ -881,7 +1095,9 @@ class InMemoryCallableTargetBindingRepository:
     def __init__(self, bindings: list[CallableTargetBindingRecord]) -> None:
         self.bindings = list(bindings)
 
-    async def list_bindings(self, *, callable_key=None, scope_type=None, scope_id=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+    async def list_bindings(
+        self, *, callable_key=None, scope_type=None, scope_id=None, limit=200, offset=0
+    ):  # noqa: ANN001, ANN201
         items = list(self.bindings)
         if callable_key:
             items = [item for item in items if item.callable_key == callable_key]
@@ -908,7 +1124,7 @@ class MockHTTPStreamResponse:
 
     async def aiter_lines(self):
         yield 'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}'
-        yield 'data: [DONE]'
+        yield "data: [DONE]"
 
 
 class MockHTTPClient:
@@ -946,7 +1162,9 @@ class MockHTTPClient:
 
         return httpx.Response(404, json={"error": "not found"})
 
-    def stream(self, method: str, url: str, headers: dict[str, str], json: dict[str, Any], timeout: int):
+    def stream(
+        self, method: str, url: str, headers: dict[str, str], json: dict[str, Any], timeout: int
+    ):
         self.stream_calls += 1
         return MockHTTPStreamResponse()
 
@@ -999,9 +1217,17 @@ async def test_app() -> FastAPI:
     )
     await app.state.callable_target_grant_service.reload()
     app.state.model_registry = {
-        "gpt-4o-mini": [{"deltallm_params": {"model": "openai/gpt-4o-mini", "api_key": "provider-key"}}],
+        "gpt-4o-mini": [
+            {"deltallm_params": {"model": "openai/gpt-4o-mini", "api_key": "provider-key"}}
+        ],
         "text-embedding-3-small": [
-            {"deltallm_params": {"model": "openai/text-embedding-3-small", "api_key": "provider-key"}}
+            {
+                "deltallm_params": {
+                    "model": "openai/text-embedding-3-small",
+                    "api_key": "provider-key",
+                },
+                "model_info": {"mode": "embedding"},
+            }
         ],
     }
     app.state.http_client = mock_http
@@ -1036,7 +1262,7 @@ async def test_app() -> FastAPI:
     cooldown_manager = CooldownManager(state_backend=state_backend)
     failover_manager = FailoverManager(
         config=FallbackConfig(),
-        deployment_registry=deployment_registry,
+        candidate_planner=router,
         state_backend=state_backend,
         cooldown_manager=cooldown_manager,
     )
@@ -1051,7 +1277,9 @@ async def test_app() -> FastAPI:
         state_backend=state_backend,
     )
     app.state.guardrail_registry = GuardrailRegistry()
-    app.state.guardrail_middleware = GuardrailMiddleware(registry=app.state.guardrail_registry, cache_backend=redis)
+    app.state.guardrail_middleware = GuardrailMiddleware(
+        registry=app.state.guardrail_registry, cache_backend=redis
+    )
     app.state.budget_service = NoopBudgetService()
     app.state.spend_tracking_service = NoopSpendTrackingService()
 

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -58,7 +58,9 @@ class _OriginalBatchModelOnlyGrantService:
 
 
 class _TierPricingService:
-    def __init__(self, pricing: dict[str, float], *, mode: str = "sync", service_mode: str = "enforce") -> None:
+    def __init__(
+        self, pricing: dict[str, float], *, mode: str = "sync", service_mode: str = "enforce"
+    ) -> None:
         self.pricing = pricing
         self.pricing_mode = mode
         self.mode = service_mode
@@ -336,12 +338,19 @@ def test_batch_item_costs_use_tier_batch_pricing_and_provider_sync_cost() -> Non
 async def test_batch_worker_logs_batch_pricing_and_spend(monkeypatch):
     async def _fake_execute_embedding(request, payload, deployment):
         del request, payload, deployment
-        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
 
     deployment = SimpleNamespace(
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -378,7 +387,11 @@ async def test_batch_worker_logs_batch_pricing_and_spend(monkeypatch):
     deployment_obj = deployment
     repo = _FakeRepository()
     spend = _SpendRecorder()
-    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend
+        )
+    )
     worker = BatchExecutorWorker(
         app=app,
         repository=repo,  # type: ignore[arg-type]
@@ -487,7 +500,9 @@ async def test_batch_worker_processes_chat_item_with_chat_batch_accounting(monke
             12.0,
         )
 
-    async def _patched_record_router_usage(state_backend, deployment_id: str, *, mode: str, usage: dict):
+    async def _patched_record_router_usage(
+        state_backend, deployment_id: str, *, mode: str, usage: dict
+    ):
         del state_backend
         router_usage_calls.append((deployment_id, mode, dict(usage)))
 
@@ -520,7 +535,9 @@ async def test_batch_worker_processes_chat_item_with_chat_batch_accounting(monke
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -609,10 +626,18 @@ async def test_batch_worker_processes_chat_item_with_chat_batch_accounting(monke
 
     await worker._process_item(job, item)
 
-    assert router_contexts == [{"metadata": {"tags": ["batch-blue"]}, "user_id": "u1"}]
+    assert router_contexts == [
+        {
+            "metadata": {"tags": ["batch-blue"]},
+            "user_id": "u1",
+            "routing_mode": "chat",
+        }
+    ]
     assert execute_calls == [{"model": "gpt-oss", "record_usage": False}]
     assert passive_health.calls == [("dep-chat", True, None)]
-    assert router_usage_calls == [("dep-chat", "chat", {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10})]
+    assert router_usage_calls == [
+        ("dep-chat", "chat", {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10})
+    ]
     assert len(repo.completed_calls) == 1
     completed = repo.completed_calls[0]
     assert completed["response_body"]["object"] == "chat.completion"
@@ -656,7 +681,9 @@ async def test_batch_worker_logs_chat_request_failure_with_batch_metadata(monkey
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -822,7 +849,9 @@ def _build_chat_batch_job() -> BatchJobRecord:
     )
 
 
-def _build_chat_batch_item(item_id: str, content: str, *, request_overrides: dict | None = None) -> BatchItemRecord:
+def _build_chat_batch_item(
+    item_id: str, content: str, *, request_overrides: dict | None = None
+) -> BatchItemRecord:
     now = datetime.now(tz=UTC)
     request_body = {
         "model": "gpt-oss",
@@ -880,7 +909,9 @@ def _build_chat_batch_worker(
             return deployment
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -949,11 +980,17 @@ async def test_batch_chat_pre_call_callback_transforms_provider_payload(monkeypa
     _patch_fake_chat_execute(monkeypatch, execute_calls)
 
     worker, repo = _build_chat_batch_worker(
-        deployment_params={"provider": "vllm", "model": "gpt-oss", "api_base": "http://localhost:9090/v1"},
+        deployment_params={
+            "provider": "vllm",
+            "model": "gpt-oss",
+            "api_base": "http://localhost:9090/v1",
+        },
         state_overrides={"callback_manager": manager},
     )
 
-    await worker._process_item(_build_chat_batch_job(), _build_chat_batch_item("chat-1", "original"))
+    await worker._process_item(
+        _build_chat_batch_job(), _build_chat_batch_item("chat-1", "original")
+    )
 
     assert execute_calls == ["rewritten"]
     assert len(repo.completed_calls) == 1
@@ -998,7 +1035,9 @@ async def test_batch_chat_authorizes_model_after_pre_call_transformation(monkeyp
 @pytest.mark.asyncio
 async def test_batch_chat_guardrail_rejection_is_terminal_item_failure(monkeypatch):
     class _BlockingGuardrailMiddleware:
-        async def run_pre_call(self, *, request_data, user_api_key_dict, call_type, override_guardrails=None):  # noqa: ANN001
+        async def run_pre_call(
+            self, *, request_data, user_api_key_dict, call_type, override_guardrails=None
+        ):  # noqa: ANN001
             del request_data, user_api_key_dict, call_type, override_guardrails
             raise GuardrailViolationError(
                 guardrail_name="blocker",
@@ -1010,7 +1049,11 @@ async def test_batch_chat_guardrail_rejection_is_terminal_item_failure(monkeypat
     _patch_fake_chat_execute(monkeypatch, execute_calls)
     repo = _FailureRepository()
     worker, _ = _build_chat_batch_worker(
-        deployment_params={"provider": "vllm", "model": "gpt-oss", "api_base": "http://localhost:9090/v1"},
+        deployment_params={
+            "provider": "vllm",
+            "model": "gpt-oss",
+            "api_base": "http://localhost:9090/v1",
+        },
         repository=repo,
         state_overrides={"guardrail_middleware": _BlockingGuardrailMiddleware()},
     )
@@ -1043,7 +1086,11 @@ async def test_batch_chat_releases_max_parallel_slot_after_provider_failure(monk
     limit_counter = LimitCounter()
     repo = _FailureRepository()
     worker, _ = _build_chat_batch_worker(
-        deployment_params={"provider": "vllm", "model": "gpt-oss", "api_base": "http://localhost:9090/v1"},
+        deployment_params={
+            "provider": "vllm",
+            "model": "gpt-oss",
+            "api_base": "http://localhost:9090/v1",
+        },
         repository=repo,
         state_overrides={
             "key_service": KeyService(repository=_KeyRepository(), redis_client=None),
@@ -1081,7 +1128,11 @@ async def test_batch_chat_max_parallel_policy_failure_does_not_mark_passive_heal
     passive_health = _PassiveHealthRecorder()
     repo = _FailureRepository()
     worker, _ = _build_chat_batch_worker(
-        deployment_params={"provider": "vllm", "model": "gpt-oss", "api_base": "http://localhost:9090/v1"},
+        deployment_params={
+            "provider": "vllm",
+            "model": "gpt-oss",
+            "api_base": "http://localhost:9090/v1",
+        },
         repository=repo,
         state_overrides={
             "key_service": KeyService(repository=_KeyRepository(), redis_client=None),
@@ -1110,7 +1161,11 @@ async def test_batch_chat_model_access_fails_closed_when_grant_service_missing(m
     _patch_fake_chat_execute(monkeypatch, execute_calls)
     repo = _FailureRepository()
     worker, _ = _build_chat_batch_worker(
-        deployment_params={"provider": "vllm", "model": "gpt-oss", "api_base": "http://localhost:9090/v1"},
+        deployment_params={
+            "provider": "vllm",
+            "model": "gpt-oss",
+            "api_base": "http://localhost:9090/v1",
+        },
         repository=repo,
         state_overrides={"callable_target_grant_service": None},
     )
@@ -1178,14 +1233,20 @@ async def test_batch_worker_sync_microbatches_compatible_chat_items():
     await worker._process_items(
         _build_chat_batch_job(),
         [
-            _build_chat_batch_item("chat-1", "hello", request_overrides={"metadata": {"tenant": "shared"}}),
-            _build_chat_batch_item("chat-2", "world", request_overrides={"metadata": {"tenant": "shared"}}),
+            _build_chat_batch_item(
+                "chat-1", "hello", request_overrides={"metadata": {"tenant": "shared"}}
+            ),
+            _build_chat_batch_item(
+                "chat-2", "world", request_overrides={"metadata": {"tenant": "shared"}}
+            ),
         ],
     )
 
     assert executor.calls == [["hello", "world"]]
     assert len(repo.completed_calls) == 2
-    assert [call["response_body"]["choices"][0]["message"]["content"] for call in repo.completed_calls] == [
+    assert [
+        call["response_body"]["choices"][0]["message"]["content"] for call in repo.completed_calls
+    ] == [
         "answer-0",
         "answer-1",
     ]
@@ -1223,8 +1284,12 @@ async def test_batch_worker_sync_microbatch_falls_back_when_metadata_differs(mon
     await worker._process_items(
         _build_chat_batch_job(),
         [
-            _build_chat_batch_item("chat-1", "hello", request_overrides={"metadata": {"tenant": "a"}}),
-            _build_chat_batch_item("chat-2", "world", request_overrides={"metadata": {"tenant": "b"}}),
+            _build_chat_batch_item(
+                "chat-1", "hello", request_overrides={"metadata": {"tenant": "a"}}
+            ),
+            _build_chat_batch_item(
+                "chat-2", "world", request_overrides={"metadata": {"tenant": "b"}}
+            ),
         ],
     )
 
@@ -1277,7 +1342,9 @@ async def test_batch_worker_sync_microbatch_uses_failover_served_deployment():
             return deployment
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):
             del model_group, kwargs
             try:
                 data = await execute(primary_deployment)
@@ -1297,7 +1364,9 @@ async def test_batch_worker_sync_microbatch_uses_failover_served_deployment():
             del request_context
             self.calls.append(deployment.deployment_id)
             if deployment.deployment_id == "dep-chat":
-                raise ServiceUnavailableError(message="primary unavailable", affects_deployment_health=True)
+                raise ServiceUnavailableError(
+                    message="primary unavailable", affects_deployment_health=True
+                )
             return [
                 {
                     "index": index,
@@ -1414,7 +1483,9 @@ async def test_batch_worker_sync_microbatch_primary_failure_with_unsupported_fal
         def __init__(self) -> None:
             self.failures: list[tuple[str, bool | None, str | None]] = []
 
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):
             del model_group, kwargs
             try:
                 data = await execute(primary_deployment)
@@ -1428,7 +1499,11 @@ async def test_batch_worker_sync_microbatch_primary_failure_with_unsupported_fal
                     served_deployment = fallback
                 except ServiceUnavailableError as fallback_exc:
                     self.failures.append(
-                        (fallback.deployment_id, fallback_exc.affects_deployment_health, fallback_exc.code)
+                        (
+                            fallback.deployment_id,
+                            fallback_exc.affects_deployment_health,
+                            fallback_exc.code,
+                        )
                     )
                     raise
             if return_deployment:
@@ -1443,8 +1518,12 @@ async def test_batch_worker_sync_microbatch_primary_failure_with_unsupported_fal
             del requests, request_context
             self.calls.append(deployment.deployment_id)
             if deployment.deployment_id != "dep-chat":
-                raise AssertionError(f"unexpected fallback microbatch call for {deployment.deployment_id}")
-            raise ServiceUnavailableError(message="primary unavailable", affects_deployment_health=True)
+                raise AssertionError(
+                    f"unexpected fallback microbatch call for {deployment.deployment_id}"
+                )
+            raise ServiceUnavailableError(
+                message="primary unavailable", affects_deployment_health=True
+            )
 
     repo = _FailureRepository()
     failover = _Failover()
@@ -1472,7 +1551,10 @@ async def test_batch_worker_sync_microbatch_primary_failure_with_unsupported_fal
 
     await worker._process_items(
         _build_chat_batch_job(),
-        [_build_chat_batch_item(f"chat-{index}", content) for index, content in enumerate(contents, start=1)],
+        [
+            _build_chat_batch_item(f"chat-{index}", content)
+            for index, content in enumerate(contents, start=1)
+        ],
     )
 
     assert executor.calls == ["dep-chat"]
@@ -1501,7 +1583,9 @@ async def test_batch_worker_sync_microbatch_primary_failure_with_unsupported_fal
 
 
 @pytest.mark.asyncio
-async def test_batch_worker_sync_microbatch_unsupported_fallback_respects_max_in_flight(monkeypatch):
+async def test_batch_worker_sync_microbatch_unsupported_fallback_respects_max_in_flight(
+    monkeypatch,
+):
     active = 0
     max_active = 0
     fallback_reasons: list[tuple[str, int]] = []
@@ -1543,7 +1627,11 @@ async def test_batch_worker_sync_microbatch_unsupported_fallback_respects_max_in
             "provider": "vllm",
             "model": "openai/gpt-oss-120b",
             "api_base": "http://vllm.primary/v1",
-            "chat_batching": {"mode": "sync_microbatch", "upstream_max_batch_size": 4, "max_in_flight": 1},
+            "chat_batching": {
+                "mode": "sync_microbatch",
+                "upstream_max_batch_size": 4,
+                "max_in_flight": 1,
+            },
         },
         input_cost_per_token=0.001,
         output_cost_per_token=0.002,
@@ -1575,7 +1663,9 @@ async def test_batch_worker_sync_microbatch_unsupported_fallback_respects_max_in
             return deployment
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):
             del model_group, kwargs
             try:
                 data = await execute(primary_deployment)
@@ -1591,7 +1681,9 @@ async def test_batch_worker_sync_microbatch_unsupported_fallback_respects_max_in
         async def execute_chat_microbatch(self, *, requests, deployment, request_context):  # noqa: ANN001
             del requests, request_context
             if deployment.deployment_id != "dep-chat":
-                raise AssertionError(f"unexpected fallback microbatch call for {deployment.deployment_id}")
+                raise AssertionError(
+                    f"unexpected fallback microbatch call for {deployment.deployment_id}"
+                )
             raise ServiceUnavailableError(
                 message="sync microbatch unsupported",
                 code="chat_microbatch_unsupported",
@@ -1673,7 +1765,9 @@ async def test_batch_worker_sync_microbatch_response_shape_failure_uses_served_d
             return deployment
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):
             del model_group, kwargs
             try:
                 data = await execute(primary_deployment)
@@ -1689,7 +1783,9 @@ async def test_batch_worker_sync_microbatch_response_shape_failure_uses_served_d
         async def execute_chat_microbatch(self, *, requests, deployment, request_context):  # noqa: ANN001
             del requests, request_context
             if deployment.deployment_id == "dep-chat":
-                raise ServiceUnavailableError(message="primary unavailable", affects_deployment_health=True)
+                raise ServiceUnavailableError(
+                    message="primary unavailable", affects_deployment_health=True
+                )
             return [
                 {
                     "index": 0,
@@ -1741,7 +1837,11 @@ async def test_batch_worker_sync_microbatch_response_shape_failure_uses_served_d
 
     assert len(repo.failed_calls) == 2
     assert passive_health.calls == [
-        ("dep-chat-fallback", False, "chat microbatch response length mismatch expected=2 actual=1"),
+        (
+            "dep-chat-fallback",
+            False,
+            "chat microbatch response length mismatch expected=2 actual=1",
+        ),
     ]
 
 
@@ -1794,7 +1894,9 @@ async def test_batch_worker_sync_microbatch_retryable_failure_requeues_chunk_and
 
 
 @pytest.mark.asyncio
-async def test_batch_worker_missing_chat_batching_config_keeps_concurrent_item_execution(monkeypatch):
+async def test_batch_worker_missing_chat_batching_config_keeps_concurrent_item_execution(
+    monkeypatch,
+):
     execute_calls: list[str] = []
 
     class _UnusedMicrobatchExecutor:
@@ -1822,7 +1924,10 @@ async def test_batch_worker_missing_chat_batching_config_keeps_concurrent_item_e
 
     assert execute_calls == ["hello", "world"]
     assert len(repo.completed_calls) == 2
-    assert [payload["batch_execution_mode"] for payload in repo.completion_outbox_calls] == ["concurrent", "concurrent"]
+    assert [payload["batch_execution_mode"] for payload in repo.completion_outbox_calls] == [
+        "concurrent",
+        "concurrent",
+    ]
 
 
 @pytest.mark.asyncio
@@ -1855,7 +1960,10 @@ async def test_batch_worker_explicit_concurrent_mode_does_not_call_microbatch_ex
 
     assert execute_calls == ["hello", "world"]
     assert len(repo.completed_calls) == 2
-    assert [payload["batch_execution_mode"] for payload in repo.completion_outbox_calls] == ["concurrent", "concurrent"]
+    assert [payload["batch_execution_mode"] for payload in repo.completion_outbox_calls] == [
+        "concurrent",
+        "concurrent",
+    ]
 
 
 @pytest.mark.asyncio
@@ -2098,7 +2206,10 @@ async def test_batch_worker_uses_post_construction_hook_patches(monkeypatch):
 
     deployment = SimpleNamespace(
         deployment_id="dep-1",
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -2163,11 +2274,15 @@ async def test_batch_worker_uses_post_construction_hook_patches(monkeypatch):
             "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
         }
 
-    async def _patched_record_router_usage(state_backend, deployment_id: str, *, mode: str, usage: dict):
+    async def _patched_record_router_usage(
+        state_backend, deployment_id: str, *, mode: str, usage: dict
+    ):
         del state_backend
         router_usage_calls.append((deployment_id, mode, dict(usage)))
 
-    def _patched_observe_batch_item_execution_latency(*, status: str, latency_seconds: float) -> None:
+    def _patched_observe_batch_item_execution_latency(
+        *, status: str, latency_seconds: float
+    ) -> None:
         assert latency_seconds >= 0
         metric_statuses.append(status)
 
@@ -2255,7 +2370,10 @@ async def test_batch_worker_process_item_uses_worker_prepare_override(monkeypatc
 
     deployment = SimpleNamespace(
         deployment_id="dep-1",
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -2292,7 +2410,11 @@ async def test_batch_worker_process_item_uses_worker_prepare_override(monkeypatc
     deployment_obj = deployment
     repo = _FakeRepository()
     worker = BatchExecutorWorker(
-        app=SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=None)),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                router=_Router(), failover_manager=_Failover(), spend_tracking_service=None
+            )
+        ),
         repository=repo,  # type: ignore[arg-type]
         storage=_FakeStorage(),  # type: ignore[arg-type]
         config=BatchWorkerConfig(worker_id="w1"),
@@ -2371,12 +2493,19 @@ async def test_batch_worker_process_item_uses_worker_prepare_override(monkeypatc
 async def test_batch_worker_normalizes_single_item_embedding_usage(monkeypatch):
     async def _fake_execute_embedding(request, payload, deployment):
         del request, payload, deployment
-        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "total_tokens": 5}}
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        }
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
 
     deployment = SimpleNamespace(
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -2395,7 +2524,9 @@ async def test_batch_worker_normalizes_single_item_embedding_usage(monkeypatch):
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -2405,7 +2536,11 @@ async def test_batch_worker_normalizes_single_item_embedding_usage(monkeypatch):
     deployment_obj = deployment
     repo = _FakeRepository()
     spend = _SpendRecorder()
-    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend
+        )
+    )
     worker = BatchExecutorWorker(
         app=app,
         repository=repo,  # type: ignore[arg-type]
@@ -2476,7 +2611,11 @@ async def test_batch_worker_normalizes_single_item_embedding_usage(monkeypatch):
         "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
         "_provider": "vllm",
     }
-    assert repo.completed_calls[0]["usage"] == {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}
+    assert repo.completed_calls[0]["usage"] == {
+        "prompt_tokens": 5,
+        "completion_tokens": 0,
+        "total_tokens": 5,
+    }
 
     artifact_now = datetime.now(tz=UTC)
 
@@ -2606,7 +2745,10 @@ async def test_batch_worker_iter_output_lines_emit_chat_batch_success_rows():
                     line_number=1,
                     custom_id="chat-1",
                     status="completed",
-                    request_body={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+                    request_body={
+                        "model": "gpt-4o-mini",
+                        "messages": [{"role": "user", "content": "hello"}],
+                    },
                     response_body={
                         "id": "chatcmpl-1",
                         "object": "chat.completion",
@@ -2643,7 +2785,10 @@ async def test_batch_worker_iter_output_lines_emit_chat_batch_success_rows():
         config=BatchWorkerConfig(worker_id="w1"),
     )
 
-    rows = [json.loads(line) async for line in worker._iter_output_lines("b1", endpoint="/v1/chat/completions")]
+    rows = [
+        json.loads(line)
+        async for line in worker._iter_output_lines("b1", endpoint="/v1/chat/completions")
+    ]
 
     assert rows == [
         {
@@ -2827,9 +2972,15 @@ async def test_batch_worker_iter_output_lines_backfill_legacy_model_and_usage_fr
     ("mutate", "match"),
     [
         pytest.param(lambda body: body.pop("model"), "missing a valid model", id="missing-model"),
-        pytest.param(lambda body: body.__setitem__("model", " "), "missing a valid model", id="blank-model"),
+        pytest.param(
+            lambda body: body.__setitem__("model", " "), "missing a valid model", id="blank-model"
+        ),
         pytest.param(lambda body: body.pop("usage"), "usage is not an object", id="missing-usage"),
-        pytest.param(lambda body: body.__setitem__("usage", "invalid"), "usage is not an object", id="non-object-usage"),
+        pytest.param(
+            lambda body: body.__setitem__("usage", "invalid"),
+            "usage is not an object",
+            id="non-object-usage",
+        ),
         pytest.param(
             lambda body: body.__setitem__("usage", {"completion_tokens": 0, "total_tokens": 5}),
             "invalid prompt_tokens",
@@ -2846,12 +2997,16 @@ async def test_batch_worker_iter_output_lines_backfill_legacy_model_and_usage_fr
             id="missing-total-tokens",
         ),
         pytest.param(
-            lambda body: body.__setitem__("usage", {"prompt_tokens": "five", "completion_tokens": 0, "total_tokens": 5}),
+            lambda body: body.__setitem__(
+                "usage", {"prompt_tokens": "five", "completion_tokens": 0, "total_tokens": 5}
+            ),
             "invalid prompt_tokens",
             id="non-int-prompt-tokens",
         ),
         pytest.param(
-            lambda body: body.__setitem__("usage", {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": -1}),
+            lambda body: body.__setitem__(
+                "usage", {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": -1}
+            ),
             "negative total_tokens",
             id="negative-total-tokens",
         ),
@@ -2978,7 +3133,11 @@ async def test_batch_worker_iter_error_lines_emit_openai_batch_error_rows():
 async def test_batch_worker_keeps_completed_state_when_side_effects_fail(monkeypatch):
     async def _fake_execute_embedding(request, payload, deployment):
         del request, payload, deployment
-        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
 
@@ -2989,7 +3148,10 @@ async def test_batch_worker_keeps_completed_state_when_side_effects_fail(monkeyp
     monkeypatch.setattr("src.batch.worker.observe_batch_item_execution_latency", _boom)
 
     deployment = SimpleNamespace(
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -3026,7 +3188,11 @@ async def test_batch_worker_keeps_completed_state_when_side_effects_fail(monkeyp
     deployment_obj = deployment
     repo = _FakeRepository()
     spend = _SpendRecorder()
-    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend
+        )
+    )
     worker = BatchExecutorWorker(
         app=app,
         repository=repo,  # type: ignore[arg-type]
@@ -3093,16 +3259,25 @@ async def test_batch_worker_keeps_completed_state_when_side_effects_fail(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_batch_worker_keeps_completed_state_when_passive_health_success_hook_fails(monkeypatch):
+async def test_batch_worker_keeps_completed_state_when_passive_health_success_hook_fails(
+    monkeypatch,
+):
     async def _fake_execute_embedding(request, payload, deployment):
         del request, payload, deployment
-        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
 
     deployment = SimpleNamespace(
         deployment_id="dep-1",
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -3137,7 +3312,9 @@ async def test_batch_worker_keeps_completed_state_when_passive_health_success_ho
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):  # noqa: ANN001
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -3234,9 +3411,14 @@ async def test_batch_worker_keeps_completed_state_when_passive_health_success_ho
 async def test_batch_worker_keeps_completed_state_when_router_usage_hook_fails(monkeypatch):
     async def _fake_execute_embedding(request, payload, deployment):
         del request, payload, deployment
-        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
+
     async def _failing_record_router_usage(*args, **kwargs):  # noqa: ANN002, ANN003
         del args, kwargs
         raise RuntimeError("router usage unavailable")
@@ -3245,7 +3427,10 @@ async def test_batch_worker_keeps_completed_state_when_router_usage_hook_fails(m
 
     deployment = SimpleNamespace(
         deployment_id="dep-1",
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -3268,7 +3453,9 @@ async def test_batch_worker_keeps_completed_state_when_router_usage_hook_fails(m
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):  # noqa: ANN001
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -3360,7 +3547,11 @@ async def test_batch_worker_enforces_budget_before_provider_execution(monkeypatc
         nonlocal execute_called
         del request, payload, deployment
         execute_called = True
-        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
 
@@ -3377,7 +3568,10 @@ async def test_batch_worker_enforces_budget_before_provider_execution(monkeypatc
 
     deployment = SimpleNamespace(
         deployment_id="dep-1",
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -3396,7 +3590,9 @@ async def test_batch_worker_enforces_budget_before_provider_execution(monkeypatc
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):  # noqa: ANN001
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -3482,7 +3678,13 @@ async def test_batch_worker_enforces_budget_before_provider_execution(monkeypatc
 
     assert execute_called is True
     assert budget.calls == [
-        {"api_key": "tok-1", "user_id": "u1", "team_id": "t1", "organization_id": "org-1", "model": "m-1"}
+        {
+            "api_key": "tok-1",
+            "user_id": "u1",
+            "team_id": "t1",
+            "organization_id": "org-1",
+            "model": "m-1",
+        }
     ]
 
 
@@ -3527,7 +3729,10 @@ async def test_batch_worker_logs_request_failure_and_health_on_error():
 
     deployment_obj = SimpleNamespace(
         deployment_id="dep-1",
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={},
@@ -3673,7 +3878,10 @@ async def test_batch_worker_keeps_failed_state_when_passive_health_failure_hook_
 
     deployment_obj = SimpleNamespace(
         deployment_id="dep-1",
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={},
@@ -3806,7 +4014,10 @@ async def test_batch_worker_keeps_failed_state_when_failure_logging_hook_raises(
 
     deployment_obj = SimpleNamespace(
         deployment_id="dep-1",
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={},
@@ -4170,14 +4381,21 @@ async def test_batch_worker_processes_items_with_bounded_concurrency(monkeypatch
         max_active_calls = max(max_active_calls, active_calls)
         try:
             await asyncio.sleep(0.05)
-            return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+            return {
+                "object": "list",
+                "data": [{"index": 0, "embedding": [0.1]}],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+            }
         finally:
             active_calls -= 1
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _slow_execute_embedding)
 
     deployment = SimpleNamespace(
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -4196,7 +4414,9 @@ async def test_batch_worker_processes_items_with_bounded_concurrency(monkeypatch
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):  # noqa: ANN001
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -4285,7 +4505,11 @@ async def test_batch_worker_processes_items_with_bounded_concurrency(monkeypatch
     deployment_obj = deployment
     repo = _ConcurrencyRepo()
     spend = _SpendRecorder()
-    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend
+        )
+    )
     worker = BatchExecutorWorker(
         app=app,
         repository=repo,  # type: ignore[arg-type]
@@ -4467,14 +4691,24 @@ async def test_batch_status_remains_completed_across_service_instances():
 
     assert first["status"] == "completed"
     assert second["status"] == "completed"
-    assert second["request_counts"] == {"total": 3, "completed": 3, "failed": 0, "cancelled": 0, "in_progress": 0}
+    assert second["request_counts"] == {
+        "total": 3,
+        "completed": 3,
+        "failed": 0,
+        "cancelled": 0,
+        "in_progress": 0,
+    }
 
 
 @pytest.mark.asyncio
 async def test_batch_worker_skips_spend_logging_when_item_completion_loses_ownership(monkeypatch):
     async def _fake_execute_embedding(request, payload, deployment):
         del request, payload, deployment
-        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
 
@@ -4484,7 +4718,10 @@ async def test_batch_worker_skips_spend_logging_when_item_completion_loses_owner
             return False
 
     deployment = SimpleNamespace(
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -4503,7 +4740,9 @@ async def test_batch_worker_skips_spend_logging_when_item_completion_loses_owner
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):  # noqa: ANN001
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -4513,7 +4752,11 @@ async def test_batch_worker_skips_spend_logging_when_item_completion_loses_owner
     deployment_obj = deployment
     repo = _LeaseLostRepository()
     spend = _SpendRecorder()
-    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend
+        )
+    )
     worker = BatchExecutorWorker(
         app=app,
         repository=repo,  # type: ignore[arg-type]
@@ -4581,7 +4824,9 @@ async def test_batch_worker_skips_spend_logging_when_item_completion_loses_owner
 
 
 @pytest.mark.asyncio
-async def test_batch_worker_retries_finalizing_job_after_storage_failure(caplog: pytest.LogCaptureFixture):
+async def test_batch_worker_retries_finalizing_job_after_storage_failure(
+    caplog: pytest.LogCaptureFixture,
+):
     now = datetime.now(tz=UTC)
 
     class _FinalizingRepo:
@@ -4681,9 +4926,13 @@ async def test_batch_worker_retries_finalizing_job_after_storage_failure(caplog:
         async def create_file(self, **kwargs):
             self.created_files += 1
             self.created_file_calls.append(kwargs)
-            return SimpleNamespace(file_id=f"file-{self.created_files}", storage_key=kwargs["storage_key"])
+            return SimpleNamespace(
+                file_id=f"file-{self.created_files}", storage_key=kwargs["storage_key"]
+            )
 
-        async def reschedule_finalization(self, *, batch_id: str, worker_id: str, retry_delay_seconds: int) -> bool:
+        async def reschedule_finalization(
+            self, *, batch_id: str, worker_id: str, retry_delay_seconds: int
+        ) -> bool:
             assert batch_id == "b-finalize"
             assert worker_id == "w1"
             self.rescheduled.append(retry_delay_seconds)
@@ -4736,7 +4985,10 @@ async def test_batch_worker_retries_finalizing_job_after_storage_failure(caplog:
     assert repo.released == 1
     assert repo.finalized is False
     assert repo.rescheduled == [60]
-    assert "batch finalization retry scheduled batch_id=b-finalize worker_id=w1 delay_seconds=60" in caplog.text
+    assert (
+        "batch finalization retry scheduled batch_id=b-finalize worker_id=w1 delay_seconds=60"
+        in caplog.text
+    )
 
     did_work = await worker.process_once()
 
@@ -4831,7 +5083,9 @@ async def test_batch_worker_marks_invalid_completed_artifacts_failed_without_ret
             self.attach_calls.append(kwargs)
             return self.job
 
-        async def reschedule_finalization(self, *, batch_id: str, worker_id: str, retry_delay_seconds: int) -> bool:
+        async def reschedule_finalization(
+            self, *, batch_id: str, worker_id: str, retry_delay_seconds: int
+        ) -> bool:
             assert batch_id == "b-finalize"
             assert worker_id == "w1"
             self.rescheduled.append(retry_delay_seconds)
@@ -5143,12 +5397,19 @@ async def test_batch_worker_renews_job_and_item_leases_during_long_execution(mon
     async def _slow_execute_embedding(request, payload, deployment):
         del request, payload, deployment
         await asyncio.sleep(0.05)
-        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _slow_execute_embedding)
 
     deployment = SimpleNamespace(
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -5167,7 +5428,9 @@ async def test_batch_worker_renews_job_and_item_leases_during_long_execution(mon
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):  # noqa: ANN001
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -5245,7 +5508,9 @@ async def test_batch_worker_renews_job_and_item_leases_during_long_execution(mon
                 )
             ]
 
-        async def renew_job_lease(self, *, batch_id: str, worker_id: str, lease_seconds: int) -> bool:
+        async def renew_job_lease(
+            self, *, batch_id: str, worker_id: str, lease_seconds: int
+        ) -> bool:
             assert batch_id == "b1"
             assert worker_id == "w1"
             assert lease_seconds == 360
@@ -5279,12 +5544,21 @@ async def test_batch_worker_renews_job_and_item_leases_during_long_execution(mon
     deployment_obj = deployment
     repo = _LeaseRepo()
     spend = _SpendRecorder()
-    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend
+        )
+    )
     worker = BatchExecutorWorker(
         app=app,
         repository=repo,  # type: ignore[arg-type]
         storage=_FakeStorage(),  # type: ignore[arg-type]
-        config=BatchWorkerConfig(worker_id="w1", heartbeat_interval_seconds=0.01, job_lease_seconds=360, item_lease_seconds=360),
+        config=BatchWorkerConfig(
+            worker_id="w1",
+            heartbeat_interval_seconds=0.01,
+            job_lease_seconds=360,
+            item_lease_seconds=360,
+        ),
     )
     worker._running = True
 
@@ -5301,12 +5575,19 @@ async def test_batch_worker_renews_job_and_item_leases_during_long_execution(mon
 async def test_second_worker_reclaims_expired_in_progress_item_after_crash(monkeypatch):
     async def _fake_execute_embedding(request, payload, deployment):
         del request, payload, deployment
-        return {"object": "list", "data": [{"index": 0, "embedding": [0.1]}], "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5}}
+        return {
+            "object": "list",
+            "data": [{"index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
 
     deployment = SimpleNamespace(
-        deltallm_params={"model": "vllm/sentence-transformers/all-MiniLM-L6-v2", "api_base": "http://localhost:9090/v1"},
+        deltallm_params={
+            "model": "vllm/sentence-transformers/all-MiniLM-L6-v2",
+            "api_base": "http://localhost:9090/v1",
+        },
         input_cost_per_token=0.001,
         output_cost_per_token=0.0,
         model_info={"batch_input_cost_per_token": 0.0005, "batch_output_cost_per_token": 0.0},
@@ -5325,7 +5606,9 @@ async def test_second_worker_reclaims_expired_in_progress_item_after_crash(monke
             return deployment_obj
 
     class _Failover:
-        async def execute_with_failover(self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs):  # noqa: ANN001
+        async def execute_with_failover(
+            self, *, primary_deployment, model_group, execute, return_deployment=False, **kwargs
+        ):  # noqa: ANN001
             del model_group, kwargs
             data = await execute(primary_deployment)
             if return_deployment:
@@ -5410,7 +5693,11 @@ async def test_second_worker_reclaims_expired_in_progress_item_after_crash(monke
 
         async def claim_items(self, *, worker_id: str, lease_seconds: int = 60, **kwargs):
             del kwargs
-            expired_in_progress = self.item_status == "in_progress" and self.item_lease_expires_at is not None and self.item_lease_expires_at < self.now
+            expired_in_progress = (
+                self.item_status == "in_progress"
+                and self.item_lease_expires_at is not None
+                and self.item_lease_expires_at < self.now
+            )
             if self.item_status == "pending" or expired_in_progress:
                 self.item_status = "in_progress"
                 self.item_locked_by = worker_id
@@ -5418,7 +5705,9 @@ async def test_second_worker_reclaims_expired_in_progress_item_after_crash(monke
                 return [self._item_record()]
             return []
 
-        async def mark_item_completed(self, *, item_id: str, worker_id: str | None, **kwargs) -> bool:
+        async def mark_item_completed(
+            self, *, item_id: str, worker_id: str | None, **kwargs
+        ) -> bool:
             del kwargs
             assert item_id == "i1"
             if worker_id != self.item_locked_by:
@@ -5429,7 +5718,9 @@ async def test_second_worker_reclaims_expired_in_progress_item_after_crash(monke
             self.completed_by = worker_id
             return True
 
-        async def complete_items_with_outbox_bulk(self, *, items: list[dict], worker_id: str | None) -> str:
+        async def complete_items_with_outbox_bulk(
+            self, *, items: list[dict], worker_id: str | None
+        ) -> str:
             assert len(items) == 1
             updated = await self.mark_item_completed(
                 item_id=items[0]["item_id"],
@@ -5454,7 +5745,9 @@ async def test_second_worker_reclaims_expired_in_progress_item_after_crash(monke
                 self.job_locked_by = None
                 self.job_lease_expires_at = self.now - timedelta(seconds=1)
 
-        async def renew_job_lease(self, *, batch_id: str, worker_id: str, lease_seconds: int) -> bool:
+        async def renew_job_lease(
+            self, *, batch_id: str, worker_id: str, lease_seconds: int
+        ) -> bool:
             assert batch_id == "b1"
             if self.job_locked_by != worker_id:
                 return False
@@ -5476,7 +5769,9 @@ async def test_second_worker_reclaims_expired_in_progress_item_after_crash(monke
             self.item_lease_expires_at = self.now + timedelta(seconds=lease_seconds)
             return True
 
-        async def release_items_for_retry(self, *, item_ids: list[str], worker_id: str, **kwargs) -> list[str]:
+        async def release_items_for_retry(
+            self, *, item_ids: list[str], worker_id: str, **kwargs
+        ) -> list[str]:
             del kwargs
             del item_ids, worker_id
             return []
@@ -5484,7 +5779,11 @@ async def test_second_worker_reclaims_expired_in_progress_item_after_crash(monke
     deployment_obj = deployment
     repo = _CrashRecoveryRepo()
     spend = _SpendRecorder()
-    app = SimpleNamespace(state=SimpleNamespace(router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            router=_Router(), failover_manager=_Failover(), spend_tracking_service=spend
+        )
+    )
     worker_a = BatchExecutorWorker(
         app=app,
         repository=repo,  # type: ignore[arg-type]
@@ -5629,7 +5928,9 @@ def test_lease_loss_metric_helper_records_each_prepared_item():
 
 
 @pytest.mark.asyncio
-async def test_batch_worker_refresh_runtime_metrics_logs_debug_on_failure(caplog: pytest.LogCaptureFixture):
+async def test_batch_worker_refresh_runtime_metrics_logs_debug_on_failure(
+    caplog: pytest.LogCaptureFixture,
+):
     class _Repo:
         async def summarize_runtime_statuses(self, *, now):  # noqa: ANN001
             del now
@@ -5701,7 +6002,9 @@ def _work_slice_job(
         failed_items=0,
         cancelled_items=0,
         locked_by="w1" if status == BatchJobStatus.FINALIZING else None,
-        lease_expires_at=now + timedelta(seconds=60) if status == BatchJobStatus.FINALIZING else None,
+        lease_expires_at=now + timedelta(seconds=60)
+        if status == BatchJobStatus.FINALIZING
+        else None,
         cancel_requested_at=None,
         status_last_updated_at=now,
         created_by_api_key="tok-1",
@@ -7028,7 +7331,7 @@ async def test_batch_worker_capacity_claim_tries_next_model_after_empty_selectio
 async def test_batch_worker_capacity_empty_claim_logs_structured_context(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
-    ) -> None:
+) -> None:
     class _CapacityRepo:
         def __init__(self) -> None:
             self.diagnostic_calls = 0
@@ -7441,7 +7744,9 @@ async def test_batch_worker_capacity_claim_uses_tenant_fair_share_when_enabled()
         async def claim_next_work(self, **kwargs):  # pragma: no cover
             del kwargs
             self.claim_next_work_called = True
-            raise AssertionError("model-only claim should not run when tenant fair-share is enabled")
+            raise AssertionError(
+                "model-only claim should not run when tenant fair-share is enabled"
+            )
 
     class _CapacityResolver:
         def __init__(self) -> None:
@@ -8134,9 +8439,7 @@ def test_batch_worker_shadow_fair_share_decision_logs_without_flow(
     )
 
     assert shadow_results == [("model-a", "standard", recommendation_result)]
-    assert shadow_comparisons == [
-        ("model_capacity_v1", "fair_share_v1", recommendation_result)
-    ]
+    assert shadow_comparisons == [("model_capacity_v1", "fair_share_v1", recommendation_result)]
     records = [
         record
         for record in caplog.records
@@ -8276,9 +8579,7 @@ async def test_batch_worker_disabled_model_group_logs_fair_share_shadow_skip(
     ]
     assert resolver.results == [("model-a", "claimed")]
     assert shadow_results == [("model-a", "standard", "fair_share_disabled")]
-    assert shadow_comparisons == [
-        ("model_capacity_v1", "fair_share_v1", "fair_share_disabled")
-    ]
+    assert shadow_comparisons == [("model_capacity_v1", "fair_share_v1", "fair_share_disabled")]
     records = [
         record
         for record in caplog.records

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,7 +8,13 @@ from typing import Any
 
 import pytest
 
-from src.cache import CacheKeyBuilder, InMemoryBackend, NoopCacheMetrics, StreamWriteContext, StreamingCacheHandler
+from src.cache import (
+    CacheKeyBuilder,
+    InMemoryBackend,
+    NoopCacheMetrics,
+    StreamWriteContext,
+    StreamingCacheHandler,
+)
 from src.cache.backends.base import CacheBackend, CacheEntry
 from src.callbacks import CallbackManager, CustomLogger
 from src.db.repositories import KeyRecord
@@ -160,8 +166,6 @@ def _refresh_runtime_registry(test_app) -> None:
     rebuilt = build_deployment_registry(test_app.state.model_registry)
     test_app.state.router.deployment_registry.clear()
     test_app.state.router.deployment_registry.update(rebuilt)
-    test_app.state.failover_manager.registry.clear()
-    test_app.state.failover_manager.registry.update(rebuilt)
     test_app.state.router_health_handler.registry.clear()
     test_app.state.router_health_handler.registry.update(rebuilt)
 
@@ -312,7 +316,9 @@ async def test_embeddings_cache_hit(client, test_app):
 
 
 @pytest.mark.asyncio
-async def test_embedding_cache_hit_uses_input_only_cached_pricing_without_live_route_selection(client, test_app):
+async def test_embedding_cache_hit_uses_input_only_cached_pricing_without_live_route_selection(
+    client, test_app
+):
     _enable_cache(test_app)
     recorder = _SpendRecorder()
     test_app.state.spend_tracking_service = recorder
@@ -413,7 +419,9 @@ async def test_streaming_cache_miss_populates_cache_entry(client, test_app):
 
 
 @pytest.mark.asyncio
-async def test_streaming_cache_hit_bills_from_estimated_usage_without_provider_cost(client, test_app):
+async def test_streaming_cache_hit_bills_from_estimated_usage_without_provider_cost(
+    client, test_app
+):
     _enable_stream_cache(test_app)
     recorder = _SpendRecorder()
     test_app.state.spend_tracking_service = recorder
@@ -445,7 +453,11 @@ async def test_streaming_cache_hit_bills_from_estimated_usage_without_provider_c
     warm = await client.post("/v1/chat/completions", headers=headers, json=body)
     assert warm.status_code == 200
     stored = next(iter(test_app.state.cache_backend._cache.values()))
-    assert stored.response["usage"] == {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4}
+    assert stored.response["usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "total_tokens": 4,
+    }
 
     hit = await client.post("/v1/chat/completions", headers=headers, json=body)
 
@@ -499,7 +511,9 @@ async def test_streaming_cache_hit_forwards_usage_when_client_requested_usage(cl
 
 
 @pytest.mark.asyncio
-async def test_cache_hit_uses_persisted_provider_metadata_when_runtime_deployment_missing(client, test_app):
+async def test_cache_hit_uses_persisted_provider_metadata_when_runtime_deployment_missing(
+    client, test_app
+):
     _enable_cache(test_app)
     _configure_groq_openai_compatible_chat_model(test_app)
     recorder = _SpendRecorder()
@@ -530,7 +544,9 @@ async def test_cache_hit_uses_persisted_provider_metadata_when_runtime_deploymen
 
 
 @pytest.mark.asyncio
-async def test_streaming_cache_hit_uses_persisted_provider_metadata_when_runtime_deployment_missing(client, test_app):
+async def test_streaming_cache_hit_uses_persisted_provider_metadata_when_runtime_deployment_missing(
+    client, test_app
+):
     _enable_stream_cache(test_app)
     _configure_groq_openai_compatible_chat_model(test_app)
     recorder = _SpendRecorder()
@@ -586,7 +602,9 @@ async def test_streaming_cache_handler_skips_store_when_buffer_limit_exceeded():
 
 
 @pytest.mark.asyncio
-async def test_streaming_cache_skips_store_after_invalid_chunk_without_breaking_stream(client, test_app):
+async def test_streaming_cache_skips_store_after_invalid_chunk_without_breaking_stream(
+    client, test_app
+):
     _enable_stream_cache(test_app)
     calls = {"count": 0}
 
@@ -603,7 +621,11 @@ async def test_streaming_cache_skips_store_after_invalid_chunk_without_breaking_
 
     test_app.state.http_client.stream = stream
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
-    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": True}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": True,
+    }
 
     first = await client.post("/v1/chat/completions", headers=headers, json=body)
     second = await client.post("/v1/chat/completions", headers=headers, json=body)
@@ -634,7 +656,11 @@ async def test_streaming_cache_malformed_usage_does_not_break_stream(client, tes
 
     test_app.state.http_client.stream = stream
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
-    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": True}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": True,
+    }
 
     response = await client.post("/v1/chat/completions", headers=headers, json=body)
 
@@ -642,7 +668,11 @@ async def test_streaming_cache_malformed_usage_does_not_break_stream(client, tes
     assert "data: [DONE]" in response.text
     assert test_app.state.streaming_cache_handler.active_stream_count == 0
     stored = next(iter(test_app.state.cache_backend._cache.values()))
-    assert stored.response["usage"] == {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4}
+    assert stored.response["usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "total_tokens": 4,
+    }
 
 
 @pytest.mark.asyncio
@@ -650,7 +680,11 @@ async def test_streaming_cache_write_failure_does_not_fail_stream_response(clien
     failing_backend = _FailingCacheBackend()
     _enable_stream_cache(test_app, backend=failing_backend)
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
-    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": True}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": True,
+    }
 
     response = await client.post("/v1/chat/completions", headers=headers, json=body)
 
@@ -689,7 +723,9 @@ async def test_cache_partitioned_by_api_key_scope(client, test_app):
     }
 
     key2 = "sk-test-2"
-    token_hash2 = hashlib.sha256(f"{test_app.state.key_service.salt}:{key2}".encode("utf-8")).hexdigest()
+    token_hash2 = hashlib.sha256(
+        f"{test_app.state.key_service.salt}:{key2}".encode("utf-8")
+    ).hexdigest()
     # Create key2 under org-default so it has model access via callable-target grants
     test_app.state._test_repo.records[token_hash2] = KeyRecord(
         token=token_hash2,
@@ -807,7 +843,10 @@ async def test_cache_hit_uses_partial_cached_pricing_without_live_route_selectio
     assert recorder.events[-1]["cost"] == 0.2500006
     assert recorder.events[-1]["metadata"]["provider_cost"] == 0.0
     assert recorder.events[-1]["metadata"]["provider_cost_avoided"] == 0.2500006
-    assert recorder.events[-1]["metadata"]["provider_cost_avoided_basis"] == "cache_hit_pricing_fallback"
+    assert (
+        recorder.events[-1]["metadata"]["provider_cost_avoided_basis"]
+        == "cache_hit_pricing_fallback"
+    )
     assert recorder.events[-1]["metadata"]["cache_cost_basis"] == "avoided_provider_cost"
     assert recorder.events[-1]["metadata"]["billing_status"] == "priced"
     assert recorder.events[-1]["metadata"]["effective_pricing_sources"] == [

--- a/tests/test_data_plane_audit_extended.py
+++ b/tests/test_data_plane_audit_extended.py
@@ -208,28 +208,42 @@ class _SpendQueryDB:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("path", "body", "expected_action"),
+    ("path", "body", "expected_action", "routing_mode"),
     [
         (
             "/v1/images/generations",
             {"model": "gpt-4o-mini", "prompt": "cat"},
             "IMAGE_GENERATION_REQUEST",
+            "image_generation",
         ),
         (
             "/v1/audio/speech",
             {"model": "gpt-4o-mini", "input": "hello", "voice": "alloy"},
             "AUDIO_SPEECH_REQUEST",
+            "audio_speech",
         ),
         (
             "/v1/rerank",
             {"model": "gpt-4o-mini", "query": "q", "documents": ["a", "b"]},
             "RERANK_REQUEST",
+            "rerank",
         ),
     ],
 )
-async def test_media_routes_emit_audit_success(client, test_app, path, body, expected_action):
+async def test_media_routes_emit_audit_success(
+    client,
+    test_app,
+    path,
+    body,
+    expected_action,
+    routing_mode,
+):
     audit = _RecordingAuditService()
     test_app.state.audit_service = audit
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.model_info["mode"] = routing_mode
+    if routing_mode == "rerank":
+        deployment.deltallm_params["provider"] = "vllm"
 
     async def media_post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
         del headers, timeout
@@ -265,6 +279,8 @@ async def test_audio_transcriptions_emits_audit_success(client, test_app):
 
     audit = _RecordingAuditService()
     test_app.state.audit_service = audit
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.model_info["mode"] = "audio_transcription"
 
     async def _noop_rate_limit():  # noqa: ANN202
         yield

--- a/tests/test_elevenlabs_stt.py
+++ b/tests/test_elevenlabs_stt.py
@@ -35,6 +35,7 @@ def _configure_elevenlabs_stt_deployment(
         "input_cost_per_second": 0.5,
         "default_params": dict(default_params or {}),
         **dict(model_info or {}),
+        "mode": "audio_transcription",
     }
 
 
@@ -113,8 +114,20 @@ async def test_audio_transcription_elevenlabs_native_multipart_defaults_and_bill
                 "language_probability": 0.98,
                 "text": "Hello world.",
                 "words": [
-                    {"text": "Hello", "start": 0.0, "end": 0.4, "type": "word", "speaker_id": "speaker_0"},
-                    {"text": "world.", "start": 0.5, "end": 1.2, "type": "word", "speaker_id": "speaker_0"},
+                    {
+                        "text": "Hello",
+                        "start": 0.0,
+                        "end": 0.4,
+                        "type": "word",
+                        "speaker_id": "speaker_0",
+                    },
+                    {
+                        "text": "world.",
+                        "start": 0.5,
+                        "end": 1.2,
+                        "type": "word",
+                        "speaker_id": "speaker_0",
+                    },
                 ],
                 "transcription_id": "tr_123",
             },
@@ -178,7 +191,16 @@ async def test_audio_transcription_elevenlabs_native_multipart_defaults_and_bill
         "use_multi_channel": "false",
         "no_verbatim": "true",
     }
-    for field in ("model", "language", "prompt", "response_format", "additional_formats", "webhook", "entity_detection", "keyterms"):
+    for field in (
+        "model",
+        "language",
+        "prompt",
+        "response_format",
+        "additional_formats",
+        "webhook",
+        "entity_detection",
+        "keyterms",
+    ):
         assert field not in upstream_data
 
     assert "x-deltallm-route-deployment" in response.headers
@@ -213,7 +235,9 @@ async def test_audio_transcription_elevenlabs_response_formats(
 ):
     _configure_elevenlabs_stt_deployment(test_app)
 
-    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+    async def post(
+        url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout
+    ):  # noqa: ANN001, ANN201
         del headers, files, data, timeout
         return httpx.Response(
             200,
@@ -252,7 +276,9 @@ async def test_audio_transcription_elevenlabs_multichannel_uses_billable_channel
         model_info={"input_cost_per_second": 0.2},
     )
 
-    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+    async def post(
+        url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout
+    ):  # noqa: ANN001, ANN201
         del headers, files, data, timeout
         return httpx.Response(
             200,
@@ -304,7 +330,9 @@ async def test_audio_transcription_elevenlabs_surfaces_upstream_errors(client, t
     test_app.state.spend_tracking_service = _SpendRecorder()
     _configure_elevenlabs_stt_deployment(test_app)
 
-    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+    async def post(
+        url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout
+    ):  # noqa: ANN001, ANN201
         del headers, files, data, timeout
         return httpx.Response(
             422,
@@ -338,7 +366,9 @@ async def test_audio_transcription_elevenlabs_invalid_json_logs_upstream_502(
     test_app.state.spend_tracking_service = _SpendRecorder()
     _configure_elevenlabs_stt_deployment(test_app)
 
-    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+    async def post(
+        url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout
+    ):  # noqa: ANN001, ANN201
         del headers, files, data, timeout
         return httpx.Response(
             200,
@@ -385,9 +415,12 @@ async def test_audio_transcription_openai_compatible_providers_keep_existing_pat
     deployment.deltallm_params["model"] = upstream_model
     deployment.deltallm_params["api_base"] = api_base
     deployment.deltallm_params["api_key"] = "provider-key"
+    deployment.model_info["mode"] = "audio_transcription"
     captured: dict[str, object] = {}
 
-    async def post(url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout):  # noqa: ANN001, ANN201
+    async def post(
+        url: str, headers: dict[str, str], files: dict, data: dict, timeout: httpx.Timeout
+    ):  # noqa: ANN001, ANN201
         del timeout
         captured["url"] = url
         captured["headers"] = headers

--- a/tests/test_elevenlabs_tts.py
+++ b/tests/test_elevenlabs_tts.py
@@ -29,6 +29,7 @@ def _configure_elevenlabs_deployment(test_app, *, default_params: dict | None = 
     deployment.model_info = {
         "input_cost_per_character": 0.01,
         "default_params": dict(default_params or {}),
+        "mode": "audio_speech",
     }
 
 
@@ -62,6 +63,7 @@ async def test_audio_speech_openai_compatible_tts_providers_stay_on_audio_speech
     deployment.deltallm_params["model"] = upstream_model
     deployment.deltallm_params["api_base"] = api_base
     deployment.deltallm_params["api_key"] = "provider-key"
+    deployment.model_info["mode"] = "audio_speech"
     captured: dict[str, object] = {}
 
     async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -25,16 +25,51 @@ from src.router import (
     HealthCheckConfig,
     PassiveHealthTracker,
     RedisStateBackend,
+    ROUTING_MODE_CONTEXT_KEY,
+    RouteGroupPolicy,
+    Router,
+    RouterConfig,
+    RoutingStrategy,
 )
 from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
 
 
-def _deployment(deployment_id: str) -> Deployment:
+def _deployment(
+    deployment_id: str,
+    *,
+    mode: str = "chat",
+    tags: list[str] | None = None,
+    priority: int = 0,
+    rpm_limit: int | None = None,
+    provider: str = "openai",
+) -> Deployment:
     return Deployment(
         deployment_id=deployment_id,
         model_name="gpt-4o-mini",
-        deltallm_params={"model": "openai/gpt-4o-mini"},
+        deltallm_params={
+            "provider": provider,
+            "model": f"{provider}/gpt-4o-mini",
+        },
+        model_info={"mode": mode},
+        tags=list(tags or []),
+        priority=priority,
+        rpm_limit=rpm_limit,
+    )
+
+
+def _planner(
+    state: RedisStateBackend,
+    registry: dict[str, list[Deployment]],
+    *,
+    config: RouterConfig | None = None,
+    strategy: RoutingStrategy = RoutingStrategy.USAGE_BASED,
+) -> Router:
+    return Router(
+        strategy=strategy,
+        state_backend=state,
+        config=config or RouterConfig(),
+        deployment_registry=registry,
     )
 
 
@@ -44,7 +79,7 @@ async def test_failover_applies_retry_override():
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -76,7 +111,7 @@ async def test_failover_applies_timeout_override():
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -102,7 +137,7 @@ async def test_failover_applies_timeout_resolver_per_deployment():
     fallback = _deployment("dep-b")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary, fallback]},
+        candidate_planner=_planner(state, {"group-a": [primary, fallback]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -129,6 +164,620 @@ async def test_failover_applies_timeout_resolver_per_deployment():
     assert data == "fallback-ok"
     assert served.deployment_id == "dep-b"
     assert attempts == ["dep-a", "dep-b"]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "chat",
+        "embedding",
+        "image_generation",
+        "audio_speech",
+        "audio_transcription",
+        "rerank",
+    ],
+)
+@pytest.mark.asyncio
+async def test_failover_never_attempts_a_different_workload_mode(mode: str):
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary", mode=mode, priority=0, provider="vllm")
+    wrong_mode = "embedding" if mode != "embedding" else "chat"
+    incompatible = _deployment(
+        "dep-incompatible",
+        mode=wrong_mode,
+        priority=1,
+        provider="vllm",
+    )
+    fallback = _deployment("dep-fallback", mode=mode, priority=2, provider="vllm")
+    registry = {"group-a": [primary, incompatible, fallback]}
+    planner = _planner(state, registry, strategy=RoutingStrategy.PRIORITY_BASED)
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    routing_context = {ROUTING_MODE_CONTEXT_KEY: mode, "metadata": {}}
+    selected = await planner.select_deployment("group-a", routing_context)
+    assert selected is primary
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment.deployment_id == primary.deployment_id:
+            raise TimeoutError(message="primary timed out")
+        return "ok"
+
+    data, served = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=run,
+        return_deployment=True,
+        routing_context=routing_context,
+    )
+
+    assert data == "ok"
+    assert served is fallback
+    assert attempts == ["dep-primary", "dep-fallback"]
+
+
+@pytest.mark.parametrize(
+    ("mode", "incompatible_provider"),
+    [
+        ("chat", "elevenlabs"),
+        ("embedding", "anthropic"),
+        ("image_generation", "anthropic"),
+        ("audio_speech", "anthropic"),
+        ("audio_transcription", "anthropic"),
+        ("rerank", "anthropic"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_failover_never_attempts_a_provider_without_workload_capability(
+    mode: str,
+    incompatible_provider: str,
+):
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary", mode=mode, priority=0, provider="vllm")
+    incompatible = _deployment(
+        "dep-incompatible",
+        mode=mode,
+        priority=1,
+        provider=incompatible_provider,
+    )
+    fallback = _deployment("dep-fallback", mode=mode, priority=2, provider="vllm")
+    registry = {"group-a": [primary, incompatible, fallback]}
+    planner = _planner(state, registry, strategy=RoutingStrategy.PRIORITY_BASED)
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    routing_context = {ROUTING_MODE_CONTEXT_KEY: mode, "metadata": {}}
+    selected = await planner.select_deployment("group-a", routing_context)
+    assert selected is primary
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            raise TimeoutError(message="primary timed out")
+        return "ok"
+
+    data, served = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=run,
+        return_deployment=True,
+        routing_context=routing_context,
+    )
+
+    assert data == "ok"
+    assert served is fallback
+    assert attempts == ["dep-primary", "dep-fallback"]
+
+
+@pytest.mark.asyncio
+async def test_general_fallback_group_reuses_all_router_eligibility_checks():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary", tags=["vip"], priority=0)
+    wrong_tag = _deployment("dep-wrong-tag", tags=["standard"], priority=0)
+    unhealthy = _deployment("dep-unhealthy", tags=["vip"], priority=1)
+    cooled = _deployment("dep-cooled", tags=["vip"], priority=2)
+    at_capacity = _deployment(
+        "dep-at-capacity",
+        tags=["vip"],
+        priority=3,
+        rpm_limit=1,
+    )
+    eligible = _deployment("dep-eligible", tags=["vip"], priority=4)
+    registry = {
+        "group-a": [primary],
+        "fallback-group": [wrong_tag, unhealthy, cooled, at_capacity, eligible],
+    }
+    await state.set_health(unhealthy.deployment_id, False)
+    await state.set_cooldown(cooled.deployment_id, 30, "manual")
+    await state.increment_usage(at_capacity.deployment_id, 0)
+    planner = _planner(
+        state,
+        registry,
+        config=RouterConfig(
+            enable_pre_call_checks=True,
+            route_group_policies={
+                "fallback-group": RouteGroupPolicy(
+                    strategy=RoutingStrategy.PRIORITY_BASED,
+                )
+            },
+        ),
+    )
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=0,
+            timeout=1.0,
+            fallbacks={"group-a": ["fallback-group"]},
+        ),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    routing_context = {
+        ROUTING_MODE_CONTEXT_KEY: "chat",
+        "metadata": {"tags": ["vip"]},
+    }
+    selected = await planner.select_deployment("group-a", routing_context)
+    assert selected is primary
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            raise TimeoutError(message="primary timed out")
+        return "fallback-ok"
+
+    data, served = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=run,
+        return_deployment=True,
+        routing_context=routing_context,
+    )
+
+    assert data == "fallback-ok"
+    assert served is eligible
+    assert attempts == ["dep-primary", "dep-eligible"]
+
+
+@pytest.mark.asyncio
+async def test_classified_fallback_group_reuses_request_tags_and_policy_order():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary", tags=["vip"], priority=0)
+    wrong_tag = _deployment("dep-wrong-tag", tags=["standard"], priority=0)
+    eligible = _deployment("dep-eligible", tags=["vip"], priority=1)
+    registry = {
+        "group-a": [primary],
+        "context-group": [wrong_tag, eligible],
+    }
+    planner = _planner(state, registry, strategy=RoutingStrategy.PRIORITY_BASED)
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=0,
+            timeout=1.0,
+            context_window_fallbacks={"group-a": ["context-group"]},
+        ),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    routing_context = {
+        ROUTING_MODE_CONTEXT_KEY: "chat",
+        "metadata": {"tags": ["vip"]},
+    }
+    selected = await planner.select_deployment("group-a", routing_context)
+    assert selected is primary
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            raise InvalidRequestError(message="maximum context length reached")
+        return "fallback-ok"
+
+    data, served = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=run,
+        return_deployment=True,
+        routing_context=routing_context,
+    )
+
+    assert data == "fallback-ok"
+    assert served is eligible
+    assert attempts == ["dep-primary", "dep-eligible"]
+
+
+@pytest.mark.asyncio
+async def test_failover_consumes_cached_plan_without_per_candidate_state_reads():
+    class CountingState(RedisStateBackend):
+        def __init__(self) -> None:
+            super().__init__(redis=None)
+            self.health_batch_calls = 0
+            self.cooldown_batch_calls = 0
+            self.health_calls = 0
+            self.cooldown_calls = 0
+            self.attempt_acquisition_calls = 0
+            self.attempt_release_calls = 0
+
+        async def get_health_batch(self, deployment_ids):  # noqa: ANN001, ANN201
+            self.health_batch_calls += 1
+            return await super().get_health_batch(deployment_ids)
+
+        async def get_cooldown_batch(self, deployment_ids):  # noqa: ANN001, ANN201
+            self.cooldown_batch_calls += 1
+            return await super().get_cooldown_batch(deployment_ids)
+
+        async def get_health(self, deployment_id):  # noqa: ANN001, ANN201
+            self.health_calls += 1
+            return await super().get_health(deployment_id)
+
+        async def is_cooled_down(self, deployment_id):  # noqa: ANN001, ANN201
+            self.cooldown_calls += 1
+            return await super().is_cooled_down(deployment_id)
+
+        async def acquire_attempt(  # noqa: ANN001, ANN201
+            self, deployment_id, capacity, *, lease_ttl_seconds=630
+        ):
+            self.attempt_acquisition_calls += 1
+            return await super().acquire_attempt(
+                deployment_id,
+                capacity,
+                lease_ttl_seconds=lease_ttl_seconds,
+            )
+
+        async def release_attempt(self, permit):  # noqa: ANN001, ANN201
+            self.attempt_release_calls += 1
+            return await super().release_attempt(permit)
+
+    state = CountingState()
+    primary = _deployment("dep-primary", priority=0)
+    fallback = _deployment("dep-fallback", priority=1)
+    planner = _planner(
+        state,
+        {"group-a": [primary, fallback]},
+        strategy=RoutingStrategy.PRIORITY_BASED,
+    )
+    manager = FailoverManager(
+        config=FallbackConfig(),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    routing_context = {ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}}
+    selected = await planner.select_deployment("group-a", routing_context)
+    assert selected is primary
+
+    result = await manager.execute_with_failover(
+        primary_deployment=primary,
+        model_group="group-a",
+        execute=lambda deployment: asyncio.sleep(0, result=deployment.deployment_id),
+        routing_context=routing_context,
+    )
+
+    assert result == "dep-primary"
+    assert state.health_batch_calls == 1
+    assert state.cooldown_batch_calls == 1
+    assert state.health_calls == 0
+    assert state.cooldown_calls == 0
+    assert state.attempt_acquisition_calls == 1
+    assert state.attempt_release_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_primary_cooldown_is_revalidated_before_provider_attempt():
+    class CountingState(RedisStateBackend):
+        def __init__(self) -> None:
+            super().__init__(redis=None)
+            self.acquisitions: list[str] = []
+            self.releases: list[str] = []
+
+        async def acquire_attempt(  # noqa: ANN001, ANN201
+            self, deployment_id, capacity, *, lease_ttl_seconds=630
+        ):
+            self.acquisitions.append(deployment_id)
+            return await super().acquire_attempt(
+                deployment_id,
+                capacity,
+                lease_ttl_seconds=lease_ttl_seconds,
+            )
+
+        async def release_attempt(self, permit):  # noqa: ANN001, ANN201
+            self.releases.append(permit.deployment_id)
+            return await super().release_attempt(permit)
+
+    state = CountingState()
+    primary = _deployment("dep-primary", priority=0)
+    fallback = _deployment("dep-fallback", priority=1)
+    planner = _planner(
+        state,
+        {"group-a": [primary, fallback]},
+        strategy=RoutingStrategy.PRIORITY_BASED,
+    )
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    routing_context = {ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}}
+    selected = await planner.select_deployment("group-a", routing_context)
+    assert selected is primary
+    await state.set_cooldown(primary.deployment_id, 30, "changed-after-selection")
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        return "ok"
+
+    result, served = await manager.execute_with_failover(
+        primary,
+        "group-a",
+        run,
+        return_deployment=True,
+        routing_context=routing_context,
+    )
+
+    assert result == "ok"
+    assert served is fallback
+    assert attempts == ["dep-fallback"]
+    assert state.acquisitions == ["dep-primary", "dep-fallback"]
+    assert state.releases == ["dep-fallback"]
+
+
+@pytest.mark.parametrize("changed_state", ["cooldown", "unhealthy", "capacity"])
+@pytest.mark.asyncio
+async def test_stale_fallback_dynamic_eligibility_is_revalidated_before_attempt(
+    changed_state: str,
+):
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary", priority=0)
+    fallback = _deployment("dep-fallback", priority=1, rpm_limit=1)
+    planner = _planner(
+        state,
+        {"group-a": [primary, fallback]},
+        config=RouterConfig(enable_pre_call_checks=True),
+        strategy=RoutingStrategy.PRIORITY_BASED,
+    )
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=1.0),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    routing_context = {ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}}
+    selected = await planner.select_deployment("group-a", routing_context)
+    assert selected is primary
+    if changed_state == "cooldown":
+        await state.set_cooldown(fallback.deployment_id, 30, "changed-after-selection")
+    elif changed_state == "unhealthy":
+        await state.set_health(fallback.deployment_id, False)
+    else:
+        await state.increment_usage(fallback.deployment_id, 0)
+
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        raise TimeoutError(message="upstream timed out")
+
+    with pytest.raises(TimeoutError, match="upstream timed out"):
+        await manager.execute_with_failover(
+            primary,
+            "group-a",
+            run,
+            routing_context=routing_context,
+        )
+
+    assert attempts == ["dep-primary"]
+    assert await state.get_active_requests(primary.deployment_id) == 0
+    assert await state.get_active_requests(fallback.deployment_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_advances_after_failure_enters_cooldown():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary", priority=0)
+    fallback = _deployment("dep-fallback", priority=1)
+    planner = _planner(
+        state,
+        {"group-a": [primary, fallback]},
+        strategy=RoutingStrategy.PRIORITY_BASED,
+    )
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=1, retry_after=0, timeout=1.0),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            raise TimeoutError(message="primary timed out")
+        return "ok"
+
+    result, served = await manager.execute_with_failover(
+        primary,
+        "group-a",
+        run,
+        return_deployment=True,
+        routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+    )
+
+    assert result == "ok"
+    assert served is fallback
+    assert attempts == ["dep-primary", "dep-fallback"]
+    assert await state.is_cooled_down(primary.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_classified_fallback_excludes_deployments_already_visited_by_request():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary", priority=0)
+    fallback = _deployment("dep-fallback", priority=1)
+    planner = _planner(
+        state,
+        {
+            "group-a": [primary],
+            "context-group": [primary, fallback],
+        },
+        strategy=RoutingStrategy.PRIORITY_BASED,
+    )
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=0,
+            timeout=1.0,
+            context_window_fallbacks={"group-a": ["context-group"]},
+        ),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            raise InvalidRequestError(message="maximum context length reached")
+        return "ok"
+
+    result, served = await manager.execute_with_failover(
+        primary,
+        "group-a",
+        run,
+        return_deployment=True,
+        routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+    )
+
+    assert result == "ok"
+    assert served is fallback
+    assert attempts == ["dep-primary", "dep-fallback"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_attempt_releases_exactly_one_acquired_permit():
+    class CountingState(RedisStateBackend):
+        def __init__(self) -> None:
+            super().__init__(redis=None)
+            self.release_calls = 0
+
+        async def release_attempt(self, permit):  # noqa: ANN001, ANN201
+            self.release_calls += 1
+            return await super().release_attempt(permit)
+
+    state = CountingState()
+    primary = _deployment("dep-primary")
+    planner = _planner(state, {"group-a": [primary]})
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=0, timeout=10.0),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    started = asyncio.Event()
+    blocked = asyncio.Event()
+
+    async def run(_deployment: Deployment) -> str:
+        started.set()
+        await blocked.wait()
+        return "unreachable"
+
+    task = asyncio.create_task(
+        manager.execute_with_failover(
+            primary,
+            "group-a",
+            run,
+            routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+        )
+    )
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert state.release_calls == 1
+    assert await state.get_active_requests(primary.deployment_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_release_failure_does_not_replace_success_or_retry_provider():
+    class ReleaseFailingState(RedisStateBackend):
+        async def release_attempt(self, permit):  # noqa: ANN001, ANN201
+            await super().release_attempt(permit)
+            raise ServiceUnavailableError(message="Router state backend unavailable")
+
+    state = ReleaseFailingState(redis=None, degraded_mode="fail_open")
+    primary = _deployment("dep-primary")
+    planner = _planner(state, {"group-a": [primary]})
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=2, timeout=1.0),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts = 0
+
+    async def run(_deployment: Deployment) -> str:
+        nonlocal attempts
+        attempts += 1
+        return "ok"
+
+    result = await manager.execute_with_failover(
+        primary,
+        "group-a",
+        run,
+        routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+    )
+
+    assert result == "ok"
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_release_failure_does_not_replace_provider_error():
+    class ReleaseFailingState(RedisStateBackend):
+        async def release_attempt(self, permit):  # noqa: ANN001, ANN201
+            await super().release_attempt(permit)
+            raise ServiceUnavailableError(message="Router state backend unavailable")
+
+    state = ReleaseFailingState(redis=None, degraded_mode="fail_open")
+    primary = _deployment("dep-primary")
+    planner = _planner(state, {"group-a": [primary]})
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=2, timeout=1.0),
+        candidate_planner=planner,
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    provider_error = InvalidRequestError(message="provider rejected the request")
+    attempts = 0
+
+    async def run(_deployment: Deployment) -> str:
+        nonlocal attempts
+        attempts += 1
+        raise provider_error
+
+    with pytest.raises(InvalidRequestError) as exc_info:
+        await manager.execute_with_failover(
+            primary,
+            "group-a",
+            run,
+            routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+        )
+
+    assert exc_info.value is provider_error
+    assert attempts == 1
 
 
 @pytest.mark.asyncio
@@ -161,7 +810,10 @@ async def test_cooldown_manager_default_marks_unhealthy_on_third_failure():
     [
         (InvalidRequestError(message="bad input"), False),
         (ServiceUnavailableError(message="local service unavailable"), False),
-        (ServiceUnavailableError(message="provider unavailable", affects_deployment_health=True), True),
+        (
+            ServiceUnavailableError(message="provider unavailable", affects_deployment_health=True),
+            True,
+        ),
         (TimeoutError(message="timed out"), True),
         (
             httpx.HTTPStatusError(
@@ -225,7 +877,7 @@ async def test_failover_does_not_cool_down_on_invalid_request_error():
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -254,7 +906,7 @@ async def test_failover_invalid_request_stops_after_first_deployment():
     fallback = _deployment("dep-b")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary, fallback]},
+        candidate_planner=_planner(state, {"group-a": [primary, fallback]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -280,7 +932,7 @@ async def test_failover_http_429_maps_to_rate_limit_error():
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
@@ -309,7 +961,7 @@ async def test_failover_http_503_maps_to_health_affecting_service_unavailable_er
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
@@ -338,7 +990,7 @@ async def test_failover_transport_error_maps_to_health_affecting_service_unavail
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
@@ -364,7 +1016,7 @@ async def test_failover_returns_structured_no_healthy_deployments_error_when_all
     await state.set_cooldown(primary.deployment_id, 30, "manual")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
@@ -389,7 +1041,7 @@ async def test_failover_http_timeout_maps_to_timeout_error():
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
@@ -415,7 +1067,7 @@ async def test_failover_local_execution_error_does_not_affect_deployment_health_
     fallback = _deployment("dep-b")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary, fallback]},
+        candidate_planner=_planner(state, {"group-a": [primary, fallback]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -454,7 +1106,10 @@ async def test_failover_classified_fallback_local_error_does_not_cool_down_or_tr
             timeout=1.0,
             context_window_fallbacks={"group-a": ["ctx-fallbacks"]},
         ),
-        deployment_registry={"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        candidate_planner=_planner(
+            state,
+            {"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        ),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -491,7 +1146,10 @@ async def test_failover_classified_fallback_continues_after_upstream_service_una
             timeout=1.0,
             context_window_fallbacks={"group-a": ["ctx-fallbacks"]},
         ),
-        deployment_registry={"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        candidate_planner=_planner(
+            state,
+            {"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        ),
         state_backend=state,
         cooldown_manager=CooldownManager(state, allowed_fails=0),
     )
@@ -536,7 +1194,10 @@ async def test_failover_applies_timeout_resolver_to_classified_fallbacks():
             timeout=1.0,
             context_window_fallbacks={"group-a": ["ctx-fallbacks"]},
         ),
-        deployment_registry={"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        candidate_planner=_planner(
+            state,
+            {"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        ),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -575,12 +1236,14 @@ async def test_failover_applies_timeout_resolver_to_classified_fallbacks():
         (503, {}),
     ],
 )
-async def test_failover_retries_transient_raw_http_errors(status_code: int, headers: dict[str, str]):
+async def test_failover_retries_transient_raw_http_errors(
+    status_code: int, headers: dict[str, str]
+):
     state = RedisStateBackend(redis=None)
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -618,7 +1281,7 @@ async def test_failover_retries_raw_http_timeout_when_route_policy_targets_timeo
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -671,7 +1334,7 @@ async def test_failover_treats_pool_timeout_as_gateway_capacity_error():
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
@@ -779,7 +1442,11 @@ async def test_provider_health_check_supports_elevenlabs_with_default_base_url()
 
     result = await probe_provider_health(
         FakeHTTPClient(),  # type: ignore[arg-type]
-        {"provider": "elevenlabs", "model": "elevenlabs/eleven_multilingual_v2", "api_key": "provider-key"},
+        {
+            "provider": "elevenlabs",
+            "model": "elevenlabs/eleven_multilingual_v2",
+            "api_key": "provider-key",
+        },
         default_openai_base_url="https://api.openai.com/v1",
     )
 
@@ -866,14 +1533,16 @@ def test_failover_event_history_is_bounded_and_preserves_recent_order():
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(event_history_size=3),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
 
     manager._record_fallback_event("group-a", "dep-1", "dep-2", "retry", "timeout", "one", 1, False)
     manager._record_fallback_event("group-a", "dep-2", "dep-3", "retry", "timeout", "two", 2, False)
-    manager._record_fallback_event("group-a", "dep-3", "dep-4", "retry", "timeout", "three", 3, False)
+    manager._record_fallback_event(
+        "group-a", "dep-3", "dep-4", "retry", "timeout", "three", 3, False
+    )
     manager._record_fallback_event("group-a", "dep-4", "dep-5", "retry", "timeout", "four", 4, True)
 
     events = manager.get_recent_fallback_events(limit=10)
@@ -888,7 +1557,7 @@ def test_failover_event_history_limit_returns_tail_subset():
     primary = _deployment("dep-a")
     manager = FailoverManager(
         config=FallbackConfig(event_history_size=5),
-        deployment_registry={"group-a": [primary]},
+        candidate_planner=_planner(state, {"group-a": [primary]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )

--- a/tests/test_provider_resolution.py
+++ b/tests/test_provider_resolution.py
@@ -36,6 +36,10 @@ def test_elevenlabs_supports_audio_modes_only() -> None:
     assert provider_supports_mode("elevenlabs", "rerank") is False
 
 
+def test_vllm_rerank_capability_matches_supported_provider_endpoint() -> None:
+    assert provider_supports_mode("vllm", "rerank") is True
+
+
 def test_resolve_upstream_model_preserves_slash_prefixed_ids_for_groq() -> None:
     params = {"provider": "groq", "model": "openai/gpt-oss-120b"}
     assert resolve_upstream_model(params) == "openai/gpt-oss-120b"

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -154,6 +154,8 @@ async def test_audio_transcription_team_model_rpm_enforced_for_multipart_request
     record.rpm_limit = 50
     record.team_model_rpm_limit = {"gpt-4o-mini": 1}
     test_app.state.limit_counter = RecordingLimitCounter()
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.model_info["mode"] = "audio_transcription"
 
     async def stt_post(url: str, headers: dict[str, str], files, data, timeout: int):  # noqa: ANN001, ANN201
         del headers, files, data, timeout
@@ -180,35 +182,36 @@ async def test_audio_transcription_team_model_rpm_enforced_for_multipart_request
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "path",
+    ("path", "routing_mode"),
     [
-        "/v1/images/generations",
-        "/v1/rerank",
-        "/v1/audio/speech",
-        "/v1/audio/transcriptions",
+        ("/v1/images/generations", "image_generation"),
+        ("/v1/rerank", "rerank"),
+        ("/v1/audio/speech", "audio_speech"),
+        ("/v1/audio/transcriptions", "audio_transcription"),
     ],
 )
 async def test_multimodal_access_denial_does_not_consume_rate_quota(
     client,
     test_app,
     path: str,
+    routing_mode: str,
 ) -> None:
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
     record = next(iter(test_app.state._test_repo.records.values()))
     record.rpm_limit = 1
     test_app.state.http_client.post = _multimodal_success_response
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.model_info["mode"] = routing_mode
+    if routing_mode == "rerank":
+        deployment.deltallm_params["provider"] = "vllm"
 
     grant_service = test_app.state.callable_target_grant_service
     grant_repository = grant_service.repository
     removed_bindings = [
-        binding
-        for binding in grant_repository.bindings
-        if binding.callable_key == "gpt-4o-mini"
+        binding for binding in grant_repository.bindings if binding.callable_key == "gpt-4o-mini"
     ]
     grant_repository.bindings = [
-        binding
-        for binding in grant_repository.bindings
-        if binding.callable_key != "gpt-4o-mini"
+        binding for binding in grant_repository.bindings if binding.callable_key != "gpt-4o-mini"
     ]
     await grant_service.reload()
 

--- a/tests/test_route_decision_multimodal.py
+++ b/tests/test_route_decision_multimodal.py
@@ -12,7 +12,11 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
         if url.endswith("/images/generations"):
             return httpx.Response(
                 200,
-                json={"created": 1700000000, "data": [{"url": "https://example.com/image.png"}], "model": json["model"]},
+                json={
+                    "created": 1700000000,
+                    "data": [{"url": "https://example.com/image.png"}],
+                    "model": json["model"],
+                },
                 request=request,
             )
         if url.endswith("/audio/speech"):
@@ -29,7 +33,9 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
 
     test_app.state.http_client.post = post
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
 
+    deployment.model_info["mode"] = "image_generation"
     image_response = await client.post(
         "/v1/images/generations",
         headers=headers,
@@ -40,10 +46,13 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
     assert image_response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
     assert image_response.headers.get("x-deltallm-route-deployment")
     assert image_response.headers.get("x-deltallm-route-fallback-used") == "false"
-    image_usage = await test_app.state.router_state_backend.get_usage(image_response.headers["x-deltallm-route-deployment"])
+    image_usage = await test_app.state.router_state_backend.get_usage(
+        image_response.headers["x-deltallm-route-deployment"]
+    )
     assert image_usage == {"rpm": 1, "tpm": 0, "image_pm": 1}
     test_app.state.redis.store.clear()
 
+    deployment.model_info["mode"] = "audio_speech"
     speech_response = await client.post(
         "/v1/audio/speech",
         headers=headers,
@@ -54,12 +63,15 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
     assert speech_response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
     assert speech_response.headers.get("x-deltallm-route-deployment")
     assert speech_response.headers.get("x-deltallm-route-fallback-used") == "false"
-    speech_usage = await test_app.state.router_state_backend.get_usage(speech_response.headers["x-deltallm-route-deployment"])
+    speech_usage = await test_app.state.router_state_backend.get_usage(
+        speech_response.headers["x-deltallm-route-deployment"]
+    )
     assert speech_usage["rpm"] == 1
     assert speech_usage.get("tpm", 0) == 0
     assert speech_usage["char_pm"] > 0
     test_app.state.redis.store.clear()
 
+    deployment.model_info["mode"] = "audio_transcription"
     transcription_response = await client.post(
         "/v1/audio/transcriptions",
         headers=headers,
@@ -79,6 +91,8 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
     assert transcription_usage["audio_seconds_pm"] > 0
     test_app.state.redis.store.clear()
 
+    deployment.model_info["mode"] = "rerank"
+    deployment.deltallm_params["provider"] = "vllm"
     rerank_response = await client.post(
         "/v1/rerank",
         headers=headers,
@@ -89,15 +103,19 @@ async def test_multimodal_endpoints_emit_route_decision_headers(client, test_app
     assert rerank_response.headers.get("x-deltallm-route-strategy") == "simple-shuffle"
     assert rerank_response.headers.get("x-deltallm-route-deployment")
     assert rerank_response.headers.get("x-deltallm-route-fallback-used") == "false"
-    rerank_usage = await test_app.state.router_state_backend.get_usage(rerank_response.headers["x-deltallm-route-deployment"])
+    rerank_usage = await test_app.state.router_state_backend.get_usage(
+        rerank_response.headers["x-deltallm-route-deployment"]
+    )
     assert rerank_usage == {"rpm": 1, "tpm": 0, "rerank_units_pm": 2}
 
 
 @pytest.mark.asyncio
-async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatible_providers(client, test_app):
+async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatible_providers(
+    client, test_app
+):
     deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
-    deployment.deltallm_params["provider"] = "openrouter"
-    deployment.deltallm_params["api_base"] = "https://openrouter.example/api/v1"
+    deployment.deltallm_params["provider"] = "vllm"
+    deployment.deltallm_params["api_base"] = "https://vllm.example/api/v1"
     deployment.deltallm_params["api_key"] = "provider-key"
     deployment.deltallm_params["auth_header_name"] = "X-Provider-Auth"
     deployment.deltallm_params["auth_header_format"] = "Token {api_key}"
@@ -111,7 +129,11 @@ async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatibl
         if url.endswith("/images/generations"):
             return httpx.Response(
                 200,
-                json={"created": 1700000000, "data": [{"url": "https://example.com/image.png"}], "model": json["model"]},
+                json={
+                    "created": 1700000000,
+                    "data": [{"url": "https://example.com/image.png"}],
+                    "model": json["model"],
+                },
                 request=request,
             )
         if url.endswith("/audio/speech"):
@@ -129,6 +151,7 @@ async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatibl
     test_app.state.http_client.post = post
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
 
+    deployment.model_info["mode"] = "image_generation"
     image_response = await client.post(
         "/v1/images/generations",
         headers=headers,
@@ -137,6 +160,7 @@ async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatibl
     assert image_response.status_code == 200
     test_app.state.redis.store.clear()
 
+    deployment.model_info["mode"] = "audio_speech"
     speech_response = await client.post(
         "/v1/audio/speech",
         headers=headers,
@@ -145,6 +169,7 @@ async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatibl
     assert speech_response.status_code == 200
     test_app.state.redis.store.clear()
 
+    deployment.model_info["mode"] = "audio_transcription"
     transcription_response = await client.post(
         "/v1/audio/transcriptions",
         headers=headers,
@@ -154,6 +179,7 @@ async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatibl
     assert transcription_response.status_code == 200
     test_app.state.redis.store.clear()
 
+    deployment.model_info["mode"] = "rerank"
     rerank_response = await client.post(
         "/v1/rerank",
         headers=headers,
@@ -161,18 +187,18 @@ async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatibl
     )
     assert rerank_response.status_code == 200
 
-    assert captured["https://openrouter.example/api/v1/images/generations"] == {
+    assert captured["https://vllm.example/api/v1/images/generations"] == {
         "X-Provider-Auth": "Token provider-key",
         "Content-Type": "application/json",
     }
-    assert captured["https://openrouter.example/api/v1/audio/speech"] == {
+    assert captured["https://vllm.example/api/v1/audio/speech"] == {
         "X-Provider-Auth": "Token provider-key",
         "Content-Type": "application/json",
     }
-    assert captured["https://openrouter.example/api/v1/audio/transcriptions"] == {
+    assert captured["https://vllm.example/api/v1/audio/transcriptions"] == {
         "X-Provider-Auth": "Token provider-key",
     }
-    assert captured["https://openrouter.example/api/v1/rerank"] == {
+    assert captured["https://vllm.example/api/v1/rerank"] == {
         "X-Provider-Auth": "Token provider-key",
         "Content-Type": "application/json",
     }

--- a/tests/test_router_redis_integration.py
+++ b/tests/test_router_redis_integration.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from uuid import uuid4
+
+import pytest
+from redis.asyncio import Redis
+
+from src.router import (
+    AttemptCapacity,
+    AttemptCapacityLimit,
+    AttemptRejectionReason,
+    RedisStateBackend,
+    Router,
+    RouterConfig,
+    RoutingStrategy,
+)
+from src.router.candidates import ROUTING_MODE_CONTEXT_KEY
+from src.router.router import Deployment
+
+
+@pytest.mark.skipif(
+    not os.getenv("DELTALLM_TEST_REDIS_URL"),
+    reason="DELTALLM_TEST_REDIS_URL is required for the Redis integration test",
+)
+async def test_candidate_eligibility_uses_real_redis_batch_state_under_concurrency() -> None:
+    redis = Redis.from_url(
+        os.environ["DELTALLM_TEST_REDIS_URL"],
+        decode_responses=True,
+    )
+    unique = uuid4().hex
+
+    def deployment(
+        suffix: str,
+        *,
+        mode: str = "chat",
+        provider: str = "openai",
+        tags: list[str] | None = None,
+        rpm_limit: int | None = None,
+    ) -> Deployment:
+        return Deployment(
+            deployment_id=f"router-integration-{suffix}-{unique}",
+            model_name="integration-group",
+            deltallm_params={
+                "provider": provider,
+                "model": f"{provider}/integration-model",
+            },
+            model_info={"mode": mode},
+            tags=list(tags or []),
+            rpm_limit=rpm_limit,
+        )
+
+    unhealthy = deployment("unhealthy", tags=["vip"])
+    cooled = deployment("cooled", tags=["vip"])
+    at_capacity = deployment("at-capacity", tags=["vip"], rpm_limit=1)
+    wrong_tag = deployment("wrong-tag", tags=["standard"])
+    wrong_mode = deployment("wrong-mode", mode="embedding", tags=["vip"])
+    unsupported = deployment("unsupported", provider="elevenlabs", tags=["vip"])
+    eligible = deployment("eligible", tags=["vip"])
+    deployments = [
+        unhealthy,
+        cooled,
+        at_capacity,
+        wrong_tag,
+        wrong_mode,
+        unsupported,
+        eligible,
+    ]
+    state = RedisStateBackend(redis, degraded_mode="fail_closed")
+    router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=state,
+        config=RouterConfig(enable_pre_call_checks=True),
+        deployment_registry={"integration-group": deployments},
+    )
+
+    try:
+        await state.set_health(unhealthy.deployment_id, False)
+        await state.set_cooldown(cooled.deployment_id, 60, "integration")
+        await state.increment_usage(at_capacity.deployment_id, 0)
+        await state.record_latency(eligible.deployment_id, 12.5)
+
+        deployment_ids = [deployment.deployment_id for deployment in deployments]
+        usage, health, cooldowns, latency = await asyncio.gather(
+            state.get_usage_batch(deployment_ids),
+            state.get_health_batch(deployment_ids),
+            state.get_cooldown_batch(deployment_ids),
+            state.get_latency_windows_batch(deployment_ids, 300_000),
+        )
+
+        assert usage[at_capacity.deployment_id]["rpm"] == 1
+        assert health[unhealthy.deployment_id]["healthy"] == "false"
+        assert cooldowns[cooled.deployment_id] is True
+        assert len(latency[eligible.deployment_id]) == 1
+
+        contexts = [
+            {
+                ROUTING_MODE_CONTEXT_KEY: "chat",
+                "metadata": {"tags": ["vip"]},
+            }
+            for _ in range(16)
+        ]
+        plans = await asyncio.gather(
+            *(router.plan_deployments(["integration-group"], context) for context in contexts)
+        )
+
+        assert [
+            [deployment.deployment_id for deployment in plan["integration-group"].deployments]
+            for plan in plans
+        ] == [[eligible.deployment_id] for _ in contexts]
+        assert state.get_backend_status()["mode"] == "redis"
+    finally:
+        keys = [key async for key in redis.scan_iter(match=f"*{unique}*")]
+        if keys:
+            await redis.delete(*keys)
+        await redis.aclose()
+
+
+@pytest.mark.skipif(
+    not os.getenv("DELTALLM_TEST_REDIS_URL"),
+    reason="DELTALLM_TEST_REDIS_URL is required for the Redis integration test",
+)
+async def test_attempt_admission_is_atomic_and_recovers_with_real_redis() -> None:
+    redis = Redis.from_url(
+        os.environ["DELTALLM_TEST_REDIS_URL"],
+        decode_responses=True,
+    )
+    unique = uuid4().hex
+
+    class ToggleEvalOutageRedis:
+        def __init__(self, delegate: Redis) -> None:
+            self.delegate = delegate
+            self.fail_eval = False
+            self.fail_release = False
+
+        async def eval(self, script: str, numkeys: int, *args):  # noqa: ANN002, ANN201
+            if self.fail_eval or (self.fail_release and "router_attempt_release_v2" in script):
+                raise RuntimeError("simulated redis outage")
+            return await self.delegate.eval(script, numkeys, *args)
+
+        def __getattr__(self, name: str):  # noqa: ANN204
+            return getattr(self.delegate, name)
+
+    wrapper = ToggleEvalOutageRedis(redis)
+    state = RedisStateBackend(wrapper, degraded_mode="fail_open")
+    cooled_id = f"router-attempt-cooled-{unique}"
+    capacity_id = f"router-attempt-capacity-{unique}"
+    active_id = f"router-attempt-active-{unique}"
+    recovery_id = f"router-attempt-recovery-{unique}"
+    release_outage_id = f"router-attempt-release-outage-{unique}"
+
+    try:
+        await state.set_cooldown(cooled_id, 60, "integration")
+        cooled_permits = await asyncio.gather(
+            *(state.acquire_attempt(cooled_id, AttemptCapacity()) for _ in range(16))
+        )
+
+        assert all(not permit.acquired for permit in cooled_permits)
+        assert {permit.rejection_reason for permit in cooled_permits} == {
+            AttemptRejectionReason.COOLDOWN
+        }
+        assert await redis.get(f"active_requests:{cooled_id}") is None
+        assert 0 < await redis.ttl(f"cooldown:{cooled_id}") <= 60
+
+        await state.increment_usage(capacity_id, 0)
+        capacity_permit = await state.acquire_attempt(
+            capacity_id,
+            AttemptCapacity((AttemptCapacityLimit("rpm", 1),)),
+        )
+
+        assert capacity_permit.acquired is False
+        assert capacity_permit.rejection_reason == AttemptRejectionReason.CAPACITY
+        assert await redis.get(f"active_requests:{capacity_id}") is None
+
+        permits = await asyncio.gather(
+            *(state.acquire_attempt(active_id, AttemptCapacity()) for _ in range(16))
+        )
+
+        assert all(permit.acquired for permit in permits)
+        assert len({permit.owner_token for permit in permits}) == len(permits)
+        assert sorted(permit.active_requests for permit in permits) == list(range(1, 17))
+        assert int(await redis.get(f"active_requests:{active_id}") or 0) == 16
+        assert 0 < await redis.ttl(f"active_requests:{active_id}") <= 631
+        assert 0 < await redis.ttl(state._attempt_owners_key(active_id)) <= 631
+
+        await asyncio.gather(*(state.release_attempt(permit) for permit in permits))
+
+        assert int(await redis.get(f"active_requests:{active_id}") or 0) == 0
+
+        wrapper.fail_eval = True
+        local_permit = await state.acquire_attempt(recovery_id, AttemptCapacity())
+
+        assert local_permit.acquired is True
+        assert local_permit.backend == "local"
+        assert state.get_backend_status()["mode"] == "degraded"
+
+        wrapper.fail_eval = False
+        assert await state.release_attempt(local_permit) == 0
+        recovered_permit = await state.acquire_attempt(recovery_id, AttemptCapacity())
+
+        assert recovered_permit.acquired is True
+        assert recovered_permit.backend == "redis"
+        assert state.get_backend_status()["mode"] == "redis"
+        assert await state.release_attempt(recovered_permit) == 0
+
+        release_outage_permit = await state.acquire_attempt(
+            release_outage_id,
+            AttemptCapacity(),
+            lease_ttl_seconds=1,
+        )
+        wrapper.fail_release = True
+
+        assert await state.release_attempt(release_outage_permit) is None
+        assert int(await redis.get(f"active_requests:{release_outage_id}") or 0) == 1
+        assert 0 < await redis.ttl(f"active_requests:{release_outage_id}") <= 2
+        assert 0 < await redis.ttl(state._attempt_owners_key(release_outage_id)) <= 2
+
+        wrapper.fail_release = False
+        deadline = asyncio.get_running_loop().time() + 5
+        while await redis.exists(f"active_requests:{release_outage_id}"):
+            if asyncio.get_running_loop().time() >= deadline:
+                pytest.fail("attempt permit keys did not expire after release outage")
+            await asyncio.sleep(0.05)
+
+        recovered_after_release_outage = await state.acquire_attempt(
+            release_outage_id,
+            AttemptCapacity(),
+        )
+        assert recovered_after_release_outage.active_requests == 1
+        assert state.get_backend_status()["mode"] == "redis"
+        assert await state.release_attempt(recovered_after_release_outage) == 0
+    finally:
+        keys = [key async for key in redis.scan_iter(match=f"*{unique}*")]
+        if keys:
+            await redis.delete(*keys)
+        await redis.aclose()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 import pytest
 
-from src.models.errors import ModelNotFoundError, NO_HEALTHY_DEPLOYMENTS_CODE, ServiceUnavailableError
+from src.models.errors import (
+    ModelNotFoundError,
+    NO_HEALTHY_DEPLOYMENTS_CODE,
+    ServiceUnavailableError,
+)
 import src.router.strategies as strategies_module
 from src.router import (
+    AttemptCapacity,
+    AttemptCapacityLimit,
+    AttemptRejectionReason,
     HealthEndpointHandler,
     RedisStateBackend,
     Router,
@@ -14,6 +21,7 @@ from src.router import (
     build_route_group_policies,
 )
 from src.router.usage import normalize_router_usage
+from tests.conftest import FakeRedis
 
 
 @pytest.mark.asyncio
@@ -44,10 +52,13 @@ async def test_least_busy_strategy_selects_lowest_active_requests():
         deployment_registry=registry,
     )
 
-    await state.increment_active("dep-a")
-    selected = await router.select_deployment("gpt-4o-mini", {})
-    assert selected is not None
-    assert selected.deployment_id == "dep-b"
+    permit = await state.acquire_attempt("dep-a", AttemptCapacity())
+    try:
+        selected = await router.select_deployment("gpt-4o-mini", {})
+        assert selected is not None
+        assert selected.deployment_id == "dep-b"
+    finally:
+        await state.release_attempt(permit)
 
 
 @pytest.mark.asyncio
@@ -163,13 +174,21 @@ async def test_priority_based_strategy_applies_priority_filtering(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_latency_based_strategy_keeps_unsampled_members_eligible(monkeypatch):
-    monkeypatch.setattr(strategies_module.random, "uniform", lambda start, end: (start + end) * 0.75)
+    monkeypatch.setattr(
+        strategies_module.random, "uniform", lambda start, end: (start + end) * 0.75
+    )
     state = RedisStateBackend(redis=None)
     registry = build_deployment_registry(
         {
             "gpt-4o-mini": [
-                {"deployment_id": "dep-sampled", "deltallm_params": {"model": "openai/gpt-4o-mini"}},
-                {"deployment_id": "dep-unsampled", "deltallm_params": {"model": "openai/gpt-4o-mini"}},
+                {
+                    "deployment_id": "dep-sampled",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                },
+                {
+                    "deployment_id": "dep-unsampled",
+                    "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                },
             ]
         }
     )
@@ -265,13 +284,279 @@ async def test_cooldown_batch_uses_local_fallback_state():
     assert cooldowns == {"dep-a": True, "dep-b": False}
 
 
+@pytest.mark.asyncio
+async def test_redis_state_batch_reads_use_one_round_trip_per_metric(test_app, monkeypatch):
+    redis = test_app.state.redis
+    state = RedisStateBackend(redis)
+    await state.increment_usage("dep-a", 7)
+    await state.record_latency("dep-a", 12.5)
+    permit = await state.acquire_attempt("dep-a", AttemptCapacity())
+    await state.set_health("dep-a", False)
+
+    calls = {"eval": 0, "mget": 0, "pipeline": 0}
+    original_eval = redis.eval
+    original_mget = redis.mget
+    original_pipeline = redis.pipeline
+
+    async def counting_eval(script, numkeys, *args):  # noqa: ANN001, ANN202
+        calls["eval"] += 1
+        return await original_eval(script, numkeys, *args)
+
+    async def counting_mget(keys):  # noqa: ANN001, ANN202
+        calls["mget"] += 1
+        return await original_mget(keys)
+
+    def counting_pipeline():  # noqa: ANN202
+        calls["pipeline"] += 1
+        return original_pipeline()
+
+    monkeypatch.setattr(redis, "eval", counting_eval)
+    monkeypatch.setattr(redis, "mget", counting_mget)
+    monkeypatch.setattr(redis, "pipeline", counting_pipeline)
+
+    active = await state.get_active_requests_batch(["dep-a", "dep-b"])
+    usage = await state.get_usage_batch(["dep-a", "dep-b"])
+    health = await state.get_health_batch(["dep-a", "dep-b"])
+    latency = await state.get_latency_windows_batch(["dep-a", "dep-b"], 300_000)
+
+    assert calls == {"eval": 1, "mget": 1, "pipeline": 2}
+    assert active == {"dep-a": 1, "dep-b": 0}
+    assert usage["dep-a"] == {"rpm": 1, "tpm": 7}
+    assert usage["dep-b"] == {"rpm": 0, "tpm": 0}
+    assert health["dep-a"]["healthy"] == "false"
+    assert health["dep-b"] == {}
+    assert len(latency["dep-a"]) == 1
+    assert latency["dep-b"] == []
+    await state.release_attempt(permit)
+
+
+@pytest.mark.asyncio
+async def test_attempt_admission_uses_one_atomic_redis_call_and_owned_release():
+    class CountingRedis(FakeRedis):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attempt_eval_calls = 0
+
+        async def eval(self, script, numkeys, *args):  # noqa: ANN001, ANN201
+            if "router_attempt_admission_v2" in script:
+                self.attempt_eval_calls += 1
+            return await super().eval(script, numkeys, *args)
+
+    redis = CountingRedis()
+    state = RedisStateBackend(redis)
+    capacity = AttemptCapacity((AttemptCapacityLimit("rpm", 1),))
+
+    permit = await state.acquire_attempt("dep-a", capacity)
+
+    assert permit.acquired is True
+    assert permit.backend == "redis"
+    assert permit.owner_token
+    assert permit.expires_at_ms
+    assert permit.active_requests == 1
+    assert redis.attempt_eval_calls == 1
+    assert redis.ttl_store["active_requests:dep-a"] > 0
+    assert redis.ttl_store[state._attempt_owners_key("dep-a")] > 0
+    assert await state.get_active_requests("dep-a") == 1
+
+    released = await state.release_attempt(permit)
+
+    assert released == 0
+    assert await state.release_attempt(permit) == 0
+    assert await state.get_active_requests("dep-a") == 0
+
+
+@pytest.mark.parametrize(
+    ("state_change", "expected_reason"),
+    [
+        ("cooldown", AttemptRejectionReason.COOLDOWN),
+        ("unhealthy", AttemptRejectionReason.UNHEALTHY),
+        ("capacity", AttemptRejectionReason.CAPACITY),
+    ],
+)
+@pytest.mark.asyncio
+async def test_attempt_admission_rejects_dynamic_state_without_incrementing_active(
+    state_change: str,
+    expected_reason: AttemptRejectionReason,
+):
+    redis = FakeRedis()
+    state = RedisStateBackend(redis)
+    capacity = AttemptCapacity((AttemptCapacityLimit("rpm", 1),))
+    if state_change == "cooldown":
+        await state.set_cooldown("dep-a", 30, "manual")
+    elif state_change == "unhealthy":
+        await state.set_health("dep-a", False)
+    else:
+        await state.increment_usage("dep-a", 0)
+
+    permit = await state.acquire_attempt("dep-a", capacity)
+
+    assert permit.acquired is False
+    assert permit.rejection_reason == expected_reason
+    assert "active_requests:dep-a" not in redis.store
+    assert await state.release_attempt(permit) == 0
+    assert "active_requests:dep-a" not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_local_attempt_permit_releases_locally_after_redis_recovery():
+    class FailingOnceRedis(FakeRedis):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fail_next_attempt = True
+
+        async def eval(self, script, numkeys, *args):  # noqa: ANN001, ANN201
+            if "router_attempt_admission_v2" in script and self.fail_next_attempt:
+                self.fail_next_attempt = False
+                raise RuntimeError("redis unavailable")
+            return await super().eval(script, numkeys, *args)
+
+    redis = FailingOnceRedis()
+    state = RedisStateBackend(redis, degraded_mode="fail_open")
+
+    local_permit = await state.acquire_attempt("dep-a", AttemptCapacity())
+
+    assert local_permit.acquired is True
+    assert local_permit.backend == "local"
+    assert state.get_backend_status()["mode"] == "degraded"
+    assert await state.release_attempt(local_permit) == 0
+    assert "active_requests:dep-a" not in redis.store
+
+    redis_permit = await state.acquire_attempt("dep-a", AttemptCapacity())
+
+    assert redis_permit.acquired is True
+    assert redis_permit.backend == "redis"
+    assert state.get_backend_status()["mode"] == "redis"
+    assert await state.release_attempt(redis_permit) == 0
+
+
+@pytest.mark.asyncio
+async def test_attempt_release_is_owner_guarded_and_idempotent():
+    state = RedisStateBackend(FakeRedis())
+    first = await state.acquire_attempt("dep-a", AttemptCapacity())
+    second = await state.acquire_attempt("dep-a", AttemptCapacity())
+
+    assert first.owner_token != second.owner_token
+    assert await state.release_attempt(first) == 1
+    assert await state.release_attempt(first) == 1
+    assert await state.get_active_requests("dep-a") == 1
+    assert await state.release_attempt(second) == 0
+
+
+@pytest.mark.asyncio
+async def test_attempt_release_outage_recovers_from_expiring_owner_state():
+    class ReleaseOutageRedis(FakeRedis):
+        fail_release = False
+
+        async def eval(self, script, numkeys, *args):  # noqa: ANN001, ANN201
+            if self.fail_release and "router_attempt_release_v2" in script:
+                raise RuntimeError("redis unavailable during release")
+            return await super().eval(script, numkeys, *args)
+
+    redis = ReleaseOutageRedis()
+    state = RedisStateBackend(redis, degraded_mode="fail_open")
+    permit = await state.acquire_attempt(
+        "dep-a",
+        AttemptCapacity(),
+        lease_ttl_seconds=1,
+    )
+    redis.fail_release = True
+
+    assert await state.release_attempt(permit) is None
+    assert state.get_backend_status()["mode"] == "degraded"
+    assert redis.ttl_store["active_requests:dep-a"] > 0
+
+    redis.fail_release = False
+    owners_key = state._attempt_owners_key("dep-a")
+    redis.zset_store[owners_key] = [(0, str(permit.owner_token))]
+
+    assert await state.get_active_requests("dep-a") == 0
+    recovered = await state.acquire_attempt("dep-a", AttemptCapacity())
+    assert recovered.active_requests == 1
+    assert state.get_backend_status()["mode"] == "redis"
+    assert await state.release_attempt(recovered) == 0
+
+
+@pytest.mark.asyncio
+async def test_local_attempt_permit_expires_without_release(monkeypatch: pytest.MonkeyPatch):
+    now = {"value": 1_000.0}
+    monkeypatch.setattr("src.router.state.time.time", lambda: now["value"])
+    state = RedisStateBackend(redis=None, degraded_mode="fail_open")
+
+    permit = await state.acquire_attempt(
+        "dep-a",
+        AttemptCapacity(),
+        lease_ttl_seconds=1,
+    )
+    assert permit.active_requests == 1
+
+    now["value"] = 1_002.0
+    assert await state.get_active_requests("dep-a") == 0
+    assert "dep-a" not in state._active_permits
+
+
+@pytest.mark.parametrize(
+    ("mode", "counter", "limit_field"),
+    [
+        ("chat", "tpm", "tpm_limit"),
+        ("embedding", "tpm", "tpm_limit"),
+        ("image_generation", "image_pm", "image_pm_limit"),
+        ("audio_speech", "audio_seconds_pm", "audio_seconds_pm_limit"),
+        ("audio_transcription", "char_pm", "char_pm_limit"),
+        ("rerank", "rerank_units_pm", "rerank_units_pm_limit"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_attempt_capacity_revalidation_uses_workload_specific_counter(
+    mode: str,
+    counter: str,
+    limit_field: str,
+):
+    state = RedisStateBackend(FakeRedis())
+    registry = build_deployment_registry(
+        {
+            "model-group": [
+                {
+                    "deployment_id": "dep-a",
+                    "deltallm_params": {
+                        "provider": "vllm",
+                        "model": "vllm/test-model",
+                    },
+                    "model_info": {
+                        "mode": mode,
+                        limit_field: 1,
+                    },
+                }
+            ]
+        }
+    )
+    router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=state,
+        config=RouterConfig(enable_pre_call_checks=True),
+        deployment_registry=registry,
+    )
+    routing_context = {"routing_mode": mode, "metadata": {}}
+    selected = await router.select_deployment("model-group", routing_context)
+    assert selected is not None
+    await state.increment_usage_counters(selected.deployment_id, {counter: 1})
+
+    permit = await router.acquire_attempt(selected, routing_context)
+
+    assert permit.acquired is False
+    assert permit.rejection_reason == AttemptRejectionReason.CAPACITY
+
+
 def test_require_deployment_raises_service_unavailable_when_group_exists_but_none_healthy():
     router = Router(
         strategy=RoutingStrategy.SIMPLE_SHUFFLE,
         state_backend=RedisStateBackend(redis=None),
         config=RouterConfig(),
         deployment_registry=build_deployment_registry(
-            {"gpt-4o-mini": [{"deployment_id": "dep-a", "deltallm_params": {"model": "openai/gpt-4o-mini"}}]}
+            {
+                "gpt-4o-mini": [
+                    {"deployment_id": "dep-a", "deltallm_params": {"model": "openai/gpt-4o-mini"}}
+                ]
+            }
         ),
     )
 
@@ -306,12 +591,20 @@ async def test_usage_based_strategy_uses_image_limits_when_configured():
                 {
                     "deployment_id": "dep-hot",
                     "deltallm_params": {"model": "openai/image"},
-                    "model_info": {"mode": "image_generation", "rpm_limit": 10, "image_pm_limit": 10},
+                    "model_info": {
+                        "mode": "image_generation",
+                        "rpm_limit": 10,
+                        "image_pm_limit": 10,
+                    },
                 },
                 {
                     "deployment_id": "dep-cool",
                     "deltallm_params": {"model": "openai/image"},
-                    "model_info": {"mode": "image_generation", "rpm_limit": 10, "image_pm_limit": 10},
+                    "model_info": {
+                        "mode": "image_generation",
+                        "rpm_limit": 10,
+                        "image_pm_limit": 10,
+                    },
                 },
             ]
         }
@@ -375,12 +668,20 @@ async def test_rate_limit_aware_strategy_uses_audio_limits_when_configured():
                 {
                     "deployment_id": "dep-hot",
                     "deltallm_params": {"model": "openai/audio"},
-                    "model_info": {"mode": "audio_transcription", "rpm_limit": 10, "audio_seconds_pm_limit": 10},
+                    "model_info": {
+                        "mode": "audio_transcription",
+                        "rpm_limit": 10,
+                        "audio_seconds_pm_limit": 10,
+                    },
                 },
                 {
                     "deployment_id": "dep-cool",
                     "deltallm_params": {"model": "openai/audio"},
-                    "model_info": {"mode": "audio_transcription", "rpm_limit": 10, "audio_seconds_pm_limit": 10},
+                    "model_info": {
+                        "mode": "audio_transcription",
+                        "rpm_limit": 10,
+                        "audio_seconds_pm_limit": 10,
+                    },
                 },
             ]
         }
@@ -476,7 +777,9 @@ def test_normalize_router_usage_keeps_non_token_modes_out_of_tpm():
     )
     assert audio_usage == {"rpm": 1, "audio_seconds_pm": 2}
 
-    rerank_usage = normalize_router_usage(mode="rerank", usage={"rerank_units": 4, "prompt_tokens": 120})
+    rerank_usage = normalize_router_usage(
+        mode="rerank", usage={"rerank_units": 4, "prompt_tokens": 120}
+    )
     assert rerank_usage == {"rpm": 1, "rerank_units_pm": 4}
 
 
@@ -571,16 +874,22 @@ async def test_group_policy_overrides_global_strategy():
         deployment_registry=registry,
     )
 
-    await state.increment_active("dep-a")
-    await state.increment_active("dep-a")
+    permits = [
+        await state.acquire_attempt("dep-a", AttemptCapacity()),
+        await state.acquire_attempt("dep-a", AttemptCapacity()),
+    ]
 
-    selected_in_group = await router.select_deployment("support-route", {})
-    selected_legacy = await router.select_deployment("gpt-4o-mini", {})
+    try:
+        selected_in_group = await router.select_deployment("support-route", {})
+        selected_legacy = await router.select_deployment("gpt-4o-mini", {})
 
-    assert selected_in_group is not None
-    assert selected_in_group.deployment_id == "dep-b"
-    assert selected_legacy is not None
-    assert selected_legacy.deployment_id == "dep-a"
+        assert selected_in_group is not None
+        assert selected_in_group.deployment_id == "dep-b"
+        assert selected_legacy is not None
+        assert selected_legacy.deployment_id == "dep-a"
+    finally:
+        for permit in permits:
+            await state.release_attempt(permit)
 
 
 @pytest.mark.asyncio
@@ -666,7 +975,7 @@ async def test_router_exposes_failover_overrides_from_policy():
 async def test_router_state_fail_open_uses_bounded_local_fallback():
     state = RedisStateBackend(redis=None, degraded_mode="fail_open", max_local_latency_samples=2)
 
-    await state.increment_active("dep-a")
+    permit = await state.acquire_attempt("dep-a", AttemptCapacity())
     await state.record_latency("dep-a", 10.0)
     await state.record_latency("dep-a", 20.0)
     await state.record_latency("dep-a", 30.0)
@@ -675,6 +984,7 @@ async def test_router_state_fail_open_uses_bounded_local_fallback():
     latency_window = await state.get_latency_window("dep-a", 300_000)
     assert [lat for _, lat in latency_window] == [20.0, 30.0]
     assert state.get_backend_status()["mode"] == "degraded"
+    assert await state.release_attempt(permit) == 0
 
 
 @pytest.mark.asyncio
@@ -691,8 +1001,8 @@ async def test_router_state_fail_closed_raises_when_backend_unavailable():
 async def test_router_state_drops_zero_active_local_entries():
     state = RedisStateBackend(redis=None, degraded_mode="fail_open")
 
-    await state.increment_active("dep-a")
-    value = await state.decrement_active("dep-a")
+    permit = await state.acquire_attempt("dep-a", AttemptCapacity())
+    value = await state.release_attempt(permit)
 
     assert value == 0
     assert await state.get_active_requests("dep-a") == 0

--- a/tests/test_uniformity_hardening.py
+++ b/tests/test_uniformity_hardening.py
@@ -29,7 +29,9 @@ class _SpendRecorder:
         error_type = kwargs.get("error_type")
         if error_type is None:
             exc = kwargs.get("exc")
-            error_type = getattr(exc, "error_type", None) or (exc.__class__.__name__ if exc is not None else None)
+            error_type = getattr(exc, "error_type", None) or (
+                exc.__class__.__name__ if exc is not None else None
+            )
         self.events.append({"status": "error", "cost": 0.0, "error_type": error_type, **kwargs})
 
 
@@ -68,7 +70,10 @@ class _RecordingAuditService:
         ("/v1/embeddings", {"json": {"model": "text-embedding-3-small", "input": "hello"}}),
         ("/v1/images/generations", {"json": {"model": "gpt-4o-mini", "prompt": "cat"}}),
         ("/v1/rerank", {"json": {"model": "gpt-4o-mini", "query": "q", "documents": ["a", "b"]}}),
-        ("/v1/audio/speech", {"json": {"model": "gpt-4o-mini", "input": "hello", "voice": "alloy"}}),
+        (
+            "/v1/audio/speech",
+            {"json": {"model": "gpt-4o-mini", "input": "hello", "voice": "alloy"}},
+        ),
     ],
 )
 async def test_budget_enforced_for_non_text_endpoints(client, test_app, path, kwargs):
@@ -87,7 +92,9 @@ async def test_budget_enforced_for_audio_transcriptions(client, test_app):
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
     files = {"file": ("audio.wav", b"abc", "audio/wav")}
     data = {"model": "gpt-4o-mini", "response_format": "json"}
-    response = await client.post("/v1/audio/transcriptions", headers=headers, files=files, data=data)
+    response = await client.post(
+        "/v1/audio/transcriptions", headers=headers, files=files, data=data
+    )
     assert response.status_code == 429
     payload = response.json()["error"]
     assert payload["type"] == "budget_exceeded"
@@ -104,8 +111,12 @@ async def test_chat_fallback_uses_served_deployment_api_base_in_spend_log(client
     fallback = type(registry[0])(
         deployment_id="gpt-4o-mini-fallback",
         model_name="gpt-4o-mini",
-        deltallm_params={"model": "openai/gpt-4o-mini", "api_key": "fallback-key", "api_base": "https://fallback.example/v1"},
-        model_info={},
+        deltallm_params={
+            "model": "openai/gpt-4o-mini",
+            "api_key": "fallback-key",
+            "api_base": "https://fallback.example/v1",
+        },
+        model_info={"mode": "chat"},
     )
     registry.append(fallback)
 
@@ -117,15 +128,26 @@ async def test_chat_fallback_uses_served_deployment_api_base_in_spend_log(client
 
     async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
         del timeout
-        if url.endswith("/chat/completions") and headers.get("Authorization") == "Bearer primary-key":
-            return httpx.Response(503, json={"error": "primary down"}, request=httpx.Request("POST", url))
+        if (
+            url.endswith("/chat/completions")
+            and headers.get("Authorization") == "Bearer primary-key"
+        ):
+            return httpx.Response(
+                503, json={"error": "primary down"}, request=httpx.Request("POST", url)
+            )
         if url.endswith("/chat/completions"):
             payload = {
                 "id": "chatcmpl-fallback",
                 "object": "chat.completion",
                 "created": 1700000000,
                 "model": json["model"],
-                "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
             }
             return httpx.Response(200, json=payload)
@@ -134,7 +156,11 @@ async def test_chat_fallback_uses_served_deployment_api_base_in_spend_log(client
     test_app.state.http_client.post = post
 
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
-    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": False,
+    }
     response = await client.post("/v1/chat/completions", headers=headers, json=body)
     assert response.status_code == 200
 
@@ -150,7 +176,11 @@ async def test_chat_fallback_uses_served_deployment_api_base_in_spend_log(client
     [
         (
             "/v1/chat/completions",
-            {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False},
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": False,
+            },
             "gpt-4o-mini",
         ),
         (
@@ -160,7 +190,9 @@ async def test_chat_fallback_uses_served_deployment_api_base_in_spend_log(client
         ),
     ],
 )
-async def test_explicit_provider_keeps_spend_logging_intact(client, test_app, path, body, registry_key):
+async def test_explicit_provider_keeps_spend_logging_intact(
+    client, test_app, path, body, registry_key
+):
     test_app.state.spend_tracking_service = _SpendRecorder()
 
     deployment = test_app.state.router.deployment_registry[registry_key][0]
@@ -185,14 +217,23 @@ async def test_chat_failure_writes_error_request_log(client, test_app):
 
     async def failing_post(url, headers, json, timeout):  # noqa: ANN001, ANN201
         del headers, json, timeout
-        return httpx.Response(503, json={"error": "upstream unavailable"}, request=httpx.Request("POST", url))
+        return httpx.Response(
+            503, json={"error": "upstream unavailable"}, request=httpx.Request("POST", url)
+        )
 
     test_app.state.http_client.post = failing_post
 
     response = await client.post(
         "/v1/chat/completions",
-        headers={"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-chat-error"},
-        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False},
+        headers={
+            "Authorization": f"Bearer {test_app.state._test_key}",
+            "x-request-id": "req-chat-error",
+        },
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+        },
     )
     assert response.status_code == 503
 
@@ -212,13 +253,18 @@ async def test_embedding_failure_writes_error_request_log(client, test_app):
 
     async def failing_post(url, headers, json, timeout):  # noqa: ANN001, ANN201
         del headers, json, timeout
-        return httpx.Response(503, json={"error": "upstream unavailable"}, request=httpx.Request("POST", url))
+        return httpx.Response(
+            503, json={"error": "upstream unavailable"}, request=httpx.Request("POST", url)
+        )
 
     test_app.state.http_client.post = failing_post
 
     response = await client.post(
         "/v1/embeddings",
-        headers={"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-embedding-error"},
+        headers={
+            "Authorization": f"Bearer {test_app.state._test_key}",
+            "x-request-id": "req-embedding-error",
+        },
         json={"model": "text-embedding-3-small", "input": "hello"},
     )
     assert response.status_code == 503
@@ -250,7 +296,7 @@ async def test_embedding_failover_failure_uses_last_attempted_deployment_metadat
             "api_key": "fallback-key",
             "api_base": "https://fallback.example/v1",
         },
-        model_info={},
+        model_info={"mode": "embedding"},
     )
     registry.append(fallback)
 
@@ -271,7 +317,10 @@ async def test_embedding_failover_failure_uses_last_attempted_deployment_metadat
 
     response = await client.post(
         "/v1/embeddings",
-        headers={"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-embedding-failover-failure"},
+        headers={
+            "Authorization": f"Bearer {test_app.state._test_key}",
+            "x-request-id": "req-embedding-failover-failure",
+        },
         json={"model": "text-embedding-3-small", "input": "hello"},
     )
     assert response.status_code == 503
@@ -307,8 +356,15 @@ async def test_denied_model_preflight_writes_request_log_and_audit_event(client,
 
     response = await client.post(
         "/v1/chat/completions",
-        headers={"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-chat-denied"},
-        json={"model": "gpts-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False},
+        headers={
+            "Authorization": f"Bearer {test_app.state._test_key}",
+            "x-request-id": "req-chat-denied",
+        },
+        json={
+            "model": "gpts-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+        },
     )
     assert response.status_code == 403
     payload = response.json()["error"]
@@ -371,7 +427,10 @@ async def test_invalid_json_writes_request_log_without_audit_event(client, test_
 async def test_audio_transcription_spend_log_includes_billing_metadata(client, test_app):
     test_app.state.spend_tracking_service = _SpendRecorder()
     deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
-    deployment.model_info = {"input_cost_per_second": 0.25}
+    deployment.model_info = {
+        "mode": "audio_transcription",
+        "input_cost_per_second": 0.25,
+    }
 
     async def post(url, headers=None, json=None, timeout=None, files=None, data=None):  # noqa: ANN001, ANN201
         del headers, json, timeout, files, data
@@ -401,6 +460,7 @@ async def test_audio_transcription_spend_log_includes_billing_metadata(client, t
 @pytest.mark.asyncio
 async def test_audio_transcription_preserves_600_second_default_timeout(client, test_app):
     deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.model_info["mode"] = "audio_transcription"
     deployment.deltallm_params.pop("timeout", None)
     test_app.state.app_config.general_settings.upstream_http_read_timeout_seconds = 123
     captured: dict[str, object] = {}
@@ -431,8 +491,11 @@ async def test_audio_transcription_preserves_600_second_default_timeout(client, 
 
 
 @pytest.mark.asyncio
-async def test_audio_transcription_short_primary_timeout_uses_per_deployment_failover_timeout(client, test_app):
+async def test_audio_transcription_short_primary_timeout_uses_per_deployment_failover_timeout(
+    client, test_app
+):
     deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.model_info["mode"] = "audio_transcription"
     deployment.deltallm_params["timeout"] = 60
     fallback = Deployment(
         deployment_id="gpt-4o-mini-fallback",
@@ -442,6 +505,7 @@ async def test_audio_transcription_short_primary_timeout_uses_per_deployment_fai
             "api_key": "fallback-key",
             "api_base": "https://fallback.example/v1",
         },
+        model_info={"mode": "audio_transcription"},
     )
     test_app.state.router.deployment_registry["gpt-4o-mini"].append(fallback)
     captured: dict[str, object] = {}
@@ -478,10 +542,15 @@ async def test_audio_transcription_short_primary_timeout_uses_per_deployment_fai
 
 
 @pytest.mark.asyncio
-async def test_audio_transcription_route_policy_timeout_overrides_default_failover_timeout(client, test_app):
+async def test_audio_transcription_route_policy_timeout_overrides_default_failover_timeout(
+    client, test_app
+):
     deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.model_info["mode"] = "audio_transcription"
     deployment.deltallm_params.pop("timeout", None)
-    test_app.state.router.config.route_group_policies["gpt-4o-mini"] = RouteGroupPolicy(timeout_seconds=45)
+    test_app.state.router.config.route_group_policies["gpt-4o-mini"] = RouteGroupPolicy(
+        timeout_seconds=45
+    )
     captured: dict[str, object] = {}
 
     async def post(url, headers=None, json=None, timeout=None, files=None, data=None):  # noqa: ANN001, ANN201
@@ -508,10 +577,15 @@ async def test_audio_transcription_route_policy_timeout_overrides_default_failov
 
 
 @pytest.mark.asyncio
-async def test_audio_transcription_forces_verbose_json_for_second_pricing_and_preserves_json_shape(client, test_app):
+async def test_audio_transcription_forces_verbose_json_for_second_pricing_and_preserves_json_shape(
+    client, test_app
+):
     test_app.state.spend_tracking_service = _SpendRecorder()
     deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
-    deployment.model_info = {"input_cost_per_second": 0.111}
+    deployment.model_info = {
+        "mode": "audio_transcription",
+        "input_cost_per_second": 0.111,
+    }
     deployment.deltallm_params["provider"] = "groq"
     deployment.deltallm_params["api_base"] = "https://api.groq.com/openai/v1"
     captured_formats: list[str] = []
@@ -553,10 +627,15 @@ async def test_audio_transcription_forces_verbose_json_for_second_pricing_and_pr
 
 
 @pytest.mark.asyncio
-async def test_audio_speech_spend_log_marks_unpriced_without_matching_pricing_unit(client, test_app):
+async def test_audio_speech_spend_log_marks_unpriced_without_matching_pricing_unit(
+    client, test_app
+):
     test_app.state.spend_tracking_service = _SpendRecorder()
     deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
-    deployment.model_info = {"output_cost_per_second": 0.25}
+    deployment.model_info = {
+        "mode": "audio_speech",
+        "output_cost_per_second": 0.25,
+    }
 
     async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
         del headers, json, timeout
@@ -581,11 +660,14 @@ async def test_audio_speech_spend_log_marks_unpriced_without_matching_pricing_un
 
 
 @pytest.mark.asyncio
-async def test_audio_speech_forces_sse_for_token_pricing_and_preserves_audio_response(client, test_app):
+async def test_audio_speech_forces_sse_for_token_pricing_and_preserves_audio_response(
+    client, test_app
+):
     test_app.state.spend_tracking_service = _SpendRecorder()
     deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
     deployment.deltallm_params["provider"] = "openai"
     deployment.model_info = {
+        "mode": "audio_speech",
         "input_cost_per_token": 1.0,
         "output_cost_per_audio_token": 0.5,
     }
@@ -598,9 +680,9 @@ async def test_audio_speech_forces_sse_for_token_pricing_and_preserves_audio_res
             captured_stream_formats.append(json.get("stream_format"))
             body = (
                 "event: speech.audio.delta\n"
-                f"data: {{\"type\":\"speech.audio.delta\",\"audio\":\"{audio_chunk}\"}}\n\n"
+                f'data: {{"type":"speech.audio.delta","audio":"{audio_chunk}"}}\n\n'
                 "event: speech.audio.done\n"
-                "data: {\"type\":\"speech.audio.done\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4}}\n\n"
+                'data: {"type":"speech.audio.done","usage":{"input_tokens":10,"output_tokens":4}}\n\n'
                 "data: [DONE]\n\n"
             )
             return httpx.Response(
@@ -616,7 +698,12 @@ async def test_audio_speech_forces_sse_for_token_pricing_and_preserves_audio_res
     response = await client.post(
         "/v1/audio/speech",
         headers={"Authorization": f"Bearer {test_app.state._test_key}"},
-        json={"model": "gpt-4o-mini", "input": "hello world", "voice": "alloy", "response_format": "mp3"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "voice": "alloy",
+            "response_format": "mp3",
+        },
     )
     assert response.status_code == 200
     assert response.content == b"hello-audio"
@@ -632,7 +719,9 @@ async def test_audio_speech_forces_sse_for_token_pricing_and_preserves_audio_res
 
 
 @pytest.mark.asyncio
-async def test_audio_speech_uses_gemini_native_endpoint_and_bills_from_usage_metadata(client, test_app):
+async def test_audio_speech_uses_gemini_native_endpoint_and_bills_from_usage_metadata(
+    client, test_app
+):
     test_app.state.spend_tracking_service = _SpendRecorder()
     deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
     deployment.deltallm_params["provider"] = "gemini"
@@ -640,6 +729,7 @@ async def test_audio_speech_uses_gemini_native_endpoint_and_bills_from_usage_met
     deployment.deltallm_params["api_base"] = "https://generativelanguage.googleapis.com/v1beta"
     deployment.deltallm_params["api_key"] = "gemini-key"
     deployment.model_info = {
+        "mode": "audio_speech",
         "input_cost_per_token": 1.0,
         "output_cost_per_audio_token": 0.5,
     }
@@ -649,7 +739,12 @@ async def test_audio_speech_uses_gemini_native_endpoint_and_bills_from_usage_met
         del headers, timeout
         if url.endswith("/models/gemini-2.5-flash-preview-tts:generateContent?key=gemini-key"):
             assert json["generationConfig"]["responseModalities"] == ["AUDIO"]
-            assert json["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
+            assert (
+                json["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"][
+                    "voiceName"
+                ]
+                == "Kore"
+            )
             payload = {
                 "candidates": [
                     {
@@ -679,7 +774,12 @@ async def test_audio_speech_uses_gemini_native_endpoint_and_bills_from_usage_met
     response = await client.post(
         "/v1/audio/speech",
         headers={"Authorization": f"Bearer {test_app.state._test_key}"},
-        json={"model": "gpt-4o-mini", "input": "hello world", "voice": "Kore", "response_format": "wav"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "voice": "Kore",
+            "response_format": "wav",
+        },
     )
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("audio/wav")
@@ -701,13 +801,25 @@ async def test_audio_speech_applies_default_params_for_gemini_native_requests(cl
     deployment.deltallm_params["model"] = "gemini/gemini-2.5-flash-preview-tts"
     deployment.deltallm_params["api_base"] = "https://generativelanguage.googleapis.com/v1beta"
     deployment.deltallm_params["api_key"] = "gemini-key"
-    deployment.model_info = {"default_params": {"safetySettings": [{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}]}}
+    deployment.model_info = {
+        "mode": "audio_speech",
+        "default_params": {
+            "safetySettings": [
+                {
+                    "category": "HARM_CATEGORY_HATE_SPEECH",
+                    "threshold": "BLOCK_NONE",
+                }
+            ]
+        },
+    }
     pcm_chunk = base64.b64encode(b"\x00\x00\x01\x00").decode("ascii")
 
     async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
         del headers, timeout
         if url.endswith("/models/gemini-2.5-flash-preview-tts:generateContent?key=gemini-key"):
-            assert json["safetySettings"] == [{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}]
+            assert json["safetySettings"] == [
+                {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}
+            ]
             payload = {
                 "candidates": [
                     {
@@ -732,7 +844,12 @@ async def test_audio_speech_applies_default_params_for_gemini_native_requests(cl
     response = await client.post(
         "/v1/audio/speech",
         headers={"Authorization": f"Bearer {test_app.state._test_key}"},
-        json={"model": "gpt-4o-mini", "input": "hello world", "voice": "Kore", "response_format": "wav"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "voice": "Kore",
+            "response_format": "wav",
+        },
     )
     assert response.status_code == 200
     assert response.content.startswith(b"RIFF")
@@ -745,11 +862,17 @@ async def test_audio_speech_rejects_unsupported_gemini_output_formats(client, te
     deployment.deltallm_params["model"] = "gemini/gemini-2.5-flash-preview-tts"
     deployment.deltallm_params["api_base"] = "https://generativelanguage.googleapis.com/v1beta"
     deployment.deltallm_params["api_key"] = "gemini-key"
+    deployment.model_info["mode"] = "audio_speech"
 
     response = await client.post(
         "/v1/audio/speech",
         headers={"Authorization": f"Bearer {test_app.state._test_key}"},
-        json={"model": "gpt-4o-mini", "input": "hello world", "voice": "Kore", "response_format": "mp3"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "voice": "Kore",
+            "response_format": "mp3",
+        },
     )
     assert response.status_code == 400
     assert "supports only 'wav' and 'pcm'" in response.text


### PR DESCRIPTION
## Summary

- establish the router as the single owner of initial and fallback candidate planning
- apply health, cooldown, tag, workload-mode, provider-capability, and pre-call capacity eligibility before every provider attempt
- preserve per-group routing strategy order across retries, general fallbacks, and classified fallbacks
- replace anonymous active-request increments with expiring owner-scoped Redis attempt permits and guarded release
- batch shared routing-state reads and add deterministic coverage across chat, embeddings, image, audio, rerank, and batch workloads

## Why

Fallback chains were previously assembled directly from the raw deployment registry. That allowed deployments excluded during initial routing to re-enter through retries or fallback, bypassing health, cooldown, tag, workload, capability, and capacity checks.

This change gives candidate eligibility one owner and revalidates dynamic state atomically immediately before each attempt. It is the first gateway-stack slice tracked by #275.

## Impact

Initial selection and all fallback paths now use the same eligibility and ordering rules. Redis reads remain batched on the request path, and active-attempt ownership is bounded by an expiring token so release is idempotent and stale ownership recovers after interruption.

The branch is stacked on `feat/gateway-hot-path-performance`; that branch's bounded telemetry ingestion, immutable runtime-registry replacement, and health ownership are preserved.

## Invariants and failure behavior

- the router is the only candidate-planning owner
- static policy is rechecked before acquisition; health, cooldown, and configured capacity are checked atomically in Redis
- Redis degraded behavior follows the existing explicit fail-open/fail-closed router setting
- permits have unique owner tokens, bounded TTLs, and guarded release
- provider retry/failover remains bounded per the existing policy; total-deadline and stream-lifetime changes remain PR2 scope

## Validation

- `git diff --check origin/feat/gateway-hot-path-performance...HEAD`
- Ruff check passed for every changed Python file
- Ruff format check passed for every changed Python file (`32 files already formatted`)
- focused routing/config/batch integration suite: `284 passed, 2 skipped`
- the two skipped tests require `DELTALLM_TEST_REDIS_URL`; CI runs the new router Redis integration test against its Redis service

## Known review follow-ups before ready

- bound TTL-less legacy `active_requests:*` counters on read and rejected admission paths so rolling-upgrade state cannot remain permanent
- replace quadratic full-chain random/weighted ordering with bounded efficient ordering and add a regression benchmark or supported member limit

Part of #275.
