### PR TITLE
Establish public API compatibility baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,24 @@ on:
     branches: [main, master, feature/org-tiers]
 
 jobs:
+  official-typescript-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install compatibility-test dependencies
+        run: npm ci
+
+      - name: Run official OpenAI TypeScript client smoke tests
+        run: npm run test:compat
+
   ui-build:
     runs-on: ubuntu-latest
     defaults:

--- a/docs/api/compatibility.md
+++ b/docs/api/compatibility.md
@@ -1,0 +1,175 @@
+# Public API compatibility baseline
+
+This document records DeltaLLM's developer-facing HTTP behavior before the public DTO and OpenAPI stabilization work tracked by [GitHub issue #280](https://github.com/deltawi/deltallm/issues/280). It is an audit baseline, not a claim that every current behavior is the intended long-term contract.
+
+Baseline revision: `9e21536e4f3e65257e182784f7b1245312eb91eb` from 2026-08-21.
+
+The executable fixtures are under `tests/contracts/fixtures/`. Any later change to response bytes, omitted-versus-null fields, media types, error status/envelopes, route classification, JSONL rows, or webhook snapshots must update those fixtures deliberately and explain the compatibility impact.
+
+## Developer API inventory
+
+The machine-checked inventory is `tests/contracts/fixtures/public_route_inventory.json`. It classifies all current runtime routes by audience and gives every developer route an explicit protocol dialect.
+
+| Method | Route | Dialect | Current purpose |
+| --- | --- | --- | --- |
+| `POST` | `/v1/chat/completions` | OpenAI | Chat completions, including streaming |
+| `POST` | `/v1/completions` | OpenAI | Legacy text completions |
+| `POST` | `/v1/responses` | OpenAI | Responses API compatibility |
+| `POST` | `/v1/embeddings` | OpenAI | Embeddings |
+| `POST` | `/v1/images/generations` | OpenAI | Image generation |
+| `POST` | `/v1/audio/speech` | OpenAI | Speech synthesis |
+| `POST` | `/v1/audio/transcriptions` | OpenAI | Audio transcription |
+| `GET` | `/v1/models` | OpenAI | Visible model list |
+| `POST` | `/v1/messages` | Anthropic | Anthropic Messages compatibility |
+| `POST` | `/v1/rerank` | Delta JSON | Reranking extension |
+| `POST` | `/mcp` | JSON-RPC | MCP gateway |
+| `POST` | `/v1/files` | OpenAI target | Upload batch JSONL |
+| `GET` | `/v1/files/{file_id}` | OpenAI target | Retrieve file metadata |
+| `GET` | `/v1/files/{file_id}/content` | OpenAI target | Download JSONL content |
+| `POST` | `/v1/batches` | OpenAI target | Create a batch |
+| `GET` | `/v1/batches` | OpenAI target | List visible batches |
+| `GET` | `/v1/batches/{batch_id}` | OpenAI target | Retrieve a batch |
+| `POST` | `/v1/batches/{batch_id}/cancel` | OpenAI target | Request cancellation |
+
+The following families are not part of the developer contract planned for `/openapi/public-v1.json`:
+
+- `/ui/api/*` administration and browser control-plane APIs;
+- `/auth/*` identity/session APIs;
+- `/health/*` and `/metrics` operator diagnostics;
+- `/spend/*` and `/global/*` legacy reporting APIs;
+- `/webhooks/email/*` provider callbacks;
+- `/ui/*` browser HTML/assets; and
+- the existing mixed `/openapi.json`, `/docs`, and `/redoc` operator/debugging surfaces.
+
+## Wire formats
+
+| Capability | Current transport | Baseline fixture |
+| --- | --- | --- |
+| Files/Batches objects and errors | JSON | `files_batches_http.json` |
+| File upload | `multipart/form-data` file plus a currently query-bound `purpose` | `files_batches_http.json` and `batch_input.jsonl` |
+| Batch input | UTF-8 JSON Lines | `batch_input.jsonl` |
+| Batch success output | UTF-8 JSON Lines | `batch_output.jsonl` |
+| Batch error output | UTF-8 JSON Lines | `batch_error.jsonl` |
+| Downloaded batch content | `application/jsonl` at runtime | `batch_output.jsonl` |
+| Terminal batch webhook | Canonical JSON bytes plus signed HTTP headers | `batch_webhook_delivery.json` |
+| Gateway streams | Server-sent events (`text/event-stream`) where supported | Existing gateway/provider tests |
+| MCP | JSON-RPC over HTTP | Existing MCP tests |
+
+OpenAPI currently documents file content as an empty `application/json` response even though runtime returns `application/jsonl`. The known-gap fixture records this mismatch without changing it in the baseline PR.
+
+## Files compatibility
+
+| Capability | Current behavior | Intended delivery slice |
+| --- | --- | --- |
+| Upload | Available through `POST /v1/files` | Slice 2 moves `purpose` into multipart form data |
+| Retrieve metadata | Available | Slice 1 adds a stable response DTO without changing bytes |
+| Download content | Available | Slice 1 documents the correct media/body type |
+| List | Not implemented | Slice 4 |
+| Delete | Not implemented | Slice 4 with durable deletion |
+
+The upload handler currently declares `purpose` as a query parameter with default `batch`. An official client succeeds for `purpose=batch` because the ignored multipart value and server default happen to agree. A conflicting query value wins. The golden test intentionally records that behavior so Slice 2 produces a visible, reviewed diff.
+
+Current `FileObject` responses include `id`, `object`, `bytes`, `created_at`, `filename`, `purpose`, and deprecated `status`. Although expiry is persisted, `expires_at` is currently omitted from the public response.
+
+## Batches compatibility
+
+Supported batch endpoints:
+
+- `/v1/embeddings`
+- `/v1/chat/completions` with `stream` omitted or `false`; function tools are accepted and MCP tools are rejected
+
+Current create fields read by the server are:
+
+- `input_file_id`
+- `endpoint`
+- `completion_window`
+- `metadata`
+- Delta extension `webhook`
+
+Missing, null, or blank `completion_window` values normalize to `24h`; other values are rejected. The handler currently accepts an arbitrary JSON object and silently ignores unrelated top-level fields. That permissiveness is recorded as current behavior, not promised as the stabilized request contract.
+
+`Idempotency-Key` is read from the request. Durable idempotency is controlled by `embeddings_batch_create_idempotency_enabled`, which currently defaults to `false`.
+
+Current batch list behavior:
+
+- accepts only `limit`, defaulting to `20` without an explicit public maximum;
+- returns `{"object":"list","data":[...]}`;
+- has no object-ID `after` cursor; and
+- omits `first_id`, `last_id`, and `has_more`.
+
+Current public batch responses map internal `queued` to `validating` and an in-progress job with `cancel_requested_at` to `cancelling`. They include nullable output/error IDs and lifecycle timestamps, `errors`, request counts, and metadata. `model`, `cancelling_at`, `cancelled_at`, `finalizing_at`, and aggregate `usage` are currently omitted.
+
+## JSONL validation
+
+Every nonblank input line must be a JSON object with:
+
+- unique, nonblank `custom_id`;
+- `method` omitted or equal to `POST`;
+- `url` omitted or exactly equal to the batch endpoint; and
+- a typed request `body` for the selected endpoint.
+
+Output and error files use the current OpenAI-compatible row wrappers shown in the fixtures. Successful rows contain `response` and `error: null`; failed/cancelled rows contain `response: null` and a typed error object. `custom_id` is preserved in both.
+
+## Webhook compatibility and safety
+
+The create-only webhook object contains `url` and `signing_secret`. Only `{"configured":true}` is returned in Batch objects. The request secret is encrypted before persistence and does not appear in HTTP responses, webhook snapshots, validation diagnostics, logs, reprs, or checked-in examples.
+
+Webhook delivery is at least once. Retries preserve the event ID and exact canonical body. Every attempt changes its timestamp, signature, and attempt header. Receivers must verify the HMAC over the raw request bytes before parsing JSON, enforce a timestamp tolerance, and deduplicate by event ID.
+
+## Errors and tenant visibility
+
+Current Files/Batches errors use FastAPI's `{"detail":...}` response shape:
+
+- missing resources return 404;
+- foreign resources currently return 403 and therefore reveal that an ID exists;
+- request binding failures return 422 `HTTPValidationError`; and
+- service/runtime validation generally returns an HTTP status with a string or structured `detail`.
+
+Slice 2 deliberately changes public REST errors to stable OpenAI/Delta envelopes, converts public request validation to HTTP 400, and makes foreign resources indistinguishable from missing resources. Anthropic Messages and MCP JSON-RPC retain their own dialects.
+
+## Limits: defaults versus production example
+
+The values near the top of `docs/features/batching.md` are an example production profile, not defaults. The authoritative defaults are the typed settings in `src/config.py` and the constructor defaults used by `BatchService`.
+
+| Setting | Code default | Example production profile | Meaning |
+| --- | ---: | ---: | --- |
+| `embeddings_batch_max_file_bytes` | 52,428,800 bytes (50 MiB) | 209,715,200 bytes (200 MiB) | Maximum uploaded batch file bytes |
+| `embeddings_batch_max_items_per_batch` | 10,000 | 50,000 | Maximum nonblank validated JSONL items |
+| `embeddings_batch_max_line_bytes` | 1,048,576 bytes (1 MiB) | Inherits default in the example | Maximum single JSONL line bytes |
+| `embeddings_batch_max_pending_batches_per_scope` | 20 | 50 | Maximum active batches for the effective scope; `0` disables the cap |
+| `embeddings_batch_create_idempotency_enabled` | `false` | Not enabled in the example | Enables durable create resolution by scoped idempotency key |
+
+Deployments may choose lower or higher bounded values. Client code must treat limits as deployment configuration rather than universal constants.
+
+## Official client smoke baseline
+
+The baseline uses public operations documented by the official [OpenAI Files API](https://developers.openai.com/api/reference/resources/files) and [OpenAI Batches API](https://developers.openai.com/api/reference/resources/batches).
+
+| Client | Locked version | Passing smoke coverage | Named known gaps |
+| --- | --- | --- | --- |
+| OpenAI Python | `3.3.1` in `uv.lock` | upload, file retrieve/content, batch create/retrieve/list/cancel, metadata, `extra_headers`, and Delta `extra_body` | Files list; correct multi-page batch cursor traversal |
+| OpenAI TypeScript | `7.5.0` in `package-lock.json` | multipart upload serialization, file retrieve/content, batch create/retrieve/list/cancel, metadata, and request headers | Files list; correct multi-page batch cursor traversal |
+
+Run the focused baseline with:
+
+```bash
+uv run pytest -v -rs tests/contracts tests/compat/openai_python
+npm run test:compat
+```
+
+Each expected failure names exactly one missing capability and its delivery slice. An unexpected pass is strict in Python so the test must be updated when a gap closes. TypeScript uses named `todo` entries until the real HTTP conformance server arrives in Slice 6.
+
+## Current OpenAPI gaps
+
+`tests/contracts/fixtures/openapi_known_gaps.json` is the executable list. At baseline:
+
+- the full schema mixes developer, admin, auth, health, metrics, and reporting routes;
+- protected routes expose an optional raw `Authorization` header parameter and no `BearerAuth` scheme;
+- Files/Batches successful response schemas are empty;
+- batch create is an arbitrary object;
+- file `purpose` is query-bound instead of multipart;
+- file content has the wrong documented media type;
+- Files list/delete and Batch cursor metadata are missing; and
+- public validation advertises the FastAPI 422 envelope.
+
+Later slices should remove a known-gap entry only in the same change that adds the intended contract, wire tests, official-client coverage, and compatibility notes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
           - Settings: admin-ui/settings.md
   - API Reference:
       - api/index.md
+      - Public Compatibility Baseline: api/compatibility.md
       - Proxy Endpoints: api/proxy.md
       - Anthropic Messages: api/messages.md
       - MCP Gateway & Tooling: api/mcp.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,14 @@
 {
-  "name": "workspace",
+  "name": "sdk-public-contract",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "playwright": "^1.59.1"
+      },
+      "devDependencies": {
+        "openai": "^7.5.0"
       }
     },
     "node_modules/fsevents": {
@@ -20,6 +23,40 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.5.0.tgz",
+      "integrity": "sha512-ZbDBz8FSB8Mv8fFYIUvzTFMdV5vl93/octp1MdtK2lfYepSpfv/ewmeugpKz/cwGtFSx+YuUM4NwpZ2P55YiPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/playwright": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,11 @@
 {
+  "scripts": {
+    "test:compat": "node --test tests/compat/openai_typescript/*.test.mjs"
+  },
   "dependencies": {
     "playwright": "^1.59.1"
+  },
+  "devDependencies": {
+    "openai": "^7.5.0"
   }
 }

--- a/plans/public-api-contract-and-sdk-plan.md
+++ b/plans/public-api-contract-and-sdk-plan.md
@@ -1,0 +1,900 @@
+# Public API contract and companion SDK implementation plan
+
+> Status: implementation in progress; Slice 0 establishes the executable compatibility baseline without changing runtime behavior.
+>
+> Decision: stabilize and publish DeltaLLM's public API contract first, then add a thin Python companion SDK in this repository. Do not create a separate SDK repository yet.
+
+## 1. Planning baseline
+
+| Item | Value |
+| --- | --- |
+| Worktree | `.worktrees/sdk-public-contract` |
+| Branch | `feat/public-contract-baseline` |
+| Remote base | `origin/main` |
+| Base commit | `9e21536e4f3e65257e182784f7b1245312eb91eb` |
+| Base commit date | 2026-08-19 |
+| Latest release visible at planning time | `v0.1.35` |
+| Plan date | 2026-08-21 |
+
+The source checkout's unrelated untracked `plans/` and `ui/design/` directories were not copied, modified, staged, or deleted. This worktree was created after fetching `origin/main` and is clean except for this plan.
+
+The external compatibility baseline is the current official OpenAI documentation for:
+
+- [Create a batch](https://developers.openai.com/api/reference/python/resources/batches/methods/create)
+- [List batches](https://developers.openai.com/api/reference/python/resources/batches/methods/list)
+- [Upload a file](https://developers.openai.com/api/reference/python/resources/files/methods/create)
+- [List files](https://developers.openai.com/api/reference/python/resources/files/methods/list)
+
+These links are comparison inputs, not a promise that DeltaLLM implements every OpenAI field or endpoint. The DeltaLLM public specification and compatibility matrix defined below become the authoritative statement of what this deployment supports.
+
+## 2. Executive decision
+
+Build the work in this order:
+
+1. Make the server's existing public behavior explicit with stable Pydantic DTOs, wire-contract tests, and an OpenAI/Anthropic/Delta error-dialect boundary.
+2. Correct the concrete interoperability gaps in Files and Batches: multipart form semantics, cursor pages, missing list/delete operations, stable errors, and documented Delta extensions.
+3. Publish a curated public OpenAPI document and public Swagger/ReDoc views that exclude admin, authentication, operational, and UI routes.
+4. Add official OpenAI Python and TypeScript client conformance tests against the server.
+5. Add a small Python package under `clients/python` for DeltaLLM-specific batch workflows and webhook verification. Continue to use the official OpenAI SDK for chat, responses, embeddings, Files, and Batches.
+6. Keep the package in the monorepo until the extraction criteria in section 16 are met.
+
+This avoids two expensive mistakes:
+
+- publishing an SDK around an undocumented, unstable wire contract; and
+- reimplementing the large OpenAI API surface that DeltaLLM intentionally claims to proxy.
+
+The SDK's initial value is not another chat client. Its value is safe batch submission, bounded waiting, streamed JSONL result handling, typed Delta extensions, idempotency, and webhook verification.
+
+## 3. Audited current state on latest `origin/main`
+
+### 3.1 What already works
+
+- Standard application clients can point the official OpenAI SDK at DeltaLLM by changing `base_url` and the API key; the README and quickstart already show this.
+- Public Files support upload, metadata retrieval, and content download.
+- Public Batches support create, retrieve, list, and cancel for `/v1/embeddings` and non-streaming `/v1/chat/completions` input lines.
+- Batch output and error artifacts already use OpenAI-shaped JSONL rows with `id`, `custom_id`, `response`, and `error`.
+- Batch ownership is scoped by API key, team, or organization, with team scope taking precedence over organization scope.
+- Batch creation has a durable create-session path and optional `Idempotency-Key` support behind configuration.
+- Terminal webhook configuration is validated, encrypted, write-only, SSRF constrained, delivered through a durable outbox, signed, retried, and redacted from logs/audit responses.
+- `docs/features/batching.md` documents the operational batch lifecycle and webhook delivery behavior in depth.
+
+These are substantial runtime foundations. The work should preserve them rather than build a parallel batch implementation in an SDK.
+
+### 3.2 Concrete contract gaps
+
+The generated OpenAPI document was inspected directly from `create_app().openapi()` at the base commit:
+
+| Finding | Current evidence | Consequence |
+| --- | --- | --- |
+| The default document mixes public and private surfaces | 209 paths total; 161 start with `/ui/api` | A developer cannot safely treat `/openapi.json` as the app-facing contract, and generated clients would contain admin APIs. |
+| Public success schemas are mostly empty | 16 public `/v1` operations have an empty JSON 200 schema; `/v1/models` is only `additionalProperties: true` | IDE completion, generated docs, validators, and client generators cannot describe responses. |
+| Batch create is untyped | `payload: dict[str, Any]`; OpenAPI emits `additionalProperties: true` | Required fields, supported endpoints, metadata, webhook fields, and unsupported behavior are undiscoverable. |
+| Files and Batches return manual dictionaries | `src/batch/service.py` and `src/batch/serialization.py` | Static types exist neither at the route boundary nor as a stable reusable contract. |
+| File upload does not match normal SDK multipart behavior | `purpose` is currently emitted as a query parameter rather than a multipart form field | The official SDK sends a form field; today the server silently falls back to the default in the common `batch` case. |
+| Batch pagination is incomplete | Public list accepts only `limit` and returns only `object` plus `data` | Official cursor-page helpers require `after`, `first_id`, `last_id`, and `has_more`. |
+| Existing repository cursor semantics are unsuitable | Internal `after: datetime` filters `created_at > after` while sorting descending; ordering has no ID tie-breaker | It cannot implement object-ID cursor pagination deterministically. |
+| Files have no list or public delete route | Only POST, GET metadata, and GET content are registered | The official Files resource is only partially compatible and user cleanup is not ergonomic. |
+| Errors have multiple wire envelopes | `ProxyError` uses `{error:{...}}`; `HTTPException` uses `{detail:...}`; validation uses 422 `detail` arrays; webhook validation may use a detail object | Clients must special-case the failure source, and OpenAPI cannot advertise one error model. |
+| Authentication is not modeled as security | OpenAPI has no `securitySchemes`; `Authorization` appears as an optional header parameter | Generated clients do not know that Bearer authentication is required. |
+| Operation IDs are framework-generated | Names include path-derived suffixes such as `create_batch_v1_batches_post` | Renaming a Python function can create an accidental generated-client breaking change. |
+| Full OpenAPI generation already warns about a duplicate admin operation ID | Duplicate UI branding GET/HEAD operation | A generated full client is not a stable release artifact. |
+| Public batch fields are only partially represented | The serializer omits `model`, cancellation timestamps, `finalizing_at`, and `usage`; Files omit `expires_at` | The official SDK can often tolerate optional omissions, but DeltaLLM's supported subset is not explicit. |
+| Unknown batch-create fields are silently ignored | The raw dict handler selects known values | New OpenAI fields such as `output_expires_after` can appear accepted while having no effect. |
+| Cross-scope retrieval returns 403 after finding the object | Files and Batches load by ID, then check access | A caller can distinguish an existing foreign ID from a missing ID. |
+| Versioning is disconnected | FastAPI and `pyproject.toml` are statically `0.1.0` while releases are at `v0.1.35` | OpenAPI `info.version` cannot currently communicate either product or contract version reliably. |
+
+### 3.3 Current public-surface classification
+
+The curated contract must classify routes by dialect and audience instead of selecting every FastAPI route with a prefix.
+
+| Surface | Routes | Public spec | Initial companion SDK |
+| --- | --- | --- | --- |
+| OpenAI-compatible | `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/embeddings`, `/v1/images/generations`, `/v1/audio/speech`, `/v1/audio/transcriptions`, `/v1/models`, `/v1/files*`, `/v1/batches*` | Yes | Official OpenAI client exposed as `client.openai`; Delta helper adds batch workflow only. |
+| Anthropic-compatible subset | `/v1/messages` | Yes, under a distinct tag and error dialect | No wrapper in v0.1; document use of the official Anthropic SDK with Bearer auth. |
+| Delta public extensions | `/v1/rerank`, `/mcp`, batch webhook request/response/event fields | Yes, explicitly marked with `x-deltallm-extension` | Webhook verification and batch extension support in v0.1; MCP helper deferred until its DTO is stable. |
+| Operational | `/health*`, `/metrics` | No; keep separate operator documentation | No. |
+| Control plane and UI | `/ui/api*`, `/auth*`, `/spend*`, `/global*`, SPA routes | No | No. A future admin SDK is a different product and permission model. |
+| Provider callback | `/webhooks/email/resend` | No | No. |
+
+## 4. Goals, non-goals, and contract rules
+
+### 4.1 Goals
+
+1. Give developers a machine-readable public contract at a stable URL and human-readable public Swagger/ReDoc pages.
+2. Preserve successful response bytes and omission/null behavior while DTOs are first introduced.
+3. Make every intentional compatibility difference visible in a checked-in matrix.
+4. Make official OpenAI SDK Files/Batches calls and cursor iteration work against DeltaLLM.
+5. Give DeltaLLM extensions stable names, schemas, examples, and secret-handling rules.
+6. Provide consistent, typed errors for each public protocol dialect.
+7. Keep pagination tenant-safe, deterministic, bounded, and one database round trip per page.
+8. Avoid adding any data-plane lookup only for documentation or SDK support.
+9. Release a small, independently versioned Python package without coupling its release to container or Helm publication.
+
+### 4.2 Non-goals for the first SDK release
+
+- Reimplementing the official OpenAI SDK's chat, Responses, embeddings, images, audio, or Files resources.
+- Generating and committing a full client from the current application-wide OpenAPI document.
+- Exposing `/ui/api`, platform sessions, master-key administration, spend reports, diagnostics, or deployment topology.
+- Claiming every current OpenAI Batch endpoint; DeltaLLM continues to support only the two worker implementations it actually owns.
+- Supporting provider-native async batch APIs as a separate public abstraction.
+- Adding JavaScript, Go, or Java DeltaLLM packages before the Python package and contract have real consumers.
+- Fetching OpenAPI at SDK runtime or making capability discovery a required request path.
+- Loading an entire batch input or output file into memory in convenience helpers.
+
+### 4.3 Contract invariants
+
+- `src/public_api/v1` owns public DTO definitions. Persistence dataclasses remain in `src/batch/models.py` and are not public API types.
+- Existing domain serializers adapt persisted records into public DTOs; route handlers do not recreate response dictionaries.
+- The checked-in `openapi/deltallm-public-v1.json` is generated from route metadata and DTOs, never hand-edited.
+- `scripts/export_public_openapi.py --check` proves the checked-in artifact matches code.
+- Public route behavior is compatible by default. A deliberate break requires a migration note, a contract-major decision, and an OpenAPI breaking-change review.
+- Secret request fields are `writeOnly`; no response schema, example, exception, log, or audit payload contains a webhook URL or signing secret.
+- The public schema is deterministic and independent of database contents, provider availability, feature-flag values, or startup lifecycle.
+- OpenAPI generation and serving are cached in process and perform no I/O after application construction.
+- Each list page is bounded and resolved with one tenant-scoped SQL query.
+- Cross-tenant and unknown resource IDs have indistinguishable public behavior.
+- The SDK never owns an unbounded background poller and never retries a non-idempotent submission without an idempotency key.
+
+## 5. Target architecture
+
+```text
+persisted/domain records
+          |
+          v
+public adapters + Pydantic DTOs  -----> webhook event snapshot
+          |
+          v
+public FastAPI route metadata
+          |
+          +----> runtime responses
+          |
+          +----> cached /openapi/public-v1.json
+          |
+          +----> checked-in openapi/deltallm-public-v1.json
+                         |
+                         +----> public docs + compatibility checks
+                         +----> server conformance tests
+                         +----> thin companion SDK contract tests
+```
+
+Create these server-side modules rather than enlarging the existing endpoint or batch worker files:
+
+```text
+src/public_api/
+  __init__.py
+  surface.py                 # public route/dialect ownership
+  errors.py                  # public exception mapping and error DTOs
+  openapi.py                 # deterministic public OpenAPI construction/cache
+  v1/
+    __init__.py
+    common.py                # JSON values, headers, shared enums
+    pagination.py
+    files.py
+    batches.py
+    batch_jsonl.py
+    webhooks.py
+    gateway.py               # non-batch response docs, streaming/binary content
+```
+
+`src/api/v1/router.py` should expose a `public_data_router` containing the actual app-facing routes and a separate operational/control composition. `/mcp` remains at its existing runtime path but is explicitly registered in `src/public_api/surface.py`. The public OpenAPI generator consumes the explicit public route collection, not the full app and not a string-prefix filter.
+
+## 6. DTO and wire-format design
+
+### 6.1 Shared DTO policy
+
+- Use Pydantic v2 models with explicit `title`, descriptions, examples, and stable component names.
+- Use `ConfigDict(extra="forbid")` for DeltaLLM-owned request bodies once the compatibility cutover is announced. During the first wire-preserving DTO PR, retain the current ignore behavior and add a test that makes this temporary state visible.
+- Use `ConfigDict(extra="allow")` for proxied provider responses where compatible providers may add fields. Do not let `response_model` strip unknown upstream fields.
+- Use `response_model_exclude_unset=True` or OpenAPI-only response declarations where necessary so adding a DTO does not turn omitted fields into explicit `null` values.
+- Timestamps are integer Unix seconds and carry `format: unixtime` in JSON Schema.
+- IDs are opaque nonblank strings. Do not require OpenAI's example prefixes because existing DeltaLLM rows use UUID strings.
+- Define recursive `JSONValue` once. Metadata remains `dict[str, JSONValue]` in contract v1 to preserve existing behavior; tightening it to OpenAI's 16 string pairs would be a later breaking change.
+- Delta-only response fields use normal JSON names plus `x-deltallm-extension: true` in their schema; do not hide them in an untyped extension blob.
+
+### 6.2 File DTOs
+
+| DTO | Fields | Notes |
+| --- | --- | --- |
+| `FileObject` | `id`, `object="file"`, `bytes`, `created_at`, `filename`, `purpose`, `status`, optional `expires_at`, optional `status_details` | `status` and `status_details` are documented as compatibility/deprecated fields. Add `expires_at` from the existing record; do not synthesize it. |
+| `FilePurpose` | `batch`, `batch_output`, `batch_error` for current responses; request accepts only `batch` | Keep internal purpose names explicit. The official Files schema uses `batch_output`, while DeltaLLM currently persists `batch_error` for error artifacts. Validate official SDK parsing; if it rejects the current value, map `batch_error` to public `batch_output` without changing persistence. |
+| `FileUploadForm` | binary `file`, `purpose="batch"` | `purpose` is a multipart form field. Preserve the current query parameter for one deprecation window and reject conflicting query/form values. |
+| `FileListPage` | `object="list"`, `data`, `first_id`, `last_id`, `has_more` | Empty page returns null IDs and `has_more=false`. |
+| `FileDeleted` | `id`, `object="file"`, `deleted=true` | Returned after a logical, durable delete request is committed. |
+| `FileContent` | binary/string response under `application/jsonl` | Document `Content-Disposition`, byte streaming, and 404 behavior. Do not model this as JSON `{}`. |
+
+Add `GET /v1/files` with `after`, `limit`, `order`, and `purpose`. Add `DELETE /v1/files/{file_id}` only with the durable deletion design in section 8; do not copy the retention worker's current storage-delete-then-row-delete sequence into a request path.
+
+### 6.3 Batch DTOs
+
+| DTO | Fields | Notes |
+| --- | --- | --- |
+| `CreateBatchRequest` | `input_file_id`, `endpoint`, `completion_window`, optional `metadata`, optional `webhook` | `endpoint` is a literal union of `/v1/embeddings` and `/v1/chat/completions`. Missing or null `completion_window` normalizes to `24h` to preserve current behavior. |
+| `BatchObject` | `id`, `object="batch"`, `endpoint`, `completion_window`, `status`, `input_file_id`, nullable output/error IDs, timestamps, nullable `errors`, `request_counts`, `metadata`, optional `model`, optional `usage`, optional `webhook` | Keep the exact existing required/nullable fields. Add already-authoritative `model`, `cancelling_at` from `cancel_requested_at`, `cancelled_at` from the terminal transition timestamp, and explicit documented null/omission behavior. Leave `finalizing_at`/`usage` absent or null until they have an authoritative persisted value. |
+| `BatchStatus` | `validating`, `failed`, `in_progress`, `finalizing`, `completed`, `expired`, `cancelling`, `cancelled` | Preserve the existing mapping from internal `queued` to `validating`. |
+| `BatchRequestCounts` | `total`, `completed`, `failed`, optional `cancelled`, optional `in_progress` | The last two are Delta extensions and remain because current users can observe them. |
+| `BatchErrors` / `BatchErrorItem` | OpenAI-compatible list and item fields | The value remains null for DeltaLLM's synchronous create validation until a real batch-level validation-error source exists. |
+| `BatchUsage` | compatible optional aggregate fields | Schema may be present while the response omits the field. Do not calculate it with a read-time scan. A future finalization-time aggregate can populate it. |
+| `BatchListPage` | `object="list"`, `data`, `first_id`, `last_id`, `has_more` | Supports official SDK cursor helpers. |
+
+Do not silently accept `output_expires_after` or unsupported OpenAI batch endpoints. After the transitional DTO PR, return a stable `invalid_request_error` with `code="unsupported_parameter"` and `param` naming the field. The compatibility matrix must list supported endpoints, current maximum file/item sizes from runtime configuration, and unsupported optional OpenAI fields.
+
+### 6.4 Batch JSONL DTOs
+
+OpenAPI cannot natively validate every line of an uploaded/downloaded JSONL document, so publish component schemas and examples and reference them from the Files/Batches descriptions.
+
+| DTO | Shape |
+| --- | --- |
+| `EmbeddingBatchInputLine` | `custom_id`, optional/default `method="POST"`, optional/default `url="/v1/embeddings"`, `body: EmbeddingRequest` |
+| `ChatBatchInputLine` | Same wrapper with `/v1/chat/completions` and a non-streaming `ChatCompletionRequest` body |
+| `BatchSuccessResponse` | `status_code`, `request_id`, `body` |
+| `BatchOutputLine` | `id`, `custom_id`, non-null `response`, `error=null` |
+| `BatchErrorLine` | `id`, `custom_id`, `response=null`, typed `error` |
+
+Cross-field validation remains in `src/batch/request_validation.py`: line URL must match the batch endpoint, method must be POST, `custom_id` must be unique, streaming must be false, and MCP tools remain unsupported in batch chat. The DTO documentation and runtime validator must use the same supported-endpoint constants.
+
+### 6.5 Webhook DTOs
+
+| DTO | Fields | Security behavior |
+| --- | --- | --- |
+| `BatchWebhookCreate` | `url`, `signing_secret` | Entire object is request-only. Both fields are `writeOnly`; the secret is `format: password`, excluded from repr, examples, validation input, and exception context. Reuse the existing validator rather than introduce a second URL policy. |
+| `BatchWebhookConfigured` | `configured=true` | The only webhook value allowed in a Batch response. |
+| `BatchWebhookEvent` | `id`, `object="event"`, terminal `type`, `created_at`, `data.batch` | Reuse the exact `BatchObject` snapshot serializer used by GET Batches. |
+| `BatchWebhookHeaders` | event ID/type/attempt/timestamp/signature and `Idempotency-Key` | Document as callback headers, not ordinary response properties. |
+
+The schema must state that webhook delivery is at least once, event ID/body are stable across retries/replay, signature timestamp changes per attempt, and a receiver verifies the signature over raw bytes before JSON parsing.
+
+### 6.6 Gateway DTO completion
+
+The curated public spec must not publish empty schemas for the rest of the gateway. Complete these without forcing response filtering:
+
+- reference the existing request DTOs for Chat, Completions, Responses, Embeddings, Images, Audio, and Rerank;
+- define known response DTOs with `extra="allow"` for provider-compatible additions;
+- describe non-stream JSON and `text/event-stream` as separate 200 media types for streaming endpoints;
+- describe audio speech as binary with its supported media types;
+- model transcription text and JSON response variants separately;
+- keep Anthropic Messages response/error components in an Anthropic-tagged namespace;
+- define JSON-RPC request/result/error components for `/mcp`, including its 202 notification response;
+- replace `/v1/models`' broad return annotation with the existing `ModelsResponse` contract while preserving output bytes.
+
+Where FastAPI `response_model` would filter an upstream response, use the route's `responses={...}` OpenAPI declaration instead. Contract documentation must never mutate the proxied payload.
+
+## 7. Public error contract
+
+### 7.1 Dialect-aware mapping
+
+Create one path-to-dialect classifier in `src/public_api/surface.py` and one public exception mapping implementation in `src/public_api/errors.py`.
+
+- OpenAI-compatible and Delta JSON REST routes use:
+
+  ```json
+  {
+    "error": {
+      "message": "...",
+      "type": "invalid_request_error",
+      "param": "input_file_id",
+      "code": "file_not_found"
+    }
+  }
+  ```
+
+- `/v1/messages` keeps the Anthropic-compatible error envelope.
+- `/mcp` keeps JSON-RPC errors for protocol methods; authentication failures before JSON-RPC dispatch use a documented HTTP error.
+- Non-public routes continue using their current handlers. Do not globally turn `/ui/api` errors into OpenAI errors.
+
+### 7.2 Status and code table
+
+Define named public exceptions and document at least:
+
+| Status | Type | Stable example codes |
+| --- | --- | --- |
+| 400 | `invalid_request_error` | `invalid_jsonl`, `unsupported_endpoint`, `unsupported_parameter`, `invalid_completion_window`, `invalid_webhook` |
+| 401 | `authentication_error` | `missing_api_key`, `invalid_api_key` |
+| 404 | `not_found_error` | `file_not_found`, `batch_not_found`, `batch_api_disabled` |
+| 409 | `conflict_error` | `idempotency_conflict`, `file_in_use` |
+| 413 | `invalid_request_error` | `file_too_large`, `line_too_large` |
+| 429 | `rate_limit_error` | `rate_limit_exceeded`, `batch_capacity_exceeded` |
+| 503 | `service_unavailable` | `batch_unavailable`, `storage_unavailable`, `webhook_unavailable` |
+
+Convert public Pydantic validation to the stable envelope and HTTP 400 in Slice 2, which is the compatibility behavior SDK callers expect. Treat this as a deliberate 0.x public-contract cutover: call it out in release notes and golden tests, but do not carry two validation envelopes or an ambiguous runtime toggle.
+
+Never return a foreign resource as 403. Public Files/Batches retrieve, content, cancel, cursor-anchor, and delete paths return the same 404 as an unknown ID. Audit still records the denied attempt with safe IDs and scope metadata.
+
+### 7.3 Authentication schema
+
+Use FastAPI's `HTTPBearer(auto_error=False)` through `Security(...)` so protected public operations emit a named `BearerAuth` security scheme instead of an optional free-form header. Preserve runtime master-key, virtual key, JWT, and custom-auth behavior by continuing to pass the raw token into `authenticate_request`.
+
+Tests must prove:
+
+- no duplicate auth read or database lookup is introduced;
+- absent, empty, malformed, invalid, and valid Bearer tokens keep the intended status;
+- public OpenAPI marks protected routes and does not mark health/operator routes accidentally;
+- secrets are never included in validation diagnostics.
+
+## 8. Deterministic pagination and file deletion
+
+### 8.1 Batch pages
+
+Change the repository interface to return a page result, not a bare list:
+
+```text
+BatchPageResult
+  items: list[BatchJobRecord]
+  has_more: bool
+```
+
+The public request is `after=<last batch id>&limit=1..100`, default 20, descending by creation time. Fetch `limit + 1`, return at most `limit`, and calculate `has_more` from the extra record.
+
+Use one SQL statement with:
+
+- the current effective API-key/team/organization scope predicate;
+- an anchor subquery scoped with the identical predicate;
+- keyset comparison `(created_at, batch_id) < (anchor.created_at, anchor.batch_id)`;
+- `ORDER BY created_at DESC, batch_id DESC`;
+- a limit of `requested + 1`.
+
+An absent or foreign anchor yields an empty page and reveals no resource existence. It does not fall back to the first page. Add composite indexes for each supported owner scope ending in `(created_at DESC, batch_id DESC)`. Do not use offset pagination or a second anchor query.
+
+### 8.2 File pages
+
+Add the equivalent `FilePageResult` and repository query with:
+
+- `after` object-ID cursor;
+- `limit` default 100 and maximum 1,000, explicitly documented as DeltaLLM's bounded deviation from OpenAI's larger Files page limit;
+- `order=asc|desc` with deterministic `file_id` tie-breaking;
+- optional purpose filter;
+- the same effective ownership rules as file retrieval;
+- `limit + 1` page calculation in one query.
+
+Compatibility means the SDK can page correctly, not that a self-hosted gateway must copy OpenAI's 10,000-row default. Load tests may justify a future additive limit increase, but contract v1 starts at the bounded values above.
+
+### 8.3 Durable public file delete
+
+Do not delete object storage synchronously and then delete the database row. Add a small durable deletion outbox and make retention cleanup use the same path:
+
+```text
+deltallm_batch_file_deletion_outbox
+  file_id              TEXT PRIMARY KEY
+  storage_backend      TEXT NOT NULL
+  storage_key          TEXT NOT NULL
+  status               TEXT NOT NULL  # queued, processing, retrying, failed
+  attempt_count        INTEGER NOT NULL DEFAULT 0
+  next_attempt_at      TIMESTAMP NULL
+  locked_by            TEXT NULL
+  lease_expires_at     TIMESTAMP NULL
+  last_error           TEXT NULL       # bounded classification only
+  created_at           TIMESTAMP NOT NULL
+  updated_at           TIMESTAMP NOT NULL
+```
+
+The DELETE transaction must:
+
+1. lock the tenant-scoped file;
+2. return 404 for missing/foreign IDs;
+3. check all batch-job and create-session references;
+4. return 409 `file_in_use` if any reference remains;
+5. insert the idempotent deletion record with a storage snapshot;
+6. make subsequent public GET/list calls treat the file as deleted; and
+7. return `FileDeleted` after commit.
+
+A bounded worker performs idempotent storage deletion, then removes the file row and outbox row transactionally where possible. Process death, storage timeout, an already-missing object, retries, lease recovery, and backend migration all need tests. Reuse lifecycle/retry/observability patterns from the webhook outbox without sharing secret material or copying a worker wholesale.
+
+`init_batch_runtime` owns this lifecycle. API-role processes enqueue only; the existing `embeddings_batch_gc_enabled` cleanup-owning batch worker role claims and drains deletions in split deployments. The deployment gate must verify at least one such worker is healthy before a server release exposing DELETE is rolled out to API pods.
+
+This slice also moves retention-triggered unreferenced files onto the deletion outbox so the repository has one deletion policy.
+
+## 9. Public OpenAPI and developer documentation
+
+### 9.1 Runtime endpoints
+
+Keep existing FastAPI defaults for backward compatibility and add:
+
+| Route | Purpose |
+| --- | --- |
+| `GET /openapi/public-v1.json` | Curated, cached public contract only. |
+| `GET /docs/api` | Swagger UI configured to load the curated public contract. |
+| `GET /redoc/api` | ReDoc configured to load the curated public contract. |
+
+These documentation routes use `include_in_schema=False`. They do not require a database or a working provider. The schema describes Bearer auth but remains readable without a token unless deployment policy explicitly disables public docs.
+
+### 9.2 Specification metadata
+
+- `info.title`: `DeltaLLM Public API`
+- `info.version`: independent public contract SemVer, starting at `1.0.0-beta.1` until compatibility gates pass
+- `servers`: examples only; do not bake deployment hostnames into the artifact
+- stable tag descriptions for OpenAI compatibility, Anthropic compatibility, and Delta extensions
+- stable explicit operation IDs such as `files.create`, `files.list`, `batches.create`, `batches.list`, and `mcp.call`
+- `BearerAuth` security scheme
+- reusable error responses and common request ID/rate-limit headers
+- `x-deltallm-compatibility`, `x-deltallm-extension`, and `x-deltallm-feature-flag` annotations where useful
+
+Do not use the server image tag as the OpenAPI contract version. Record the minimum DeltaLLM server release in the compatibility matrix and SDK metadata instead.
+
+### 9.3 Checked-in artifact and CI
+
+Add:
+
+```text
+openapi/deltallm-public-v1.json
+scripts/export_public_openapi.py
+tests/contracts/test_public_openapi.py
+tests/contracts/test_public_wire_examples.py
+docs/api/public-contract.md
+docs/api/compatibility.md
+```
+
+The exporter writes canonical UTF-8 JSON with sorted keys and a final newline. `--check` exits nonzero and prints the first differing logical path when regeneration is required.
+
+CI gates:
+
+1. build the schema twice and prove byte-for-byte determinism;
+2. prove the checked-in artifact is current;
+3. validate the OpenAPI document;
+4. reject admin/auth/health/metrics/spend/UI paths;
+5. reject duplicate operation IDs;
+6. reject protected operations without `BearerAuth`;
+7. reject empty 2xx schemas or undocumented binary/SSE bodies;
+8. reject `signing_secret` without `writeOnly` and reject webhook secret examples;
+9. run a pinned OpenAPI breaking-change checker against the base-branch artifact after the initial baseline exists;
+10. require an explicit reviewed waiver plus contract-major plan for a breaking change.
+
+The public spec is the developer discovery endpoint. The checked-in copy is the review/release artifact. Both come from the same code, so they cannot become competing hand-maintained sources.
+
+### 9.4 Human documentation
+
+Update `mkdocs.yml`, `README.md`, `docs/getting-started/quickstart.md`, `docs/api/proxy.md`, and `docs/features/batching.md` to include:
+
+- links to `/docs/api`, `/redoc/api`, and `/openapi/public-v1.json`;
+- official OpenAI Python and TypeScript Files/Batches examples against a DeltaLLM base URL;
+- DeltaLLM batch limits as configuration-dependent values, not hard-coded universal promises;
+- the supported endpoint/field matrix and known differences;
+- idempotency configuration and retry semantics;
+- cursor iteration examples;
+- JSONL input/output schemas and streamed processing examples;
+- webhook signing, raw-body verification, timestamp tolerance, deduplication, and replay behavior;
+- error envelopes with request IDs and retry guidance;
+- the companion SDK as optional convenience, not a prerequisite for gateway use.
+
+Resolve the current documentation mismatch between the 50,000-item/200 MB production example and the 10,000-item/52 MB defaults by labeling each value with its actual configuration source.
+
+## 10. Official client conformance suite
+
+Before publishing the companion package, prove that the standard clients work without it.
+
+### 10.1 Python matrix
+
+Create `tests/compat/openai_python/` and run the oldest declared supported official OpenAI Python SDK plus the version locked on main. The tests must use only public SDK methods and request options.
+
+Cover:
+
+1. `OpenAI(base_url=".../v1", api_key=...)` initialization;
+2. file upload with multipart `purpose=batch`;
+3. file retrieve and streamed content download;
+4. batch create, retrieve, cancel, and list;
+5. auto-pagination across at least three pages with equal `created_at` values;
+6. Delta webhook payload through the SDK's documented `extra_body` mechanism;
+7. `Idempotency-Key` through documented `extra_headers`;
+8. parsing Delta request-count and webhook extension fields without losing standard fields;
+9. typed error handling for 400, 401, 404, 409, 429, and 503;
+10. no secret in exception text/repr.
+
+If a tested official SDK version does not preserve extension response fields, the companion helper may return its own Delta extension view, but the server must not distort the standard Batch object to accommodate one client implementation.
+
+### 10.2 TypeScript matrix
+
+Create an isolated locked fixture under `tests/compat/openai_typescript/`. Cover upload, batch create/retrieve/list pagination, content, extension request options, and error parsing. Do not add the OpenAI package to the admin UI bundle.
+
+### 10.3 Test server
+
+Run compatibility tests against a real local ASGI/HTTP server with:
+
+- real PostgreSQL for cursor and ownership behavior;
+- a deterministic local artifact backend;
+- a deterministic fake upstream for embeddings/chat;
+- one API-key scope, one same-team key, one same-organization key, and a foreign scope;
+- fixed clocks/fixtures for equal-timestamp cursor cases;
+- batching enabled and idempotency enabled;
+- webhook delivery disabled unless the test explicitly owns a safe local receiver.
+
+Do not mock the HTTP serialization layer in the official-client tests.
+
+## 11. Python companion SDK
+
+### 11.1 Location and package identity
+
+Add an independently buildable project:
+
+```text
+clients/python/
+  pyproject.toml
+  README.md
+  CHANGELOG.md
+  src/deltallm/
+    __init__.py
+    _client.py
+    _async_client.py
+    _batch_workflow.py
+    _webhooks.py
+    _errors.py
+    types.py
+    py.typed
+  tests/
+```
+
+Working distribution name: `deltallm-sdk`; import package: `deltallm`. Registry ownership/availability must be verified before the first public publish. Do not rename the server distribution or move server source as part of this work.
+
+The SDK has its own SemVer, changelog, build metadata, lock file, release workflow, and tags such as `sdk-python-v0.1.0`. It declares a tested range of the official `openai` package and Python 3.11+.
+
+### 11.2 Public API
+
+The intended ergonomic surface is:
+
+```python
+from deltallm import DeltaLLM, WebhookConfig
+
+with DeltaLLM(base_url="https://gateway.example/v1", api_key="...") as client:
+    # Standard API: the official OpenAI client.
+    response = client.openai.responses.create(model="...", input="...")
+
+    # Delta value-add: a bounded batch workflow.
+    handle = client.batch.submit_jsonl(
+        path="requests.jsonl",
+        endpoint="/v1/embeddings",
+        idempotency_key="job-2026-08-21",
+        webhook=WebhookConfig(url="https://...", signing_secret="..."),
+    )
+    terminal = handle.wait(timeout=3600)
+    for row in handle.iter_results():
+        process(row)
+```
+
+The v0.1 public names are `DeltaLLM`, `AsyncDeltaLLM`, `WebhookConfig`, `.openai`, and `.batch`. Lock them with import/API tests before the preview release; later changes follow SDK SemVer.
+
+### 11.3 Implementation constraints
+
+- `client.openai` is an official `OpenAI`/`AsyncOpenAI` instance, not a fork or subclass.
+- Batch standard operations call documented official SDK resource methods.
+- Delta request fields use documented `extra_body`; idempotency uses documented `extra_headers`. Add a conformance test for every supported official SDK version.
+- Do not call private `_client` methods or depend on generated internal OpenAI classes.
+- If the caller supplies an official client, DeltaLLM does not close it. If DeltaLLM constructs it, the context manager owns and closes it.
+- Do not create a second HTTP connection pool for normal operation.
+- Sync and async APIs have feature parity and separate tests.
+- `submit_jsonl` streams/spools input, validates lines incrementally, and never buffers an unbounded file.
+- Submission generates or requires an idempotency key and reuses it for retries. Surface the key safely to the caller but never log the API key or webhook secret.
+- `wait` requires a finite timeout/deadline, uses monotonic time, honors `Retry-After`, applies bounded jitter, and stops on every terminal Batch status.
+- `iter_results` streams file content line by line, validates each row, preserves `custom_id`, and closes the response on early exit/cancellation.
+- HTTP retries remain owned by the official SDK. Workflow polling controls only the interval between retrieve calls.
+- Webhook verification is pure and constant-time, accepts raw bytes, enforces timestamp tolerance before parsing, supports the `v1=` signature, and returns a typed verified event.
+- Typed SDK exceptions retain status, request ID, code, and retry-after without embedding response bodies that may contain sensitive caller data.
+- Ship `py.typed` and pass strict type checks for the package's public modules.
+
+### 11.4 Generated versus handwritten code
+
+Do not generate a second full OpenAI client. Keep the workflow/resource code handwritten and small. Generate nothing in the initial SDK unless a concrete extension model cannot be kept aligned through the OpenAPI contract tests.
+
+The canonical model source remains the server's public OpenAPI document. SDK tests load the checked-in schema and assert the small handwritten extension types and examples remain compatible. If extension types grow enough that this becomes repetitive, add a deterministic tag-filtered type-generation step in a later SDK minor; do not start with thousands of generated OpenAI files.
+
+## 12. Implementation sequence
+
+Each slice should be independently reviewable and deployable. Do not combine public error cutover, pagination migrations, OpenAPI publication, and package publishing in one PR.
+
+### Slice 0 — Baseline and contract inventory
+
+Purpose: freeze current behavior before DTOs can accidentally alter it.
+
+Changes:
+
+- add golden HTTP fixtures for successful/error Files and Batches responses, multipart requests, JSONL rows, webhook events, headers, and omitted/null fields;
+- add an audited route inventory with audience and dialect classifications;
+- add tests that record the current OpenAPI gaps without yet requiring the final schema;
+- add current official OpenAI Python/TypeScript smoke fixtures for upload and basic batch calls, marked expected-failure only for named known gaps;
+- record actual configured batch default and recommended production limits in the compatibility matrix draft.
+
+Primary files:
+
+- `tests/contracts/fixtures/*`
+- `tests/contracts/test_public_wire_examples.py`
+- `tests/compat/openai_python/*`
+- `tests/compat/openai_typescript/*`
+- `docs/api/compatibility.md`
+
+Exit gate: every later wire change produces an intentional golden diff; expected failures name one missing capability each and cannot mask unrelated failures.
+
+### Slice 1 — Public DTO foundation with zero wire changes
+
+Purpose: establish typed models and one serializer without changing HTTP bytes.
+
+Changes:
+
+- add `src/public_api/v1` DTO modules from section 6;
+- make `serialize_public_batch` and file serialization validate through the DTOs;
+- reuse the same batch DTO for webhook event snapshots;
+- add explicit OpenAPI response models/declarations to Files and Batches with unset-field exclusion;
+- keep temporary unknown-field ignore semantics and current error status/envelopes;
+- add schema unit tests, serializer parity tests, and secret-repr tests.
+
+Primary files:
+
+- `src/public_api/v1/*`
+- `src/batch/serialization.py`
+- `src/batch/service.py`
+- `src/batch/webhooks/events.py`
+- `src/api/v1/endpoints/files.py`
+- `src/api/v1/endpoints/batches.py`
+- focused batch/webhook tests
+
+Exit gate: every successful Files/Batches golden response is byte-equivalent; their OpenAPI 2xx schemas are nonempty; webhook secret tests still pass.
+
+### Slice 2 — Request and error compatibility cutover
+
+Purpose: make requests/errors predictable and official-client compatible.
+
+Changes:
+
+- accept `purpose` as multipart form data; preserve query compatibility for one documented deprecation window;
+- enforce `purpose=batch` for user uploads;
+- switch batch create to `CreateBatchRequest` and reject unsupported fields after the announced transition;
+- add the authoritative additive response fields (`FileObject.expires_at`, `BatchObject.model`, and cancellation timestamps) with explicit omission/null golden tests;
+- add dialect-aware public HTTP/validation exception handlers;
+- replace foreign-resource 403 responses with non-enumerating 404s;
+- add Bearer security metadata through `Security(HTTPBearer)` without an extra auth lookup;
+- assign explicit operation IDs and documented response/error headers.
+
+Primary files:
+
+- `src/public_api/errors.py`
+- `src/public_api/surface.py`
+- `src/middleware/auth.py`
+- `src/middleware/errors.py`
+- Files/Batches endpoints and service exceptions
+- `docs/api/compatibility.md`
+
+Exit gate: official client upload/create work; all public failure classes match the code/status table; admin/UI error fixtures are unchanged; secret/non-enumeration tests pass.
+
+### Slice 3 — Batch cursor pages
+
+Purpose: enable stable official SDK list iteration.
+
+Changes:
+
+- replace datetime pagination with object-ID keyset pagination;
+- return `BatchListPage` metadata;
+- add scoped composite indexes through an additive Prisma migration;
+- add same-timestamp, insert-between-pages, empty-page, foreign-anchor, and concurrent-list integration tests;
+- keep one SQL round trip per page and measure query plans at representative cardinality.
+
+Primary files:
+
+- `src/batch/repositories/job_repository.py`
+- `src/batch/repository.py`
+- `src/batch/service.py`
+- `src/api/v1/endpoints/batches.py`
+- `prisma/schema.prisma`
+- new migration and repository/integration tests
+
+Exit gate: official Python and TypeScript auto-pagination visit each visible batch exactly once in the fixed dataset; query plan uses a scoped index; fresh and last-release migrations pass.
+
+### Slice 4 — File list and durable delete
+
+Purpose: complete the batch-related Files lifecycle safely.
+
+Changes:
+
+- add tenant-scoped file cursor repository and `GET /v1/files`;
+- add the deletion outbox, claim/lease/retry worker, metrics, and recovery logic;
+- add idempotent `DELETE /v1/files/{id}`;
+- route retention cleanup through the same durable deletion policy;
+- document reference conflicts and eventual physical deletion.
+
+Primary files:
+
+- `src/batch/repositories/file_repository.py`
+- new focused deletion-outbox repository/service/worker modules
+- `src/batch/cleanup.py`
+- `src/api/v1/endpoints/files.py`
+- Prisma schema/migration
+- bootstrap lifecycle/config/metrics modules
+- focused unit and real PostgreSQL/storage-failure tests
+
+Exit gate: process death at every state boundary is replay-safe; referenced files are never deleted; public list/delete work through official clients; cleanup does not create orphaned DB/object-store state.
+
+### Slice 5 — Complete curated public OpenAPI
+
+Purpose: provide the actual public discovery endpoint requested by developers.
+
+Changes:
+
+- split route composition into explicit public and non-public collections without changing runtime paths;
+- finish nonempty gateway, streaming, binary, Anthropic, MCP, and Delta extension schemas;
+- add cached public OpenAPI and public Swagger/ReDoc routes;
+- add deterministic exporter, checked-in artifact, lints, and breaking-change CI;
+- fix public operation IDs without requiring the unrelated admin duplicate-ID cleanup.
+
+Primary files:
+
+- `src/api/v1/router.py`
+- `src/public_api/openapi.py`
+- `src/public_api/surface.py`
+- relevant public routers/DTOs
+- `src/main.py`
+- `scripts/export_public_openapi.py`
+- `openapi/deltallm-public-v1.json`
+- `.github/workflows/ci.yml`
+- contract tests
+
+Exit gate: public spec contains only classified public routes, no empty successful response bodies, stable operation IDs, correct media types/security, and no secret-bearing response schema.
+
+### Slice 6 — Server conformance and documentation GA gate
+
+Purpose: prove the contract is usable before adding a branded package.
+
+Changes:
+
+- remove named expected failures from official Python/TypeScript client suites;
+- run a real lifecycle: upload, create, page, retrieve, finish/cancel, stream output, delete when unreferenced;
+- publish compatibility matrix, request/error examples, and public schema links;
+- add load measurements for page sizes and schema generation;
+- mark the public contract `1.0.0` only after the gates pass.
+
+Exit gate: the documented standard workflow needs no Delta SDK; CI protects the public schema; operator routes remain excluded.
+
+### Slice 7 — Python SDK preview
+
+Purpose: add Delta-specific ergonomics without duplicating the gateway.
+
+Changes:
+
+- scaffold `clients/python` and its isolated tests/build;
+- implement sync/async client ownership, batch workflow, streaming result iterator, and webhook verifier;
+- test against the same real conformance server and public schema artifact;
+- publish docs/examples but do not publish to PyPI until package API review and registry ownership are complete.
+
+Exit gate: package builds reproducibly, type checks, passes sync/async lifecycle/cancellation/secret tests, and uses no private OpenAI SDK API.
+
+### Slice 8 — SDK release automation and v0.1 publish
+
+Purpose: release the package independently and safely.
+
+Changes:
+
+- add `.github/workflows/sdk-python.yml` for `sdk-python-v*` tags;
+- build sdist/wheel, inspect metadata, install each artifact in a clean environment, run a smoke test, and publish with PyPI trusted publishing plus attestations;
+- add tag guards to the existing release-artifacts workflow so an SDK release cannot publish server images/Helm/Railway artifacts;
+- generate release notes from the SDK changelog and record the minimum tested server version/public contract version.
+
+Exit gate: a test-index release installs and completes the sample workflow; a production publish requires a protected GitHub environment approval; server release jobs are skipped for SDK tags.
+
+## 13. Verification matrix
+
+Run focused checks first and the broader gate required by each slice.
+
+### Every server change
+
+```bash
+uv run ruff check <touched Python paths>
+uv run ruff format --check <touched Python paths>
+uv run pytest <focused tests>
+git diff --check
+```
+
+### Contract/OpenAPI changes
+
+```bash
+uv run python scripts/export_public_openapi.py --check
+uv run pytest tests/contracts tests/compat/openai_python
+npm --prefix tests/compat/openai_typescript ci
+npm --prefix tests/compat/openai_typescript test
+git diff --check
+```
+
+Also run the pinned OpenAPI validator and breaking-change command installed by the implementation PR. The tool and version must be explicit in CI and locally reproducible.
+
+### Pagination or deletion persistence changes
+
+```bash
+uv run prisma generate --schema=./prisma/schema.prisma
+uv run python scripts/verify_migration_paths.py --base-ref v0.1.35
+uv run pytest tests/test_batch_repository.py tests/test_batch_db_integration.py tests/test_batch_service.py
+uv lock --check
+git diff --check
+```
+
+Add real PostgreSQL concurrency and last-release-upgrade cases. Deletion also requires real or failure-injecting storage tests for timeout, already missing, permission failure, retry, lease expiry, recovery, and shutdown cancellation.
+
+### SDK changes
+
+```bash
+uv sync --project clients/python --extra dev
+uv run --project clients/python ruff check clients/python
+uv run --project clients/python ruff format --check clients/python
+uv run --project clients/python pytest clients/python/tests
+uv build --project clients/python
+uv lock --project clients/python --check
+git diff --check
+```
+
+Install the built wheel and sdist independently, import `deltallm`, verify `py.typed`, and run the public example against the conformance server. Add the selected strict type checker to the SDK dev dependencies and CI rather than assuming Ruff performs type checking.
+
+### Full pre-release gate
+
+- full backend suite with PostgreSQL and Redis;
+- public OpenAPI determinism/lint/breaking-change checks;
+- Python and TypeScript official-client suites;
+- Python companion SDK suite and artifact install tests;
+- container startup smoke proving public docs are available without DB-backed schema generation;
+- docs build and link/path/command parity review;
+- secret scan over generated OpenAPI, examples, wheel, sdist, logs, and test snapshots.
+
+## 14. Rollout, compatibility, and observability
+
+### 14.1 Rollout order
+
+1. Deploy wire-preserving DTOs and observe validation/serialization metrics.
+2. Deploy multipart dual-read and new error envelope with explicit release notes; retain the query-purpose compatibility window.
+3. Deploy additive pagination indexes before or with cursor reads. Old servers ignore new indexes; new servers remain compatible with old rows.
+4. Enable Files list first. Enable public delete only after at least one deletion worker is healthy and outbox metrics are visible.
+5. Publish the beta public spec, run consumer trials, then mark contract 1.0.
+6. Publish SDK 0.1 only against a released server version containing contract 1.0.
+
+### 14.2 Compatibility policy
+
+- Public contract major versions are represented by distinct immutable artifacts/URLs if a breaking major is ever required.
+- Additive fields and endpoints are minor changes; clarifications and schema corrections without wire change are patches.
+- Removing/renaming a field, tightening accepted input, changing omitted to null, changing status/envelope, or altering pagination order is breaking unless covered by a documented deprecation window.
+- The SDK supports an explicit minimum server release and public contract major; it does not guess server internals.
+- Delta extensions remain optional in the standard OpenAI workflow.
+
+### 14.3 Metrics and logs
+
+Use bounded labels only:
+
+- public validation failures by operation ID, dialect, status, and stable code;
+- page size and query latency by resource/scope type, never scope ID;
+- cursor outcome (`first`, `next`, `exhausted`, `invalid_or_foreign`) without cursor value;
+- deletion outbox queue/due/oldest age, attempts, retries, lease recovery, and terminal failures;
+- SDK workflow metrics are opt-in hooks owned by the application, not built-in network telemetry.
+
+Logs may include request ID, operation ID, resource type, status, bounded code, and duration. They must not include API keys, metadata values, JSONL bodies, webhook URL/secret, raw signature, or response bodies.
+
+### 14.4 Rollback
+
+- DTO/OpenAPI code can roll back without data changes because the first slice preserves wire behavior.
+- Pagination migrations are additive and stay in place during rollback.
+- During mixed-version rollout, new page response fields are additive; clients must tolerate an old pod only if rollout policy permits mixed versions. Prefer completing the server rollout before SDK publication.
+- Do not roll back past the public-delete feature while queued deletion rows exist. Drain or leave a compatible worker running first.
+- SDK releases are independent. Yank only a broken package release; do not mutate an already published version.
+
+## 15. Definition of done
+
+The public-contract program is complete when:
+
+- `/openapi/public-v1.json`, `/docs/api`, and `/redoc/api` exist and expose no private route;
+- every public success/error body and media type is described without filtering actual proxy responses;
+- Files and Batches DTOs are the shared source for HTTP responses, webhook events, examples, and tests;
+- upload form semantics, Batch pages, File pages, and safe File delete pass official Python/TypeScript client tests;
+- page ordering is deterministic and tenant scoped with one SQL query;
+- foreign/missing resources are non-enumerating;
+- errors are stable by dialect and have documented codes/retry behavior;
+- webhook secrets remain write-only through validation, logging, OpenAPI, artifacts, and SDK reprs;
+- the checked-in spec is deterministic and protected by breaking-change CI;
+- docs include a compatibility matrix and both official-client and optional Delta SDK examples;
+- the Python SDK uses public official OpenAI SDK APIs, owns no duplicate pool, has bounded polling/streaming, and has sync/async parity;
+- SDK artifacts build, install, type check, and publish independently without triggering server releases;
+- all focused and proportionate repository gates pass, including migration paths for persistence changes; and
+- no separate SDK repository is required to use or release the first package.
+
+## 16. When to create a separate SDK repository
+
+Re-evaluate extraction only after at least two of these are true:
+
+1. two or more Delta-specific language SDKs have active maintainers and independent CI needs;
+2. SDK releases regularly occur without server changes and server releases regularly occur without SDK changes;
+3. external contributors need package write/release access but should not have equivalent server-repository access;
+4. generated artifacts or multi-language tooling materially slow the server repository's CI/review workflow;
+5. the public contract has remained stable across at least two server minor releases and SDK 1.0 is being planned;
+6. package adoption and issue volume justify a dedicated roadmap, triage, security policy, and release ownership.
+
+If extraction is approved, preserve history for `clients/` with a filtered repository split, keep the existing package names and tags, move contract fixtures with the clients, and leave server conformance tests in this repository. The public OpenAPI artifact remains owned and released by the server; the SDK repository consumes released artifacts and must not become the source of truth for server behavior.
+
+## 17. Immediate next action
+
+Slice 0 is the first implementation PR. It creates the compatibility baseline needed to review every later decision safely and gives an early answer to the highest-risk question: which official OpenAI SDK calls fail today, and exactly why. Do not scaffold or publish the companion package before that evidence exists.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "openai>=3.3,<4.0",
   "pytest>=7.4,<9.0",
   "pytest-asyncio>=0.23,<1.0",
   "ruff>=0.2,<1.0",

--- a/tests/compat/openai_python/test_files_batches_smoke.py
+++ b/tests/compat/openai_python/test_files_batches_smoke.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+
+from src.models.responses import UserAPIKeyAuth
+
+
+FIXTURE_DIR = Path(__file__).parents[2] / "contracts" / "fixtures"
+HTTP_FIXTURE_PATH = FIXTURE_DIR / "files_batches_http.json"
+
+
+def _load_http_fixture() -> dict[str, Any]:
+    return json.loads(HTTP_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+class _OfficialClientKeyService:
+    async def validate_key(self, raw_key: str) -> UserAPIKeyAuth:
+        assert raw_key == "sk-compat-fixture"
+        return UserAPIKeyAuth(
+            api_key="fixture-owner-key",
+            team_id="team-default",
+            organization_id="org-default",
+        )
+
+
+class _OfficialClientFileRecord:
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+        self.created_by_api_key = "fixture-owner-key"
+        self.created_by_team_id = "team-default"
+        self.created_by_organization_id = "org-default"
+
+
+class _OfficialClientRepository:
+    def __init__(self, fixture: dict[str, Any]) -> None:
+        self.file_response = fixture["file_retrieve"]["response"]["body"]
+
+    async def get_file(self, file_id: str) -> _OfficialClientFileRecord | None:
+        if file_id not in {"file_input_001", "file_output_001"}:
+            return None
+        return _OfficialClientFileRecord(self.file_response)
+
+
+class _OfficialClientBatchService:
+    def __init__(self, fixture: dict[str, Any]) -> None:
+        self.fixture = fixture
+        self.uploaded_bytes: bytes | None = None
+        self.uploaded_purpose: str | None = None
+        self.create_arguments: dict[str, Any] | None = None
+
+    async def create_file(self, *, auth, upload, purpose: str) -> dict[str, Any]:  # noqa: ANN001
+        del auth
+        self.uploaded_bytes = await upload.read()
+        self.uploaded_purpose = purpose
+        return self.fixture["file_retrieve"]["response"]["body"]
+
+    def file_to_response(self, file_record: _OfficialClientFileRecord) -> dict[str, Any]:
+        return file_record.response
+
+    async def get_file_content(self, *, file_id: str, auth) -> bytes:  # noqa: ANN001
+        del auth
+        assert file_id == "file_output_001"
+        return (FIXTURE_DIR / "batch_output.jsonl").read_bytes()
+
+    async def create_batch_result(self, **kwargs: Any) -> SimpleNamespace:
+        self.create_arguments = kwargs
+        return SimpleNamespace(
+            response=self.fixture["batch_create"]["response"]["body"],
+            audit_metadata={"idempotency_replayed": False},
+        )
+
+    async def get_batch(self, *, batch_id: str, auth) -> dict[str, Any]:  # noqa: ANN001
+        del auth
+        assert batch_id == "batch_completed_001"
+        return self.fixture["batch_retrieve"]["response"]["body"]
+
+    async def list_batches(self, *, auth, limit: int) -> dict[str, Any]:  # noqa: ANN001
+        del auth
+        assert 1 <= limit <= 20
+        return self.fixture["batch_list"]["response"]["body"]
+
+    async def cancel_batch(self, *, batch_id: str, auth) -> dict[str, Any]:  # noqa: ANN001
+        del auth
+        assert batch_id == "batch_completed_001"
+        return self.fixture["batch_cancel"]["response"]["body"]
+
+
+@pytest.fixture
+async def official_client(test_app):
+    fixture = _load_http_fixture()
+    service = _OfficialClientBatchService(fixture)
+    test_app.state.key_service = _OfficialClientKeyService()
+    test_app.state.batch_service = service
+    test_app.state.batch_repository = _OfficialClientRepository(fixture)
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.ASGITransport(app=test_app),
+        base_url="http://deltallm.test",
+    )
+    client = AsyncOpenAI(
+        api_key="sk-compat-fixture",
+        base_url="http://deltallm.test/v1",
+        http_client=http_client,
+        max_retries=0,
+    )
+    try:
+        yield SimpleNamespace(client=client, service=service)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_official_openai_python_upload_and_basic_batch_calls(official_client) -> None:
+    sdk = official_client.client
+    input_path = FIXTURE_DIR / "batch_input.jsonl"
+    with input_path.open("rb") as input_file:
+        uploaded = await sdk.files.create(file=input_file, purpose="batch")
+
+    created = await sdk.batches.create(
+        input_file_id=uploaded.id,
+        endpoint="/v1/embeddings",
+        completion_window="24h",
+        metadata={"customer_job_id": "job-42"},
+        extra_headers={"Idempotency-Key": "compat-python-001"},
+        extra_body={
+            "webhook": {
+                "url": "https://receiver.example/deltallm/batches",
+                "signing_secret": "w" * 32,
+            }
+        },
+    )
+    retrieved_file = await sdk.files.retrieve(uploaded.id)
+    retrieved_batch = await sdk.batches.retrieve("batch_completed_001")
+    page = await sdk.batches.list(limit=20)
+    cancelled = await sdk.batches.cancel("batch_completed_001")
+    content = await sdk.files.content("file_output_001")
+
+    assert uploaded.id == "file_input_001"
+    assert retrieved_file.purpose == "batch"
+    assert created.status == "validating"
+    assert retrieved_batch.status == "completed"
+    assert retrieved_batch.request_counts.completed == 2
+    assert [batch.id for batch in page.data] == ["batch_completed_001"]
+    assert cancelled.status == "cancelling"
+    assert content.content == (FIXTURE_DIR / "batch_output.jsonl").read_bytes()
+    assert official_client.service.uploaded_bytes == input_path.read_bytes()
+    assert official_client.service.uploaded_purpose == "batch"
+    assert official_client.service.create_arguments["idempotency_key"] == "compat-python-001"
+    assert official_client.service.create_arguments["webhook"]["signing_secret"] == "w" * 32
+    assert "w" * 32 not in repr(created)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason="known gap: GET /v1/files is not implemented (tracked by issue #280 Slice 4)",
+)
+async def test_official_openai_python_file_listing_known_gap(official_client) -> None:
+    page = await official_client.client.files.list(limit=1)
+    assert page.data
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "known gap: batch list ignores object-ID cursors and omits has_more "
+        "(tracked by issue #280 Slice 3)"
+    ),
+)
+async def test_official_openai_python_batch_auto_pagination_known_gap(
+    official_client,
+) -> None:
+    first_page = await official_client.client.batches.list(limit=1)
+    second_page = await first_page.get_next_page()
+
+    assert second_page.data[0].id != first_page.data[0].id

--- a/tests/compat/openai_typescript/files_batches_smoke.test.mjs
+++ b/tests/compat/openai_typescript/files_batches_smoke.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+
+import OpenAI, { toFile } from "openai";
+
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDirectory = path.resolve(currentDirectory, "../../contracts/fixtures");
+const httpFixture = JSON.parse(
+  await readFile(path.join(fixtureDirectory, "files_batches_http.json"), "utf8"),
+);
+const inputBytes = await readFile(path.join(fixtureDirectory, "batch_input.jsonl"));
+const outputBytes = await readFile(path.join(fixtureDirectory, "batch_output.jsonl"));
+
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Request-Id": "req_compat_typescript_001",
+    },
+  });
+}
+
+
+function buildFixtureFetch(observed) {
+  return async (input, init) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const url = new URL(request.url);
+    const route = `${request.method} ${url.pathname}`;
+    // The SDK probes custom fetch implementations with a non-API request.
+    if (route === "GET ,") {
+      return new Response(null, { status: 204 });
+    }
+    observed.routes.push(route);
+
+    if (route === "POST /v1/files") {
+      const form = await request.clone().formData();
+      const file = form.get("file");
+      observed.uploadPurpose = form.get("purpose");
+      observed.uploadFilename = file?.name;
+      observed.uploadBytes = file ? Buffer.from(await file.arrayBuffer()) : null;
+      return jsonResponse(httpFixture.file_retrieve.response.body);
+    }
+    if (route === "GET /v1/files/file_input_001") {
+      return jsonResponse(httpFixture.file_retrieve.response.body);
+    }
+    if (route === "GET /v1/files/file_output_001/content") {
+      return new Response(outputBytes, {
+        status: 200,
+        headers: { "Content-Type": "application/jsonl" },
+      });
+    }
+    if (route === "POST /v1/batches") {
+      observed.batchCreateBody = await request.clone().json();
+      observed.idempotencyKey = request.headers.get("Idempotency-Key");
+      return jsonResponse(httpFixture.batch_create.response.body);
+    }
+    if (route === "GET /v1/batches/batch_completed_001") {
+      return jsonResponse(httpFixture.batch_retrieve.response.body);
+    }
+    if (route === "GET /v1/batches") {
+      return jsonResponse(httpFixture.batch_list.response.body);
+    }
+    if (route === "POST /v1/batches/batch_completed_001/cancel") {
+      return jsonResponse(httpFixture.batch_cancel.response.body);
+    }
+    if (route === "GET /v1/files") {
+      return jsonResponse({ detail: "Method Not Allowed" }, 405);
+    }
+    throw new Error(`unexpected compatibility request: ${route}`);
+  };
+}
+
+
+test("official OpenAI TypeScript client supports upload and basic batch calls", async () => {
+  const observed = { routes: [] };
+  const client = new OpenAI({
+    apiKey: "sk-compat-fixture",
+    baseURL: "http://deltallm.test/v1",
+    fetch: buildFixtureFetch(observed),
+    maxRetries: 0,
+  });
+
+  const uploaded = await client.files.create({
+    file: await toFile(inputBytes, "batch_input.jsonl"),
+    purpose: "batch",
+  });
+  const created = await client.batches.create(
+    {
+      input_file_id: uploaded.id,
+      endpoint: "/v1/embeddings",
+      completion_window: "24h",
+      metadata: { customer_job_id: "job-42" },
+    },
+    { headers: { "Idempotency-Key": "compat-typescript-001" } },
+  );
+  const retrievedFile = await client.files.retrieve(uploaded.id);
+  const retrievedBatch = await client.batches.retrieve("batch_completed_001");
+  const page = await client.batches.list({ limit: 20 });
+  const cancelled = await client.batches.cancel("batch_completed_001");
+  const content = await client.files.content("file_output_001");
+
+  assert.equal(uploaded.id, "file_input_001");
+  assert.equal(retrievedFile.purpose, "batch");
+  assert.equal(created.status, "validating");
+  assert.equal(retrievedBatch.status, "completed");
+  assert.equal(retrievedBatch.request_counts.completed, 2);
+  assert.deepEqual(page.data.map((batch) => batch.id), ["batch_completed_001"]);
+  assert.equal(cancelled.status, "cancelling");
+  assert.deepEqual(Buffer.from(await content.arrayBuffer()), outputBytes);
+  assert.equal(observed.uploadPurpose, "batch");
+  assert.equal(observed.uploadFilename, "batch_input.jsonl");
+  assert.deepEqual(observed.uploadBytes, inputBytes);
+  assert.equal(observed.idempotencyKey, "compat-typescript-001");
+  assert.deepEqual(observed.batchCreateBody, {
+    input_file_id: "file_input_001",
+    endpoint: "/v1/embeddings",
+    completion_window: "24h",
+    metadata: { customer_job_id: "job-42" },
+  });
+  assert.deepEqual(observed.routes, [
+    "POST /v1/files",
+    "POST /v1/batches",
+    "GET /v1/files/file_input_001",
+    "GET /v1/batches/batch_completed_001",
+    "GET /v1/batches",
+    "POST /v1/batches/batch_completed_001/cancel",
+    "GET /v1/files/file_output_001/content",
+  ]);
+});
+
+
+test.todo("known gap: GET /v1/files is not implemented (issue #280 Slice 4)");
+test.todo(
+  "known gap: batch pages omit has_more and ignore after cursors (issue #280 Slice 3)",
+);

