### PR TITLE
Apply Delta branding as the default UI theme

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -50,9 +50,9 @@ general_settings:
   instance_name: DeltaLLM
   # Installation-wide UI branding. Logo and favicon BLOBs are managed from Settings > Theme.
   ui_branding:
-    primary_color: "#2563EB"
-    secondary_color: "#7C3AED"
-    menu_hover_color: "#F9FAFB"
+    primary_color: "#5B50D6"
+    secondary_color: "#8B7CFF"
+    menu_hover_color: "#F7F5FF"
 
   # Required secrets
   master_key: os.environ/DELTALLM_MASTER_KEY

--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -34,9 +34,9 @@ general_settings:
 general_settings:
   instance_name: DeltaLLM
   ui_branding:
-    primary_color: "#2563EB"
-    secondary_color: "#7C3AED"
-    menu_hover_color: "#F9FAFB"
+    primary_color: "#5B50D6"
+    secondary_color: "#8B7CFF"
+    menu_hover_color: "#F7F5FF"
   master_key: os.environ/DELTALLM_MASTER_KEY
   deltallm_key_header_name: Authorization
   salt_key: os.environ/DELTALLM_SALT_KEY
@@ -197,13 +197,13 @@ Platform administrators can update the installation-wide appearance from the **T
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `instance_name` | `DeltaLLM` | Product name shown in the shell, authentication flows, browser title, examples, and notification copy. |
-| `ui_branding.primary_color` | `#2563EB` | Primary actions, links, and focus treatments. |
-| `ui_branding.secondary_color` | `#7C3AED` | Secondary actions and navigation accents. |
-| `ui_branding.menu_hover_color` | `#F9FAFB` | Navigation hover background. |
+| `ui_branding.primary_color` | `#5B50D6` | Primary actions, links, and focus treatments. |
+| `ui_branding.secondary_color` | `#8B7CFF` | Secondary actions and navigation accents. |
+| `ui_branding.menu_hover_color` | `#F7F5FF` | Navigation hover background. |
 
 Logo and favicon files are managed from **Settings > Theme**, not from file configuration. The service accepts PNG, JPEG, WebP, and SVG files, plus ICO for favicons, with a 2 MB limit per asset. SVG files containing scripts, executable attributes, document type/entity declarations, embedded documents, or external resource references are rejected. Asset bytes are stored in PostgreSQL `BYTEA` columns; the dynamic configuration contains only the versioned internal asset reference.
 
-The supplied colours are base colours, not a request to use one fixed text colour. DeltaLLM derives normal, hover, foreground, and soft-surface tokens at runtime so button labels and branded text retain WCAG AA contrast. Very light primary or secondary colours are adjusted for visible control boundaries, and a menu hover colour that would disappear against the white navigation background is adjusted slightly. A full wordmark falls back to the configured mark and instance name when it cannot load. Failed logo assets receive one delayed retry and become eligible again after branding is saved or refreshed; a failed custom favicon falls back to the built-in favicon.
+The supplied colours are base colours, not a request to use one fixed text colour. DeltaLLM derives normal, hover, foreground, and soft-surface tokens at runtime so button labels and branded text retain WCAG AA contrast. Very light primary or secondary colours are adjusted for visible control boundaries, and a menu hover colour that would disappear against the white navigation background is adjusted slightly. A full wordmark falls back to the configured mark and instance name when it cannot load. When no custom logo assets are configured, the built-in Delta mark and wordmark are used. Failed logo assets receive one delayed retry and become eligible again after branding is saved or refreshed; a failed custom favicon falls back to the built-in favicon.
 
 Theme values saved in the Admin UI are persisted as dynamic database overrides and take precedence over file configuration until changed again. Asset BLOB changes and their versioned theme references commit in the same serialized database transaction. Redis broadcasts the small configuration change; each replica then refreshes its in-memory asset cache from PostgreSQL once, while the existing database poll remains the fallback when pub/sub is unavailable. Public asset reads are served from replica memory with ETags and immutable caching, so normal page rendering does not query PostgreSQL. Theme-only updates refresh application identity without rebuilding model and routing runtime state. Clients load only the public branding projection, never the broader settings payload, and an already-open browser refreshes it when the page regains focus or visibility. During the initial request, the UI shows a neutral loading state and does not render default DeltaLLM branding before the configured branding is known; if that request fails or exceeds three seconds, the built-in defaults are used.
 

