### PR TITLE
Add animated Delta branding to login and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./ui/public/brand/deltallm-delta-lockup-on-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="./ui/public/brand/deltallm-delta-lockup-on-light.svg">
+    <img alt="DeltaLLM" src="./ui/public/brand/deltallm-delta-lockup-on-light.svg" width="236">
+  </picture>
+</p>
+
 [![CI](https://github.com/deltawi/deltallm/actions/workflows/ci.yml/badge.svg)](https://github.com/deltawi/deltallm/actions/workflows/ci.yml)
 [![Documentation](https://img.shields.io/badge/docs-readthedocs-blue.svg)](https://deltallm.readthedocs.io/en/latest)
 [![Latest Release](https://img.shields.io/github/v/release/deltawi/deltallm.svg?sort=semver)](https://github.com/deltawi/deltallm/releases)

--- a/ui/public/brand/deltallm-delta-lockup-on-dark.svg
+++ b/ui/public/brand/deltallm-delta-lockup-on-dark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 64" role="img" aria-labelledby="title">
+  <title id="title">DeltaLLM logo on dark surfaces</title>
+  <path fill="#F2F0FF" fill-rule="evenodd" d="M10 52 28 12h8l18 40H10Zm13-8h20L32 23 23 44Z"/>
+  <path fill="#8B7CFF" d="M36 12h7l12 20-12 20h-7l12-20-12-20Z"/>
+  <text x="78" y="44" fill="#F2F0FF" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="32" font-weight="700" letter-spacing="-1.5">DeltaLLM</text>
+</svg>

--- a/ui/public/brand/deltallm-delta-reveal-light.svg
+++ b/ui/public/brand/deltallm-delta-reveal-light.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 224 64" role="img" aria-labelledby="title">
+  <title id="title">Animated DeltaLLM logo reveal for light surfaces</title>
+  <style>
+    .delta-base { animation: delta-out 2.2s ease forwards; }
+    .delta-corner {
+      transform-box: view-box;
+      transform-origin: 44px 52px;
+      transform-style: preserve-3d;
+      animation: corner-flip 2.2s ease forwards, corner-blink 0.75s 2.2s ease-in-out 3;
+    }
+    .resolved-d { opacity: 0; animation: d-in 2.2s ease forwards; }
+    .word-rest { animation: word-close 2.2s ease forwards; }
+    @keyframes corner-flip {
+      0% { transform: perspective(80px) translateX(0) rotateY(0deg) scale(1); fill: #5B50D6; stroke: transparent; stroke-width: 0; opacity: 1; }
+      54% { transform: perspective(80px) translateX(0) rotateY(360deg) scale(1); fill: #5B50D6; stroke: transparent; stroke-width: 0; opacity: 1; }
+      60% { transform: perspective(80px) translateX(0) translateY(-2px) rotateY(360deg) scale(0.62); fill: #5B50D6; stroke: #5B50D6; stroke-width: 2.5; opacity: 1; }
+      68%, 100% { transform: perspective(80px) translateX(145px) translateY(-2px) rotateY(360deg) scale(0.62); fill: #090A16; stroke: #090A16; stroke-width: 2.5; opacity: 1; }
+    }
+    @keyframes corner-blink {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0; }
+    }
+    @keyframes delta-out {
+      0%, 57% { opacity: 1; }
+      68%, 100% { opacity: 0; }
+    }
+    @keyframes d-in {
+      0%, 57% { opacity: 0; }
+      68%, 100% { opacity: 1; }
+    }
+    @keyframes word-close {
+      0%, 57% { transform: translateX(0); }
+      68%, 100% { transform: translateX(-25px); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .delta-corner { animation: none; }
+      .delta-base { animation: none; opacity: 1; }
+      .resolved-d { animation: none; opacity: 0; }
+      .word-rest { animation: none; transform: none; }
+    }
+  </style>
+  <defs>
+    <linearGradient id="wordmark-gradient" gradientUnits="userSpaceOnUse" x1="10" y1="0" x2="210" y2="0">
+      <stop offset="0%" stop-color="#090A16"/>
+      <stop offset="52%" stop-color="#4C467A"/>
+      <stop offset="100%" stop-color="#7C3AED"/>
+    </linearGradient>
+  </defs>
+  <g class="delta-base">
+    <path fill="#090A16" fill-rule="evenodd" d="M10 52 28 12h8l18 40H10Zm13-8h20L32 23 23 44Z"/>
+  </g>
+  <path class="delta-corner" fill="#5B50D6" d="M36 12h7l12 20-12 20h-7l12-20-12-20Z"/>
+  <text class="resolved-d" x="10" y="50" fill="url(#wordmark-gradient)" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="36" font-weight="700">D</text>
+  <text class="word-rest" x="60" y="50" fill="url(#wordmark-gradient)" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="36" font-weight="700" letter-spacing="-1.5">eltaLLM</text>
+</svg>

--- a/ui/public/brand/deltallm-delta-reveal.svg
+++ b/ui/public/brand/deltallm-delta-reveal.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 224 64" role="img" aria-labelledby="title">
+  <title id="title">Animated DeltaLLM logo reveal</title>
+  <style>
+    .delta-base { animation: delta-out 2.2s ease forwards; }
+    .delta-corner {
+      transform-box: view-box;
+      transform-origin: 44px 52px;
+      transform-style: preserve-3d;
+      animation: corner-flip 2.2s ease forwards, corner-blink 0.75s 2.2s ease-in-out 3;
+    }
+    .resolved-d { opacity: 0; animation: d-in 2.2s ease forwards; }
+    .word-rest { animation: word-close 2.2s ease forwards; }
+    @keyframes corner-flip {
+      0% { transform: perspective(80px) translateX(0) rotateY(0deg) scale(1); fill: #8B7CFF; stroke: transparent; stroke-width: 0; opacity: 1; }
+      54% { transform: perspective(80px) translateX(0) rotateY(360deg) scale(1); fill: #8B7CFF; stroke: transparent; stroke-width: 0; opacity: 1; }
+      60% { transform: perspective(80px) translateX(0) translateY(-2px) rotateY(360deg) scale(0.62); fill: #8B7CFF; stroke: #8B7CFF; stroke-width: 2.5; opacity: 1; }
+      68%, 100% { transform: perspective(80px) translateX(145px) translateY(-2px) rotateY(360deg) scale(0.62); fill: #F2F0FF; stroke: #F2F0FF; stroke-width: 2.5; opacity: 1; }
+    }
+    @keyframes corner-blink {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0; }
+    }
+    @keyframes delta-out {
+      0%, 57% { opacity: 1; }
+      68%, 100% { opacity: 0; }
+    }
+    @keyframes d-in {
+      0%, 57% { opacity: 0; }
+      68%, 100% { opacity: 1; }
+    }
+    @keyframes word-close {
+      0%, 57% { transform: translateX(0); }
+      68%, 100% { transform: translateX(-25px); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .delta-corner { animation: none; }
+      .delta-base { animation: none; opacity: 1; }
+      .resolved-d { animation: none; opacity: 0; }
+      .word-rest { animation: none; transform: none; }
+    }
+  </style>
+  <defs>
+    <linearGradient id="wordmark-gradient" gradientUnits="userSpaceOnUse" x1="10" y1="0" x2="210" y2="0">
+      <stop offset="0%" stop-color="#F2F0FF"/>
+      <stop offset="52%" stop-color="#D9D4FF"/>
+      <stop offset="100%" stop-color="#8B7CFF"/>
+    </linearGradient>
+  </defs>
+  <g class="delta-base">
+    <path fill="#F2F0FF" fill-rule="evenodd" d="M10 52 28 12h8l18 40H10Zm13-8h20L32 23 23 44Z"/>
+  </g>
+  <path class="delta-corner" fill="#8B7CFF" d="M36 12h7l12 20-12 20h-7l12-20-12-20Z"/>
+  <text class="resolved-d" x="10" y="50" fill="url(#wordmark-gradient)" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="36" font-weight="700">D</text>
+  <text class="word-rest" x="60" y="50" fill="url(#wordmark-gradient)" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="36" font-weight="700" letter-spacing="-1.5">eltaLLM</text>
+</svg>

--- a/ui/src/components/BrandLogo.tsx
+++ b/ui/src/components/BrandLogo.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { Zap } from 'lucide-react';
 import clsx from 'clsx';
 import {
   BUILT_IN_BRAND_ASSETS,
@@ -10,7 +9,7 @@ import {
 import { useBranding } from '../lib/brandingContext';
 
 interface BrandLogoProps {
-  variant?: 'mark' | 'expanded';
+  variant?: 'mark' | 'expanded' | 'reveal';
   className?: string;
   markClassName?: string;
   fullClassName?: string;
@@ -40,9 +39,11 @@ export default function BrandLogo({
   const retryTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   const failedUrls = failures.key === failureKey ? failures.urls : [];
   const builtInExpandedAsset = branding.instance_name === DEFAULT_BRANDING.instance_name
-    ? BUILT_IN_BRAND_ASSETS.logo_full
+    ? variant === 'reveal'
+      ? '/brand/deltallm-delta-reveal-light.svg'
+      : BUILT_IN_BRAND_ASSETS.logo_full
     : BUILT_IN_BRAND_ASSETS.logo_mark;
-  const candidates = variant === 'expanded'
+  const candidates = variant !== 'mark'
     ? [branding.logo_full_url, branding.logo_mark_url, builtInExpandedAsset]
     : [branding.logo_mark_url, BUILT_IN_BRAND_ASSETS.logo_mark];
   const visibleUrl = candidates.find((candidate) => candidate && !failedUrls.includes(candidate)) || null;
@@ -83,9 +84,11 @@ export default function BrandLogo({
     retryTimers.current.set(retryKey, timer);
   };
 
-  const fullLogoUrl = variant === 'expanded'
-    && visibleUrl
-    && (visibleUrl === branding.logo_full_url || visibleUrl === BUILT_IN_BRAND_ASSETS.logo_full)
+  const fullLogoUrl = variant !== 'mark'
+    && (
+      visibleUrl === branding.logo_full_url
+      || (visibleUrl === builtInExpandedAsset && builtInExpandedAsset !== BUILT_IN_BRAND_ASSETS.logo_mark)
+    )
     ? visibleUrl
     : null;
 
@@ -115,15 +118,16 @@ export default function BrandLogo({
         <span
           role={variant === 'mark' ? 'img' : undefined}
           aria-label={variant === 'mark' ? `${branding.instance_name} logo` : undefined}
+          aria-hidden={variant === 'mark' ? undefined : true}
           className={clsx(
-            'flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] border border-brand-secondary/20 bg-brand-secondary-soft shadow-sm',
+            'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-brand-secondary/20 bg-brand-secondary-soft text-brand-secondary-ink',
             markClassName,
           )}
         >
-          <Zap className="h-1/2 w-1/2 fill-brand-secondary text-brand-secondary-ink" />
+          Δ
         </span>
       )}
-      {variant === 'expanded' && (
+      {variant !== 'mark' && (
         <span className={clsx('truncate text-lg font-bold text-gray-900', nameClassName)}>
           {branding.instance_name}
         </span>

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -8,7 +8,6 @@ import { returnToFromSearch } from '../lib/authRedirect';
 import { Mail, KeyRound, Globe } from 'lucide-react';
 import BrandLogo from '../components/BrandLogo';
 import Button from '../components/Button';
-import { useBranding } from '../lib/brandingContext';
 
 type Tab = 'credentials' | 'master_key' | 'sso';
 
@@ -25,7 +24,6 @@ function errorMessage(err: unknown, fallback: string): string {
 
 export default function Login() {
   const { loginWithCredentials, loginWithMasterKey, isLoading } = useAuth();
-  const { branding } = useBranding();
   const location = useLocation();
   const returnTo = returnToFromSearch(location.search);
   const [tab, setTab] = useState<Tab>('credentials');
@@ -132,8 +130,13 @@ export default function Login() {
     <div className="brand-auth-background min-h-screen flex items-center justify-center px-4">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
-          <BrandLogo variant="mark" className="mb-4 justify-center" markClassName="h-16 w-16 rounded-2xl" />
-          <h1 className="text-2xl font-bold text-gray-900">{branding.instance_name} Admin</h1>
+          <BrandLogo
+            variant="reveal"
+            className="mb-4 justify-center"
+            markClassName="h-16 w-16 rounded-2xl"
+            fullClassName="h-16"
+          />
+          <h1 className="text-2xl font-bold text-gray-900">Admin Console</h1>
           <p className="text-gray-500 mt-2">Sign in to continue</p>
         </div>
 

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -134,7 +134,7 @@ export default function Login() {
             variant="reveal"
             className="mb-4 justify-center"
             markClassName="h-16 w-16 rounded-2xl"
-            fullClassName="h-20 max-w-none sm:h-40 lg:h-60"
+            fullClassName="h-[4.5rem]"
           />
           <h1 className="text-lg font-semibold text-gray-900">Admin Console</h1>
         </div>

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -134,10 +134,9 @@ export default function Login() {
             variant="reveal"
             className="mb-4 justify-center"
             markClassName="h-16 w-16 rounded-2xl"
-            fullClassName="h-16"
+            fullClassName="h-20"
           />
-          <h1 className="text-2xl font-bold text-gray-900">Admin Console</h1>
-          <p className="text-gray-500 mt-2">Sign in to continue</p>
+          <h1 className="text-lg font-semibold text-gray-900">Admin Console</h1>
         </div>
 
         <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -134,7 +134,7 @@ export default function Login() {
             variant="reveal"
             className="mb-4 justify-center"
             markClassName="h-16 w-16 rounded-2xl"
-            fullClassName="h-20"
+            fullClassName="h-20 max-w-none sm:h-40 lg:h-60"
           />
           <h1 className="text-lg font-semibold text-gray-900">Admin Console</h1>
         </div>

--- a/ui/tests/brandingComponents.test.ts
+++ b/ui/tests/brandingComponents.test.ts
@@ -9,7 +9,10 @@ import Button from '../src/components/Button';
 import { BUILT_IN_BRAND_ASSETS, DEFAULT_BRANDING, type UIBranding } from '../src/lib/branding';
 import { BrandingContext, type BrandingContextValue } from '../src/lib/brandingContext';
 
-function renderLogo(branding: UIBranding, variant: 'mark' | 'expanded'): string {
+function renderLogo(
+  branding: UIBranding,
+  variant: 'mark' | 'expanded' | 'reveal',
+): string {
   const value: BrandingContextValue = {
     branding,
     assetRevision: 0,
@@ -24,9 +27,25 @@ function renderLogo(branding: UIBranding, variant: 'mark' | 'expanded'): string 
 }
 
 test('built-in brand asset URLs resolve to packaged public files', () => {
-  Object.values(BUILT_IN_BRAND_ASSETS).forEach((assetUrl) => {
+  [
+    ...Object.values(BUILT_IN_BRAND_ASSETS),
+    '/brand/deltallm-delta-reveal.svg',
+    '/brand/deltallm-delta-reveal-light.svg',
+  ].forEach((assetUrl) => {
     const asset = readFileSync(`public${assetUrl}`, 'utf8');
     assert.match(asset, /^<svg\b/);
+  });
+});
+
+test('reveal motion finishes within five seconds and respects reduced-motion preferences', () => {
+  [
+    '/brand/deltallm-delta-reveal.svg',
+    '/brand/deltallm-delta-reveal-light.svg',
+  ].forEach((assetUrl) => {
+    const asset = readFileSync(`public${assetUrl}`, 'utf8');
+    assert.match(asset, /corner-blink 0\.75s 2\.2s ease-in-out 3/);
+    assert.match(asset, /@media \(prefers-reduced-motion: reduce\)/);
+    assert.match(asset, /\.delta-corner \{ animation: none; \}/);
   });
 });
 
@@ -35,6 +54,32 @@ test('expanded default branding uses the built-in Delta wordmark', () => {
 
   assert.match(markup, /src="\/brand\/deltallm-delta-lockup-on-light\.svg"/);
   assert.match(markup, /alt="DeltaLLM"/);
+});
+
+test('default reveal branding uses the light-surface asset', () => {
+  const markup = renderLogo(DEFAULT_BRANDING, 'reveal');
+
+  assert.match(markup, /src="\/brand\/deltallm-delta-reveal-light\.svg"/);
+});
+
+test('reveal branding preserves custom logo priority', () => {
+  const markup = renderLogo({
+    ...DEFAULT_BRANDING,
+    instance_name: 'Acme AI',
+    logo_mark_url: '/branding/mark.svg',
+    logo_full_url: '/branding/wordmark.svg',
+  }, 'reveal');
+
+  assert.match(markup, /src="\/branding\/wordmark\.svg"/);
+  assert.doesNotMatch(markup, /deltallm-delta-reveal/);
+});
+
+test('a custom instance without uploads never receives the Delta reveal', () => {
+  const markup = renderLogo({ ...DEFAULT_BRANDING, instance_name: 'Acme AI' }, 'reveal');
+
+  assert.match(markup, /src="\/brand\/deltallm-delta-on-light\.svg"/);
+  assert.match(markup, />Acme AI</);
+  assert.doesNotMatch(markup, /deltallm-delta-reveal/);
 });
 
 test('a custom instance without uploads uses the built-in mark and configured name', () => {

--- a/ui/tests/brandingProvider.test.ts
+++ b/ui/tests/brandingProvider.test.ts
@@ -227,3 +227,47 @@ test('failed logos retry once and a branding revision makes the same URL eligibl
     restoreDom();
   }
 });
+
+test('expanded logo fallback hides its decorative glyph from assistive technology', async () => {
+  const restoreDom = installDom();
+  const rootNode = document.getElementById('root');
+  assert.ok(rootNode);
+  const root = createRoot(rootNode);
+  const branding: UIBranding = {
+    ...DEFAULT_BRANDING,
+    instance_name: 'Acme AI',
+    logo_mark_url: '/branding/mark.svg',
+    logo_full_url: '/branding/wordmark.svg',
+  };
+  const value: BrandingContextValue = {
+    branding,
+    assetRevision: 0,
+    refreshBranding: async () => branding,
+    setBranding: () => undefined,
+  };
+
+  try {
+    await act(async () => root.render(createElement(
+      BrandingContext.Provider,
+      { value },
+      createElement(BrandLogo, { variant: 'expanded' }),
+    )));
+
+    for (const expectedUrl of [
+      '/branding/wordmark.svg',
+      '/branding/mark.svg',
+      '/brand/deltallm-delta-on-light.svg',
+    ]) {
+      const image = document.querySelector<HTMLImageElement>('img');
+      assert.equal(image?.getAttribute('src'), expectedUrl);
+      act(() => image!.dispatchEvent(new window.Event('error', { bubbles: true })));
+    }
+
+    const fallback = document.querySelector<HTMLSpanElement>('span[aria-hidden="true"]');
+    assert.equal(fallback?.textContent, 'Δ');
+    assert.match(rootNode.textContent || '', /Acme AI/);
+  } finally {
+    await act(async () => root.unmount());
+    restoreDom();
+  }
+});


### PR DESCRIPTION
## Summary

- package the light and dark DeltaLLM reveal assets and add a theme-aware README lockup
- play the reveal once on the default login while preserving custom white-label logo priority
- keep persistent navigation static and use an accessible branded fallback
- cap the reveal motion at 4.45 seconds and honor reduced-motion preferences
- use a 4.5rem animated wordmark with a compact Admin Console heading

## Validation

- npm run test:unit — 135 passed
- touched-file ESLint — passed
- npm run build — passed
- SVG XML and packaged-asset checks — passed
- git diff --check — passed
- initial JS and CSS gzip: 442,080 bytes versus 442,117-byte baseline (-37 bytes)
- full UI lint remains at the existing baseline: 287 findings (276 errors, 11 warnings); touched files are clean