--- a/tests/contracts/fixtures/batch_error.jsonl
+++ b/tests/contracts/fixtures/batch_error.jsonl
@@ -1,0 +1,1 @@
+{"id": "batch_req_item_002", "custom_id": "embed-2", "response": null, "error": {"message": "provider unavailable", "type": "BatchItemError"}}

--- a/tests/contracts/fixtures/batch_input.jsonl
+++ b/tests/contracts/fixtures/batch_input.jsonl
@@ -1,0 +1,2 @@
+{"custom_id":"embed-1","method":"POST","url":"/v1/embeddings","body":{"model":"text-embedding-3-small","input":"first document"}}
+{"custom_id":"embed-2","method":"POST","url":"/v1/embeddings","body":{"model":"text-embedding-3-small","input":"second document"}}

--- a/tests/contracts/fixtures/batch_output.jsonl
+++ b/tests/contracts/fixtures/batch_output.jsonl
@@ -1,0 +1,1 @@
+{"id": "batch_req_item_001", "custom_id": "embed-1", "response": {"status_code": 200, "request_id": "req_batch_item_001", "body": {"object": "list", "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}], "model": "text-embedding-3-small", "usage": {"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2}}}, "error": null}

--- a/tests/contracts/fixtures/batch_webhook_delivery.json
+++ b/tests/contracts/fixtures/batch_webhook_delivery.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "event": {
+    "id": "evt_contract_001",
+    "object": "event",
+    "type": "batch.completed",
+    "created_at": 1700000400,
+    "data": {
+      "batch": {
+        "id": "batch_completed_001",
+        "object": "batch",
+        "endpoint": "/v1/embeddings",
+        "completion_window": "24h",
+        "status": "completed",
+        "input_file_id": "file_input_001",
+        "output_file_id": "file_output_001",
+        "error_file_id": null,
+        "created_at": 1700000000,
+        "expires_at": 1702592000,
+        "in_progress_at": 1700000060,
+        "completed_at": 1700000300,
+        "failed_at": null,
+        "expired_at": null,
+        "errors": null,
+        "request_counts": {
+          "total": 2,
+          "completed": 2,
+          "failed": 0,
+          "cancelled": 0,
+          "in_progress": 0
+        },
+        "metadata": {
+          "customer_job_id": "job-42"
+        },
+        "webhook": {
+          "configured": true
+        }
+      }
+    }
+  },
+  "canonical_body_sha256": "28e34233ca15784e7f554c383ff988f2fc31be4bc6c29c3a67d60fbbacffaeb4",
+  "headers": {
+    "Content-Type": "application/json",
+    "User-Agent": "DeltaLLM-Webhooks/1.0",
+    "Idempotency-Key": "evt_contract_001",
+    "X-DeltaLLM-Event-Id": "evt_contract_001",
+    "X-DeltaLLM-Event-Type": "batch.completed",
+    "X-DeltaLLM-Webhook-Attempt": "2",
+    "X-DeltaLLM-Timestamp": "1700000500",
+    "X-DeltaLLM-Signature": "v1=5c134fe83e50a0bdd077e3066e7ab83a5df1754890b04598b3efd103c13c9c99"
+  }
+}