--- a/src/config.py
+++ b/src/config.py
@@ -491,9 +491,9 @@ class UIBrandingSettings(BaseModel):
     logo_mark_url: str | None = None
     logo_full_url: str | None = None
     favicon_url: str | None = None
-    primary_color: str = Field(default="#2563EB", pattern=r"^#[0-9A-Fa-f]{6}$")
-    secondary_color: str = Field(default="#7C3AED", pattern=r"^#[0-9A-Fa-f]{6}$")
-    menu_hover_color: str = Field(default="#F9FAFB", pattern=r"^#[0-9A-Fa-f]{6}$")
+    primary_color: str = Field(default="#5B50D6", pattern=r"^#[0-9A-Fa-f]{6}$")
+    secondary_color: str = Field(default="#8B7CFF", pattern=r"^#[0-9A-Fa-f]{6}$")
+    menu_hover_color: str = Field(default="#F7F5FF", pattern=r"^#[0-9A-Fa-f]{6}$")
 
     @field_validator("logo_mark_url", "logo_full_url", "favicon_url", mode="before")
     @classmethod
@@ -521,9 +521,9 @@ class UIBrandingUpdatePayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     instance_name: str = Field(default="DeltaLLM", min_length=1, max_length=80)
-    primary_color: str = Field(default="#2563EB", pattern=r"^#[0-9A-Fa-f]{6}$")
-    secondary_color: str = Field(default="#7C3AED", pattern=r"^#[0-9A-Fa-f]{6}$")
-    menu_hover_color: str = Field(default="#F9FAFB", pattern=r"^#[0-9A-Fa-f]{6}$")
+    primary_color: str = Field(default="#5B50D6", pattern=r"^#[0-9A-Fa-f]{6}$")
+    secondary_color: str = Field(default="#8B7CFF", pattern=r"^#[0-9A-Fa-f]{6}$")
+    menu_hover_color: str = Field(default="#F7F5FF", pattern=r"^#[0-9A-Fa-f]{6}$")
 
     @field_validator("instance_name")
     @classmethod

--- a/tests/test_ui_branding.py
+++ b/tests/test_ui_branding.py
@@ -163,9 +163,9 @@ async def test_public_ui_branding_returns_safe_defaults_without_authentication(c
         "logo_mark_url": None,
         "logo_full_url": None,
         "favicon_url": None,
-        "primary_color": "#2563EB",
-        "secondary_color": "#7C3AED",
-        "menu_hover_color": "#F9FAFB",
+        "primary_color": "#5B50D6",
+        "secondary_color": "#8B7CFF",
+        "menu_hover_color": "#F7F5FF",
     }
     assert "master_key" not in response.json()
 

--- a/ui/public/brand/deltallm-delta-lockup-on-light.svg
+++ b/ui/public/brand/deltallm-delta-lockup-on-light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 64" role="img" aria-labelledby="title">
+  <title id="title">DeltaLLM logo on light surfaces</title>
+  <path fill="#090A16" fill-rule="evenodd" d="M10 52 28 12h8l18 40H10Zm13-8h20L32 23 23 44Z"/>
+  <path fill="#5B50D6" d="M36 12h7l12 20-12 20h-7l12-20-12-20Z"/>
+  <text x="78" y="44" fill="#090A16" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="32" font-weight="700" letter-spacing="-1.5">DeltaLLM</text>
+</svg>

