### PR TITLE
Prevent MCP side-effect replay during failover

### DIFF
--- a/src/chat/mcp_execution.py
+++ b/src/chat/mcp_execution.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from src.guardrails.middleware import GuardrailMiddleware
+from src.mcp.orchestrator import MCPChatOrchestrator, MCPRequestContext
+from src.models.errors import ProxyError, ServiceUnavailableError
+from src.models.requests import ChatCompletionRequest
+from src.models.responses import UserAPIKeyAuth
+from src.router import Deployment, FailoverManager
+
+
+ChatDeploymentCall = Callable[
+    [ChatCompletionRequest, Deployment],
+    Awaitable[tuple[dict[str, Any], float]],
+]
+DeploymentAttemptObserver = Callable[[Deployment], None]
+
+
+@dataclass(frozen=True, slots=True)
+class MCPModelRouting:
+    primary_deployment: Deployment
+    model_group: str
+    routing_context: dict[str, Any]
+    timeout_seconds: float | None = None
+    retry_max_attempts: int | None = None
+    retryable_error_classes: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MCPChatExecutionResult:
+    payload: dict[str, Any]
+    api_latency_ms: float
+    served_deployment: Deployment
+    fallback_used: bool
+
+
+class MCPChatExecutionService:
+    """Own the model/tool phase sequence without making tool calls retryable."""
+
+    def __init__(
+        self,
+        *,
+        failover_manager: FailoverManager,
+        orchestrator: MCPChatOrchestrator,
+        execute_chat_call: ChatDeploymentCall,
+    ) -> None:
+        self.failover_manager = failover_manager
+        self.orchestrator = orchestrator
+        self.execute_chat_call = execute_chat_call
+
+    async def execute(
+        self,
+        *,
+        request_context: MCPRequestContext,
+        auth: UserAPIKeyAuth,
+        payload: ChatCompletionRequest,
+        guardrail_middleware: GuardrailMiddleware,
+        routing: MCPModelRouting,
+        on_attempt: DeploymentAttemptObserver | None = None,
+    ) -> MCPChatExecutionResult:
+        deadline = self.failover_manager.create_request_deadline(routing.timeout_seconds)
+        served_deployment: Deployment | None = None
+        phase_primary = routing.primary_deployment
+        fallback_used = False
+
+        async def execute_model_phase(
+            phase_payload: ChatCompletionRequest,
+        ) -> tuple[dict[str, Any], float]:
+            nonlocal fallback_used, phase_primary, served_deployment
+            attempted_primary = phase_primary
+            result, phase_served_deployment = await self.failover_manager.execute_with_failover(
+                primary_deployment=attempted_primary,
+                model_group=routing.model_group,
+                execute=lambda deployment: self.execute_chat_call(phase_payload, deployment),
+                return_deployment=True,
+                on_attempt=on_attempt,
+                timeout_seconds=routing.timeout_seconds,
+                retry_max_attempts=routing.retry_max_attempts,
+                retryable_error_classes=list(routing.retryable_error_classes)
+                if routing.retryable_error_classes is not None
+                else None,
+                routing_context=routing.routing_context,
+                request_deadline=deadline,
+            )
+            fallback_used = fallback_used or (
+                attempted_primary.deployment_id != phase_served_deployment.deployment_id
+            )
+            served_deployment = phase_served_deployment
+            phase_primary = phase_served_deployment
+            return result
+
+        try:
+            response_payload, api_latency_ms = await deadline.wait_for(
+                self.orchestrator.execute(
+                    request_context=request_context,
+                    auth=auth,
+                    payload=payload,
+                    execute_chat_call=execute_model_phase,
+                    guardrail_middleware=guardrail_middleware,
+                )
+            )
+        except ProxyError:
+            raise
+        except Exception as exc:
+            raise ServiceUnavailableError(message="MCP orchestration failed") from exc
+        if served_deployment is None:
+            raise ServiceUnavailableError(
+                message="MCP orchestration completed without a model result"
+            )
+        return MCPChatExecutionResult(
+            payload=response_payload,
+            api_latency_ms=api_latency_ms,
+            served_deployment=served_deployment,
+            fallback_used=fallback_used,
+        )

--- a/src/mcp/orchestrator.py
+++ b/src/mcp/orchestrator.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from time import perf_counter
 from typing import Any
 from uuid import NAMESPACE_URL, uuid4, uuid5
 
-from fastapi import Request
-
 from src.audit.actions import AuditAction
 from src.audit.delivery import AuditDeliveryClass