--- a/tests/contracts/fixtures/files_batches_http.json
+++ b/tests/contracts/fixtures/files_batches_http.json
@@ -1,0 +1,259 @@
+{
+  "schema_version": 1,
+  "file_upload": {
+    "request": {
+      "method": "POST",
+      "path": "/v1/files?purpose=batch_output",
+      "multipart_filename": "batch_input.jsonl",
+      "multipart_purpose": "batch",
+      "service_observed_purpose": "batch_output"
+    },
+    "response": {
+      "status_code": 200,
+      "body": {
+        "id": "file_input_001",
+        "object": "file",
+        "bytes": 261,
+        "created_at": 1700000000,
+        "filename": "batch_input.jsonl",
+        "purpose": "batch_output",
+        "status": "uploaded"
+      }
+    }
+  },
+  "file_retrieve": {
+    "response": {
+      "status_code": 200,
+      "body": {
+        "id": "file_input_001",
+        "object": "file",
+        "bytes": 261,
+        "created_at": 1700000000,
+        "filename": "batch_input.jsonl",
+        "purpose": "batch",
+        "status": "uploaded"
+      }
+    }
+  },
+  "file_content": {
+    "response": {
+      "status_code": 200,
+      "content_type": "application/jsonl",
+      "fixture": "batch_output.jsonl"
+    }
+  },
+  "batch_create": {
+    "request": {
+      "input_file_id": "file_input_001",
+      "endpoint": "/v1/embeddings",
+      "completion_window": "24h",
+      "metadata": {
+        "customer_job_id": "job-42"
+      },
+      "webhook": {
+        "url": "https://receiver.example/deltallm/batches",
+        "signing_secret_present": true
+      }
+    },
+    "response": {
+      "status_code": 200,
+      "body": {
+        "id": "batch_queued_001",
+        "object": "batch",
+        "endpoint": "/v1/embeddings",
+        "completion_window": "24h",
+        "status": "validating",
+        "input_file_id": "file_input_001",
+        "output_file_id": null,
+        "error_file_id": null,
+        "created_at": 1700000000,
+        "expires_at": 1702592000,
+        "in_progress_at": null,
+        "completed_at": null,
+        "failed_at": null,
+        "expired_at": null,
+        "errors": null,
+        "request_counts": {
+          "total": 2,
+          "completed": 0,
+          "failed": 0,
+          "cancelled": 0,
+          "in_progress": 0
+        },
+        "metadata": {
+          "customer_job_id": "job-42"
+        },
+        "webhook": {
+          "configured": true
+        }
+      }
+    }
+  },
+  "batch_retrieve": {
+    "response": {
+      "status_code": 200,
+      "body": {
+        "id": "batch_completed_001",
+        "object": "batch",
+        "endpoint": "/v1/embeddings",
+        "completion_window": "24h",
+        "status": "completed",
+        "input_file_id": "file_input_001",
+        "output_file_id": "file_output_001",
+        "error_file_id": null,
+        "created_at": 1700000000,
+        "expires_at": 1702592000,
+        "in_progress_at": 1700000060,
+        "completed_at": 1700000300,
+        "failed_at": null,
+        "expired_at": null,
+        "errors": null,
+        "request_counts": {
+          "total": 2,
+          "completed": 2,
+          "failed": 0,
+          "cancelled": 0,
+          "in_progress": 0
+        },
+        "metadata": {
+          "customer_job_id": "job-42"
+        },
+        "webhook": {
+          "configured": true
+        }
+      }
+    }
+  },
+  "batch_list": {
+    "response": {
+      "status_code": 200,
+      "body": {
+        "object": "list",
+        "data": [
+          {
+            "id": "batch_completed_001",
+            "object": "batch",
+            "endpoint": "/v1/embeddings",
+            "completion_window": "24h",
+            "status": "completed",
+            "input_file_id": "file_input_001",
+            "output_file_id": "file_output_001",
+            "error_file_id": null,
+            "created_at": 1700000000,
+            "expires_at": 1702592000,
+            "in_progress_at": 1700000060,
+            "completed_at": 1700000300,
+            "failed_at": null,
+            "expired_at": null,
+            "errors": null,
+            "request_counts": {
+              "total": 2,
+              "completed": 2,
+              "failed": 0,
+              "cancelled": 0,
+              "in_progress": 0
+            },
+            "metadata": {
+              "customer_job_id": "job-42"
+            },
+            "webhook": {
+              "configured": true
+            }
+          }
+        ]
+      }
+    }
+  },
+  "batch_cancel": {
+    "response": {
+      "status_code": 200,
+      "body": {
+        "id": "batch_completed_001",
+        "object": "batch",
+        "endpoint": "/v1/embeddings",
+        "completion_window": "24h",
+        "status": "cancelling",
+        "input_file_id": "file_input_001",
+        "output_file_id": null,
+        "error_file_id": null,
+        "created_at": 1700000000,
+        "expires_at": 1702592000,
+        "in_progress_at": 1700000060,
+        "completed_at": null,
+        "failed_at": null,
+        "expired_at": null,
+        "errors": null,
+        "request_counts": {
+          "total": 2,
+          "completed": 1,
+          "failed": 0,
+          "cancelled": 0,
+          "in_progress": 1
+        },
+        "metadata": {
+          "customer_job_id": "job-42"
+        },
+        "webhook": {
+          "configured": true
+        }
+      }
+    }
+  },
+  "errors": {
+    "file_missing": {
+      "status_code": 404,
+      "body": {
+        "detail": "File not found"
+      }
+    },
+    "file_foreign": {
+      "status_code": 403,
+      "body": {
+        "detail": "File access denied"
+      }
+    },
+    "batch_missing": {
+      "status_code": 404,
+      "body": {
+        "detail": "Batch not found"
+      }
+    },
+    "batch_foreign": {
+      "status_code": 403,
+      "body": {
+        "detail": "Batch access denied"
+      }
+    },
+    "file_upload_validation": {
+      "status_code": 422,
+      "body": {
+        "detail": [
+          {
+            "type": "missing",
+            "loc": [
+              "body",
+              "file"
+            ],
+            "msg": "Field required",
+            "input": null
+          }
+        ]
+      }
+    },
+    "batch_body_validation": {
+      "status_code": 422,
+      "body": {
+        "detail": [
+          {
+            "type": "missing",
+            "loc": [
+              "body"
+            ],
+            "msg": "Field required",
+            "input": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/contracts/fixtures/openapi_known_gaps.json
+++ b/tests/contracts/fixtures/openapi_known_gaps.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "baseline_revision": "9e21536e4f3e65257e182784f7b1245312eb91eb",
+  "gaps": [
+    {
+      "id": "auth_is_optional_header_without_bearer_scheme",
+      "summary": "Protected developer routes expose Authorization as an optional header parameter and define no BearerAuth security scheme.",
+      "target_slice": 2
+    },
+    {
+      "id": "batch_create_body_is_untyped",
+      "summary": "POST /v1/batches accepts an arbitrary JSON object in OpenAPI.",
+      "target_slice": 1
+    },
+    {
+      "id": "batch_cursor_contract_is_missing",
+      "summary": "GET /v1/batches has no after cursor and no typed page metadata.",
+      "target_slice": 3
+    },
+    {
+      "id": "file_content_is_documented_as_json",
+      "summary": "GET file content is documented as an empty application/json response instead of application/jsonl bytes.",
+      "target_slice": 1
+    },
+    {
+      "id": "file_list_and_delete_are_missing",
+      "summary": "The public Files list and delete operations are not implemented.",
+      "target_slice": 4
+    },
+    {
+      "id": "file_purpose_is_query_not_multipart",
+      "summary": "POST /v1/files documents purpose as a query parameter rather than a multipart form field.",
+      "target_slice": 2
+    },
+    {
+      "id": "files_and_batches_success_schemas_are_empty",
+      "summary": "Files and Batches operations expose empty successful response schemas.",
+      "target_slice": 1
+    },
+    {
+      "id": "full_schema_mixes_developer_and_private_routes",
+      "summary": "The default OpenAPI document mixes developer APIs with auth, admin, health, metrics, and reporting routes.",
+      "target_slice": 5
+    },
+    {
+      "id": "validation_errors_are_fastapi_422",
+      "summary": "Public request validation is documented with FastAPI's 422 HTTPValidationError rather than a stable dialect-aware 400 envelope.",
+      "target_slice": 2
+    }
+  ]
+}

--- a/tests/contracts/fixtures/public_route_inventory.json
+++ b/tests/contracts/fixtures/public_route_inventory.json
@@ -1,0 +1,191 @@
+{
+  "schema_version": 1,
+  "baseline_revision": "9e21536e4f3e65257e182784f7b1245312eb91eb",
+  "baseline_route_count": 279,
+  "classification_precedence": "exact developer routes, then longest matching non-developer prefix",
+  "developer_routes": [
+    {
+      "method": "POST",
+      "path": "/mcp",
+      "audience": "developer",
+      "dialect": "json_rpc",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/files",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/files/{file_id}",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/files/{file_id}/content",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/batches",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/batches/{batch_id}",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/batches",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/batches/{batch_id}/cancel",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/chat/completions",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/completions",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/responses",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/messages",
+      "audience": "developer",
+      "dialect": "anthropic",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/embeddings",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/images/generations",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/audio/speech",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/audio/transcriptions",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/rerank",
+      "audience": "developer",
+      "dialect": "delta_json",
+      "authentication": "bearer"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/models",
+      "audience": "developer",
+      "dialect": "openai",
+      "authentication": "bearer"
+    }
+  ],
+  "non_developer_route_families": [
+    {
+      "prefix": "/ui/api",
+      "audience": "admin_control_plane",
+      "dialect": "delta_json"
+    },
+    {
+      "prefix": "/webhooks/email",
+      "audience": "system_callback",
+      "dialect": "provider_webhook"
+    },
+    {
+      "prefix": "/openapi.json",
+      "audience": "operator_documentation",
+      "dialect": "openapi"
+    },
+    {
+      "prefix": "/docs",
+      "audience": "operator_documentation",
+      "dialect": "html"
+    },
+    {
+      "prefix": "/redoc",
+      "audience": "operator_documentation",
+      "dialect": "html"
+    },
+    {
+      "prefix": "/health",
+      "audience": "operator_diagnostics",
+      "dialect": "delta_json"
+    },
+    {
+      "prefix": "/metrics",
+      "audience": "internal_observability",
+      "dialect": "prometheus"
+    },
+    {
+      "prefix": "/spend",
+      "audience": "legacy_reporting",
+      "dialect": "delta_json"
+    },
+    {
+      "prefix": "/global",
+      "audience": "legacy_reporting",
+      "dialect": "delta_json"
+    },
+    {
+      "prefix": "/auth",
+      "audience": "identity_control_plane",
+      "dialect": "delta_json"
+    },
+    {
+      "prefix": "/ui",
+      "audience": "browser_application",
+      "dialect": "html_or_asset"
+    }
+  ]
+}

--- a/tests/contracts/test_public_openapi_baseline.py
+++ b/tests/contracts/test_public_openapi_baseline.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from src.main import create_app
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "openapi_known_gaps.json"
+FILES_BATCHES_OPERATIONS = (
+    ("/v1/files", "post"),
+    ("/v1/files/{file_id}", "get"),
+    ("/v1/files/{file_id}/content", "get"),
+    ("/v1/batches", "post"),
+    ("/v1/batches", "get"),
+    ("/v1/batches/{batch_id}", "get"),
+    ("/v1/batches/{batch_id}/cancel", "post"),
+)
+
+
+def _load_known_gaps() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _resolve_schema(document: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
+    reference = schema.get("$ref")
+    if not reference:
+        return schema
+    prefix = "#/components/schemas/"
+    assert reference.startswith(prefix)
+    return document["components"]["schemas"][reference.removeprefix(prefix)]
+
+
+def _detected_gap_ids(document: dict[str, Any]) -> set[str]:
+    gaps: set[str] = set()
+    paths = document["paths"]
+
+    security_schemes = document.get("components", {}).get("securitySchemes", {})
+    auth_parameters = [
+        parameter
+        for path, method in FILES_BATCHES_OPERATIONS
+        for parameter in paths[path][method].get("parameters", [])
+        if parameter.get("name") == "Authorization" and parameter.get("in") == "header"
+    ]
+    if (
+        "BearerAuth" not in security_schemes
+        and auth_parameters
+        and all(parameter.get("required") is False for parameter in auth_parameters)
+    ):
+        gaps.add("auth_is_optional_header_without_bearer_scheme")
+
+    batch_create_schema = paths["/v1/batches"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    if batch_create_schema == {
+        "additionalProperties": True,
+        "title": "Payload",
+        "type": "object",
+    }:
+        gaps.add("batch_create_body_is_untyped")
+
+    batch_list = paths["/v1/batches"]["get"]
+    batch_list_parameters = {parameter["name"] for parameter in batch_list.get("parameters", [])}
+    if "after" not in batch_list_parameters:
+        gaps.add("batch_cursor_contract_is_missing")
+
+    file_content_types = set(
+        paths["/v1/files/{file_id}/content"]["get"]["responses"]["200"]["content"]
+    )
+    if file_content_types == {"application/json"}:
+        gaps.add("file_content_is_documented_as_json")
+
+    if "get" not in paths["/v1/files"] and "delete" not in paths["/v1/files/{file_id}"]:
+        gaps.add("file_list_and_delete_are_missing")
+
+    file_create = paths["/v1/files"]["post"]
+    purpose_parameters = [
+        parameter
+        for parameter in file_create.get("parameters", [])
+        if parameter.get("name") == "purpose"
+    ]
+    multipart_schema = _resolve_schema(
+        document,
+        file_create["requestBody"]["content"]["multipart/form-data"]["schema"],
+    )
+    if purpose_parameters == [
+        {
+            "in": "query",
+            "name": "purpose",
+            "required": False,
+            "schema": {
+                "default": "batch",
+                "title": "Purpose",
+                "type": "string",
+            },
+        }
+    ] and "purpose" not in multipart_schema.get("properties", {}):
+        gaps.add("file_purpose_is_query_not_multipart")
+
+    success_schemas = [
+        paths[path][method]["responses"]["200"]["content"]["application/json"]["schema"]
+        for path, method in FILES_BATCHES_OPERATIONS
+    ]
+    if success_schemas and all(schema == {} for schema in success_schemas):
+        gaps.add("files_and_batches_success_schemas_are_empty")
+
+    if any(
+        path.startswith(("/auth", "/ui/api", "/health", "/metrics", "/spend", "/global"))
+        for path in paths
+    ):
+        gaps.add("full_schema_mixes_developer_and_private_routes")
+
+    if all("422" in paths[path][method]["responses"] for path, method in FILES_BATCHES_OPERATIONS):
+        gaps.add("validation_errors_are_fastapi_422")
+
+    return gaps
+
+
+def test_current_public_openapi_gaps_are_explicit_and_complete() -> None:
+    fixture = _load_known_gaps()
+    document = create_app().openapi()
+    expected = {gap["id"] for gap in fixture["gaps"]}
+
+    assert _detected_gap_ids(document) == expected
+
+
+def test_every_known_openapi_gap_names_its_delivery_slice() -> None:
+    fixture = _load_known_gaps()
+    gaps = fixture["gaps"]
+
+    assert len({gap["id"] for gap in gaps}) == len(gaps)
+    assert all(gap["summary"].endswith(".") for gap in gaps)
+    assert all(gap["target_slice"] in {1, 2, 3, 4, 5} for gap in gaps)

--- a/tests/contracts/test_public_route_inventory.py
+++ b/tests/contracts/test_public_route_inventory.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi.routing import APIRoute
+
+from src.main import create_app
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "public_route_inventory.json"
+
+
+def _load_inventory() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _route_methods(route: APIRoute) -> set[str]:
+    return {method for method in route.methods if method not in {"HEAD", "OPTIONS"}}
+
+
+def test_every_runtime_route_has_an_audited_audience_classification() -> None:
+    inventory = _load_inventory()
+    app = create_app()
+    developer_routes = {
+        (route["method"], route["path"]): route for route in inventory["developer_routes"]
+    }
+    family_prefixes = sorted(
+        (family["prefix"] for family in inventory["non_developer_route_families"]),
+        key=len,
+        reverse=True,
+    )
+
+    assert len(app.routes) == inventory["baseline_route_count"]
+    assert len(developer_routes) == len(inventory["developer_routes"])
+
+    uncovered: list[tuple[list[str], str]] = []
+    actual_developer_routes: set[tuple[str, str]] = set()
+    for route in app.routes:
+        methods = _route_methods(route)
+        for method in methods:
+            key = (method, route.path)
+            if key in developer_routes:
+                actual_developer_routes.add(key)
+                continue
+            if any(route.path.startswith(prefix) for prefix in family_prefixes):
+                continue
+            uncovered.append((sorted(methods), route.path))
+
+    assert uncovered == []
+    assert actual_developer_routes == set(developer_routes)
+
+
+def test_every_v1_and_mcp_route_is_explicitly_classified() -> None:
+    inventory = _load_inventory()
+    app = create_app()
+    expected = {(route["method"], route["path"]) for route in inventory["developer_routes"]}
+    actual = {
+        (method, route.path)
+        for route in app.routes
+        if isinstance(route, APIRoute) and (route.path.startswith("/v1/") or route.path == "/mcp")
+        for method in _route_methods(route)
+    }
+
+    assert actual == expected
+
+
+def test_developer_route_contract_metadata_is_bounded() -> None:
+    inventory = _load_inventory()
+    assert {route["audience"] for route in inventory["developer_routes"]} == {"developer"}
+    assert {route["dialect"] for route in inventory["developer_routes"]} <= {
+        "openai",
+        "anthropic",
+        "delta_json",
+        "json_rpc",
+    }
+    assert {route["authentication"] for route in inventory["developer_routes"]} == {"bearer"}

--- a/tests/contracts/test_public_wire_examples.py
+++ b/tests/contracts/test_public_wire_examples.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.batch.models import (
+    BatchFileRecord,
+    BatchItemRecord,
+    BatchJobRecord,
+    BatchJobStatus,
+    BatchWebhookDeliveryStatus,
+    BatchWebhookEventType,
+    BatchWebhookOutboxRecord,
+)
+from src.batch.request_validation import parse_batch_input_line
+from src.batch.service import BatchService
+from src.batch.webhooks.events import build_batch_webhook_event, canonical_batch_webhook_event_bytes
+from src.batch.webhooks.signing import build_batch_webhook_headers
+from src.batch.worker_artifacts import BatchArtifactFinalizer
+from src.batch.worker_types import BatchWorkerConfig
+from src.models.responses import UserAPIKeyAuth
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+HTTP_FIXTURE_PATH = FIXTURE_DIR / "files_batches_http.json"
+CREATED_AT = datetime.fromtimestamp(1_700_000_000, tz=UTC)
+STARTED_AT = datetime.fromtimestamp(1_700_000_060, tz=UTC)
+COMPLETED_AT = datetime.fromtimestamp(1_700_000_300, tz=UTC)
+EXPIRES_AT = datetime.fromtimestamp(1_702_592_000, tz=UTC)
+
+
+def _load_http_fixture() -> dict[str, Any]:
+    return json.loads(HTTP_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _job(
+    *,
+    batch_id: str = "batch_completed_001",
+    status: BatchJobStatus = BatchJobStatus.COMPLETED,
+    foreign: bool = False,
+) -> BatchJobRecord:
+    is_completed = status is BatchJobStatus.COMPLETED
+    is_cancelling = status is BatchJobStatus.IN_PROGRESS
+    return BatchJobRecord(
+        batch_id=batch_id,
+        endpoint="/v1/embeddings",
+        status=status,
+        execution_mode="managed_internal",
+        input_file_id="file_input_001",
+        output_file_id="file_output_001" if is_completed else None,
+        error_file_id=None,
+        model="text-embedding-3-small",
+        metadata={"customer_job_id": "job-42"},
+        provider_batch_id=None,
+        provider_status=None,
+        provider_error=None,
+        provider_last_sync_at=None,
+        total_items=2,
+        in_progress_items=1 if is_cancelling else 0,
+        completed_items=1 if is_cancelling else (2 if is_completed else 0),
+        failed_items=0,
+        cancelled_items=0,
+        locked_by=None,
+        lease_expires_at=None,
+        cancel_requested_at=STARTED_AT if is_cancelling else None,
+        status_last_updated_at=COMPLETED_AT if is_completed else CREATED_AT,
+        created_by_api_key="foreign-key" if foreign else "fixture-owner-key",
+        created_by_user_id=None,
+        created_by_team_id="foreign-team" if foreign else "team-default",
+        created_by_organization_id="foreign-org" if foreign else "org-default",
+        created_at=CREATED_AT,
+        started_at=STARTED_AT if is_completed or is_cancelling else None,
+        completed_at=COMPLETED_AT if is_completed else None,
+        expires_at=EXPIRES_AT,
+        webhook_config_ciphertext="encrypted-fixture-placeholder",
+        webhook_config_fingerprint="f" * 64,
+    )
+
+
+class _ContractStorage:
+    backend_name = "memory"
+
+    def __init__(self) -> None:
+        self.written_payload: bytes | None = None
+
+    async def write_chunks(self, *, purpose: str, filename: str, chunks):  # noqa: ANN001
+        del purpose, filename
+        payload = b"".join([chunk async for chunk in chunks])
+        self.written_payload = payload
+        return (
+            "input/file_input_001.jsonl",
+            len(payload),
+            hashlib.sha256(payload).hexdigest(),
+        )
+
+    async def read_bytes(self, storage_key: str) -> bytes:
+        assert storage_key == "output/file_output_001.jsonl"
+        return (FIXTURE_DIR / "batch_output.jsonl").read_bytes()
+
+    async def delete(self, storage_key: str) -> None:
+        raise AssertionError(f"unexpected artifact deletion: {storage_key}")
+
+
+class _ContractRepository:
+    def __init__(self) -> None:
+        self.created_file: BatchFileRecord | None = None
+
+    async def create_file(
+        self,
+        *,
+        purpose: str,
+        filename: str,
+        bytes_size: int,
+        storage_backend: str,
+        storage_key: str,
+        checksum: str,
+        created_by_api_key: str,
+        created_by_user_id: str | None,
+        created_by_team_id: str | None,
+        created_by_organization_id: str | None,
+        expires_at: datetime,
+    ) -> BatchFileRecord:
+        del checksum, created_by_api_key, created_by_user_id, expires_at
+        self.created_file = BatchFileRecord(
+            file_id="file_input_001",
+            purpose=purpose,
+            filename=filename,
+            bytes=bytes_size,
+            status="uploaded",
+            storage_backend=storage_backend,
+            storage_key=storage_key,
+            checksum=None,
+            created_by_api_key="fixture-owner-key",
+            created_by_user_id=None,
+            created_by_team_id=created_by_team_id,
+            created_by_organization_id=created_by_organization_id,
+            created_at=CREATED_AT,
+            expires_at=EXPIRES_AT,
+        )
+        return self.created_file
+
+    async def get_file(self, file_id: str) -> BatchFileRecord | None:
+        if file_id == "file_missing":
+            return None
+        if file_id == "file_foreign":
+            return replace(
+                self._input_file(),
+                file_id=file_id,
+                created_by_team_id="foreign-team",
+                created_by_organization_id="foreign-org",
+            )
+        if file_id == "file_output_001":
+            return replace(
+                self._input_file(),
+                file_id=file_id,
+                purpose="batch_output",
+                filename="batch_output.jsonl",
+                bytes=(FIXTURE_DIR / "batch_output.jsonl").stat().st_size,
+                storage_key="output/file_output_001.jsonl",
+            )
+        return self._input_file()
+
+    async def get_job(self, batch_id: str) -> BatchJobRecord | None:
+        if batch_id == "batch_missing":
+            return None
+        if batch_id == "batch_foreign":
+            return _job(batch_id=batch_id, foreign=True)
+        return _job(batch_id=batch_id)
+
+    async def list_jobs(self, **kwargs: Any) -> list[BatchJobRecord]:
+        assert kwargs["limit"] == 20
+        assert kwargs["created_by_api_key"]
+        assert kwargs["created_by_team_id"] == "team-default"
+        assert kwargs["created_by_organization_id"] is None
+        assert set(kwargs) == {
+            "limit",
+            "created_by_api_key",
+            "created_by_team_id",
+            "created_by_organization_id",
+        }
+        return [_job()]
+
+    async def request_cancel(self, batch_id: str) -> BatchJobRecord:
+        return _job(batch_id=batch_id, status=BatchJobStatus.IN_PROGRESS)
+
+    def _input_file(self) -> BatchFileRecord:
+        return self.created_file or BatchFileRecord(
+            file_id="file_input_001",
+            purpose="batch",
+            filename="batch_input.jsonl",
+            bytes=(FIXTURE_DIR / "batch_input.jsonl").stat().st_size,
+            status="uploaded",
+            storage_backend="memory",
+            storage_key="input/file_input_001.jsonl",
+            checksum=None,
+            created_by_api_key="fixture-owner-key",
+            created_by_user_id=None,
+            created_by_team_id="team-default",
+            created_by_organization_id="org-default",
+            created_at=CREATED_AT,
+            expires_at=EXPIRES_AT,
+        )
+
+
+class _ContractCreateSessionService:
+    def __init__(self) -> None:
+        self.last_webhook: object | None = None
+
+    async def create_batch(self, **kwargs: Any) -> SimpleNamespace:
+        self.last_webhook = kwargs["webhook"]
+        return SimpleNamespace(
+            job=_job(batch_id="batch_queued_001", status=BatchJobStatus.QUEUED),
+            audit_metadata={"idempotency_replayed": False},
+        )
+
+
+@pytest.fixture
+def contract_runtime(test_app):
+    repository = _ContractRepository()
+    storage = _ContractStorage()
+    create_session_service = _ContractCreateSessionService()
+    service = BatchService(
+        repository=repository,  # type: ignore[arg-type]
+        storage=storage,  # type: ignore[arg-type]
+        create_session_service=create_session_service,  # type: ignore[arg-type]
+    )
+    test_app.state.batch_repository = repository
+    test_app.state.batch_service = service
+    return SimpleNamespace(
+        repository=repository,
+        storage=storage,
+        create_session_service=create_session_service,
+    )
+
+
+def _headers(test_app) -> dict[str, str]:
+    return {"Authorization": f"Bearer {test_app.state._test_key}"}
+
+
+def _assert_json_response(response, fixture: dict[str, Any]) -> None:  # noqa: ANN001
+    assert response.status_code == fixture["status_code"]
+    assert response.headers["content-type"] == "application/json"
+    assert response.json() == fixture["body"]
+
+
+@pytest.mark.asyncio
+async def test_file_upload_wire_contract_is_frozen(
+    client,
+    test_app,
+    contract_runtime,
+) -> None:
+    fixture = _load_http_fixture()["file_upload"]
+    request_fixture = fixture["request"]
+    input_bytes = (FIXTURE_DIR / "batch_input.jsonl").read_bytes()
+
+    response = await client.post(
+        request_fixture["path"],
+        headers=_headers(test_app),
+        files={
+            "file": (
+                request_fixture["multipart_filename"],
+                input_bytes,
+                "application/jsonl",
+            )
+        },
+        data={"purpose": request_fixture["multipart_purpose"]},
+    )
+
+    _assert_json_response(response, fixture["response"])
+    assert (
+        contract_runtime.repository.created_file.purpose
+        == request_fixture["service_observed_purpose"]
+    )
+    assert contract_runtime.storage.written_payload == input_bytes
+
+
+@pytest.mark.asyncio
+async def test_file_retrieve_wire_contract_is_frozen(client, test_app, contract_runtime) -> None:
+    del contract_runtime
+    fixture = _load_http_fixture()["file_retrieve"]["response"]
+
+    response = await client.get(
+        "/v1/files/file_input_001",
+        headers=_headers(test_app),
+    )
+
+    _assert_json_response(response, fixture)
+
+
+@pytest.mark.asyncio
+async def test_file_content_wire_contract_is_frozen(client, test_app, contract_runtime) -> None:
+    del contract_runtime
+    fixture = _load_http_fixture()["file_content"]["response"]
+
+    response = await client.get(
+        "/v1/files/file_output_001/content",
+        headers=_headers(test_app),
+    )
+
+    assert response.status_code == fixture["status_code"]
+    assert response.headers["content-type"] == fixture["content_type"]
+    assert response.content == (FIXTURE_DIR / fixture["fixture"]).read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_batch_create_wire_contract_is_frozen(client, test_app, contract_runtime) -> None:
+    fixture = _load_http_fixture()["batch_create"]
+    request_payload = dict(fixture["request"])
+    webhook_fixture = request_payload.pop("webhook")
+    request_payload["webhook"] = {
+        "url": webhook_fixture["url"],
+        "signing_secret": "w" * 32,
+    }
+
+    response = await client.post(
+        "/v1/batches",
+        headers=_headers(test_app),
+        json=request_payload,
+    )
+
+    _assert_json_response(response, fixture["response"])
+    assert webhook_fixture["signing_secret_present"] is True
+    assert contract_runtime.create_session_service.last_webhook == request_payload["webhook"]
+    assert request_payload["webhook"]["signing_secret"] not in response.text
+
+
+@pytest.mark.asyncio
+async def test_batch_retrieve_wire_contract_is_frozen(client, test_app, contract_runtime) -> None:
+    del contract_runtime
+    fixture = _load_http_fixture()["batch_retrieve"]["response"]
+
+    response = await client.get(
+        "/v1/batches/batch_completed_001",
+        headers=_headers(test_app),
+    )
+
+    _assert_json_response(response, fixture)
+
+
+@pytest.mark.asyncio
+async def test_batch_list_wire_contract_is_frozen(client, test_app, contract_runtime) -> None:
+    del contract_runtime
+    fixture = _load_http_fixture()["batch_list"]["response"]
+
+    response = await client.get("/v1/batches", headers=_headers(test_app))
+
+    _assert_json_response(response, fixture)
+
+
+@pytest.mark.asyncio
+async def test_batch_cancel_wire_contract_is_frozen(client, test_app, contract_runtime) -> None:
+    del contract_runtime
+    fixture = _load_http_fixture()["batch_cancel"]["response"]
+
+    response = await client.post(
+        "/v1/batches/batch_completed_001/cancel",
+        headers=_headers(test_app),
+    )
+
+    _assert_json_response(response, fixture)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("fixture_name", "path"),
+    [
+        ("file_missing", "/v1/files/file_missing"),
+        ("file_foreign", "/v1/files/file_foreign"),
+        ("batch_missing", "/v1/batches/batch_missing"),
+        ("batch_foreign", "/v1/batches/batch_foreign"),
+    ],
+)
+async def test_current_missing_and_foreign_error_wire_contracts_are_frozen(
+    client,
+    test_app,
+    contract_runtime,
+    fixture_name: str,
+    path: str,
+) -> None:
+    del contract_runtime
+    fixture = _load_http_fixture()["errors"][fixture_name]
+
+    response = await client.get(path, headers=_headers(test_app))
+
+    _assert_json_response(response, fixture)
+
+
+@pytest.mark.asyncio
+async def test_current_file_validation_error_wire_contract_is_frozen(client, test_app) -> None:
+    fixture = _load_http_fixture()["errors"]["file_upload_validation"]
+
+    response = await client.post("/v1/files", headers=_headers(test_app))
+
+    _assert_json_response(response, fixture)
+
+
+@pytest.mark.asyncio
+async def test_current_batch_validation_error_wire_contract_is_frozen(client, test_app) -> None:
+    fixture = _load_http_fixture()["errors"]["batch_body_validation"]
+
+    response = await client.post("/v1/batches", headers=_headers(test_app))
+
+    _assert_json_response(response, fixture)
+
+
+def test_batch_jsonl_success_and_error_rows_are_byte_frozen() -> None:
+    finalizer = BatchArtifactFinalizer(
+        repository=object(),  # type: ignore[arg-type]
+        storage=object(),  # type: ignore[arg-type]
+        config=BatchWorkerConfig(worker_id="contract-fixture"),
+    )
+    success_item = BatchItemRecord(
+        item_id="item_001",
+        batch_id="batch_completed_001",
+        line_number=1,
+        custom_id="embed-1",
+        status="completed",
+        request_body={"model": "text-embedding-3-small", "input": "first document"},
+        response_body={
+            "object": "list",
+            "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+            "model": "text-embedding-3-small",
+            "usage": {"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2},
+        },
+        error_body=None,
+        usage={"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2},
+        provider_cost=0.0,
+        billed_cost=0.0,
+        attempts=1,
+        last_error=None,
+        locked_by=None,
+        lease_expires_at=None,
+        created_at=CREATED_AT,
+        started_at=STARTED_AT,
+        completed_at=COMPLETED_AT,
+    )
+    error_item = replace(
+        success_item,
+        item_id="item_002",
+        line_number=2,
+        custom_id="embed-2",
+        status="failed",
+        response_body=None,
+        error_body={"message": "provider unavailable", "type": "BatchItemError"},
+        last_error="provider unavailable",
+    )
+
+    success_line = json.dumps(finalizer._serialize_completed_artifact_row(success_item)) + "\n"
+    error_line = json.dumps(finalizer._serialize_failed_artifact_row(error_item)) + "\n"
+
+    assert success_line.encode() == (FIXTURE_DIR / "batch_output.jsonl").read_bytes()
+    assert error_line.encode() == (FIXTURE_DIR / "batch_error.jsonl").read_bytes()
+
+
+def test_batch_input_jsonl_rows_remain_accepted_by_the_runtime_validator() -> None:
+    seen_custom_ids: set[str] = set()
+    parsed_rows = []
+    for line_number, raw_line in enumerate(
+        (FIXTURE_DIR / "batch_input.jsonl").read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        parsed_rows.append(
+            parse_batch_input_line(
+                raw_line,
+                line_number=line_number,
+                endpoint="/v1/embeddings",
+                auth=UserAPIKeyAuth(api_key="fixture-key"),
+                seen_custom_ids=seen_custom_ids,
+                callable_target_grant_service=None,
+                callable_target_scope_policy_mode="disabled",
+                model_access_validator=lambda *args, **kwargs: None,
+            )
+        )
+
+    assert [row.custom_id for row in parsed_rows if row is not None] == [
+        "embed-1",
+        "embed-2",
+    ]
+
+
+def test_batch_webhook_event_body_and_headers_are_byte_frozen() -> None:
+    fixture = json.loads((FIXTURE_DIR / "batch_webhook_delivery.json").read_text(encoding="utf-8"))
+    event = build_batch_webhook_event(
+        _job(),
+        event_id="evt_contract_001",
+        created_at=datetime.fromtimestamp(1_700_000_400, tz=UTC),
+    )
+    record = BatchWebhookOutboxRecord(
+        event_id=event.event_id,
+        batch_id="batch_completed_001",
+        event_type=BatchWebhookEventType.COMPLETED,
+        target_config_ciphertext="encrypted-fixture-placeholder",
+        payload_json=event.payload_json,
+        payload_sha256=event.payload_sha256,
+        status=BatchWebhookDeliveryStatus.PROCESSING,
+        attempt_count=2,
+        max_attempts=8,
+        next_attempt_at=CREATED_AT,
+        last_status_code=None,
+        last_error=None,
+        locked_by="contract-worker",
+        lease_expires_at=EXPIRES_AT,
+        created_at=CREATED_AT,
+        updated_at=CREATED_AT,
+        delivered_at=None,
+    )
+    headers = build_batch_webhook_headers(
+        record,
+        signing_secret="w" * 32,
+        timestamp=1_700_000_500,
+    )
+
+    assert event.payload_json == fixture["event"]
+    assert event.payload_sha256 == fixture["canonical_body_sha256"]
+    assert headers == fixture["headers"]
+    rendered = canonical_batch_webhook_event_bytes(event.payload_json)
+    assert b"encrypted-fixture-placeholder" not in rendered
+    assert b"signing_secret" not in rendered
+
+
+def test_omitted_and_null_fields_are_explicit_in_the_golden_contract() -> None:
+    fixture = _load_http_fixture()
+    file_body = fixture["file_retrieve"]["response"]["body"]
+    batch_body = fixture["batch_retrieve"]["response"]["body"]
+
+    assert "expires_at" not in file_body
+    assert "status_details" not in file_body
+    assert batch_body["error_file_id"] is None
+    assert batch_body["errors"] is None
+    assert batch_body["failed_at"] is None
+    assert batch_body["expired_at"] is None
+    assert {
+        "model",
+        "cancelling_at",
+        "cancelled_at",
+        "finalizing_at",
+        "usage",
+    }.isdisjoint(batch_body)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' or sys_platform != 'emscripten'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -465,6 +469,7 @@ batch-s3 = [
     { name = "boto3" },
 ]
 dev = [
+    { name = "openai" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -481,6 +486,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42,<47" },
     { name = "fastapi", specifier = ">=0.109,<1.0" },
     { name = "httpx", specifier = ">=0.26,<1.0" },
+    { name = "openai", marker = "extra == 'dev'", specifier = ">=3.3,<4.0" },
     { name = "presidio-analyzer", marker = "extra == 'guardrails-presidio'", specifier = ">=2.2,<3.0" },
     { name = "presidio-anonymizer", marker = "extra == 'guardrails-presidio'", specifier = ">=2.2,<3.0" },
     { name = "prisma", specifier = ">=0.12,<1.0" },
@@ -546,6 +552,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -597,12 +616,38 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.11"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -624,6 +669,92 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -872,6 +1003,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/58/ad/1100d7229bb248394939a12a8074d485b655e8ed44207d328fdd7fcebc7b/numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e58765ad74dcebd3ef0208a5078fba32dc8ec3578fe84a604432950cd043d79", size = 15800434, upload-time = "2026-03-09T07:58:44.837Z" },
     { url = "https://files.pythonhosted.org/packages/0c/fd/16d710c085d28ba4feaf29ac60c936c9d662e390344f94a6beaa2ac9899b/numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e236dbda4e1d319d681afcbb136c0c4a8e0f1a5c58ceec2adebb547357fe857", size = 16729409, upload-time = "2026-03-09T07:58:47.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/a7/b35835e278c18b85206834b3aa3abe68e77a98769c59233d1f6300284781/numpy-2.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4b42639cdde6d24e732ff823a3fa5b701d8acad89c4142bc1d0bd6dc85200ba5", size = 12504685, upload-time = "2026-03-09T07:58:50.525Z" },
+]
+
+[[package]]
+name = "openai"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/9c/ba0c292b4032ede74c249ca314ad64eb1bb5a03a843f6e01facb02f80cd8/openai-3.3.1.tar.gz", hash = "sha256:6f22807de1a976c932cecda620e8172a8c3fdbaeed29c7f21564e0c2410edf56", size = 1282113, upload-time = "2026-08-19T16:31:35.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/db/2b7a1b3de659bb82aef979116c74e809982b13e42c057759767552b5155f/openai-3.3.1-py3-none-any.whl", hash = "sha256:9652df7fdf8ee6f5bd58e0a12f2b1d414a18e0f06bb7a9a57c8643a5f5469bd3", size = 1690337, upload-time = "2026-08-19T16:31:32.812Z" },
 ]
 
 [[package]]
@@ -1513,6 +1661,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "spacy"
 version = "3.8.13"
 source = { registry = "https://pypi.org/simple" }
@@ -1743,6 +1900,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- establish an executable inventory of every developer route, its audience, protocol dialect, and authentication boundary
- freeze current Files, Batches, JSONL, webhook, omitted/null, tenancy, and error behavior in golden fixtures
- record the exact current OpenAPI gaps without changing the runtime contract
- add official OpenAI Python 3.3.1 and TypeScript 7.5.0 compatibility smoke tests, with narrowly named expected gaps
- add the compatibility matrix and the implementation-ready contract/SDK plan
- run the TypeScript compatibility fixture in CI

This is Slice 0 of the public-contract work in #280. It intentionally changes no production runtime behavior. Slices 1 and 2 will be separate stacked PRs.

## Verification

- `uv run pytest -q tests/test_batch_*.py tests/test_embeddings_batch.py tests/contracts tests/compat/openai_python`
  - 808 passed, 100 skipped, 2 strict expected failures
- `npm run test:compat`
  - 1 passed, 2 named TODO gaps
- `uv run ruff check tests/contracts tests/compat/openai_python`
- `uv run ruff format --check tests/contracts tests/compat/openai_python`
- `uv lock --check`
- JSON fixture/manifest parsing and YAML workflow/navigation parsing
- `git diff --check`

## Expected compatibility gaps carried forward

- Files list/delete are missing (Slice 4)
- Batch list does not implement object-ID cursors or `has_more` metadata (Slice 3)
- the curated typed public OpenAPI contract and stabilized error/request DTOs are delivered in Slices 1, 2, and 5

Part of #280.