--- a/ui/public/brand/deltallm-delta-on-light.svg
+++ b/ui/public/brand/deltallm-delta-on-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">DeltaLLM Delta mark on light surfaces</title>
+  <path fill="#090A16" fill-rule="evenodd" d="M10 52 28 12h8l18 40H10Zm13-8h20L32 23 23 44Z"/>
+  <path fill="#5B50D6" d="M36 12h7l12 20-12 20h-7l12-20-12-20Z"/>
+</svg>

--- a/ui/public/brand/deltallm-delta.svg
+++ b/ui/public/brand/deltallm-delta.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">DeltaLLM Delta mark</title>
+  <path fill="#F2F0FF" fill-rule="evenodd" d="M10 52 28 12h8l18 40H10Zm13-8h20L32 23 23 44Z"/>
+  <path fill="#8B7CFF" d="M36 12h7l12 20-12 20h-7l12-20-12-20Z"/>
+</svg>

--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,5 +1,7 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <title>DeltaLLM</title>
-  <rect x="8" y="8" width="48" height="48" rx="14" fill="#F5F3FF" stroke="#DDD6FE" stroke-width="2"/>
-  <path d="M35.1614 12L22 31.7188H31.4642L28.8386 52L42 32.2812H32.5358L35.1614 12Z" fill="#7C3AED"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="DeltaLLM">
+  <rect width="32" height="32" rx="7" fill="#090A16"/>
+  <g transform="translate(4.5 4.5) scale(.36)">
+    <path fill="#F2F0FF" fill-rule="evenodd" d="M10 52 28 12h8l18 40H10Zm13-8h20L32 23 23 44Z"/>
+    <path fill="#8B7CFF" d="M36 12h7l12 20-12 20h-7l12-20-12-20Z"/>
+  </g>
 </svg>

--- a/ui/src/components/BrandLogo.tsx
+++ b/ui/src/components/BrandLogo.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { Zap } from 'lucide-react';
 import clsx from 'clsx';