-from src.chat.audit import request_client_ip
+from src.guardrails.middleware import GuardrailMiddleware
 from src.models.errors import (
     InvalidRequestError,
     PermissionDeniedError,
@@ -23,6 +22,7 @@ from src.models.requests import (
     FunctionToolDefinition,
     MCPToolDefinition,
 )
+from src.models.responses import UserAPIKeyAuth
 from src.services.audit_service import (
     AuditEventInput,
     AuditPayloadInput,
@@ -56,6 +56,21 @@ class ResolvedMCPTool:
     scope_id: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class MCPRequestContext:
+    request_headers: Mapping[str, str]
+    request_id: str | None
+    correlation_id: str | None
+    client_ip: str | None
+    user_agent: str | None
+
+
+MCPChatCall = Callable[
+    [ChatCompletionRequest],
+    Awaitable[tuple[dict[str, Any], float]],
+]
+
+
 def chat_request_has_mcp_tools(payload: ChatCompletionRequest) -> bool:
     return any(isinstance(tool, MCPToolDefinition) for tool in payload.tools or [])
 
@@ -76,7 +91,7 @@ class MCPChatOrchestrator:
 
     async def prepare_payload(
         self,
-        auth: Any,
+        auth: UserAPIKeyAuth,
         payload: ChatCompletionRequest,
     ) -> tuple[ChatCompletionRequest, dict[str, ResolvedMCPTool]]:
         requested_mcp_tools = [
@@ -150,11 +165,11 @@ class MCPChatOrchestrator:
     async def execute(
         self,
         *,
-        request: Request,
-        auth: Any,
+        request_context: MCPRequestContext,
+        auth: UserAPIKeyAuth,
         payload: ChatCompletionRequest,
-        execute_chat_call: Any,
-        guardrail_middleware: Any,
+        execute_chat_call: MCPChatCall,
+        guardrail_middleware: GuardrailMiddleware,
     ) -> tuple[dict[str, Any], float]:
         translated_payload, resolved_tools = await self.prepare_payload(auth, payload)
         if not resolved_tools:
@@ -197,7 +212,7 @@ class MCPChatOrchestrator:
                 tool_started = perf_counter()
                 tool_operation_id = str(uuid4())
                 await self._emit_tool_audit_attempt_event(
-                    request=request,
+                    request_context=request_context,
                     auth=auth,
                     namespaced_tool_name=tool_name,
                     server_key=resolved.server_key,
@@ -211,13 +226,13 @@ class MCPChatOrchestrator:
                         auth,
                         namespaced_tool_name=tool_name,
                         arguments=guarded_arguments,
-                        request_headers=dict(request.headers),
-                        request_id=request.headers.get("x-request-id"),
-                        correlation_id=request.headers.get("x-request-id"),
+                        request_headers=dict(request_context.request_headers),
+                        request_id=request_context.request_id,
+                        correlation_id=request_context.correlation_id,
                     )
                 except MCPToolNotFoundError as exc:
                     await self._emit_tool_audit_failure_event(
-                        request=request,
+                        request_context=request_context,
                         auth=auth,
                         namespaced_tool_name=tool_name,
                         server_key=resolved.server_key,
@@ -231,7 +246,7 @@ class MCPChatOrchestrator:
                     raise InvalidRequestError(message=str(exc)) from exc
                 except MCPApprovalRequiredError as exc:
                     await self._emit_tool_audit_failure_event(
-                        request=request,
+                        request_context=request_context,
                         auth=auth,
                         namespaced_tool_name=tool_name,
                         server_key=resolved.server_key,
@@ -250,7 +265,7 @@ class MCPChatOrchestrator:
                     ) from exc
                 except (MCPAccessDeniedError, MCPPolicyDeniedError) as exc:
                     await self._emit_tool_audit_failure_event(
-                        request=request,
+                        request_context=request_context,
                         auth=auth,
                         namespaced_tool_name=tool_name,
                         server_key=resolved.server_key,
@@ -264,7 +279,7 @@ class MCPChatOrchestrator:
                     raise PermissionDeniedError(message=str(exc)) from exc
                 except MCPRateLimitError as exc:
                     await self._emit_tool_audit_failure_event(
-                        request=request,
+                        request_context=request_context,
                         auth=auth,
                         namespaced_tool_name=tool_name,
                         server_key=resolved.server_key,
@@ -283,7 +298,7 @@ class MCPChatOrchestrator:
                     MCPError,
                 ) as exc:
                     await self._emit_tool_audit_failure_event(
-                        request=request,
+                        request_context=request_context,
                         auth=auth,
                         namespaced_tool_name=tool_name,
                         server_key=resolved.server_key,
@@ -304,7 +319,7 @@ class MCPChatOrchestrator:
                     result=result,
                 )
                 await self._emit_tool_audit_event(
-                    request=request,
+                    request_context=request_context,
                     auth=auth,
                     namespaced_tool_name=tool_name,
                     server_key=resolved.server_key,
@@ -399,8 +414,8 @@ class MCPChatOrchestrator:
     async def _run_tool_input_guardrails(
         self,
         *,
-        guardrail_middleware: Any,
-        auth: Any,
+        guardrail_middleware: GuardrailMiddleware,
+        auth: UserAPIKeyAuth,
         server_key: str,
         tool_name: str,
         arguments: dict[str, Any],
@@ -426,8 +441,8 @@ class MCPChatOrchestrator:
     async def _run_tool_output_guardrails(
         self,
         *,
-        guardrail_middleware: Any,
-        auth: Any,
+        guardrail_middleware: GuardrailMiddleware,
+        auth: UserAPIKeyAuth,
         server_key: str,
         tool_name: str,
         result: Any,
@@ -467,8 +482,8 @@ class MCPChatOrchestrator:
     async def _emit_tool_audit_event(
         self,
         *,
-        request: Request,
-        auth: Any,
+        request_context: MCPRequestContext,
+        auth: UserAPIKeyAuth,
         namespaced_tool_name: str,
         server_key: str,
         scope_type: str | None,
@@ -481,7 +496,7 @@ class MCPChatOrchestrator:
         audit_service = self.audit_service
         if audit_service is None:
             return
-        request_id = request.headers.get("x-request-id")
+        request_id = request_context.request_id
         await enqueue_audit_event(
             audit_service,
             AuditEventInput(
@@ -493,9 +508,9 @@ class MCPChatOrchestrator:
                 resource_type="mcp_tool",
                 resource_id=namespaced_tool_name,
                 request_id=request_id,
-                correlation_id=request_id,
-                ip=request_client_ip(request),
-                user_agent=request.headers.get("user-agent"),
+                correlation_id=request_context.correlation_id,
+                ip=request_context.client_ip,
+                user_agent=request_context.user_agent,
                 status="error" if bool(result_payload.get("is_error")) else "success",
                 latency_ms=int((perf_counter() - request_start) * 1000),
                 metadata={
@@ -518,8 +533,8 @@ class MCPChatOrchestrator:
     async def _emit_tool_audit_failure_event(
         self,
         *,
-        request: Request,
-        auth: Any,
+        request_context: MCPRequestContext,
+        auth: UserAPIKeyAuth,
         namespaced_tool_name: str,
         server_key: str,
         scope_type: str | None,
@@ -532,7 +547,7 @@ class MCPChatOrchestrator:
         audit_service = self.audit_service
         if audit_service is None:
             return
-        request_id = request.headers.get("x-request-id")
+        request_id = request_context.request_id
         await enqueue_audit_event(
             audit_service,
             AuditEventInput(
@@ -544,9 +559,9 @@ class MCPChatOrchestrator:
                 resource_type="mcp_tool",
                 resource_id=namespaced_tool_name,
                 request_id=request_id,
-                correlation_id=request_id,
-                ip=request_client_ip(request),
-                user_agent=request.headers.get("user-agent"),
+                correlation_id=request_context.correlation_id,
+                ip=request_context.client_ip,
+                user_agent=request_context.user_agent,
                 status="error",
                 latency_ms=int((perf_counter() - request_start) * 1000),
                 error_type=error.__class__.__name__,
@@ -567,8 +582,8 @@ class MCPChatOrchestrator:
     async def _emit_tool_audit_attempt_event(
         self,
         *,
-        request: Request,
-        auth: Any,
+        request_context: MCPRequestContext,
+        auth: UserAPIKeyAuth,
         namespaced_tool_name: str,
         server_key: str,
         scope_type: str | None,
@@ -577,7 +592,7 @@ class MCPChatOrchestrator:
         operation_id: str,
     ) -> None:
         audit_service = require_audit_service(self.audit_service)
-        request_id = request.headers.get("x-request-id")
+        request_id = request_context.request_id
         await enqueue_audit_event(
             audit_service,
             AuditEventInput(
@@ -589,9 +604,9 @@ class MCPChatOrchestrator:
                 resource_type="mcp_tool",
                 resource_id=namespaced_tool_name,
                 request_id=request_id,
-                correlation_id=request_id,
-                ip=request_client_ip(request),
-                user_agent=request.headers.get("user-agent"),
+                correlation_id=request_context.correlation_id,
+                ip=request_context.client_ip,
+                user_agent=request_context.user_agent,
                 status="attempted",
                 metadata={
                     "operation_id": operation_id,

--- a/src/mcp/transport_http.py
+++ b/src/mcp/transport_http.py
@@ -21,6 +21,7 @@ MCP_PROTOCOL_VERSION = "2025-11-25"
 _MCP_ACCEPT = "application/json, text/event-stream"
 _MCP_SESSION_TTL_SECONDS = 30 * 60
 _MCP_MAX_SESSION_STATES = 1024
+_SESSION_REPLAY_SAFE_METHODS = frozenset({"tools/list"})
 
 
 @dataclass
@@ -132,6 +133,11 @@ class StreamableHTTPMCPClient:
             )
         except _StaleMCPSessionError as exc:
             await self._clear_session(key, state, stale_session_id=exc.session_id)
+            if envelope.method not in _SESSION_REPLAY_SAFE_METHODS:
+                raise MCPTransportError(
+                    f"MCP session expired during non-replay-safe method '{envelope.method}'; "
+                    "the request was not retried"
+                ) from exc
             state = await self._ensure_initialized(server, request_headers=request_headers, key=key)
             try:
                 return await self._send(

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -359,10 +359,11 @@ class FailoverManager:
         retry_max_attempts: int | None = None,
         retryable_error_classes: list[str] | set[str] | None = None,
         routing_context: dict[str, Any] | None = None,
+        request_deadline: RequestDeadline | None = None,
         _manage_attempt_lifecycle: bool = False,
     ) -> Any:
         routing_context = routing_context if routing_context is not None else {}
-        deadline = RequestDeadline.after(self._effective_timeout(timeout_seconds))
+        deadline = request_deadline or self.create_request_deadline(timeout_seconds)
         chain = await deadline.wait_for(
             self._build_fallback_chain(
                 primary_deployment,
@@ -533,6 +534,9 @@ class FailoverManager:
             message="No healthy deployments available",
             code=NO_HEALTHY_DEPLOYMENTS_CODE,
         )
+
+    def create_request_deadline(self, timeout_seconds: float | None = None) -> RequestDeadline:
+        return RequestDeadline.after(self._effective_timeout(timeout_seconds))
 
     async def execute_managed_with_failover(
         self,

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -21,6 +21,11 @@ from src.chat import (
     open_stream_with_first_chunk,
     run_text_preflight,
 )
+from src.chat.audit import request_client_ip
+from src.chat.mcp_execution import (
+    MCPChatExecutionService,
+    MCPModelRouting,
+)
 from src.chat.stream_usage import StreamUsageTracker
 from src.chat.stream_response import (
     DeadlineStreamingResponse,
@@ -28,7 +33,11 @@ from src.chat.stream_response import (
     close_stream_resources,
 )
 from src.middleware.auth import require_api_key
-from src.mcp.orchestrator import MCPChatOrchestrator, chat_request_has_mcp_tools
+from src.mcp.orchestrator import (
+    MCPChatOrchestrator,
+    MCPRequestContext,
+    chat_request_has_mcp_tools,
+)
 from src.models.errors import InvalidRequestError, ServiceUnavailableError
 from src.models.requests import ChatCompletionRequest
 from src.providers.registry import resolve_chat_upstream
@@ -319,9 +328,8 @@ async def handle_chat_like_request(
                 raise
             return response
 
-        async def _execute_for_deployment(deployment):  # noqa: ANN001, ANN202
-            if not has_mcp_tools:
-                return await execute_chat(request, payload, deployment)
+        route_fallback_used: bool | None = None
+        if has_mcp_tools:
             gateway = getattr(request.app.state, "mcp_gateway_service", None)
             if gateway is None:
                 raise ServiceUnavailableError(message="MCP gateway service is not available")
@@ -329,32 +337,60 @@ async def handle_chat_like_request(
                 gateway,
                 audit_service=getattr(request.app.state, "audit_service", None),
             )
-            return await orchestrator.execute(
-                request=request,
+            mcp_result = await MCPChatExecutionService(
+                failover_manager=request.app.state.failover_manager,
+                orchestrator=orchestrator,
+                execute_chat_call=lambda phase_payload, deployment: execute_chat(
+                    request,
+                    phase_payload,
+                    deployment,
+                ),
+            ).execute(
+                request_context=MCPRequestContext(
+                    request_headers=dict(request.headers),
+                    request_id=request_id,
+                    correlation_id=request_id,
+                    client_ip=request_client_ip(request),
+                    user_agent=request.headers.get("user-agent"),
+                ),
                 auth=auth,
                 payload=payload,
-                execute_chat_call=lambda request_payload: execute_chat(
-                    request, request_payload, deployment
-                ),
                 guardrail_middleware=guardrail_middleware,
+                routing=MCPModelRouting(
+                    primary_deployment=primary,
+                    model_group=model_group,
+                    routing_context=request_context,
+                    timeout_seconds=failover_kwargs.get("timeout_seconds"),
+                    retry_max_attempts=failover_kwargs.get("retry_max_attempts"),
+                    retryable_error_classes=tuple(
+                        failover_kwargs.get("retryable_error_classes", [])
+                    )
+                    or None,
+                ),
+                on_attempt=track_attempt,
             )
-
-        (
-            (payload_data, api_latency_ms),
-            served_deployment,
-        ) = await request.app.state.failover_manager.execute_with_failover(
-            primary_deployment=primary,
-            model_group=model_group,
-            execute=_execute_for_deployment,
-            return_deployment=True,
-            on_attempt=track_attempt,
-            routing_context=request_context,
-            **failover_kwargs,
-        )
+            payload_data = mcp_result.payload
+            api_latency_ms = mcp_result.api_latency_ms
+            served_deployment = mcp_result.served_deployment
+            route_fallback_used = mcp_result.fallback_used
+        else:
+            (
+                (payload_data, api_latency_ms),
+                served_deployment,
+            ) = await request.app.state.failover_manager.execute_with_failover(
+                primary_deployment=primary,
+                model_group=model_group,
+                execute=lambda deployment: execute_chat(request, payload, deployment),
+                return_deployment=True,
+                on_attempt=track_attempt,
+                routing_context=request_context,
+                **failover_kwargs,
+            )
         update_served_route_decision(
             request,
             primary_deployment_id=primary.deployment_id,
             served_deployment_id=served_deployment.deployment_id,
+            fallback_used=route_fallback_used,
         )
         request.state.cache_store_pricing = cache_pricing_snapshot_from_deployment(
             served_deployment

--- a/src/routers/routing_decision.py
+++ b/src/routers/routing_decision.py
@@ -47,7 +47,9 @@ def _build_failure_target(request: Request, deployment: Any) -> FailureTarget:
         raw_provider = str(params.get("provider") or "").strip()
         provider = raw_provider or None
 
-    default_api_base = getattr(getattr(request.app.state, "settings", None), "openai_base_url", None)
+    default_api_base = getattr(
+        getattr(request.app.state, "settings", None), "openai_base_url", None
+    )
     raw_api_base = params.get("api_base", default_api_base)
     api_base = str(raw_api_base).rstrip("/") if raw_api_base else None
     deployment_model = params.get("model")
@@ -79,7 +81,9 @@ def resolve_failure_target(
     return FailureTarget()
 
 
-def capture_initial_route_decision(request: Request, request_context: dict[str, Any]) -> dict[str, Any] | None:
+def capture_initial_route_decision(
+    request: Request, request_context: dict[str, Any]
+) -> dict[str, Any] | None:
     decision = request_context.get("route_decision")
     if not isinstance(decision, dict):
         return None
@@ -94,12 +98,15 @@ def update_served_route_decision(
     *,
     primary_deployment_id: str,
     served_deployment_id: str,
+    fallback_used: bool | None = None,
 ) -> dict[str, Any]:
     current = getattr(request.state, "route_decision", None)
     decision = dict(current) if isinstance(current, dict) else {}
     decision["primary_deployment_id"] = primary_deployment_id
     decision["served_deployment_id"] = served_deployment_id
-    decision["fallback_used"] = primary_deployment_id != served_deployment_id
+    decision["fallback_used"] = (
+        primary_deployment_id != served_deployment_id if fallback_used is None else fallback_used
+    )
     request.state.route_decision = decision
     _refresh_request_resolution(request)
     return decision
@@ -112,7 +119,9 @@ def route_decision_metadata(request: Request) -> dict[str, Any] | None:
     return deepcopy(decision)
 
 
-def set_prompt_provenance(request: Request, provenance: dict[str, Any] | None) -> dict[str, Any] | None:
+def set_prompt_provenance(
+    request: Request, provenance: dict[str, Any] | None
+) -> dict[str, Any] | None:
     request.state.prompt_provenance = deepcopy(provenance) if isinstance(provenance, dict) else None
     return _refresh_request_resolution(request)
 

--- a/tests/mcp/test_chat_execution.py
+++ b/tests/mcp/test_chat_execution.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.chat.mcp_execution import MCPChatExecutionService, MCPModelRouting
+from src.mcp.models import MCPToolCallResult
+from src.mcp.orchestrator import MCPChatOrchestrator, MCPRequestContext
+from src.models.errors import ServiceUnavailableError, TimeoutError
+from src.models.requests import ChatCompletionRequest
+from src.models.responses import UserAPIKeyAuth
+from src.router import ROUTING_MODE_CONTEXT_KEY, RequestDeadline
+
+
+class _RecordingAuditService:
+    def __init__(self) -> None:
+        self.records: list[object] = []
+
+    def record_event(self, event, *, payloads=None, critical=False):  # noqa: ANN001, ANN201
+        del payloads, critical
+        self.records.append(event)
+
+
+class _RecordingGateway:
+    def __init__(self, *, after_call: Callable[[], None] | None = None) -> None:
+        self.tool_calls: list[str] = []
+        self.after_call = after_call
+
+    async def list_visible_tools(self, auth):  # noqa: ANN001, ANN201
+        del auth
+        return [
+            SimpleNamespace(
+                server_key="docs",
+                original_name="search",
+                namespaced_name="docs.search",
+                description="Search docs",
+                input_schema={"type": "object"},
+                scope_type="team",
+                scope_id="team-default",
+            )
+        ]
+
+    async def tool_requires_manual_approval(self, auth, *, server_key, tool_name):  # noqa: ANN001, ANN201
+        del auth, server_key, tool_name
+        return False
+
+    async def call_tool(
+        self,
+        auth,
+        *,
+        namespaced_tool_name,
+        arguments,
+        request_headers=None,
+        request_id=None,
+        correlation_id=None,
+    ):  # noqa: ANN001, ANN201
+        del auth, arguments, request_headers, request_id, correlation_id
+        self.tool_calls.append(namespaced_tool_name)
+        if self.after_call is not None:
+            self.after_call()
+        return MCPToolCallResult(
+            content=[{"type": "text", "text": "result"}],
+            structured_content={"answer": "result"},
+            is_error=False,
+        )
+
+
+class _RaisingOrchestrator:
+    async def execute(
+        self, request_context, auth, payload, execute_chat_call, guardrail_middleware
+    ):  # noqa: ANN001, ANN002, ANN003, ANN204
+        del request_context, auth, payload, execute_chat_call, guardrail_middleware
+        raise RuntimeError("MCP orchestration failed unexpectedly")
+
+
+def _tool_call_response() -> dict[str, Any]:
+    return {
+        "id": "chatcmpl-tool",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_docs_search",
+                            "type": "function",
+                            "function": {
+                                "name": "docs.search",
+                                "arguments": json.dumps({"query": "delta"}),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _request_payload() -> ChatCompletionRequest:
+    return ChatCompletionRequest.model_validate(
+        {
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "Search docs"}],
+            "tools": [
+                {
+                    "type": "mcp",
+                    "server": "docs",
+                    "allowed_tools": ["search"],
+                    "require_approval": "never",
+                }
+            ],
+        }
+    )
+
+
+def _request_context(request_id: str) -> MCPRequestContext:
+    return MCPRequestContext(
+        request_headers={},
+        request_id=request_id,
+        correlation_id=request_id,
+        client_ip=None,
+        user_agent=None,
+    )
+
+
+def _routing(test_app) -> MCPModelRouting:  # noqa: ANN001
+    primary = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    return MCPModelRouting(
+        primary_deployment=primary,
+        model_group="gpt-4o-mini",
+        routing_context={
+            "metadata": {},
+            ROUTING_MODE_CONTEXT_KEY: "chat",
+        },
+    )
+
+
+def _auth() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(api_key="sk-test", models=["gpt-4o-mini"])
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_tool_success_does_not_replay_tool(test_app) -> None:
+    gateway = _RecordingGateway()
+    audit = _RecordingAuditService()
+    manager = test_app.state.failover_manager
+    routing = _routing(test_app)
+    final_model_started = asyncio.Event()
+    never_complete = asyncio.Event()
+    observed_deadlines: list[RequestDeadline] = []
+    original_execute_with_failover = manager.execute_with_failover
+
+    async def recording_execute_with_failover(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        observed_deadlines.append(kwargs["request_deadline"])
+        return await original_execute_with_failover(*args, **kwargs)
+
+    manager.execute_with_failover = recording_execute_with_failover
+
+    async def execute_chat(payload, deployment):  # noqa: ANN001, ANN202
+        del deployment
+        if any(message.role == "tool" for message in payload.messages):
+            final_model_started.set()
+            await never_complete.wait()
+        return _tool_call_response(), 1.0
+
+    service = MCPChatExecutionService(
+        failover_manager=manager,
+        orchestrator=MCPChatOrchestrator(gateway, audit_service=audit),  # type: ignore[arg-type]
+        execute_chat_call=execute_chat,
+    )
+    async with asyncio.TaskGroup() as task_group:
+        task = task_group.create_task(
+            service.execute(
+                request_context=_request_context("req-cancel"),
+                auth=_auth(),
+                payload=_request_payload(),
+                guardrail_middleware=test_app.state.guardrail_middleware,
+                routing=routing,
+            )
+        )
+        await asyncio.wait_for(final_model_started.wait(), timeout=1)
+        task.cancel()
+
+    assert task.cancelled()
+    assert gateway.tool_calls == ["docs.search"]
+    assert len(observed_deadlines) == 2
+    assert observed_deadlines[0] is observed_deadlines[1]
+    assert (
+        await test_app.state.router_state_backend.get_active_requests(
+            routing.primary_deployment.deployment_id
+        )
+        == 0
+    )
+    assert [getattr(event, "status", None) for event in audit.records] == [
+        "attempted",
+        "success",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tool_and_model_phases_share_one_total_deadline(test_app) -> None:
+    manager = test_app.state.failover_manager
+    deadline = RequestDeadline.after(60)
+    gateway = _RecordingGateway(
+        after_call=lambda: object.__setattr__(
+            deadline,
+            "expires_at",
+            asyncio.get_running_loop().time(),
+        )
+    )
+    audit = _RecordingAuditService()
+    model_calls = 0
+    manager.create_request_deadline = lambda timeout_seconds=None: deadline
+
+    async def execute_chat(payload, deployment):  # noqa: ANN001, ANN202
+        nonlocal model_calls
+        del payload, deployment
+        model_calls += 1
+        return _tool_call_response(), 1.0
+
+    service = MCPChatExecutionService(
+        failover_manager=manager,
+        orchestrator=MCPChatOrchestrator(gateway, audit_service=audit),  # type: ignore[arg-type]
+        execute_chat_call=execute_chat,
+    )
+
+    with pytest.raises(TimeoutError, match="Request deadline exceeded"):
+        await service.execute(
+            request_context=_request_context("req-deadline"),
+            auth=_auth(),
+            payload=_request_payload(),
+            guardrail_middleware=test_app.state.guardrail_middleware,
+            routing=_routing(test_app),
+        )
+
+    assert model_calls == 1
+    assert gateway.tool_calls == ["docs.search"]
+    assert [getattr(event, "status", None) for event in audit.records] == [
+        "attempted",
+        "success",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_classifies_unexpected_orchestrator_exceptions(test_app) -> None:
+    service = MCPChatExecutionService(
+        failover_manager=test_app.state.failover_manager,
+        orchestrator=_RaisingOrchestrator(),  # type: ignore[arg-type]
+        execute_chat_call=lambda phase_payload, deployment: (_tool_call_response(), 1.0),  # noqa: ARG005
+    )
+
+    with pytest.raises(ServiceUnavailableError, match="MCP orchestration failed") as exc_info:
+        await service.execute(
+            request_context=_request_context("req-orchestrator-fail"),
+            auth=_auth(),
+            payload=_request_payload(),
+            guardrail_middleware=test_app.state.guardrail_middleware,
+            routing=_routing(test_app),
+        )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "unexpectedly" not in str(exc_info.value)

--- a/tests/mcp/test_transport_http.py
+++ b/tests/mcp/test_transport_http.py
@@ -707,6 +707,61 @@ async def test_send_reinitializes_once_after_stale_session() -> None:
 
 
 @pytest.mark.asyncio
+async def test_call_tool_does_not_replay_after_stale_session() -> None:
+    client = _FakeHTTPClient(
+        responses=[
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "stale-session"},
+            ),
+            _accepted_response(),
+            _response(
+                404,
+                {
+                    "jsonrpc": "2.0",
+                    "id": "server-error",
+                    "error": {"message": "session expired"},
+                },
+            ),
+            _response(
+                200,
+                {"jsonrpc": "2.0", "id": 3, "result": {"protocolVersion": "2025-11-25"}},
+                headers={"MCP-Session-Id": "fresh-session"},
+            ),
+            _accepted_response(),
+            _response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "result": {
+                        "content": [{"type": "text", "text": "ok"}],
+                        "isError": False,
+                    },
+                },
+            ),
+        ]
+    )
+    transport = StreamableHTTPMCPClient(client)  # type: ignore[arg-type]
+
+    with pytest.raises(MCPTransportError, match="request was not retried"):
+        await transport.call_tool(_server(), tool_name="search", arguments={"q": "test"})
+
+    recovered = await transport.call_tool(
+        _server(),
+        tool_name="search",
+        arguments={"q": "retry-from-caller"},
+    )
+    tool_calls = [call for call in client.calls if call["json"].get("method") == "tools/call"]
+    assert len(tool_calls) == 2
+    assert recovered.content == [{"type": "text", "text": "ok"}]
+    recovered_headers = tool_calls[1]["headers"]
+    assert isinstance(recovered_headers, dict)
+    assert recovered_headers["MCP-Session-Id"] == "fresh-session"
+
+
+@pytest.mark.asyncio
 async def test_send_maps_second_stale_session_to_transport_error() -> None:
     client = _FakeHTTPClient(
         responses=[

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -9,6 +9,7 @@ from uuid import UUID
 import httpx
 import pytest
 
+import src.routers.chat as chat_router
 from src.audit.actions import AuditAction
 from src.callbacks import CallbackManager, CustomLogger
 from src.guardrails.base import CustomGuardrail, GuardrailAction
@@ -175,6 +176,17 @@ class _ExplodingMCPGateway:
     async def call_tool(self, auth, **kwargs):  # noqa: ANN001, ANN201
         del auth, kwargs
         raise AssertionError("MCP gateway should not be used for non-MCP requests")
+
+
+class _RaisingMCPOrchestrator:
+    def __init__(self, gateway, audit_service=None, max_mcp_tool_hops=4, max_mcp_tools_per_turn=8):
+        del gateway, audit_service, max_mcp_tool_hops, max_mcp_tools_per_turn
+
+    async def execute(
+        self, request_context, auth, payload, execute_chat_call, guardrail_middleware
+    ):  # noqa: ANN001, ANN002, ANN003, ANN204
+        del request_context, auth, payload, execute_chat_call, guardrail_middleware
+        raise RuntimeError("unexpected orchestration failure")
 
 
 class _FakeMCPGateway:
@@ -553,6 +565,81 @@ def _mcp_success_post(upstream_calls: list[dict[str, object]]):  # noqa: ANN202
     return post
 
 
+def _mcp_tool_call_response(model: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "chatcmpl-tool-call",
+            "object": "chat.completion",
+            "created": 1700000000,
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_docs_search",
+                                "type": "function",
+                                "function": {
+                                    "name": "docs.search",
+                                    "arguments": jsonlib.dumps({"query": "delta"}),
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        },
+    )
+
+
+def _mcp_final_response(model: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "chatcmpl-tool-final",
+            "object": "chat.completion",
+            "created": 1700000001,
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "done"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+        },
+    )
+
+
+def _configure_chat_fallback(test_app):  # noqa: ANN001, ANN201
+    registry = test_app.state.router.deployment_registry["gpt-4o-mini"]
+    primary = registry[0]
+    fallback = type(primary)(
+        deployment_id="gpt-4o-mini-mcp-fallback",
+        model_name=primary.model_name,
+        deltallm_params={
+            **primary.deltallm_params,
+            "api_key": "provider-key-fallback",
+        },
+        model_info=dict(primary.model_info),
+    )
+    registry.append(fallback)
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return primary
+
+    test_app.state.router.select_deployment = choose_primary
+    return primary, fallback
+
+
 @pytest.mark.asyncio
 async def test_chat_completion_with_mcp_tool_auto_executes_and_audits(client, test_app):
     gateway = _FakeMCPGateway()
@@ -600,6 +687,193 @@ async def test_chat_completion_with_mcp_tool_auto_executes_and_audits(client, te
     ]
     assert [critical for _, critical in mcp_audits] == [True, False]
     assert mcp_audits[0][0].event_id != mcp_audits[1][0].event_id
+
+
+@pytest.mark.parametrize("followup_failure", ["429", "5xx", "timeout"])
+@pytest.mark.asyncio
+async def test_mcp_tool_is_not_replayed_when_followup_model_fails_over(
+    client,
+    test_app,
+    followup_failure: str,
+):
+    gateway = _FakeMCPGateway()
+    audit = _RecordingAuditService()
+    test_app.state.mcp_gateway_service = gateway
+    test_app.state.audit_service = audit
+    primary, fallback = _configure_chat_fallback(test_app)
+    upstream_calls: list[tuple[str | None, bool]] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del timeout
+        has_tool_result = any(message.get("role") == "tool" for message in json["messages"])
+        authorization = headers.get("Authorization")
+        upstream_calls.append((authorization, has_tool_result))
+        if not has_tool_result:
+            return _mcp_tool_call_response(json["model"])
+        if authorization == "Bearer provider-key":
+            request = httpx.Request("POST", url)
+            if followup_failure == "timeout":
+                raise httpx.ReadTimeout("final model timed out", request=request)
+            status_code = 429 if followup_failure == "429" else 503
+            return httpx.Response(
+                status_code,
+                json={"error": {"message": f"follow-up {followup_failure}"}},
+                request=request,
+            )
+        return _mcp_final_response(json["model"])
+
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {test_app.state._test_key}",
+            "x-request-id": f"req-mcp-followup-{followup_failure}",
+        },
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "Search docs"}],
+            "tools": [
+                {
+                    "type": "mcp",
+                    "server": "docs",
+                    "allowed_tools": ["search"],
+                    "require_approval": "never",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "done"
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    assert gateway.tool_calls == [
+        ("docs.search", {"query": "delta"}, f"req-mcp-followup-{followup_failure}")
+    ]
+    assert upstream_calls == [
+        ("Bearer provider-key", False),
+        ("Bearer provider-key", True),
+        ("Bearer provider-key-fallback", True),
+    ]
+    tool_audits = [
+        event
+        for event, _, _ in audit.records
+        if getattr(event, "action", None) == AuditAction.MCP_TOOL_CALL.value
+    ]
+    assert [event.status for event in tool_audits] == ["attempted", "success"]
+    assert primary.deployment_id != fallback.deployment_id
+
+
+@pytest.mark.asyncio
+async def test_mcp_model_phases_keep_fallback_affinity_and_report_any_fallback(
+    client,
+    test_app,
+):
+    gateway = _FakeMCPGateway()
+    test_app.state.mcp_gateway_service = gateway
+    test_app.state.audit_service = _RecordingAuditService()
+    primary, fallback = _configure_chat_fallback(test_app)
+    upstream_calls: list[tuple[str | None, bool]] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del timeout
+        has_tool_result = any(message.get("role") == "tool" for message in json["messages"])
+        authorization = headers.get("Authorization")
+        upstream_calls.append((authorization, has_tool_result))
+        if not has_tool_result and authorization == "Bearer provider-key":
+            return httpx.Response(
+                503,
+                json={"error": {"message": "initial primary unavailable"}},
+                request=httpx.Request("POST", url),
+            )
+        if not has_tool_result:
+            return _mcp_tool_call_response(json["model"])
+        if authorization == "Bearer provider-key-fallback":
+            return httpx.Response(
+                503,
+                json={"error": {"message": "fallback follow-up unavailable"}},
+                request=httpx.Request("POST", url),
+            )
+        return _mcp_final_response(json["model"])
+
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "Search docs"}],
+            "tools": [
+                {
+                    "type": "mcp",
+                    "server": "docs",
+                    "allowed_tools": ["search"],
+                    "require_approval": "never",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "done"
+    assert upstream_calls == [
+        ("Bearer provider-key", False),
+        ("Bearer provider-key-fallback", False),
+        ("Bearer provider-key-fallback", True),
+        ("Bearer provider-key", True),
+    ]
+    assert gateway.tool_calls == [("docs.search", {"query": "delta"}, None)]
+    assert response.headers["x-deltallm-route-deployment"] == primary.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    assert primary.deployment_id != fallback.deployment_id
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_is_not_replayed_when_followup_model_retries(client, test_app):
+    gateway = _FakeMCPGateway()
+    test_app.state.mcp_gateway_service = gateway
+    test_app.state.audit_service = _RecordingAuditService()
+    test_app.state.failover_manager.config.num_retries = 1
+    test_app.state.failover_manager.config.retry_after = 0.001
+    test_app.state.failover_manager.config.backoff_jitter = False
+    upstream_phases: list[bool] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del headers, timeout
+        has_tool_result = any(message.get("role") == "tool" for message in json["messages"])
+        upstream_phases.append(has_tool_result)
+        if not has_tool_result:
+            return _mcp_tool_call_response(json["model"])
+        if upstream_phases.count(True) == 1:
+            return httpx.Response(
+                503,
+                json={"error": {"message": "retry follow-up"}},
+                request=httpx.Request("POST", url),
+            )
+        return _mcp_final_response(json["model"])
+
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "Search docs"}],
+            "tools": [
+                {
+                    "type": "mcp",
+                    "server": "docs",
+                    "allowed_tools": ["search"],
+                    "require_approval": "never",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert upstream_phases == [False, True, True]
+    assert gateway.tool_calls == [("docs.search", {"query": "delta"}, None)]
+    assert response.headers["x-deltallm-route-fallback-used"] == "false"
 
 
 @pytest.mark.asyncio
@@ -1006,6 +1280,35 @@ async def test_chat_completion_with_mcp_tool_timeout_returns_503(client, test_ap
 
 
 @pytest.mark.asyncio
+async def test_chat_completion_with_mcp_orchestration_unexpected_error_returns_503(
+    client, test_app, monkeypatch
+):
+    monkeypatch.setattr(chat_router, "MCPChatOrchestrator", _RaisingMCPOrchestrator)
+    test_app.state.mcp_gateway_service = _FakeMCPGateway()
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "Search docs for DeltaLLM"}],
+            "tools": [
+                {
+                    "type": "mcp",
+                    "server": "docs",
+                    "allowed_tools": ["search"],
+                    "require_approval": "never",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["type"] == "service_unavailable"
+    assert response.json()["error"]["message"] == "MCP orchestration failed"
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_with_local_mcp_gateway_error_does_not_affect_deployment_health(
     client, test_app
 ):
@@ -1036,6 +1339,7 @@ async def test_chat_completion_with_local_mcp_gateway_error_does_not_affect_depl
 
     assert response.status_code == 503
     assert response.json()["error"]["type"] == "service_unavailable"
+    assert response.json()["error"]["message"] == "MCP orchestration failed"
     health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
     assert health.get("healthy", "true") != "false"
     assert int(health.get("consecutive_failures", 0) or 0) == 0

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -25,6 +25,7 @@ from src.router import (
     HealthCheckConfig,
     PassiveHealthTracker,
     RedisStateBackend,
+    RequestDeadline,
     ROUTING_MODE_CONTEXT_KEY,
     RouteGroupPolicy,
     Router,
@@ -1368,6 +1369,35 @@ async def test_total_deadline_bounds_retry_backoff():
         await manager.execute_with_failover(primary, "group-a", run)
 
     assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_failover_reuses_caller_owned_request_deadline():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    manager = FailoverManager(
+        config=FallbackConfig(timeout=10.0),
+        candidate_planner=_planner(state, {"group-a": [primary]}),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    deadline = RequestDeadline(expires_at=asyncio.get_running_loop().time())
+    attempts = 0
+
+    async def run(_deployment: Deployment) -> str:
+        nonlocal attempts
+        attempts += 1
+        return "unexpected"
+
+    with pytest.raises(TimeoutError, match="Request deadline exceeded"):
+        await manager.execute_with_failover(
+            primary,
+            "group-a",
+            run,
+            request_deadline=deadline,
+        )
+
+    assert attempts == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_text_endpoints.py
+++ b/tests/test_text_endpoints.py
@@ -14,6 +14,7 @@ class _AlwaysBudgetExceeded:
     async def check_budgets(self, **kwargs):
         del kwargs
         from src.billing.budget import BudgetExceeded
+
         raise BudgetExceeded(entity_type="key", entity_id="k1", spend=10.0, max_budget=5.0)
 
 
@@ -45,7 +46,16 @@ class _FakeMCPGateway:
             )()
         ]
 
-    async def call_tool(self, auth, *, namespaced_tool_name, arguments, request_headers=None, request_id=None, correlation_id=None):  # noqa: ANN001, ANN201
+    async def call_tool(
+        self,
+        auth,
+        *,
+        namespaced_tool_name,
+        arguments,
+        request_headers=None,
+        request_id=None,
+        correlation_id=None,
+    ):  # noqa: ANN001, ANN201
         del auth, request_headers, request_id, correlation_id
         self.tool_calls.append((namespaced_tool_name, dict(arguments or {})))
         return MCPToolCallResult(
@@ -115,7 +125,14 @@ def test_responses_to_chat_request_preserves_mcp_tools() -> None:
         {
             "model": "gpt-4o-mini",
             "input": "hello",
-            "tools": [{"type": "mcp", "server": "docs", "allowed_tools": ["search"], "require_approval": "never"}],
+            "tools": [
+                {
+                    "type": "mcp",
+                    "server": "docs",
+                    "allowed_tools": ["search"],
+                    "require_approval": "never",
+                }
+            ],
             "tool_choice": "auto",
         }
     )
@@ -133,11 +150,31 @@ async def test_responses_with_mcp_tool_auto_executes(client, test_app):
     gateway = _FakeMCPGateway()
     test_app.state.mcp_gateway_service = gateway
     test_app.state.audit_service = _RecordingAuditService()
+    registry = test_app.state.router.deployment_registry["gpt-4o-mini"]
+    primary = registry[0]
+    fallback = type(primary)(
+        deployment_id="gpt-4o-mini-responses-fallback",
+        model_name=primary.model_name,
+        deltallm_params={
+            **primary.deltallm_params,
+            "api_key": "provider-key-fallback",
+        },
+        model_info=dict(primary.model_info),
+    )
+    registry.append(fallback)
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return primary
+
+    test_app.state.router.select_deployment = choose_primary
     upstream_calls: list[dict[str, object]] = []
+    attempted_auths: list[str | None] = []
 
     async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
-        del headers, timeout
+        del timeout
         upstream_calls.append(json)
+        attempted_auths.append(headers.get("Authorization"))
         assert url.endswith("/chat/completions")
         if len(upstream_calls) == 1:
             payload = {
@@ -170,12 +207,24 @@ async def test_responses_with_mcp_tool_auto_executes(client, test_app):
             return httpx.Response(200, json=payload)
 
         assert any(message.get("role") == "tool" for message in json["messages"])
+        if headers.get("Authorization") == "Bearer provider-key":
+            return httpx.Response(
+                503,
+                json={"error": {"message": "follow-up unavailable"}},
+                request=httpx.Request("POST", url),
+            )
         payload = {
             "id": "chatcmpl-resp-tool-2",
             "object": "chat.completion",
             "created": 1700000001,
             "model": json["model"],
-            "choices": [{"index": 0, "message": {"role": "assistant", "content": "done"}, "finish_reason": "stop"}],
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "done"},
+                    "finish_reason": "stop",
+                }
+            ],
             "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
         }
         return httpx.Response(200, json=payload)
@@ -185,7 +234,14 @@ async def test_responses_with_mcp_tool_auto_executes(client, test_app):
     body = {
         "model": "gpt-4o-mini",
         "input": "Search docs for DeltaLLM",
-        "tools": [{"type": "mcp", "server": "docs", "allowed_tools": ["search"], "require_approval": "never"}],
+        "tools": [
+            {
+                "type": "mcp",
+                "server": "docs",
+                "allowed_tools": ["search"],
+                "require_approval": "never",
+            }
+        ],
     }
 
     response = await client.post("/v1/responses", headers=headers, json=body)
@@ -193,7 +249,14 @@ async def test_responses_with_mcp_tool_auto_executes(client, test_app):
     assert response.status_code == 200
     assert response.json()["object"] == "response"
     assert response.json()["output"][0]["content"][0]["text"] == "done"
-    assert len(upstream_calls) == 2
+    assert len(upstream_calls) == 3
+    assert attempted_auths == [
+        "Bearer provider-key",
+        "Bearer provider-key",
+        "Bearer provider-key-fallback",
+    ]
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
     assert gateway.tool_calls == [("docs.search", {"query": "delta"})]
 
 
@@ -217,7 +280,14 @@ async def test_responses_stream_with_mcp_tools_returns_400(client, test_app):
         "model": "gpt-4o-mini",
         "input": "hello",
         "stream": True,
-        "tools": [{"type": "mcp", "server": "docs", "allowed_tools": ["search"], "require_approval": "never"}],
+        "tools": [
+            {
+                "type": "mcp",
+                "server": "docs",
+                "allowed_tools": ["search"],
+                "require_approval": "never",
+            }
+        ],
     }
 
     response = await client.post("/v1/responses", headers=headers, json=body)
@@ -233,7 +303,14 @@ async def test_responses_with_manual_approval_mcp_tools_returns_400(client, test
     body = {
         "model": "gpt-4o-mini",
         "input": "Search docs for DeltaLLM",
-        "tools": [{"type": "mcp", "server": "docs", "allowed_tools": ["search"], "require_approval": "never"}],
+        "tools": [
+            {
+                "type": "mcp",
+                "server": "docs",
+                "allowed_tools": ["search"],
+                "require_approval": "never",
+            }
+        ],
     }
 
     response = await client.post("/v1/responses", headers=headers, json=body)
@@ -246,7 +323,10 @@ async def test_responses_with_manual_approval_mcp_tools_returns_400(client, test
 @pytest.mark.parametrize(
     ("path", "body"),
     [
-        ("/v1/chat/completions", {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]}),
+        (
+            "/v1/chat/completions",
+            {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+        ),
         ("/v1/completions", {"model": "gpt-4o-mini", "prompt": "hello"}),
         ("/v1/responses", {"model": "gpt-4o-mini", "input": "hello"}),
     ],
@@ -265,17 +345,40 @@ async def test_text_endpoints_budget_exceeded_returns_429(client, test_app, path
 @pytest.mark.parametrize(
     ("path", "body", "expected_action"),
     [
-        ("/v1/chat/completions", {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": False}, "CHAT_COMPLETION_REQUEST"),
-        ("/v1/completions", {"model": "gpt-4o-mini", "prompt": "hello", "stream": False}, "COMPLETION_REQUEST"),
-        ("/v1/responses", {"model": "gpt-4o-mini", "input": "hello", "stream": False}, "RESPONSES_REQUEST"),
-        ("/v1/embeddings", {"model": "text-embedding-3-small", "input": "hello"}, "EMBEDDING_REQUEST"),
+        (
+            "/v1/chat/completions",
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": False,
+            },
+            "CHAT_COMPLETION_REQUEST",
+        ),
+        (
+            "/v1/completions",
+            {"model": "gpt-4o-mini", "prompt": "hello", "stream": False},
+            "COMPLETION_REQUEST",
+        ),
+        (
+            "/v1/responses",
+            {"model": "gpt-4o-mini", "input": "hello", "stream": False},
+            "RESPONSES_REQUEST",
+        ),
+        (
+            "/v1/embeddings",
+            {"model": "text-embedding-3-small", "input": "hello"},
+            "EMBEDDING_REQUEST",
+        ),
     ],
 )
 async def test_data_plane_routes_emit_audit_success(client, test_app, path, body, expected_action):
     audit = _RecordingAuditService()
     test_app.state.audit_service = audit
 
-    headers = {"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-audit-success"}
+    headers = {
+        "Authorization": f"Bearer {test_app.state._test_key}",
+        "x-request-id": "req-audit-success",
+    }
     response = await client.post(path, headers=headers, json=body)
     assert response.status_code == 200
 
@@ -294,8 +397,15 @@ async def test_data_plane_routes_emit_audit_success(client, test_app, path, body
 async def test_chat_stream_emits_audit_success(client, test_app):
     audit = _RecordingAuditService()
     test_app.state.audit_service = audit
-    headers = {"Authorization": f"Bearer {test_app.state._test_key}", "x-request-id": "req-stream-audit"}
-    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": True}
+    headers = {
+        "Authorization": f"Bearer {test_app.state._test_key}",
+        "x-request-id": "req-stream-audit",
+    }
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": True,
+    }
 
     response = await client.post("/v1/chat/completions", headers=headers, json=body)
     assert response.status_code == 200


### PR DESCRIPTION
## Summary

- separate retryable model execution from non-idempotent MCP tool execution
- prevent stale-session recovery from automatically replaying `tools/call`
- share one end-to-end request deadline across all MCP model and tool phases
- preserve deployment affinity across model phases and report fallback use across the complete MCP turn
- replace deep FastAPI request coupling with a typed MCP request context
- return sanitized OpenAI-compatible errors for unexpected local MCP orchestration failures without penalizing provider health

## Why

MCP orchestration previously ran inside the provider failover callback. If a tool succeeded and a later model call failed with a retryable error, retry or fallback could rerun the full orchestration and execute the non-idempotent tool again. Streamable HTTP stale-session recovery could also replay a `tools/call` after an ambiguous server response.

This is the third production-safety slice tracked by #275.

## Impact

Provider retries and failover now apply independently to each model phase, while MCP tool calls remain outside every provider retry boundary. A successful deployment becomes the primary for the next model phase, and route metadata records whether any phase used fallback even if the final phase returns to the original primary.

Unexpected local MCP failures are classified as sanitized `503 service_unavailable` responses, remain health-neutral, and are never retried as provider failures. Existing typed MCP, timeout, cancellation, and provider errors preserve their established handling.

No additional SQL, Redis, MCP, or provider round trips were added to the normal request path.

## Invariants and failure behavior

- non-idempotent MCP side effects never execute inside provider retry/failover scope
- `tools/call` is not replayed automatically after an ambiguous stale-session response
- all phases share one total deadline; retry layers cannot multiply the request timeout
- cancellation propagates without replaying successful tool calls
- local orchestration failures do not enter provider cooldown or health accounting
- OpenAI-compatible error envelopes and route-decision headers remain stable and sanitized

## Validation

- Ruff check passed for all 11 changed Python files
- Ruff format check passed for all 11 changed Python files
- affected MCP/chat/failover/responses suite: `167 passed`
- `git diff --check` passed

## Stack

- Feature base: `feat/gateway-hot-path-performance`
- PR1: #277, merged into the feature branch
- PR2: #278, merged into the feature branch
- Part of #275
