### PR TITLE
Enforce failover deadlines and streaming lifecycle ownership

### DIFF
--- a/docs/admin-ui/route-groups.md
+++ b/docs/admin-ui/route-groups.md
@@ -81,6 +81,10 @@ The supported policy fields today are:
 - `retry.max_attempts`
 - `retry.retryable_error_classes`
 
+`retry.max_attempts` is the maximum number of additional same-deployment retries for the
+whole routed request. The budget is shared across all primary and fallback candidates; it
+is not reset for each candidate. Candidate failover attempts remain separate from retries.
+
 ## Policy Modes
 
 The UI can present policy modes as shortcuts:

--- a/src/chat/executor.py
+++ b/src/chat/executor.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from time import perf_counter
 from typing import Any
 
+import asyncio
 import httpx
 from fastapi import Request
 
@@ -31,22 +32,24 @@ class OpenedStream:
     internal_stream_usage_requested: bool
     upstream_started: float
     _closed: bool = False
+    _close_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
 
     async def close(self, exc: BaseException | None = None) -> None:
-        if self._closed:
-            return
-        self._closed = True
-        if exc is None:
-            await self.context_manager.__aexit__(None, None, None)
-        else:
-            await self.context_manager.__aexit__(type(exc), exc, exc.__traceback__)
-        observe_request_phase(
-            route="chat_completions",
-            phase="upstream_stream",
-            outcome="error" if exc is not None else "success",
-            response_kind="stream",
-            latency_seconds=perf_counter() - self.upstream_started,
-        )
+        async with self._close_lock:
+            if self._closed:
+                return
+            if exc is None:
+                await self.context_manager.__aexit__(None, None, None)
+            else:
+                await self.context_manager.__aexit__(type(exc), exc, exc.__traceback__)
+            self._closed = True
+            observe_request_phase(
+                route="chat_completions",
+                phase="upstream_stream",
+                outcome="error" if exc is not None else "success",
+                response_kind="stream",
+                latency_seconds=perf_counter() - self.upstream_started,
+            )
 
 
 async def execute_chat(

--- a/src/chat/executor.py
+++ b/src/chat/executor.py
@@ -32,7 +32,7 @@ class OpenedStream:
     upstream_started: float
     _closed: bool = False
 
-    async def close(self, exc: Exception | None = None) -> None:
+    async def close(self, exc: BaseException | None = None) -> None:
         if self._closed:
             return
         self._closed = True
@@ -273,7 +273,7 @@ async def open_stream_with_first_chunk(
             internal_stream_usage_requested=internal_stream_usage_requested,
             upstream_started=upstream_started,
         )
-    except Exception as exc:
+    except BaseException as exc:
         observe_request_phase(
             route="chat_completions",
             phase="upstream_http",

--- a/src/chat/stream_response.py
+++ b/src/chat/stream_response.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import anyio
+from fastapi.responses import StreamingResponse
+
+from src.chat.executor import OpenedStream
+from src.router.execution import ManagedFailoverResult, RequestDeadline
+
+
+logger = logging.getLogger(__name__)
+
+# Cleanup has a separate, short grace period because the request deadline may
+# already be exhausted. Provider connections and distributed leases must not
+# remain owned indefinitely when their close path is unhealthy.
+STREAM_CLEANUP_TIMEOUT_SECONDS = 5.0
+
+
+class ManagedStreamLifecycle:
+    """Single idempotent owner for an opened upstream and its capacity permit."""
+
+    def __init__(
+        self,
+        opened_stream: OpenedStream,
+        managed_stream: ManagedFailoverResult[OpenedStream],
+    ) -> None:
+        self.opened_stream = opened_stream
+        self.managed_stream = managed_stream
+        self._closed = False
+        self._close_lock = anyio.Lock()
+
+    async def close(self, exc: BaseException | None = None) -> None:
+        async with self._close_lock:
+            if self._closed:
+                return
+            try:
+                await self.opened_stream.close(exc)
+            finally:
+                await self.managed_stream.release()
+            self._closed = True
+
+
+async def close_stream_resources(
+    close: Callable[[], Awaitable[None]],
+    *,
+    timeout_seconds: float = STREAM_CLEANUP_TIMEOUT_SECONDS,
+) -> bool:
+    """Run stream cleanup under cancellation shielding and a bounded grace period."""
+
+    with anyio.move_on_after(timeout_seconds, shield=True) as cleanup_scope:
+        await close()
+    if cleanup_scope.cancel_called:
+        logger.warning("stream resource cleanup timed out after %.1fs", timeout_seconds)
+        return False
+    return True
+
+
+class DeadlineStreamingResponse(StreamingResponse):
+    """Streaming response that owns the total send deadline and body cleanup."""
+
+    def __init__(
+        self,
+        content: Any,
+        *,
+        deadline: RequestDeadline,
+        close: Callable[[BaseException | None], Awaitable[None]],
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(content, **kwargs)
+        self._deadline = deadline
+        self._close = close
+
+    async def stream_response(self, send: Callable[..., Awaitable[None]]) -> None:
+        failure: BaseException | None = None
+        try:
+            await self._deadline.wait_for(super().stream_response(send))
+        except BaseException as exc:
+            failure = exc
+            raise
+        finally:
+            try:
+                await close_stream_resources(lambda: self._close(failure))
+            finally:
+                body_close = getattr(self.body_iterator, "aclose", None)
+                if body_close is not None:
+                    await close_stream_resources(body_close)

--- a/src/router/__init__.py
+++ b/src/router/__init__.py
@@ -9,6 +9,7 @@ from src.router.candidates import (
     RouteCandidatePlanner,
 )
 from src.router.failover import ErrorClassification, FallbackConfig, FailoverManager, RetryPolicy
+from src.router.execution import ManagedFailoverResult, RequestDeadline
 from src.router.health import (
     BackgroundHealthChecker,
     HealthCheckConfig,
@@ -40,8 +41,10 @@ __all__ = [
     "FailoverManager",
     "HealthCheckConfig",
     "HealthEndpointHandler",
+    "ManagedFailoverResult",
     "PassiveHealthTracker",
     "RedisStateBackend",
+    "RequestDeadline",
     "ROUTING_MODE_CONTEXT_KEY",
     "RouteCandidatePlan",
     "RouteCandidatePlanner",

--- a/src/router/execution.py
+++ b/src/router/execution.py
@@ -54,9 +54,11 @@ class ManagedFailoverResult(Generic[T]):
     deadline: RequestDeadline
     _release: Callable[[], Awaitable[None]] = field(repr=False)
     _released: bool = field(default=False, init=False, repr=False)
+    _release_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
 
     async def release(self) -> None:
-        if self._released:
-            return
-        self._released = True
-        await self._release()
+        async with self._release_lock:
+            if self._released:
+                return
+            await self._release()
+            self._released = True

--- a/src/router/execution.py
+++ b/src/router/execution.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Generic, TypeVar
+
+from src.models.errors import TimeoutError
+from src.router.router import Deployment
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class RequestDeadline:
+    """One monotonic budget shared by planning, retries, and provider work."""
+
+    expires_at: float
+
+    @classmethod
+    def after(cls, timeout_seconds: float) -> RequestDeadline:
+        return cls(asyncio.get_running_loop().time() + timeout_seconds)
+
+    def remaining(self) -> float:
+        return max(0.0, self.expires_at - asyncio.get_running_loop().time())
+
+    def require_remaining(self) -> float:
+        remaining = self.remaining()
+        if remaining <= 0:
+            raise TimeoutError(message="Request deadline exceeded")
+        return remaining
+
+    async def wait_for(self, awaitable: Awaitable[T], *, limit: float | None = None) -> T:
+        try:
+            remaining = self.require_remaining()
+        except BaseException:
+            if inspect.iscoroutine(awaitable):
+                awaitable.close()
+            raise
+        timeout = remaining if limit is None else min(remaining, limit)
+        try:
+            return await asyncio.wait_for(awaitable, timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(message="Request deadline exceeded") from exc
+
+
+@dataclass(slots=True)
+class ManagedFailoverResult(Generic[T]):
+    """A successful attempt whose capacity permit is owned by the caller."""
+
+    value: T
+    deployment: Deployment
+    deadline: RequestDeadline
+    _release: Callable[[], Awaitable[None]] = field(repr=False)
+    _released: bool = field(default=False, init=False, repr=False)
+
+    async def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        await self._release()

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -7,6 +7,7 @@ import random
 import time
 from collections import deque
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Any, Awaitable, Callable
 
 import httpx
@@ -21,8 +22,13 @@ from src.models.errors import (
     TimeoutError,
     parse_retry_after_header,
 )
-from src.router.candidates import DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS, RouteCandidatePlanner
+from src.router.candidates import (
+    AttemptPermit,
+    DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
+    RouteCandidatePlanner,
+)
 from src.router.cooldown import CooldownManager
+from src.router.execution import ManagedFailoverResult, RequestDeadline
 from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
 from src.router.state import DeploymentStateBackend
@@ -232,13 +238,19 @@ class FailoverManager:
                 error_msg[:200],
             )
 
-    def _compute_backoff(self, attempt: int) -> float:
+    def _compute_backoff(self, attempt: int, error: Exception | None = None) -> float:
         base = self.config.retry_after or 1.0
         delay = base * (self.config.backoff_multiplier**attempt)
         delay = min(delay, self.config.backoff_max)
         if self.config.backoff_jitter:
             delay = delay * (0.5 + random.random() * 0.5)
-        return delay
+        retry_after = getattr(error, "retry_after", None)
+        if retry_after is not None:
+            try:
+                delay = max(delay, max(0.0, float(retry_after)))
+            except (TypeError, ValueError):
+                pass
+        return min(delay, self.config.backoff_max)
 
     @staticmethod
     def _notify_attempt(
@@ -347,13 +359,17 @@ class FailoverManager:
         retry_max_attempts: int | None = None,
         retryable_error_classes: list[str] | set[str] | None = None,
         routing_context: dict[str, Any] | None = None,
+        _manage_attempt_lifecycle: bool = False,
     ) -> Any:
         routing_context = routing_context if routing_context is not None else {}
-        chain = await self._build_fallback_chain(
-            primary_deployment,
-            model_group,
-            request_tokens,
-            routing_context,
+        deadline = RequestDeadline.after(self._effective_timeout(timeout_seconds))
+        chain = await deadline.wait_for(
+            self._build_fallback_chain(
+                primary_deployment,
+                model_group,
+                request_tokens,
+                routing_context,
+            )
         )
         effective_retries = self._effective_retry_count(retry_max_attempts)
         effective_retry_classes = self._normalize_retryable_error_classes(retryable_error_classes)
@@ -361,19 +377,22 @@ class FailoverManager:
         previous_deployment_id = primary_deployment.deployment_id
         visited_ids: set[str] = set()
         attempted_ids: set[str] = set()
+        retries_used = 0
 
         for chain_index, deployment in enumerate(chain):
             if deployment.deployment_id in visited_ids:
                 continue
             visited_ids.add(deployment.deployment_id)
             deployment_was_attempted = False
-            for attempt in range(effective_retries + 1):
+            attempt = 0
+            while True:
                 try:
-                    attempted, result = await self._execute_attempt(
+                    attempted, result, permit = await self._execute_attempt(
                         deployment,
                         execute,
                         routing_context,
                         attempted_ids,
+                        deadline,
                         on_attempt=on_attempt,
                         timeout_seconds=timeout_seconds,
                         timeout_for_deployment=timeout_for_deployment,
@@ -381,22 +400,36 @@ class FailoverManager:
                     if not attempted:
                         break
                     deployment_was_attempted = True
+                    try:
+                        if chain_index > 0:
+                            self._record_fallback_event(
+                                model_group=model_group,
+                                from_id=previous_deployment_id,
+                                to_id=deployment.deployment_id,
+                                reason="primary_failed",
+                                classification="success",
+                                error_msg="",
+                                attempt=attempt,
+                                success=True,
+                            )
 
-                    if chain_index > 0:
-                        self._record_fallback_event(
-                            model_group=model_group,
-                            from_id=previous_deployment_id,
-                            to_id=deployment.deployment_id,
-                            reason="primary_failed",
-                            classification="success",
-                            error_msg="",
-                            attempt=attempt,
-                            success=True,
-                        )
-
-                    if return_deployment:
-                        return result, deployment
-                    return result
+                        if _manage_attempt_lifecycle:
+                            managed = ManagedFailoverResult(
+                                value=result,
+                                deployment=deployment,
+                                deadline=deadline,
+                                _release=partial(self._release_attempt, permit, deployment),
+                            )
+                            permit = None
+                            return managed
+                        await self._release_attempt(permit, deployment)
+                        permit = None
+                        if return_deployment:
+                            return result, deployment
+                        return result
+                    finally:
+                        if permit is not None:
+                            await self._release_attempt(permit, deployment)
                 except Exception as exc:
                     deployment_was_attempted = deployment.deployment_id in attempted_ids
                     last_error, classification, allow_classified_fallbacks = (
@@ -429,11 +462,13 @@ class FailoverManager:
                     )
 
                     if allow_classified_fallbacks:
-                        extra_chain = await self._get_classified_fallbacks(
-                            classification,
-                            model_group,
-                            routing_context,
-                            excluded_ids=visited_ids | attempted_ids,
+                        extra_chain = await deadline.wait_for(
+                            self._get_classified_fallbacks(
+                                classification,
+                                model_group,
+                                routing_context,
+                                excluded_ids=visited_ids | attempted_ids,
+                            )
                         )
                         if extra_chain:
                             extra_result = await self._try_classified_fallbacks(
@@ -445,15 +480,26 @@ class FailoverManager:
                                 routing_context,
                                 visited_ids,
                                 attempted_ids,
+                                deadline,
                                 on_attempt=on_attempt,
                                 timeout_seconds=timeout_seconds,
                                 timeout_for_deployment=timeout_for_deployment,
                             )
                             if extra_result is not None:
+                                result, served, permit = extra_result
+                                if _manage_attempt_lifecycle:
+                                    managed = ManagedFailoverResult(
+                                        value=result,
+                                        deployment=served,
+                                        deadline=deadline,
+                                        _release=partial(self._release_attempt, permit, served),
+                                    )
+                                    permit = None
+                                    return managed
+                                await self._release_attempt(permit, served)
                                 if return_deployment:
-                                    result, served = extra_result
                                     return result, served
-                                return extra_result[0]
+                                return result
 
                     if not affects_deployment_health(last_error):
                         if last_error is exc:
@@ -467,9 +513,12 @@ class FailoverManager:
                             last_error,
                             effective_retry_classes,
                         )
-                        and attempt < effective_retries
+                        and retries_used < effective_retries
                     ):
-                        await asyncio.sleep(self._compute_backoff(attempt))
+                        delay = self._compute_backoff(retries_used, last_error)
+                        retries_used += 1
+                        await deadline.wait_for(asyncio.sleep(delay))
+                        attempt += 1
                         continue
                     break
 
@@ -483,6 +532,34 @@ class FailoverManager:
         raise ServiceUnavailableError(
             message="No healthy deployments available",
             code=NO_HEALTHY_DEPLOYMENTS_CODE,
+        )
+
+    async def execute_managed_with_failover(
+        self,
+        primary_deployment: Deployment,
+        model_group: str,
+        execute: Callable[[Deployment], Awaitable[Any]],
+        request_tokens: int = 0,
+        *,
+        on_attempt: Callable[[Deployment], None] | None = None,
+        timeout_seconds: float | None = None,
+        timeout_for_deployment: TimeoutForDeployment | None = None,
+        retry_max_attempts: int | None = None,
+        retryable_error_classes: list[str] | set[str] | None = None,
+        routing_context: dict[str, Any] | None = None,
+    ) -> ManagedFailoverResult[Any]:
+        return await self.execute_with_failover(
+            primary_deployment=primary_deployment,
+            model_group=model_group,
+            execute=execute,
+            request_tokens=request_tokens,
+            on_attempt=on_attempt,
+            timeout_seconds=timeout_seconds,
+            timeout_for_deployment=timeout_for_deployment,
+            retry_max_attempts=retry_max_attempts,
+            retryable_error_classes=retryable_error_classes,
+            routing_context=routing_context,
+            _manage_attempt_lifecycle=True,
         )
 
     async def _get_classified_fallbacks(
@@ -530,21 +607,23 @@ class FailoverManager:
         routing_context: dict[str, Any],
         visited_ids: set[str],
         attempted_ids: set[str],
+        deadline: RequestDeadline,
         *,
         on_attempt: Callable[[Deployment], None] | None = None,
         timeout_seconds: float | None,
         timeout_for_deployment: TimeoutForDeployment | None = None,
-    ) -> tuple[Any, Deployment] | None:
+    ) -> tuple[Any, Deployment, AttemptPermit] | None:
         for deployment in chain:
             if deployment.deployment_id in visited_ids:
                 continue
             visited_ids.add(deployment.deployment_id)
             try:
-                attempted, result = await self._execute_attempt(
+                attempted, result, permit = await self._execute_attempt(
                     deployment,
                     execute,
                     routing_context,
                     attempted_ids,
+                    deadline,
                     on_attempt=on_attempt,
                     timeout_seconds=timeout_seconds,
                     timeout_for_deployment=timeout_for_deployment,
@@ -562,7 +641,7 @@ class FailoverManager:
                     success=True,
                 )
 
-                return result, deployment
+                return result, deployment, permit
             except Exception as exc:
                 normalized_error, failure_classification, allow_classified_fallbacks = (
                     self._normalize_execution_error(
@@ -606,48 +685,57 @@ class FailoverManager:
         execute: Callable[[Deployment], Awaitable[Any]],
         routing_context: dict[str, Any],
         attempted_ids: set[str],
+        deadline: RequestDeadline,
         *,
         on_attempt: Callable[[Deployment], None] | None,
         timeout_seconds: float | None,
         timeout_for_deployment: TimeoutForDeployment | None,
-    ) -> tuple[bool, Any]:
+    ) -> tuple[bool, Any, AttemptPermit | None]:
         attempt_timeout = self._effective_attempt_timeout(
             deployment,
             timeout_seconds,
             timeout_for_deployment,
         )
-        permit = await self.candidate_planner.acquire_attempt(
-            deployment,
-            routing_context,
-            lease_ttl_seconds=self._attempt_permit_ttl_seconds(attempt_timeout),
+        attempt_timeout = min(attempt_timeout, deadline.require_remaining())
+        permit = await deadline.wait_for(
+            self.candidate_planner.acquire_attempt(
+                deployment,
+                routing_context,
+                lease_ttl_seconds=self._attempt_permit_ttl_seconds(attempt_timeout),
+            )
         )
         if not permit.acquired:
-            return False, None
+            return False, None, None
 
         attempted_ids.add(deployment.deployment_id)
         try:
             self._notify_attempt(on_attempt, deployment)
             started = time.monotonic()
-            result = await asyncio.wait_for(
-                execute(deployment),
-                timeout=attempt_timeout,
-            )
+            result = await deadline.wait_for(execute(deployment), limit=attempt_timeout)
             latency_ms = (time.monotonic() - started) * 1000
             await self.state.record_latency(deployment.deployment_id, latency_ms)
             await self.cooldown.record_success(deployment.deployment_id)
-            return True, result
-        finally:
-            try:
-                await self.candidate_planner.release_attempt(permit)
-            except Exception:
-                # Cleanup failure is local routing-state degradation. The expiring,
-                # owner-scoped permit bounds the stale count, and a provider result or
-                # provider error must never be replaced or retried because release failed.
-                logger.warning(
-                    "router attempt permit release failed deployment_id=%s",
-                    deployment.deployment_id,
-                    exc_info=True,
-                )
+            return True, result, permit
+        except BaseException:
+            await self._release_attempt(permit, deployment)
+            raise
+
+    async def _release_attempt(
+        self,
+        permit: AttemptPermit,
+        deployment: Deployment,
+    ) -> None:
+        try:
+            await self.candidate_planner.release_attempt(permit)
+        except Exception:
+            # Cleanup failure is local routing-state degradation. The expiring,
+            # owner-scoped permit bounds the stale count, and a provider result or
+            # provider error must never be replaced or retried because release failed.
+            logger.warning(
+                "router attempt permit release failed deployment_id=%s",
+                deployment.deployment_id,
+                exc_info=True,
+            )
 
     @staticmethod
     def _attempt_permit_ttl_seconds(attempt_timeout: float) -> int:

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 
 import httpx
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse
 
 from src.cache.pricing import cache_pricing_snapshot_from_deployment
 from src.cache.streaming import StreamWriteContext
@@ -22,6 +22,11 @@ from src.chat import (
     run_text_preflight,
 )
 from src.chat.stream_usage import StreamUsageTracker
+from src.chat.stream_response import (
+    DeadlineStreamingResponse,
+    ManagedStreamLifecycle,
+    close_stream_resources,
+)
 from src.middleware.auth import require_api_key
 from src.mcp.orchestrator import MCPChatOrchestrator, chat_request_has_mcp_tools
 from src.models.errors import InvalidRequestError, ServiceUnavailableError
@@ -118,12 +123,17 @@ async def handle_chat_like_request(
                 **failover_kwargs,
             )
             opened_stream = managed_stream.value
+            stream_lifecycle = ManagedStreamLifecycle(opened_stream, managed_stream)
             served_deployment = managed_stream.deployment
-            update_served_route_decision(
-                request,
-                primary_deployment_id=primary.deployment_id,
-                served_deployment_id=served_deployment.deployment_id,
-            )
+            try:
+                update_served_route_decision(
+                    request,
+                    primary_deployment_id=primary.deployment_id,
+                    served_deployment_id=served_deployment.deployment_id,
+                )
+            except BaseException as exc:
+                await close_stream_resources(lambda failure=exc: stream_lifecycle.close(failure))
+                raise
 
             async def stream_sse():
                 cache_context = getattr(request.state, "cache_context", None)
@@ -132,10 +142,10 @@ async def handle_chat_like_request(
                 stream_write_context: StreamWriteContext | None = None
                 stream_usage = StreamUsageTracker()
                 failure_exc: BaseException | None = None
+                stream_error: Exception | None = None
                 stream_cache_complete = False
+                resolved_usage = None
                 try:
-                    params = opened_stream.params
-                    api_base_local = opened_stream.api_base
                     if (
                         enable_stream_cache
                         and request.url.path == "/v1/chat/completions"
@@ -170,102 +180,65 @@ async def handle_chat_like_request(
                         )
                         stream_handler.start_stream(stream_id)
 
-                    async with asyncio.timeout(managed_stream.deadline.require_remaining()):
-                        initial = opened_stream.first_line
-                        if initial:
-                            line_info = stream_usage.add_line(initial)
-                            if stream_id is not None and stream_handler is not None:
-                                stream_handler.add_chunk_from_line(stream_id, initial)
-                            if not (
-                                line_info.is_usage_only_chunk
-                                and not opened_stream.client_stream_usage_requested
-                            ):
-                                out_line = (
-                                    stream_line_transform(initial)
-                                    if stream_line_transform is not None
-                                    else initial
-                                )
-                                if out_line is not None:
-                                    yield f"{out_line}\n\n"
-                        async for line in opened_stream.translated_stream:
-                            if not line:
-                                continue
-
-                            line_info = stream_usage.add_line(line)
-                            if stream_id is not None and stream_handler is not None:
-                                stream_handler.add_chunk_from_line(stream_id, line)
-                                if line.strip() == "data: [DONE]":
-                                    stream_cache_complete = True
-
-                            if (
-                                line_info.is_usage_only_chunk
-                                and not opened_stream.client_stream_usage_requested
-                            ):
-                                continue
-
+                    initial = opened_stream.first_line
+                    if initial:
+                        line_info = stream_usage.add_line(initial)
+                        if stream_id is not None and stream_handler is not None:
+                            stream_handler.add_chunk_from_line(stream_id, initial)
+                        if not (
+                            line_info.is_usage_only_chunk
+                            and not opened_stream.client_stream_usage_requested
+                        ):
                             out_line = (
-                                stream_line_transform(line)
+                                stream_line_transform(initial)
                                 if stream_line_transform is not None
-                                else line
+                                else initial
                             )
-                            if out_line is None:
-                                continue
-                            yield f"{out_line}\n\n"
+                            if out_line is not None:
+                                yield f"{out_line}\n\n"
+                    async for line in opened_stream.translated_stream:
+                        if not line:
+                            continue
+
+                        line_info = stream_usage.add_line(line)
+                        if stream_id is not None and stream_handler is not None:
+                            stream_handler.add_chunk_from_line(stream_id, line)
+                            if line.strip() == "data: [DONE]":
+                                stream_cache_complete = True
+
+                        if (
+                            line_info.is_usage_only_chunk
+                            and not opened_stream.client_stream_usage_requested
+                        ):
+                            continue
+
+                        out_line = (
+                            stream_line_transform(line)
+                            if stream_line_transform is not None
+                            else line
+                        )
+                        if out_line is None:
+                            continue
+                        yield f"{out_line}\n\n"
                     resolved_usage = stream_usage.resolve(payload)
-                    if (
-                        stream_id is not None
-                        and stream_handler is not None
-                        and stream_write_context is not None
-                    ):
-                        if stream_cache_complete:
-                            await stream_handler.finalize_and_store(
-                                stream_id,
-                                stream_write_context,
-                                usage=resolved_usage.usage,
-                            )
-                        else:
-                            stream_handler.discard_stream(stream_id)
-                    await record_router_usage(
-                        request.app.state.router_state_backend,
-                        served_deployment.deployment_id,
-                        mode="chat",
-                        usage=resolved_usage.usage,
-                    )
-                    await emit_stream_success(
-                        request=request,
-                        auth=auth,
-                        payload=payload,
-                        request_data=request_data,
-                        callback_manager=callback_manager,
-                        guardrail_middleware=guardrail_middleware,
-                        callback_start=callback_start,
-                        request_start=request_start,
-                        request_id=request_id,
-                        stream_response_object=stream_response_object,
-                        cache_hit=cache_hit,
-                        cache_key=cache_key,
-                        audit_action=audit_action,
-                        served_deployment=served_deployment,
-                        api_base=api_base_local,
-                        params=params,
-                        usage=resolved_usage.usage,
-                        usage_metadata=resolved_usage.metadata(),
-                    )
                 except asyncio.CancelledError as exc:
                     failure_exc = exc
                     raise
                 except Exception as exc:
                     failure_exc = exc
-                    if stream_id is not None and stream_handler is not None:
+                    stream_error = exc
+                finally:
+                    if (
+                        stream_id is not None
+                        and stream_handler is not None
+                        and (failure_exc is not None or not stream_cache_complete)
+                    ):
                         stream_handler.discard_stream(stream_id)
-                    failure_params = (
-                        opened_stream.params
-                        if opened_stream is not None
-                        else primary.deltallm_params
-                    )
-                    failure_api_base = (
-                        opened_stream.api_base if opened_stream is not None else api_base
-                    )
+                    await close_stream_resources(lambda: stream_lifecycle.close(failure_exc))
+
+                if stream_error is not None:
+                    failure_params = opened_stream.params
+                    failure_api_base = opened_stream.api_base
                     await emit_stream_failure(
                         request=request,
                         auth=auth,
@@ -282,25 +255,69 @@ async def handle_chat_like_request(
                         primary_deployment=primary,
                         api_base=failure_api_base,
                         params=failure_params,
-                        exc=exc,
+                        exc=stream_error,
                     )
-                    raise
-                finally:
-                    try:
-                        await opened_stream.close(failure_exc)
-                    finally:
-                        await managed_stream.release()
+                    raise stream_error
 
-            return StreamingResponse(
-                stream_sse(),
-                media_type="text/event-stream",
-                headers={
-                    "Cache-Control": "no-cache",
-                    "Connection": "keep-alive",
-                    "x-deltallm-cache-hit": "false",
-                    **route_decision_headers(request),
-                },
-            )
+                if resolved_usage is None:
+                    return
+                if (
+                    stream_id is not None
+                    and stream_handler is not None
+                    and stream_write_context is not None
+                ):
+                    if stream_cache_complete:
+                        await stream_handler.finalize_and_store(
+                            stream_id,
+                            stream_write_context,
+                            usage=resolved_usage.usage,
+                        )
+                    else:
+                        stream_handler.discard_stream(stream_id)
+                await record_router_usage(
+                    request.app.state.router_state_backend,
+                    served_deployment.deployment_id,
+                    mode="chat",
+                    usage=resolved_usage.usage,
+                )
+                await emit_stream_success(
+                    request=request,
+                    auth=auth,
+                    payload=payload,
+                    request_data=request_data,
+                    callback_manager=callback_manager,
+                    guardrail_middleware=guardrail_middleware,
+                    callback_start=callback_start,
+                    request_start=request_start,
+                    request_id=request_id,
+                    stream_response_object=stream_response_object,
+                    cache_hit=cache_hit,
+                    cache_key=cache_key,
+                    audit_action=audit_action,
+                    served_deployment=served_deployment,
+                    api_base=opened_stream.api_base,
+                    params=opened_stream.params,
+                    usage=resolved_usage.usage,
+                    usage_metadata=resolved_usage.metadata(),
+                )
+
+            try:
+                response = DeadlineStreamingResponse(
+                    stream_sse(),
+                    deadline=managed_stream.deadline,
+                    close=stream_lifecycle.close,
+                    media_type="text/event-stream",
+                    headers={
+                        "Cache-Control": "no-cache",
+                        "Connection": "keep-alive",
+                        "x-deltallm-cache-hit": "false",
+                        **route_decision_headers(request),
+                    },
+                )
+            except BaseException as exc:
+                await close_stream_resources(lambda failure=exc: stream_lifecycle.close(failure))
+                raise
+            return response
 
         async def _execute_for_deployment(deployment):  # noqa: ANN001, ANN202
             if not has_mcp_tools:

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from time import perf_counter
 from typing import Any, Callable
@@ -108,34 +109,31 @@ async def handle_chat_like_request(
             # so unsupported stream providers fail as a normal HTTP error.
             resolve_chat_upstream(request, primary.deltallm_params, is_stream=True)
 
+            managed_stream = await request.app.state.failover_manager.execute_managed_with_failover(
+                primary_deployment=primary,
+                model_group=model_group,
+                execute=lambda dep: open_stream_with_first_chunk(request, payload, dep),
+                on_attempt=track_attempt,
+                routing_context=request_context,
+                **failover_kwargs,
+            )
+            opened_stream = managed_stream.value
+            served_deployment = managed_stream.deployment
+            update_served_route_decision(
+                request,
+                primary_deployment_id=primary.deployment_id,
+                served_deployment_id=served_deployment.deployment_id,
+            )
+
             async def stream_sse():
                 cache_context = getattr(request.state, "cache_context", None)
                 stream_handler = getattr(request.app.state, "streaming_cache_handler", None)
                 stream_id = None
                 stream_write_context: StreamWriteContext | None = None
                 stream_usage = StreamUsageTracker()
-                opened_stream = None
-                served_deployment = None
-                failure_exc: Exception | None = None
+                failure_exc: BaseException | None = None
                 stream_cache_complete = False
                 try:
-                    (
-                        opened_stream,
-                        served_deployment,
-                    ) = await request.app.state.failover_manager.execute_with_failover(
-                        primary_deployment=primary,
-                        model_group=model_group,
-                        execute=lambda dep: open_stream_with_first_chunk(request, payload, dep),
-                        return_deployment=True,
-                        on_attempt=track_attempt,
-                        routing_context=request_context,
-                        **failover_kwargs,
-                    )
-                    update_served_route_decision(
-                        request,
-                        primary_deployment_id=primary.deployment_id,
-                        served_deployment_id=served_deployment.deployment_id,
-                    )
                     params = opened_stream.params
                     api_base_local = opened_stream.api_base
                     if (
@@ -172,46 +170,47 @@ async def handle_chat_like_request(
                         )
                         stream_handler.start_stream(stream_id)
 
-                    initial = opened_stream.first_line
-                    if initial:
-                        line_info = stream_usage.add_line(initial)
-                        if stream_id is not None and stream_handler is not None:
-                            stream_handler.add_chunk_from_line(stream_id, initial)
-                        if not (
-                            line_info.is_usage_only_chunk
-                            and not opened_stream.client_stream_usage_requested
-                        ):
+                    async with asyncio.timeout(managed_stream.deadline.require_remaining()):
+                        initial = opened_stream.first_line
+                        if initial:
+                            line_info = stream_usage.add_line(initial)
+                            if stream_id is not None and stream_handler is not None:
+                                stream_handler.add_chunk_from_line(stream_id, initial)
+                            if not (
+                                line_info.is_usage_only_chunk
+                                and not opened_stream.client_stream_usage_requested
+                            ):
+                                out_line = (
+                                    stream_line_transform(initial)
+                                    if stream_line_transform is not None
+                                    else initial
+                                )
+                                if out_line is not None:
+                                    yield f"{out_line}\n\n"
+                        async for line in opened_stream.translated_stream:
+                            if not line:
+                                continue
+
+                            line_info = stream_usage.add_line(line)
+                            if stream_id is not None and stream_handler is not None:
+                                stream_handler.add_chunk_from_line(stream_id, line)
+                                if line.strip() == "data: [DONE]":
+                                    stream_cache_complete = True
+
+                            if (
+                                line_info.is_usage_only_chunk
+                                and not opened_stream.client_stream_usage_requested
+                            ):
+                                continue
+
                             out_line = (
-                                stream_line_transform(initial)
+                                stream_line_transform(line)
                                 if stream_line_transform is not None
-                                else initial
+                                else line
                             )
-                            if out_line is not None:
-                                yield f"{out_line}\n\n"
-                    async for line in opened_stream.translated_stream:
-                        if not line:
-                            continue
-
-                        line_info = stream_usage.add_line(line)
-                        if stream_id is not None and stream_handler is not None:
-                            stream_handler.add_chunk_from_line(stream_id, line)
-                            if line.strip() == "data: [DONE]":
-                                stream_cache_complete = True
-
-                        if (
-                            line_info.is_usage_only_chunk
-                            and not opened_stream.client_stream_usage_requested
-                        ):
-                            continue
-
-                        out_line = (
-                            stream_line_transform(line)
-                            if stream_line_transform is not None
-                            else line
-                        )
-                        if out_line is None:
-                            continue
-                        yield f"{out_line}\n\n"
+                            if out_line is None:
+                                continue
+                            yield f"{out_line}\n\n"
                     resolved_usage = stream_usage.resolve(payload)
                     if (
                         stream_id is not None
@@ -252,6 +251,9 @@ async def handle_chat_like_request(
                         usage=resolved_usage.usage,
                         usage_metadata=resolved_usage.metadata(),
                     )
+                except asyncio.CancelledError as exc:
+                    failure_exc = exc
+                    raise
                 except Exception as exc:
                     failure_exc = exc
                     if stream_id is not None and stream_handler is not None:
@@ -284,8 +286,10 @@ async def handle_chat_like_request(
                     )
                     raise
                 finally:
-                    if opened_stream is not None:
+                    try:
                         await opened_stream.close(failure_exc)
+                    finally:
+                        await managed_stream.release()
 
             return StreamingResponse(
                 stream_sse(),

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -696,6 +696,53 @@ async def test_streaming_cache_write_failure_does_not_fail_stream_response(clien
 
 
 @pytest.mark.asyncio
+async def test_cancelled_stream_discards_active_cache_accumulator(client, test_app):
+    _enable_stream_cache(test_app)
+    waiting_for_next_chunk = asyncio.Event()
+
+    class BlockingStreamContext(_StreamContext):
+        async def aiter_lines(self):
+            yield (
+                'data: {"id":"chatcmpl-cancel-cache","object":"chat.completion.chunk",'
+                '"choices":[{"index":0,"delta":{"content":"partial"},'
+                '"finish_reason":null}]}'
+            )
+            waiting_for_next_chunk.set()
+            await asyncio.Event().wait()
+
+    def stream(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        timeout: int,
+    ):  # noqa: ANN201
+        del method, url, headers, json, timeout
+        return BlockingStreamContext(lines=[])
+
+    test_app.state.http_client.stream = stream
+    request_task = asyncio.create_task(
+        client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+            },
+        )
+    )
+    await waiting_for_next_chunk.wait()
+
+    assert test_app.state.streaming_cache_handler.active_stream_count == 1
+    request_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+
+    assert test_app.state.streaming_cache_handler.active_stream_count == 0
+
+
+@pytest.mark.asyncio
 async def test_cache_hit_still_requires_auth(client, test_app):
     _enable_cache(test_app)
     headers = {"Authorization": f"Bearer {test_app.state._test_key}"}

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1079,6 +1079,43 @@ async def test_chat_completion_streaming_success(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_stream_releases_capacity_before_post_call_hooks(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    observed_active_requests: list[int] = []
+
+    class CapacityObservingCallback(CustomLogger):
+        async def async_post_call_success_hook(
+            self,
+            data: dict[str, Any],
+            user_api_key_dict: dict[str, Any],
+            response: Any,
+        ) -> None:
+            del data, user_api_key_dict, response
+            observed_active_requests.append(
+                await test_app.state.router_state_backend.get_active_requests(
+                    deployment.deployment_id
+                )
+            )
+
+    manager = CallbackManager()
+    manager.register_callback(CapacityObservingCallback())
+    test_app.state.callback_manager = manager
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert observed_active_requests == [0]
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_streaming_success_ignores_router_usage_write_failure(
     client, test_app
 ):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1370,11 +1370,13 @@ class _StreamContext:
         self.status_code = status_code
         self._lines = lines
         self._line_error = line_error
+        self.exited = False
 
     async def __aenter__(self):
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
+        self.exited = True
         return None
 
     async def aiter_lines(self):
@@ -1686,6 +1688,58 @@ async def test_stream_retries_before_first_token_with_failover(client, test_app)
     assert response.status_code == 200
     assert "data: [DONE]" in response.text
     assert calls["count"] == 2
+    assert response.headers["x-deltallm-route-deployment"] == "gpt-4o-mini-fallback"
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation_closes_upstream_and_releases_active_permit(client, test_app):
+    stream_started = asyncio.Event()
+    keep_stream_open = asyncio.Event()
+
+    class BlockingStreamContext(_StreamContext):
+        async def aiter_lines(self):
+            yield (
+                'data: {"id":"chatcmpl-cancel","object":"chat.completion.chunk",'
+                '"choices":[{"index":0,"delta":{"role":"assistant"},'
+                '"finish_reason":null}]}'
+            )
+            stream_started.set()
+            await keep_stream_open.wait()
+
+    context = BlockingStreamContext(status_code=200, lines=[])
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
+        del method, url, headers, json, timeout
+        return context
+
+    test_app.state.http_client.stream = stream
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    request_task = asyncio.create_task(
+        client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+            },
+        )
+    )
+    await asyncio.wait_for(stream_started.wait(), timeout=1.0)
+
+    assert (
+        await test_app.state.router_state_backend.get_active_requests(deployment.deployment_id) == 1
+    )
+
+    request_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+
+    assert context.exited is True
+    assert (
+        await test_app.state.router_state_backend.get_active_requests(deployment.deployment_id) == 0
+    )
 
 
 @pytest.mark.asyncio
@@ -1713,18 +1767,23 @@ async def test_stream_failure_after_failover_uses_last_attempted_deployment(clie
 
     test_app.state.router.select_deployment = choose_primary
 
+    stream_contexts: list[_StreamContext] = []
+
     def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
         del method, url, json, timeout
         auth = headers.get("Authorization", "")
         if auth.endswith("provider-key"):
-            return _StreamContext(status_code=503, lines=[])
-        return _StreamContext(
-            status_code=200,
-            lines=[
-                'data: {"id":"chatcmpl-fb","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}',
-            ],
-            line_error=httpx.ReadError("fallback stream broke"),
-        )
+            context = _StreamContext(status_code=503, lines=[])
+        else:
+            context = _StreamContext(
+                status_code=200,
+                lines=[
+                    'data: {"id":"chatcmpl-fb","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}',
+                ],
+                line_error=httpx.ReadError("fallback stream broke"),
+            )
+        stream_contexts.append(context)
+        return context
 
     test_app.state.http_client.stream = stream
     headers = {
@@ -1754,6 +1813,11 @@ async def test_stream_failure_after_failover_uses_last_attempted_deployment(clie
     fallback_health = await test_app.state.router_state_backend.get_health("gpt-4o-mini-fallback")
     assert primary_health.get("last_error") == "Provider error: 503"
     assert fallback_health.get("last_error") == "fallback stream broke"
+    assert len(stream_contexts) == 2
+    assert all(context.exited for context in stream_contexts)
+    assert (
+        await test_app.state.router_state_backend.get_active_requests(fallback.deployment_id) == 0
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -1232,7 +1232,7 @@ async def test_failover_applies_timeout_resolver_to_classified_fallbacks():
 @pytest.mark.parametrize(
     ("status_code", "headers"),
     [
-        (429, {"Retry-After": "7"}),
+        (429, {"Retry-After": "0"}),
         (503, {}),
     ],
 )
@@ -1308,6 +1308,97 @@ async def test_failover_retries_raw_http_timeout_when_route_policy_targets_timeo
     health = await state.get_health(primary.deployment_id)
     assert health.get("healthy", "true") != "false"
     assert int(health.get("consecutive_failures", 0) or 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_budget_is_shared_across_fallback_candidates():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback = _deployment("dep-b")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=1,
+            retry_after=0.001,
+            timeout=1.0,
+            backoff_jitter=False,
+            fallbacks={"group-a": ["group-b"]},
+        ),
+        candidate_planner=_planner(
+            state,
+            {"group-a": [primary], "group-b": [fallback]},
+        ),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        raise TimeoutError(message="provider timed out")
+
+    with pytest.raises(TimeoutError):
+        await manager.execute_with_failover(primary, "group-a", run)
+
+    assert attempts == ["dep-a", "dep-a", "dep-b"]
+
+
+@pytest.mark.asyncio
+async def test_total_deadline_bounds_retry_backoff():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=1,
+            retry_after=0.05,
+            timeout=0.01,
+            backoff_jitter=False,
+        ),
+        candidate_planner=_planner(state, {"group-a": [primary]}),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts = 0
+
+    async def run(_deployment: Deployment) -> str:
+        nonlocal attempts
+        attempts += 1
+        raise TimeoutError(message="provider timed out")
+
+    with pytest.raises(TimeoutError, match="Request deadline exceeded"):
+        await manager.execute_with_failover(primary, "group-a", run)
+
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_managed_attempt_holds_capacity_until_caller_releases():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(timeout=1.0),
+        candidate_planner=_planner(state, {"group-a": [primary]}),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+
+    async def run(_deployment: Deployment) -> str:
+        return "stream-open"
+
+    managed = await manager.execute_managed_with_failover(
+        primary,
+        "group-a",
+        run,
+        routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+    )
+
+    assert managed.value == "stream-open"
+    assert managed.deployment is primary
+    assert await state.get_active_requests(primary.deployment_id) == 1
+
+    await managed.release()
+    await managed.release()
+
+    assert await state.get_active_requests(primary.deployment_id) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_router_redis_integration.py
+++ b/tests/test_router_redis_integration.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from redis.asyncio import Redis
 
+from src.chat.stream_response import DeadlineStreamingResponse
 from src.router import (
     AttemptCapacity,
     AttemptCapacityLimit,
@@ -17,6 +18,7 @@ from src.router import (
     RoutingStrategy,
 )
 from src.router.candidates import ROUTING_MODE_CONTEXT_KEY
+from src.router.execution import ManagedFailoverResult, RequestDeadline
 from src.router.router import Deployment
 
 
@@ -110,6 +112,64 @@ async def test_candidate_eligibility_uses_real_redis_batch_state_under_concurren
             for plan in plans
         ] == [[eligible.deployment_id] for _ in contexts]
         assert state.get_backend_status()["mode"] == "redis"
+    finally:
+        keys = [key async for key in redis.scan_iter(match=f"*{unique}*")]
+        if keys:
+            await redis.delete(*keys)
+        await redis.aclose()
+
+
+@pytest.mark.skipif(
+    not os.getenv("DELTALLM_TEST_REDIS_URL"),
+    reason="DELTALLM_TEST_REDIS_URL is required for the Redis integration test",
+)
+async def test_stream_disconnect_releases_managed_attempt_in_real_redis() -> None:
+    redis = Redis.from_url(
+        os.environ["DELTALLM_TEST_REDIS_URL"],
+        decode_responses=True,
+    )
+    unique = uuid4().hex
+    deployment = Deployment(
+        deployment_id=f"router-managed-stream-{unique}",
+        model_name="integration-group",
+        deltallm_params={"provider": "openai", "model": "openai/integration-model"},
+        model_info={"mode": "chat"},
+    )
+    state = RedisStateBackend(redis, degraded_mode="fail_closed")
+
+    try:
+        permit = await state.acquire_attempt(deployment.deployment_id, AttemptCapacity())
+        assert permit.acquired is True
+
+        async def release() -> None:
+            await state.release_attempt(permit)
+
+        managed = ManagedFailoverResult(
+            value="opened-stream",
+            deployment=deployment,
+            deadline=RequestDeadline.after(10),
+            _release=release,
+        )
+
+        async def body():
+            yield "data: chunk\n\n"
+
+        async def send(message):  # noqa: ANN001, ANN202
+            if message["type"] != "http.response.body" or not message.get("more_body"):
+                return
+            assert int(await redis.get(f"active_requests:{deployment.deployment_id}") or 0) == 1
+            raise OSError("client disconnected")
+
+        response = DeadlineStreamingResponse(
+            body(),
+            deadline=managed.deadline,
+            close=lambda _exc: managed.release(),
+            media_type="text/event-stream",
+        )
+        with pytest.raises(OSError, match="client disconnected"):
+            await response.stream_response(send)
+
+        assert int(await redis.get(f"active_requests:{deployment.deployment_id}") or 0) == 0
     finally:
         keys = [key async for key in redis.scan_iter(match=f"*{unique}*")]
         if keys:

--- a/tests/test_stream_response.py
+++ b/tests/test_stream_response.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.chat.executor import OpenedStream
+from src.chat.stream_response import DeadlineStreamingResponse
+from src.models.errors import TimeoutError
+from src.router.execution import ManagedFailoverResult, RequestDeadline
+from src.router.router import Deployment
+
+
+def _deployment() -> Deployment:
+    return Deployment(
+        deployment_id="stream-deployment",
+        model_name="stream-group",
+        deltallm_params={"provider": "openai", "model": "openai/test"},
+        model_info={"mode": "chat"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_response_deadline_covers_blocked_downstream_send_and_closes_resources() -> None:
+    send_started = asyncio.Event()
+    body_finalized = asyncio.Event()
+    resources_closed = asyncio.Event()
+
+    async def body():
+        try:
+            yield "data: chunk\n\n"
+        finally:
+            body_finalized.set()
+
+    async def send(message: dict[str, Any]) -> None:
+        if message["type"] == "http.response.body" and message.get("more_body"):
+            send_started.set()
+            await asyncio.Event().wait()
+
+    async def close(_exc: BaseException | None) -> None:
+        resources_closed.set()
+
+    response = DeadlineStreamingResponse(
+        body(),
+        deadline=RequestDeadline.after(0.05),
+        close=close,
+        media_type="text/event-stream",
+    )
+
+    with pytest.raises(TimeoutError, match="Request deadline exceeded"):
+        await response.stream_response(send)
+
+    assert send_started.is_set()
+    assert body_finalized.is_set()
+    assert resources_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_response_cancellation_closes_resources_when_body_never_starts() -> None:
+    response_started = asyncio.Event()
+    resources_closed = asyncio.Event()
+    body_started = False
+
+    async def body():
+        nonlocal body_started
+        body_started = True
+        yield "data: chunk\n\n"
+
+    async def send(message: dict[str, Any]) -> None:
+        if message["type"] == "http.response.start":
+            response_started.set()
+            await asyncio.Event().wait()
+
+    async def close(_exc: BaseException | None) -> None:
+        resources_closed.set()
+
+    response = DeadlineStreamingResponse(
+        body(),
+        deadline=RequestDeadline.after(10),
+        close=close,
+        media_type="text/event-stream",
+    )
+    response_task = asyncio.create_task(response.stream_response(send))
+    await response_started.wait()
+
+    response_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await response_task
+
+    assert body_started is False
+    assert resources_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_downstream_disconnect_closes_body_and_resources() -> None:
+    body_finalized = asyncio.Event()
+    resources_closed = asyncio.Event()
+
+    async def body():
+        try:
+            yield "data: chunk\n\n"
+        finally:
+            body_finalized.set()
+
+    async def send(message: dict[str, Any]) -> None:
+        if message["type"] == "http.response.body" and message.get("more_body"):
+            raise OSError("client disconnected")
+
+    async def close(_exc: BaseException | None) -> None:
+        resources_closed.set()
+
+    response = DeadlineStreamingResponse(
+        body(),
+        deadline=RequestDeadline.after(10),
+        close=close,
+        media_type="text/event-stream",
+    )
+
+    with pytest.raises(OSError, match="client disconnected"):
+        await response.stream_response(send)
+
+    assert body_finalized.is_set()
+    assert resources_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_managed_release_can_retry_after_interrupted_cleanup() -> None:
+    release_started = asyncio.Event()
+    release_calls = 0
+
+    async def release() -> None:
+        nonlocal release_calls
+        release_calls += 1
+        if release_calls == 1:
+            release_started.set()
+            await asyncio.Event().wait()
+
+    managed = ManagedFailoverResult(
+        value="value",
+        deployment=_deployment(),
+        deadline=RequestDeadline.after(10),
+        _release=release,
+    )
+    first_release = asyncio.create_task(managed.release())
+    await release_started.wait()
+
+    first_release.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_release
+    await managed.release()
+    await managed.release()
+
+    assert release_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_opened_stream_close_can_retry_after_interrupted_cleanup() -> None:
+    close_started = asyncio.Event()
+
+    class ContextManager:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        async def __aexit__(self, *_args: Any) -> None:
+            self.close_calls += 1
+            if self.close_calls == 1:
+                close_started.set()
+                await asyncio.Event().wait()
+
+    context_manager = ContextManager()
+    opened = OpenedStream(
+        context_manager=context_manager,
+        response=None,
+        translated_stream=None,
+        first_line="data: first",
+        deployment=_deployment(),
+        params={},
+        api_base="https://example.test",
+        client_stream_usage_requested=False,
+        internal_stream_usage_requested=False,
+        upstream_started=0,
+    )
+    first_close = asyncio.create_task(opened.close())
+    await close_started.wait()
+
+    first_close.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_close
+    await opened.close()
+    await opened.close()
+
+    assert context_manager.close_calls == 2


### PR DESCRIPTION
## Summary

- propagate one total failover deadline through candidate planning, admission, retries, backoff, provider startup, streaming, and downstream ASGI sends
- keep the acquired deployment permit and upstream stream owned until the final frame, timeout, cancellation, or client disconnect
- make upstream close and managed permit release idempotent and retryable after interrupted cleanup
- discard incomplete streaming-cache accumulators on cancellation
- release upstream resources and capacity before post-call telemetry and hooks
- add deterministic backpressure, disconnect, cancellation, cleanup-interruption, cache, and real-Redis lease coverage

## Why

The stream generator previously owned its timeout and cleanup, but Starlette performs the downstream `send()` after each generator yield. A stalled or failed client send could therefore prevent the generator from resuming, leaving the upstream response and capacity permit held until garbage collection or lease expiry.

Cleanup state was also marked complete before the awaited close/release operation finished, which prevented a retry if cancellation interrupted cleanup. Cancelled cached streams could leave their in-memory accumulators registered indefinitely.

## Impact

Streaming requests now have a response-level lifecycle owner. The same total deadline covers downstream backpressure, and cleanup receives a separate bounded, cancellation-shielded grace period. Provider connections, cache accumulators, and distributed attempt permits are released consistently without changing the OpenAI-compatible SSE framing or route-decision headers.

No additional SQL, Redis, or provider round trips were added to the normal request path.

## Validation

- Ruff check passed for all changed Python files
- Ruff format check passed for all changed Python files
- affected chat/cache/failover/stream suite: `150 passed`
- focused real-Redis managed stream disconnect test: `1 passed`
- `git diff --check` passed

## Stack

- Feature base: `feat/gateway-hot-path-performance`
- PR1: #277, already merged into the feature branch
- Part of #275