-import { normalizeBranding, type UIBranding } from '../lib/branding';
+import {
+  BUILT_IN_BRAND_ASSETS,
+  DEFAULT_BRANDING,
+  normalizeBranding,
+  type UIBranding,
+} from '../lib/branding';
 import { useBranding } from '../lib/brandingContext';
 
 interface BrandLogoProps {
@@ -26,6 +31,7 @@ export default function BrandLogo({
   const failureKey = JSON.stringify([
     assetRevision,
     variant,
+    branding.instance_name,
     branding.logo_full_url || '',
     branding.logo_mark_url || '',
   ]);
@@ -33,9 +39,12 @@ export default function BrandLogo({
   const retryCounts = useRef(new Map<string, number>());
   const retryTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   const failedUrls = failures.key === failureKey ? failures.urls : [];
+  const builtInExpandedAsset = branding.instance_name === DEFAULT_BRANDING.instance_name
+    ? BUILT_IN_BRAND_ASSETS.logo_full
+    : BUILT_IN_BRAND_ASSETS.logo_mark;
   const candidates = variant === 'expanded'
-    ? [branding.logo_full_url, branding.logo_mark_url]
-    : [branding.logo_mark_url];
+    ? [branding.logo_full_url, branding.logo_mark_url, builtInExpandedAsset]
+    : [branding.logo_mark_url, BUILT_IN_BRAND_ASSETS.logo_mark];
   const visibleUrl = candidates.find((candidate) => candidate && !failedUrls.includes(candidate)) || null;
 
   useEffect(() => {
@@ -74,14 +83,20 @@ export default function BrandLogo({
     retryTimers.current.set(retryKey, timer);
   };
 
-  if (variant === 'expanded' && visibleUrl && visibleUrl === branding.logo_full_url) {
+  const fullLogoUrl = variant === 'expanded'
+    && visibleUrl
+    && (visibleUrl === branding.logo_full_url || visibleUrl === BUILT_IN_BRAND_ASSETS.logo_full)
+    ? visibleUrl
+    : null;
+
+  if (fullLogoUrl) {
     return (
       <div className={clsx('flex min-w-0 items-center', className)}>
         <img
-          src={visibleUrl}
+          src={fullLogoUrl}
           alt={branding.instance_name}
           className={clsx('h-8 w-auto max-w-full object-contain object-left', fullClassName)}
-          onError={() => markFailed(visibleUrl)}
+          onError={() => markFailed(fullLogoUrl)}
         />
       </div>
     );

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -151,13 +151,13 @@ function SidebarContent({
     <>
       <div
         className={clsx(
-          'min-w-0 shrink-0 px-3 py-4',
+          'min-w-0 shrink-0 gap-2 px-3 py-4',
           showExpanded ? 'flex items-center justify-between' : 'flex flex-col items-center gap-2',
         )}
       >
         <BrandLogo
           variant={showExpanded ? 'expanded' : 'mark'}
-          className={clsx(!showExpanded && 'w-full justify-center')}
+          className={clsx(showExpanded ? 'max-w-[9.5rem]' : 'w-full justify-center')}
         />
         {canCollapse && showExpanded && (
           <button

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3,19 +3,19 @@
 @tailwind utilities;
 
 :root {
-  --brand-primary: 37 99 235;
-  --brand-primary-ink: 37 99 235;
-  --brand-primary-ink-hover: 32 85 202;
-  --brand-primary-hover: 32 85 202;
-  --brand-primary-soft: 233 239 253;
+  --brand-primary: 91 80 214;
+  --brand-primary-ink: 91 80 214;
+  --brand-primary-ink-hover: 78 69 184;
+  --brand-primary-hover: 78 69 184;
+  --brand-primary-soft: 239 238 251;
   --brand-on-primary: 255 255 255;
-  --brand-secondary: 124 58 237;
-  --brand-secondary-ink: 124 58 237;
-  --brand-secondary-ink-hover: 107 50 204;
-  --brand-secondary-hover: 107 50 204;
-  --brand-secondary-soft: 245 239 254;
-  --brand-on-secondary: 255 255 255;
-  --brand-menu-hover: 249 250 251;
+  --brand-secondary: 139 124 255;
+  --brand-secondary-ink: 108 97 199;
+  --brand-secondary-ink-hover: 93 83 171;
+  --brand-secondary-hover: 155 142 255;
+  --brand-secondary-soft: 246 245 255;
+  --brand-on-secondary: 17 24 39;
+  --brand-menu-hover: 237 235 245;
   --brand-menu-hover-foreground: 17 24 39;
 }
 
@@ -24,6 +24,18 @@ body {
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+::selection {
+  background: rgb(var(--brand-secondary-soft));
+  color: rgb(var(--brand-secondary-ink));
+}
+
+.brand-auth-background {
+  background-color: #fff;
+  background-image:
+    radial-gradient(circle at 50% -12%, rgb(var(--brand-primary) / 0.16), transparent 34rem),
+    radial-gradient(circle at 100% 100%, rgb(var(--brand-primary) / 0.08), transparent 28rem);
 }
 
 #root {

--- a/ui/src/lib/branding.ts
+++ b/ui/src/lib/branding.ts
@@ -8,14 +8,19 @@ export interface UIBranding {
   menu_hover_color: string;
 }
 
+export const BUILT_IN_BRAND_ASSETS = {
+  logo_mark: '/brand/deltallm-delta-on-light.svg',
+  logo_full: '/brand/deltallm-delta-lockup-on-light.svg',
+} as const;
+
 export const DEFAULT_BRANDING: UIBranding = {
   instance_name: 'DeltaLLM',
   logo_mark_url: null,
   logo_full_url: null,
   favicon_url: null,
-  primary_color: '#2563EB',
-  secondary_color: '#7C3AED',
-  menu_hover_color: '#F9FAFB',
+  primary_color: '#5B50D6',
+  secondary_color: '#8B7CFF',
+  menu_hover_color: '#F7F5FF',
 };
 
 const HEX_COLOR = /^#[0-9A-F]{6}$/;

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -61,7 +61,7 @@ export default function Login() {
 
   if (isLoading || ssoLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="brand-auth-background min-h-screen flex items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-brand-primary" />
       </div>
     );
@@ -129,7 +129,7 @@ export default function Login() {
   tabs.push({ key: 'master_key', label: 'Master Key', icon: KeyRound });
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+    <div className="brand-auth-background min-h-screen flex items-center justify-center px-4">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
           <BrandLogo variant="mark" className="mb-4 justify-center" markClassName="h-16 w-16 rounded-2xl" />

--- a/ui/tests/brandingComponents.test.ts
+++ b/ui/tests/brandingComponents.test.ts
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import BrandLogo from '../src/components/BrandLogo';
 import Button from '../src/components/Button';
-import { DEFAULT_BRANDING, type UIBranding } from '../src/lib/branding';
+import { BUILT_IN_BRAND_ASSETS, DEFAULT_BRANDING, type UIBranding } from '../src/lib/branding';
 import { BrandingContext, type BrandingContextValue } from '../src/lib/brandingContext';
 
 function renderLogo(branding: UIBranding, variant: 'mark' | 'expanded'): string {
@@ -22,12 +23,25 @@ function renderLogo(branding: UIBranding, variant: 'mark' | 'expanded'): string 
   ));
 }
 
-test('expanded logo falls back to the built-in mark and instance name', () => {
+test('built-in brand asset URLs resolve to packaged public files', () => {
+  Object.values(BUILT_IN_BRAND_ASSETS).forEach((assetUrl) => {
+    const asset = readFileSync(`public${assetUrl}`, 'utf8');
+    assert.match(asset, /^<svg\b/);
+  });
+});
+
+test('expanded default branding uses the built-in Delta wordmark', () => {
   const markup = renderLogo(DEFAULT_BRANDING, 'expanded');
 
-  assert.match(markup, />DeltaLLM</);
-  assert.doesNotMatch(markup, /<img/);
-  assert.match(markup, /h-1\/2 w-1\/2/);
+  assert.match(markup, /src="\/brand\/deltallm-delta-lockup-on-light\.svg"/);
+  assert.match(markup, /alt="DeltaLLM"/);
+});
+
+test('a custom instance without uploads uses the built-in mark and configured name', () => {
+  const markup = renderLogo({ ...DEFAULT_BRANDING, instance_name: 'Acme AI' }, 'expanded');
+
+  assert.match(markup, /src="\/brand\/deltallm-delta-on-light\.svg"/);
+  assert.match(markup, />Acme AI</);
 });
 
 test('logo previews normalize unsafe asset overrides before rendering', () => {
@@ -49,8 +63,7 @@ test('logo previews normalize unsafe asset overrides before rendering', () => {
     }),
   ));
 
-  assert.doesNotMatch(markup, /<img/);
-  assert.match(markup, />DeltaLLM</);
+  assert.match(markup, /src="\/brand\/deltallm-delta-lockup-on-light\.svg"/);
 });
 
 test('expanded logo prefers a configured full wordmark', () => {


### PR DESCRIPTION
## Summary

- make the Delta logo, favicon, and color palette the built-in default theme
- integrate those defaults with the existing database-backed theme customization and custom asset overrides
- give the expanded sidebar wordmark enough space without affecting the collapsed navigation
- use a white, theme-tinted background for both login loading and rendered states
- document the defaults and add regression coverage for fallback behavior and packaged assets

## Validation

- `npm run test:unit` — 130 tests passed
- focused ESLint checks passed
- `npm run build` passed
- `uv run pytest tests/test_ui_branding.py tests/config/test_settings.py` — 112 tests passed
- Ruff lint and formatting checks passed
- Docker Compose smoke test passed: app healthy; login, branding API, and built-in brand assets returned HTTP 200

## Notes

- The Vite build retains the repository's existing large-chunk and stale Browserslist data warnings.
- `npm ci` reports the repository's existing audit findings; this PR does not change dependencies.
