### PR TITLE
feat(route-groups): complete policy UI contracts and simulation

### DIFF
--- a/docs/admin-ui/route-groups.md
+++ b/docs/admin-ui/route-groups.md
@@ -234,6 +234,40 @@ The simulation view is especially useful for:
 - checking weighted splits
 - confirming fallback order
 - confirming prompt-derived tag routing
+- testing retries and fallback under assumed timeout, rate-limit, or unavailable outcomes
+
+## Policy Simulation
+
+Open **Advanced → Policy Simulation** to dry-run the policy currently shown in the guided or JSON
+editor. The simulation can use request tags and a per-deployment assumed outcome. A successful
+outcome is the default; failure outcomes pass through the same retry classification, retry budget,
+candidate ordering, and fallback decisions used by gateway requests.
+
+The policy shown in the editor is simulated as a complete replacement, matching validation and
+publication semantics. Clearing retry or timeout controls removes those overrides, and choosing
+**Inherit enabled** uses the route group's enabled membership rather than retaining the published
+policy's prior explicit subset.
+
+The results distinguish:
+
+- the initially selected deployment
+- the deployment that ultimately served each request
+- requests that required fallback
+- terminal success, timeout, rate-limit, unavailable, or no-selection outcomes
+- a bounded sample trace of primary, retry, and fallback attempts
+- eligibility decision reasons from the router
+
+This is a control-plane dry run. It pins one routing-runtime generation, snapshots the required
+health, cooldown, active-request, usage, and latency state once, and performs all attempt accounting
+locally. It does not call a provider, wait for configured retry backoff, emit operational fallback
+events, or mutate live health, cooldown, usage, latency, or concurrency state. The result therefore
+answers “what would this policy do against this captured state and these assumed outcomes?”; it is
+not a provider availability forecast.
+
+Editing the policy, request tags, iteration count, or assumed outcomes marks the last result stale.
+Starting a new simulation cancels the prior UI request, and an older completion cannot replace a
+newer result. A failed refresh leaves the last successful result visible with its stale/error state.
+Route-group administration permission is required.
 
 ## Prompt Binding
 

--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -251,6 +251,36 @@ Access-group binding upserts use this payload:
 | `POST` | `/ui/api/route-groups/{group_key}/policy/simulate` | Simulate routing behavior |
 | `PUT` | `/ui/api/route-groups/{group_key}/policy` | Replace the active policy |
 
+Policy simulation accepts a bounded scenario (1–5000 iterations):
+
+```json
+{
+  "iterations": 100,
+  "policy": {
+    "mode": "fallback",
+    "members": [
+      {"deployment_id": "primary", "priority": 0},
+      {"deployment_id": "standby", "priority": 1}
+    ],
+    "retry": {"max_attempts": 1, "retryable_error_classes": ["timeout"]}
+  },
+  "metadata": {"tags": ["vip"]},
+  "outcomes": [
+    {"deployment_id": "primary", "outcome": "timeout"}
+  ]
+}
+```
+
+Supported assumed outcomes are `success`, `timeout`, `rate_limit`, and `unavailable`. Omitted
+deployments default to `success`. The response includes initial `selections`,
+`served_deployments`, `terminal_outcomes`, aggregate retry/fallback counts, eligibility
+`reason_counts`, and a bounded `sample_attempts` trace. `basis` is `live_state_dry_run`: the server
+pins one runtime generation and snapshots routing state before iterating, calls no provider, and
+does not mutate live routing state. When `policy` is present, it is the complete client-owned policy
+document rather than a patch: omitted `members` inherit the group's enabled membership, omitted
+`retry` and `timeouts` clear published overrides, and omitted `strategy` falls back to the route
+group's configured strategy.
+
 ### Prompt Registry
 
 | Method | Endpoint | Purpose |

--- a/src/api/admin/endpoints/route_groups.py
+++ b/src/api/admin/endpoints/route_groups.py
@@ -6,6 +6,7 @@ from time import perf_counter
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import ValidationError
 
 from src.auth.roles import Permission
 from src.audit.actions import AuditAction
@@ -24,6 +25,8 @@ from src.api.admin.route_group_contracts import (
     RouteGroupDeleteResponse,
     RouteGroupMemberMutationResponse,
     RouteGroupMutationResponse,
+    RoutePolicySimulationRequest,
+    RoutePolicySimulationResponse,
     RoutePolicyMutationResponse,
     RoutePolicyRollbackResponse,
 )
@@ -34,7 +37,6 @@ from src.governance.access_groups import InvalidAccessGroupError, normalize_acce
 from src.middleware.admin import require_admin_permission
 from src.router.policy_validation import (
     PolicyMemberInventoryItem,
-    merge_policy_members,
     validate_route_policy,
 )
 from src.router.route_group_validation import (
@@ -42,13 +44,8 @@ from src.router.route_group_validation import (
     normalize_route_group_mode,
     validate_route_group_member_modes,
 )
-from src.router import (
-    Router,
-    RouterConfig,
-    RoutingStrategy,
-    build_deployment_registry,
-    build_route_group_policies,
-)
+from src.router import RoutingStrategy
+from src.router.runtime_generation import require_routing_runtime_generation
 from src.services.asset_ownership import (
     apply_owner_scope_to_metadata,
     normalize_owner_scope_type,
@@ -59,7 +56,12 @@ from src.services.asset_scopes import normalize_scope_type
 from src.services.organization_callable_target_sync import (
     maybe_disable_organization_auto_follow_for_scope_mutation,
 )
-from src.services.prompt_registry import apply_route_preferences_to_metadata, parse_prompt_reference
+from src.services.route_policy_simulation import (
+    RoutePolicySimulationInvalidError,
+    RoutePolicySimulationNotFoundError,
+    RoutePolicySimulationService,
+    RoutePolicySimulationUnavailableError,
+)
 from src.services.route_group_refresh import refresh_route_group_runtime
 from src.services.route_group_mutations import RouteGroupMutationService
 from src.services.route_groups import RouteGroupRuntimeCache
@@ -184,47 +186,6 @@ def _validate_bool(value: Any, *, field_name: str) -> bool:
             detail=f"{field_name} must be a boolean",
         )
     return value
-
-
-def _validate_iterations(value: Any) -> int:
-    parsed = _validate_int_or_none(value, field_name="iterations")
-    iterations = parsed if parsed is not None else 100
-    if iterations < 1 or iterations > 5000:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="iterations must be between 1 and 5000"
-        )
-    return iterations
-
-
-def _apply_policy_simulation_override(
-    runtime_groups: list[dict[str, Any]],
-    *,
-    group_key: str,
-    policy: dict[str, Any],
-) -> list[dict[str, Any]]:
-    updated: list[dict[str, Any]] = []
-    found = False
-    for group in runtime_groups:
-        if str(group.get("key") or "") != group_key:
-            updated.append(group)
-            continue
-        found = True
-        patched = dict(group)
-        if "strategy" in policy:
-            patched["strategy"] = policy.get("strategy")
-        if "timeouts" in policy:
-            patched["timeouts"] = policy.get("timeouts")
-        if "retry" in policy:
-            patched["retry"] = policy.get("retry")
-        if "members" in policy:
-            patched["members"] = merge_policy_members(
-                list(group.get("members") or []), policy.get("members")
-            )
-        updated.append(patched)
-
-    if not found:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Route group not found")
-    return updated
 
 
 async def _resolve_policy_members(
@@ -1124,157 +1085,44 @@ async def rollback_route_group_policy(
 
 @router.post(
     "/ui/api/route-groups/{group_key}/policy/simulate",
+    response_model=RoutePolicySimulationResponse,
     dependencies=[Depends(require_admin_permission(Permission.CONFIG_READ))],
 )
 async def simulate_route_group_policy(
     request: Request, group_key: str, payload: dict[str, Any] | None = None
-) -> dict[str, Any]:
-    repository = _repository_or_503(request)
-    group = await repository.get_group(group_key)
-    if group is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Route group not found")
-
-    body = payload or {}
-    iterations = _validate_iterations(body.get("iterations"))
-    metadata = body.get("metadata")
-    if metadata is not None and not isinstance(metadata, dict):
+) -> RoutePolicySimulationResponse:
+    try:
+        simulation_request = RoutePolicySimulationRequest.model_validate(payload or {})
+    except ValidationError as exc:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="metadata must be an object"
-        )
-    metadata = metadata or {}
-    user_id = str(body.get("user_id") or "policy-simulation")
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=exc.errors(include_url=False),
+        ) from exc
 
-    runtime_groups = await repository.list_runtime_groups()
-    available_members = await _resolve_policy_members(repository, group_key)
-
-    warnings: list[str] = []
-    prompt_summary: dict[str, Any] | None = None
-    if "prompt_ref" in body:
-        prompt_ref = parse_prompt_reference(body.get("prompt_ref"))
-        if prompt_ref is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="prompt_ref could not be parsed"
-            )
-        prompt_repository = _prompt_resolution_repository(request)
-        if prompt_repository is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Prompt registry repository unavailable",
-            )
-        resolved_prompt = await prompt_repository.resolve_prompt(
-            template_key=prompt_ref.template_key,
-            label=prompt_ref.label,
-            version=prompt_ref.version,
-        )
-        if resolved_prompt is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="prompt_ref could not be resolved"
-            )
-        try:
-            metadata, route_preferences = apply_route_preferences_to_metadata(
-                metadata, resolved_prompt.route_preferences
-            )
-        except ValueError as exc:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-        prompt_summary = {
-            "template_key": resolved_prompt.template_key,
-            "version": resolved_prompt.version,
-            "label": resolved_prompt.label or prompt_ref.label,
-            "route_preferences": route_preferences,
-        }
-        preferred_group = (
-            route_preferences.get("route_group") if isinstance(route_preferences, dict) else None
-        )
-        if isinstance(preferred_group, str) and preferred_group and preferred_group != group_key:
-            warnings.append(
-                f"prompt route_preferences.route_group={preferred_group!r} is advisory and does not override simulation group {group_key!r}"
-            )
-
-    policy_override = body.get("policy")
-    if policy_override is not None:
-        if not isinstance(policy_override, dict):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="policy must be an object"
-            )
-        normalized, policy_warnings = _validate_policy_payload(
-            policy_override, available_members=available_members
-        )
-        warnings.extend(policy_warnings)
-        runtime_groups = _apply_policy_simulation_override(
-            runtime_groups, group_key=group_key, policy=normalized
-        )
-
-    base_router = getattr(request.app.state, "router", None)
-    if base_router is None:
+    try:
+        runtime = require_routing_runtime_generation(request.app.state)
+    except RuntimeError as exc:
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Router runtime unavailable"
-        )
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Router runtime unavailable",
+        ) from exc
 
-    model_registry = getattr(request.app.state, "model_registry", {})
-    state_backend = getattr(request.app.state, "router_state_backend", base_router.state)
-    deployment_registry = build_deployment_registry(model_registry, route_groups=runtime_groups)
-    simulation_router = Router(
-        strategy=base_router.strategy,
-        state_backend=state_backend,
-        config=RouterConfig(
-            num_retries=base_router.config.num_retries,
-            retry_after=base_router.config.retry_after,
-            timeout=base_router.config.timeout,
-            cooldown_time=base_router.config.cooldown_time,
-            allowed_fails=base_router.config.allowed_fails,
-            enable_pre_call_checks=base_router.config.enable_pre_call_checks,
-            model_group_alias=base_router.config.model_group_alias,
-            route_group_policies=build_route_group_policies(runtime_groups),
-        ),
-        deployment_registry=deployment_registry,
+    service = RoutePolicySimulationService(
+        route_groups=_repository_or_503(request),
+        runtime=runtime,
+        prompts=_prompt_resolution_repository(request),
     )
-
-    selection_counts: dict[str, int] = {}
-    reason_counts: dict[str, int] = {}
-    no_selection_count = 0
-    sample_decision: dict[str, Any] | None = None
-
-    for _ in range(iterations):
-        request_context: dict[str, Any] = {"metadata": dict(metadata), "user_id": user_id}
-        selected = await simulation_router.select_deployment(group_key, request_context)
-        decision = request_context.get("route_decision")
-        if isinstance(decision, dict):
-            reason = str(decision.get("reason") or "unknown")
-            reason_counts[reason] = reason_counts.get(reason, 0) + 1
-            if sample_decision is None:
-                sample_decision = to_json_value(decision)
-        if selected is None:
-            no_selection_count += 1
-            continue
-        selection_counts[selected.deployment_id] = (
-            selection_counts.get(selected.deployment_id, 0) + 1
-        )
-
-    selections = [
-        {
-            "deployment_id": deployment_id,
-            "count": count,
-            "ratio": count / iterations if iterations > 0 else 0.0,
-        }
-        for deployment_id, count in sorted(
-            selection_counts.items(), key=lambda item: (-item[1], item[0])
-        )
-    ]
-
-    return {
-        "group_key": group_key,
-        "iterations": iterations,
-        "warnings": warnings,
-        "prompt": prompt_summary,
-        "effective_metadata": metadata,
-        "summary": {
-            "selected_requests": iterations - no_selection_count,
-            "no_selection_requests": no_selection_count,
-        },
-        "reason_counts": reason_counts,
-        "selections": selections,
-        "sample_decision": sample_decision,
-    }
+    try:
+        return await service.simulate(group_key, simulation_request)
+    except RoutePolicySimulationNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except RoutePolicySimulationInvalidError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except RoutePolicySimulationUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
 
 
 @router.put(

--- a/src/api/admin/route_group_contracts.py
+++ b/src/api/admin/route_group_contracts.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class RouteGroupMutationResponse(BaseModel):
@@ -61,3 +61,83 @@ class RoutePolicyMutationResponse(BaseModel):
 
 class RoutePolicyRollbackResponse(RoutePolicyMutationResponse):
     rolled_back_from_version: int
+
+
+RoutePolicySimulationOutcome = Literal[
+    "success",
+    "timeout",
+    "rate_limit",
+    "unavailable",
+]
+
+
+class RoutePolicySimulationDeploymentOutcome(BaseModel):
+    deployment_id: str = Field(min_length=1, max_length=256)
+    outcome: RoutePolicySimulationOutcome
+
+    @field_validator("deployment_id")
+    @classmethod
+    def normalize_deployment_id(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("deployment_id must not be blank")
+        return normalized
+
+
+class RoutePolicySimulationRequest(BaseModel):
+    iterations: int = Field(default=100, ge=1, le=5000)
+    policy: dict[str, Any] | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    user_id: str = Field(default="policy-simulation", min_length=1, max_length=256)
+    prompt_ref: dict[str, Any] | None = None
+    outcomes: list[RoutePolicySimulationDeploymentOutcome] = Field(
+        default_factory=list,
+        max_length=500,
+    )
+
+
+class RoutePolicySimulationPrompt(BaseModel):
+    template_key: str
+    version: int
+    label: str | None = None
+    route_preferences: dict[str, Any]
+
+
+class RoutePolicySimulationSelection(BaseModel):
+    deployment_id: str
+    count: int
+    ratio: float
+
+
+class RoutePolicySimulationSummary(BaseModel):
+    selected_requests: int
+    no_selection_requests: int
+    served_requests: int
+    failed_requests: int
+    fallback_requests: int
+    timed_out_requests: int
+    total_attempts: int
+
+
+class RoutePolicySimulationAttempt(BaseModel):
+    iteration: int
+    attempt: int
+    deployment_id: str
+    outcome: RoutePolicySimulationOutcome
+    transition: Literal["primary", "retry", "fallback"]
+
+
+class RoutePolicySimulationResponse(BaseModel):
+    group_key: str
+    iterations: int
+    basis: Literal["live_state_dry_run"] = "live_state_dry_run"
+    warnings: list[str] = Field(default_factory=list)
+    prompt: RoutePolicySimulationPrompt | None = None
+    effective_metadata: dict[str, Any]
+    summary: RoutePolicySimulationSummary
+    reason_counts: dict[str, int]
+    selections: list[RoutePolicySimulationSelection]
+    served_deployments: list[RoutePolicySimulationSelection]
+    terminal_outcomes: dict[str, int]
+    sample_decision: dict[str, Any] | None = None
+    sample_attempts: list[RoutePolicySimulationAttempt] = Field(default_factory=list)

--- a/src/router/simulation_state.py
+++ b/src/router/simulation_state.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from src.router.candidates import (
+    DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
+    AttemptCapacity,
+    AttemptPermit,
+    AttemptRejectionReason,
+)
+from src.router.health_state import (
+    DeploymentHealthState,
+    HealthRefInput,
+    HealthProbeClaim,
+    HealthTransitionResult,
+    coerce_health_ref,
+)
+from src.router.redis_keys import RouterHealthProbeScope
+from src.router.state import DeploymentStateBackend
+
+
+class RoutingStateSnapshotMiss(RuntimeError):
+    """Raised when simulation would need mutable state after its snapshot is frozen."""
+
+
+class RoutingSimulationState:
+    """Read live routing state once, then provide isolated attempt semantics.
+
+    Planning reads are cached by deployment and frozen before any simulated
+    iteration. Attempt permits and health reporting are process-local no-ops so
+    a control-plane dry run cannot influence live traffic.
+    """
+
+    def __init__(self, source: DeploymentStateBackend) -> None:
+        self._source = source
+        self._frozen = False
+        self._health: dict[str, dict[str, Any]] = {}
+        self._cooldowns: dict[str, bool] = {}
+        self._active: dict[str, int] = {}
+        self._usage: dict[str, dict[str, int]] = {}
+        self._latency: dict[tuple[str, int], list[tuple[int, float]]] = {}
+        self._owned_attempts: dict[str, int] = {}
+        self._request_failures: dict[str, int] = {}
+        self._request_cooldowns: set[str] = set()
+        self._next_owner = 0
+
+    def freeze(self) -> None:
+        self._frozen = True
+
+    def reset_attempt_effects(self) -> None:
+        """Start an independent request against the same captured live state."""
+
+        self._owned_attempts.clear()
+        self._request_failures.clear()
+        self._request_cooldowns.clear()
+
+    def _require_loading(self, capability: str, deployment_ids: list[str]) -> None:
+        if self._frozen:
+            missing = ", ".join(sorted(deployment_ids))
+            raise RoutingStateSnapshotMiss(
+                f"routing simulation snapshot is missing {capability} state for: {missing}"
+            )
+
+    async def get_health_batch(
+        self, health_refs: list[HealthRefInput]
+    ) -> dict[str, dict[str, Any]]:
+        resolved = [coerce_health_ref(item) for item in health_refs]
+        missing = [item for item in resolved if item.deployment_id not in self._health]
+        if missing:
+            self._require_loading("health", [item.deployment_id for item in missing])
+            loaded = await self._source.get_health_batch(missing)
+            for item in missing:
+                self._health[item.deployment_id] = dict(loaded.get(item.deployment_id, {}))
+        return {item.deployment_id: dict(self._health[item.deployment_id]) for item in resolved}
+
+    async def get_cooldown_batch(self, health_refs: list[HealthRefInput]) -> dict[str, bool]:
+        resolved = [coerce_health_ref(item) for item in health_refs]
+        missing = [item for item in resolved if item.deployment_id not in self._cooldowns]
+        if missing:
+            self._require_loading("cooldown", [item.deployment_id for item in missing])
+            loaded = await self._source.get_cooldown_batch(missing)
+            for item in missing:
+                self._cooldowns[item.deployment_id] = bool(loaded.get(item.deployment_id, False))
+        return {item.deployment_id: self._cooldowns[item.deployment_id] for item in resolved}
+
+    async def get_active_requests_batch(self, deployment_ids: list[str]) -> dict[str, int]:
+        missing = [item for item in deployment_ids if item not in self._active]
+        if missing:
+            self._require_loading("active-request", missing)
+            loaded = await self._source.get_active_requests_batch(missing)
+            for deployment_id in missing:
+                self._active[deployment_id] = int(loaded.get(deployment_id, 0))
+        return {deployment_id: self._active[deployment_id] for deployment_id in deployment_ids}
+
+    async def get_usage_batch(self, deployment_ids: list[str]) -> dict[str, dict[str, int]]:
+        missing = [item for item in deployment_ids if item not in self._usage]
+        if missing:
+            self._require_loading("usage", missing)
+            loaded = await self._source.get_usage_batch(missing)
+            for deployment_id in missing:
+                self._usage[deployment_id] = {
+                    str(key): int(value) for key, value in loaded.get(deployment_id, {}).items()
+                }
+        return {deployment_id: dict(self._usage[deployment_id]) for deployment_id in deployment_ids}
+
+    async def get_latency_windows_batch(
+        self,
+        deployment_ids: list[str],
+        window_ms: int,
+    ) -> dict[str, list[tuple[int, float]]]:
+        missing = [
+            deployment_id
+            for deployment_id in deployment_ids
+            if (deployment_id, window_ms) not in self._latency
+        ]
+        if missing:
+            self._require_loading("latency", missing)
+            loaded = await self._source.get_latency_windows_batch(missing, window_ms)
+            for deployment_id in missing:
+                self._latency[(deployment_id, window_ms)] = list(loaded.get(deployment_id, []))
+        return {
+            deployment_id: list(self._latency[(deployment_id, window_ms)])
+            for deployment_id in deployment_ids
+        }
+
+    async def acquire_attempt(
+        self,
+        health_ref: HealthRefInput,
+        capacity: AttemptCapacity,
+        *,
+        lease_ttl_seconds: int = DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
+    ) -> AttemptPermit:
+        del lease_ttl_seconds
+        resolved = coerce_health_ref(health_ref)
+        deployment_id = resolved.deployment_id
+        if self._cooldowns.get(deployment_id, False) or deployment_id in self._request_cooldowns:
+            return AttemptPermit(
+                deployment_id=deployment_id,
+                health_ref=resolved,
+                acquired=False,
+                rejection_reason=AttemptRejectionReason.COOLDOWN,
+            )
+        health = self._health.get(deployment_id, {})
+        if health.get("healthy", "true") == "false" and health.get("recovery_required") != "true":
+            return AttemptPermit(
+                deployment_id=deployment_id,
+                health_ref=resolved,
+                acquired=False,
+                rejection_reason=AttemptRejectionReason.UNHEALTHY,
+            )
+        usage = self._usage.get(deployment_id, {})
+        if any(usage.get(item.counter, 0) >= item.limit for item in capacity.limits):
+            return AttemptPermit(
+                deployment_id=deployment_id,
+                health_ref=resolved,
+                acquired=False,
+                rejection_reason=AttemptRejectionReason.CAPACITY,
+            )
+
+        self._next_owner += 1
+        self._owned_attempts[deployment_id] = self._owned_attempts.get(deployment_id, 0) + 1
+        return AttemptPermit(
+            deployment_id=deployment_id,
+            health_ref=resolved,
+            acquired=True,
+            backend="local",
+            owner_token=f"simulation-{self._next_owner}",
+            active_requests=self._active.get(deployment_id, 0)
+            + self._owned_attempts[deployment_id],
+        )
+
+    async def release_attempt(self, permit: AttemptPermit) -> int | None:
+        if not permit.acquired:
+            return 0
+        current = max(0, self._owned_attempts.get(permit.deployment_id, 0) - 1)
+        if current:
+            self._owned_attempts[permit.deployment_id] = current
+        else:
+            self._owned_attempts.pop(permit.deployment_id, None)
+        return self._active.get(permit.deployment_id, 0) + current
+
+    async def record_latency(self, deployment_id: str, latency_ms: float) -> None:
+        del deployment_id, latency_ms
+
+    async def increment_usage(
+        self,
+        deployment_id: str,
+        tokens: int,
+        window: str | None = None,
+    ) -> None:
+        del deployment_id, tokens, window
+
+    async def increment_usage_counters(
+        self,
+        deployment_id: str,
+        counters: Mapping[str, int],
+        window: str | None = None,
+    ) -> None:
+        del deployment_id, counters, window
+
+    async def apply_health_success(
+        self,
+        health_ref: HealthRefInput,
+        *,
+        recovery_token: str | None = None,
+    ) -> HealthTransitionResult:
+        del health_ref, recovery_token
+        return HealthTransitionResult(applied=False, state=DeploymentHealthState.HEALTHY)
+
+    async def apply_health_failure(
+        self,
+        health_ref: HealthRefInput,
+        error: str,
+        *,
+        allowed_fails: int,
+        cooldown_seconds: int,
+        recovery_token: str | None = None,
+    ) -> HealthTransitionResult:
+        del error, cooldown_seconds, recovery_token
+        resolved = coerce_health_ref(health_ref)
+        deployment_id = resolved.deployment_id
+        health = self._health.get(deployment_id, {})
+        try:
+            captured_failures = int(health.get("consecutive_failures", 0) or 0)
+        except (TypeError, ValueError):
+            captured_failures = 0
+        failure_count = self._request_failures.get(deployment_id, captured_failures) + 1
+        self._request_failures[deployment_id] = failure_count
+        entered_cooldown = health.get("recovery_required") == "true" or failure_count > max(
+            0, int(allowed_fails)
+        )
+        if entered_cooldown:
+            self._request_cooldowns.add(deployment_id)
+        return HealthTransitionResult(
+            applied=True,
+            state=(
+                DeploymentHealthState.COOLDOWN
+                if entered_cooldown
+                else DeploymentHealthState.HEALTHY
+            ),
+            failure_count=failure_count,
+            entered_cooldown=entered_cooldown,
+        )
+
+    async def apply_manual_cooldown(
+        self,
+        health_ref: HealthRefInput,
+        duration_seconds: int,
+        reason: str,
+    ) -> None:
+        del health_ref, duration_seconds, reason
+
+    async def claim_health_probe(
+        self,
+        health_ref: HealthRefInput,
+        ttl_seconds: int,
+        *,
+        scope: RouterHealthProbeScope = "background",
+    ) -> HealthProbeClaim | None:
+        del health_ref, ttl_seconds, scope
+        return None
+
+    async def release_health_probe(
+        self,
+        health_ref: HealthRefInput,
+        claim: HealthProbeClaim,
+    ) -> None:
+        del health_ref, claim
+
+    async def release_health_recovery(
+        self,
+        health_ref: HealthRefInput,
+        owner_token: str,
+    ) -> None:
+        del health_ref, owner_token
+
+    async def invalidate_health_state(self, health_refs: list[HealthRefInput]) -> bool:
+        del health_refs
+        return False
+
+    async def get_health(self, health_ref: HealthRefInput) -> dict[str, Any]:
+        resolved = coerce_health_ref(health_ref)
+        return (await self.get_health_batch([resolved])).get(resolved.deployment_id, {})
+
+    async def is_cooled_down(self, health_ref: HealthRefInput) -> bool:
+        resolved = coerce_health_ref(health_ref)
+        return (await self.get_cooldown_batch([resolved])).get(resolved.deployment_id, False)
+
+    async def get_active_requests(self, deployment_id: str) -> int:
+        return (await self.get_active_requests_batch([deployment_id])).get(deployment_id, 0)
+
+    async def get_usage(self, deployment_id: str) -> dict[str, int]:
+        return (await self.get_usage_batch([deployment_id])).get(deployment_id, {})
+
+    async def get_latency_window(
+        self, deployment_id: str, window_ms: int
+    ) -> list[tuple[int, float]]:
+        return (await self.get_latency_windows_batch([deployment_id], window_ms)).get(
+            deployment_id, []
+        )
+
+    @property
+    def captured_usage(self) -> Mapping[str, Mapping[str, int]]:
+        return self._usage

--- a/src/services/route_policy_simulation.py
+++ b/src/services/route_policy_simulation.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, replace
+from typing import Any
+
+from src.api.admin.route_group_contracts import (
+    RoutePolicySimulationAttempt,
+    RoutePolicySimulationPrompt,
+    RoutePolicySimulationRequest,
+    RoutePolicySimulationResponse,
+    RoutePolicySimulationSelection,
+    RoutePolicySimulationSummary,
+)
+from src.db.prompt_registry import PromptRegistryRepository
+from src.db.route_groups import RouteGroupRepository
+from src.models.errors import RateLimitError, ServiceUnavailableError, TimeoutError
+from src.router import (
+    ROUTING_MODE_CONTEXT_KEY,
+    CooldownManager,
+    Deployment,
+    FailoverManager,
+    Router,
+    RouterConfig,
+    build_deployment_registry,
+    build_route_group_policies,
+)
+from src.router.policy_validation import (
+    PolicyMemberInventoryItem,
+    merge_policy_members,
+    validate_route_policy,
+)
+from src.router.runtime_generation import RoutingRuntimeGeneration
+from src.router.simulation_state import RoutingSimulationState, RoutingStateSnapshotMiss
+from src.services.prompt_registry import apply_route_preferences_to_metadata, parse_prompt_reference
+
+_MAX_SAMPLE_ATTEMPTS = 50
+
+
+class RoutePolicySimulationError(RuntimeError):
+    pass
+
+
+class RoutePolicySimulationNotFoundError(RoutePolicySimulationError):
+    pass
+
+
+class RoutePolicySimulationInvalidError(RoutePolicySimulationError):
+    pass
+
+
+class RoutePolicySimulationUnavailableError(RoutePolicySimulationError):
+    pass
+
+
+class _SimulationFailoverManager(FailoverManager):
+    """Use production failover decisions without sleeps or operational events."""
+
+    def _compute_backoff(self, attempt: int, error: Exception | None = None) -> float:
+        del attempt, error
+        return 0.0
+
+    def _record_fallback_event(
+        self,
+        model_group: str,
+        from_id: str,
+        to_id: str | None,
+        reason: str,
+        classification: str,
+        error_msg: str,
+        attempt: int,
+        success: bool,
+    ) -> None:
+        del (
+            model_group,
+            from_id,
+            to_id,
+            reason,
+            classification,
+            error_msg,
+            attempt,
+            success,
+        )
+
+
+@dataclass(slots=True)
+class _SimulationCounters:
+    initial: Counter[str]
+    served: Counter[str]
+    reasons: Counter[str]
+    terminal: Counter[str]
+    selected_requests: int = 0
+    no_selection_requests: int = 0
+    served_requests: int = 0
+    failed_requests: int = 0
+    fallback_requests: int = 0
+    timed_out_requests: int = 0
+    total_attempts: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class _PolicyMembership:
+    inventory: dict[str, PolicyMemberInventoryItem]
+    runtime_members: list[dict[str, Any]]
+
+
+class RoutePolicySimulationService:
+    def __init__(
+        self,
+        *,
+        route_groups: RouteGroupRepository,
+        runtime: RoutingRuntimeGeneration,
+        prompts: PromptRegistryRepository | None = None,
+    ) -> None:
+        self._route_groups = route_groups
+        self._runtime = runtime
+        self._prompts = prompts
+
+    async def simulate(
+        self,
+        group_key: str,
+        request: RoutePolicySimulationRequest,
+    ) -> RoutePolicySimulationResponse:
+        group = await self._route_groups.get_group(group_key)
+        if group is None:
+            raise RoutePolicySimulationNotFoundError("Route group not found")
+
+        runtime_groups = await self._route_groups.list_runtime_groups()
+        membership = await self._policy_membership(group_key)
+        warnings: list[str] = []
+        if request.policy is not None:
+            try:
+                normalized, policy_warnings = validate_route_policy(
+                    request.policy,
+                    available_members=membership.inventory,
+                )
+            except ValueError as exc:
+                raise RoutePolicySimulationInvalidError(str(exc)) from exc
+            warnings.extend(policy_warnings)
+            runtime_groups = _apply_policy_override(
+                runtime_groups,
+                group_key=group_key,
+                policy=normalized,
+                base_members=membership.runtime_members,
+                base_strategy=group.routing_strategy,
+            )
+
+        metadata, prompt, prompt_warnings = await self._resolve_prompt(
+            group_key,
+            dict(request.metadata),
+            request.prompt_ref,
+        )
+        warnings.extend(prompt_warnings)
+        try:
+            (
+                router,
+                failover,
+                simulation_state,
+                available_outcome_ids,
+            ) = await self._build_simulation_runtime(
+                group_key=group_key,
+                group_mode=str(group.mode or "chat"),
+                runtime_groups=runtime_groups,
+                metadata=metadata,
+                user_id=request.user_id,
+            )
+        except ValueError as exc:
+            raise RoutePolicySimulationInvalidError(str(exc)) from exc
+        except RoutingStateSnapshotMiss as exc:
+            raise RoutePolicySimulationUnavailableError(
+                "Routing state could not be captured for simulation"
+            ) from exc
+        outcomes = _outcomes_by_deployment(
+            request,
+            available_deployment_ids=available_outcome_ids,
+        )
+
+        counters = _SimulationCounters(
+            initial=Counter(),
+            served=Counter(),
+            reasons=Counter(),
+            terminal=Counter(),
+        )
+        sample_attempts: list[RoutePolicySimulationAttempt] = []
+        sample_decision: dict[str, Any] | None = None
+
+        for iteration in range(1, request.iterations + 1):
+            simulation_state.reset_attempt_effects()
+            context: dict[str, Any] = {
+                "metadata": dict(metadata),
+                "user_id": request.user_id,
+                ROUTING_MODE_CONTEXT_KEY: str(group.mode or "chat"),
+            }
+            selected = await router.select_deployment(group_key, context)
+            decision = context.get("route_decision")
+            if isinstance(decision, dict):
+                counters.reasons[str(decision.get("reason") or "unknown")] += 1
+                if sample_decision is None:
+                    sample_decision = dict(decision)
+            if selected is None:
+                counters.no_selection_requests += 1
+                counters.failed_requests += 1
+                counters.terminal["no_selection"] += 1
+                continue
+
+            counters.selected_requests += 1
+            counters.initial[selected.deployment_id] += 1
+            attempt_ids: list[str] = []
+
+            async def execute(deployment: Deployment) -> str:
+                outcome = outcomes.get(deployment.deployment_id, "success")
+                attempt_ids.append(deployment.deployment_id)
+                counters.total_attempts += 1
+                if len(sample_attempts) < _MAX_SAMPLE_ATTEMPTS:
+                    previous_id = attempt_ids[-2] if len(attempt_ids) > 1 else None
+                    transition = (
+                        "primary"
+                        if previous_id is None
+                        else "retry"
+                        if previous_id == deployment.deployment_id
+                        else "fallback"
+                    )
+                    sample_attempts.append(
+                        RoutePolicySimulationAttempt(
+                            iteration=iteration,
+                            attempt=len(attempt_ids),
+                            deployment_id=deployment.deployment_id,
+                            outcome=outcome,
+                            transition=transition,
+                        )
+                    )
+                if outcome == "success":
+                    return "simulated-success"
+                if outcome == "timeout":
+                    raise TimeoutError(
+                        message="Simulated provider timeout",
+                        affects_deployment_health=True,
+                    )
+                if outcome == "rate_limit":
+                    raise RateLimitError(
+                        message="Simulated provider rate limit",
+                        affects_deployment_health=True,
+                    )
+                raise ServiceUnavailableError(
+                    message="Simulated provider unavailability",
+                    affects_deployment_health=True,
+                )
+
+            route_policy = context.get("route_policy")
+            failover_kwargs = route_policy if isinstance(route_policy, dict) else {}
+            try:
+                _, served = await failover.execute_with_failover(
+                    primary_deployment=selected,
+                    model_group=group_key,
+                    execute=execute,
+                    return_deployment=True,
+                    routing_context=context,
+                    timeout_seconds=_positive_float(failover_kwargs.get("timeout_seconds")),
+                    retry_max_attempts=_nonnegative_int(failover_kwargs.get("retry_max_attempts")),
+                    retryable_error_classes=_string_list(
+                        failover_kwargs.get("retryable_error_classes")
+                    ),
+                )
+            except TimeoutError:
+                counters.failed_requests += 1
+                counters.timed_out_requests += 1
+                counters.terminal["timeout"] += 1
+                continue
+            except (RateLimitError, ServiceUnavailableError) as exc:
+                counters.failed_requests += 1
+                terminal = "rate_limit" if isinstance(exc, RateLimitError) else "unavailable"
+                counters.terminal[terminal] += 1
+                continue
+
+            counters.served_requests += 1
+            counters.served[served.deployment_id] += 1
+            counters.terminal["success"] += 1
+            if served.deployment_id != selected.deployment_id:
+                counters.fallback_requests += 1
+
+        return RoutePolicySimulationResponse(
+            group_key=group_key,
+            iterations=request.iterations,
+            warnings=warnings,
+            prompt=prompt,
+            effective_metadata=metadata,
+            summary=RoutePolicySimulationSummary(
+                selected_requests=counters.selected_requests,
+                no_selection_requests=counters.no_selection_requests,
+                served_requests=counters.served_requests,
+                failed_requests=counters.failed_requests,
+                fallback_requests=counters.fallback_requests,
+                timed_out_requests=counters.timed_out_requests,
+                total_attempts=counters.total_attempts,
+            ),
+            reason_counts=dict(counters.reasons),
+            selections=_selection_summaries(counters.initial, request.iterations),
+            served_deployments=_selection_summaries(counters.served, request.iterations),
+            terminal_outcomes=dict(counters.terminal),
+            sample_decision=sample_decision,
+            sample_attempts=sample_attempts,
+        )
+
+    async def _policy_membership(self, group_key: str) -> _PolicyMembership:
+        members = await self._route_groups.list_members(group_key)
+        inventory = {
+            member.deployment_id.strip(): PolicyMemberInventoryItem(
+                deployment_id=member.deployment_id.strip(),
+                enabled=member.enabled,
+            )
+            for member in members
+            if isinstance(member.deployment_id, str) and member.deployment_id.strip()
+        }
+        runtime_members = [
+            {
+                "deployment_id": deployment_id,
+                "enabled": member.enabled,
+                "weight": member.weight,
+                "priority": member.priority,
+            }
+            for member in members
+            if isinstance(member.deployment_id, str)
+            and (deployment_id := member.deployment_id.strip())
+        ]
+        return _PolicyMembership(
+            inventory=inventory,
+            runtime_members=runtime_members,
+        )
+
+    async def _resolve_prompt(
+        self,
+        group_key: str,
+        metadata: dict[str, Any],
+        prompt_ref_payload: dict[str, Any] | None,
+    ) -> tuple[dict[str, Any], RoutePolicySimulationPrompt | None, list[str]]:
+        if prompt_ref_payload is None:
+            return metadata, None, []
+        prompt_ref = parse_prompt_reference(prompt_ref_payload)
+        if prompt_ref is None:
+            raise RoutePolicySimulationInvalidError("prompt_ref could not be parsed")
+        if self._prompts is None:
+            raise RoutePolicySimulationUnavailableError("Prompt registry repository unavailable")
+        resolved = await self._prompts.resolve_prompt(
+            template_key=prompt_ref.template_key,
+            label=prompt_ref.label,
+            version=prompt_ref.version,
+        )
+        if resolved is None:
+            raise RoutePolicySimulationInvalidError("prompt_ref could not be resolved")
+        try:
+            effective, preferences = apply_route_preferences_to_metadata(
+                metadata,
+                resolved.route_preferences,
+            )
+        except ValueError as exc:
+            raise RoutePolicySimulationInvalidError(str(exc)) from exc
+        warnings: list[str] = []
+        preferred_group = preferences.get("route_group")
+        if isinstance(preferred_group, str) and preferred_group and preferred_group != group_key:
+            warnings.append(
+                f"prompt route_preferences.route_group={preferred_group!r} is advisory "
+                f"and does not override simulation group {group_key!r}"
+            )
+        return (
+            effective,
+            RoutePolicySimulationPrompt(
+                template_key=resolved.template_key,
+                version=resolved.version,
+                label=resolved.label or prompt_ref.label,
+                route_preferences=preferences,
+            ),
+            warnings,
+        )
+
+    async def _build_simulation_runtime(
+        self,
+        *,
+        group_key: str,
+        group_mode: str,
+        runtime_groups: list[dict[str, Any]],
+        metadata: dict[str, Any],
+        user_id: str,
+    ) -> tuple[Router, FailoverManager, RoutingSimulationState, set[str]]:
+        model_registry = {
+            key: [dict(entry) for entry in entries]
+            for key, entries in self._runtime.model_registry.items()
+        }
+        deployment_registry = build_deployment_registry(
+            model_registry,
+            route_groups=runtime_groups,
+        )
+        snapshot_state = RoutingSimulationState(self._runtime.router.state)
+        router = Router(
+            strategy=self._runtime.strategy,
+            state_backend=snapshot_state,
+            config=RouterConfig(
+                num_retries=self._runtime.router_config.num_retries,
+                retry_after=self._runtime.router_config.retry_after,
+                timeout=self._runtime.router_config.timeout,
+                cooldown_time=self._runtime.router_config.cooldown_time,
+                allowed_fails=self._runtime.router_config.allowed_fails,
+                enable_pre_call_checks=self._runtime.router_config.enable_pre_call_checks,
+                model_group_alias=dict(self._runtime.router_config.model_group_alias),
+                route_group_policies=build_route_group_policies(runtime_groups),
+            ),
+            deployment_registry=deployment_registry,
+        )
+        fallback_groups = list(self._runtime.failover_config.fallbacks.get(group_key, []))
+        warm_context: dict[str, Any] = {
+            "metadata": dict(metadata),
+            "user_id": user_id,
+            ROUTING_MODE_CONTEXT_KEY: group_mode,
+        }
+        await router.plan_deployments([group_key, *fallback_groups], warm_context)
+        snapshot_state.freeze()
+        cooldown = CooldownManager(
+            snapshot_state,
+            cooldown_time=self._runtime.router_config.cooldown_time,
+            allowed_fails=self._runtime.router_config.allowed_fails,
+        )
+        failover = _SimulationFailoverManager(
+            config=replace(self._runtime.failover_config),
+            candidate_planner=router,
+            state_backend=snapshot_state,
+            cooldown_manager=cooldown,
+        )
+        reachable_ids = {
+            deployment.deployment_id
+            for model_group in [group_key, *fallback_groups]
+            for deployment in router.deployment_registry.get(model_group, ())
+        }
+        return router, failover, snapshot_state, reachable_ids
+
+
+def _apply_policy_override(
+    runtime_groups: list[dict[str, Any]],
+    *,
+    group_key: str,
+    policy: dict[str, Any],
+    base_members: list[dict[str, Any]],
+    base_strategy: str | None,
+) -> list[dict[str, Any]]:
+    updated: list[dict[str, Any]] = []
+    found = False
+    for group in runtime_groups:
+        if str(group.get("key") or "") != group_key:
+            updated.append(group)
+            continue
+        found = True
+        patched = dict(group)
+        policy_strategy = policy.get("strategy")
+        patched["strategy"] = (
+            policy_strategy
+            if isinstance(policy_strategy, str) and policy_strategy
+            else base_strategy
+        )
+        patched["timeouts"] = policy.get("timeouts")
+        patched["retry"] = policy.get("retry")
+        patched["members"] = merge_policy_members(
+            base_members,
+            policy.get("members") if "members" in policy else None,
+        )
+        updated.append(patched)
+    if not found:
+        raise RoutePolicySimulationNotFoundError("Route group not found")
+    return updated
+
+
+def _outcomes_by_deployment(
+    request: RoutePolicySimulationRequest,
+    *,
+    available_deployment_ids: set[str],
+) -> dict[str, str]:
+    outcomes: dict[str, str] = {}
+    for item in request.outcomes:
+        deployment_id = item.deployment_id.strip()
+        if deployment_id in outcomes:
+            raise RoutePolicySimulationInvalidError(
+                f"outcomes contains duplicate deployment_id: {deployment_id}"
+            )
+        if deployment_id not in available_deployment_ids:
+            raise RoutePolicySimulationInvalidError(
+                f"outcomes references unknown deployment_id: {deployment_id}"
+            )
+        outcomes[deployment_id] = item.outcome
+    return outcomes
+
+
+def _selection_summaries(
+    counts: Counter[str], iterations: int
+) -> list[RoutePolicySimulationSelection]:
+    return [
+        RoutePolicySimulationSelection(
+            deployment_id=deployment_id,
+            count=count,
+            ratio=count / iterations,
+        )
+        for deployment_id, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def _positive_float(value: Any) -> float | None:
+    return float(value) if isinstance(value, (int, float)) and float(value) > 0 else None
+
+
+def _nonnegative_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and value >= 0 else None
+
+
+def _string_list(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    normalized = [str(item).strip() for item in value if str(item).strip()]
+    return normalized or None

--- a/tests/test_routing_simulation_state.py
+++ b/tests/test_routing_simulation_state.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from src.router.candidates import AttemptCapacity, AttemptRejectionReason
+from src.router.simulation_state import RoutingSimulationState, RoutingStateSnapshotMiss
+
+
+class _SnapshotSource:
+    def __init__(self) -> None:
+        self.calls: Counter[str] = Counter()
+
+    async def get_health_batch(self, health_refs):  # noqa: ANN001, ANN201
+        self.calls["health"] += 1
+        return {item.deployment_id: {"healthy": "true"} for item in health_refs}
+
+    async def get_cooldown_batch(self, health_refs):  # noqa: ANN001, ANN201
+        self.calls["cooldown"] += 1
+        return {item.deployment_id: False for item in health_refs}
+
+    async def get_active_requests_batch(self, deployment_ids):  # noqa: ANN001, ANN201
+        self.calls["active"] += 1
+        return dict.fromkeys(deployment_ids, 2)
+
+    async def get_usage_batch(self, deployment_ids):  # noqa: ANN001, ANN201
+        self.calls["usage"] += 1
+        return {deployment_id: {"rpm": 3} for deployment_id in deployment_ids}
+
+    async def get_latency_windows_batch(self, deployment_ids, window_ms):  # noqa: ANN001, ANN201
+        self.calls["latency"] += 1
+        return {deployment_id: [(window_ms, 12.5)] for deployment_id in deployment_ids}
+
+
+@pytest.mark.asyncio
+async def test_routing_simulation_state_caches_reads_and_isolates_mutations() -> None:
+    source = _SnapshotSource()
+    state = RoutingSimulationState(source)  # type: ignore[arg-type]
+
+    await state.get_health_batch(["dep-a"])
+    await state.get_cooldown_batch(["dep-a"])
+    await state.get_active_requests_batch(["dep-a"])
+    await state.get_usage_batch(["dep-a"])
+    await state.get_latency_windows_batch(["dep-a"], 60_000)
+    state.freeze()
+
+    await state.get_health_batch(["dep-a"])
+    await state.get_cooldown_batch(["dep-a"])
+    await state.get_active_requests_batch(["dep-a"])
+    await state.get_usage_batch(["dep-a"])
+    await state.get_latency_windows_batch(["dep-a"], 60_000)
+    assert source.calls == Counter(
+        {"health": 1, "cooldown": 1, "active": 1, "usage": 1, "latency": 1}
+    )
+
+    permit = await state.acquire_attempt("dep-a", AttemptCapacity())
+    assert permit.acquired is True
+    assert permit.backend == "local"
+    assert await state.release_attempt(permit) == 2
+    await state.increment_usage("dep-a", 100)
+    await state.record_latency("dep-a", 50)
+    await state.apply_manual_cooldown("dep-a", 30, "simulation")
+
+    transition = await state.apply_health_failure(
+        "dep-a",
+        "simulated timeout",
+        allowed_fails=0,
+        cooldown_seconds=60,
+    )
+    assert transition.entered_cooldown is True
+    rejected = await state.acquire_attempt("dep-a", AttemptCapacity())
+    assert rejected.rejection_reason is AttemptRejectionReason.COOLDOWN
+    state.reset_attempt_effects()
+    assert (await state.acquire_attempt("dep-a", AttemptCapacity())).acquired is True
+
+    with pytest.raises(RoutingStateSnapshotMiss, match="dep-b"):
+        await state.get_health_batch(["dep-b"])

--- a/tests/test_ui_route_groups.py
+++ b/tests/test_ui_route_groups.py
@@ -14,9 +14,15 @@ from src.db.route_groups import (
     RouteGroupRecord,
     RoutePolicyRecord,
 )
-from src.router.policy_validation import merge_policy_document_for_write
+from src.router import build_deployment_registry
+from src.router.policy_validation import (
+    merge_policy_document_for_write,
+    merge_policy_members,
+)
+from src.router.runtime_generation import rebuild_routing_runtime_generation
 from src.services.asset_ownership import owner_scope_from_metadata
 from src.services.asset_scopes import normalize_scope_type
+from src.services.callable_targets import build_callable_target_catalog
 
 
 def _extract_default_prompt(metadata: dict[str, Any] | None) -> dict[str, str] | None:
@@ -33,6 +39,23 @@ def _extract_default_prompt(metadata: dict[str, Any] | None) -> dict[str, str] |
     if label:
         payload["label"] = label
     return payload
+
+
+def _publish_test_model_registry(test_app: Any) -> None:
+    """Keep the immutable routing generation aligned with test registry overrides."""
+
+    store = test_app.state.routing_runtime_generation_store
+    current = store.require_snapshot()
+    model_registry = test_app.state.model_registry
+    store.replace(
+        rebuild_routing_runtime_generation(
+            current,
+            model_registry=model_registry,
+            route_groups=list(current.route_groups),
+            callable_target_catalog=build_callable_target_catalog(model_registry),
+            deployment_registry=build_deployment_registry(model_registry),
+        )
+    )
 
 
 class _FakeRouteGroupRepository:
@@ -206,6 +229,15 @@ class _FakeRouteGroupRepository:
                 if isinstance(policy_json.get("strategy"), str)
                 else group.routing_strategy
             )
+            base_members = [
+                {
+                    "deployment_id": member.deployment_id,
+                    "enabled": member.enabled,
+                    "weight": member.weight,
+                    "priority": member.priority,
+                }
+                for member in self.members.get(group_key, [])
+            ]
             runtime_groups.append(
                 {
                     "key": group.group_key,
@@ -222,15 +254,15 @@ class _FakeRouteGroupRepository:
                     if isinstance(policy_json.get("retry"), dict)
                     else None,
                     "default_prompt": group.default_prompt,
-                    "members": [
-                        {
-                            "deployment_id": member.deployment_id,
-                            "enabled": member.enabled,
-                            "weight": member.weight,
-                            "priority": member.priority,
-                        }
-                        for member in self.members.get(group_key, [])
-                    ],
+                    "members": merge_policy_members(
+                        base_members,
+                        policy_json.get("members"),
+                        semantics_version=(
+                            policy.semantics_version
+                            if policy is not None and policy.status == "published"
+                            else 2
+                        ),
+                    ),
                 }
             )
         return runtime_groups
@@ -868,6 +900,7 @@ async def test_route_group_policy_simulation_returns_selection_summary(client, t
             }
         ]
     }
+    _publish_test_model_registry(test_app)
     headers = {"Authorization": "Bearer mk-test"}
 
     await client.post(
@@ -921,6 +954,7 @@ async def test_route_group_policy_simulation_applies_prompt_route_preferences(cl
             },
         ]
     }
+    _publish_test_model_registry(test_app)
 
     class _PromptRepoForSimulation:
         async def resolve_prompt(
@@ -979,6 +1013,206 @@ async def test_route_group_policy_simulation_applies_prompt_route_preferences(cl
     assert payload["effective_metadata"]["tags"] == ["vip"]
     assert payload["selections"][0]["deployment_id"] == "dep-b"
     assert payload["selections"][0]["count"] == 20
+
+
+@pytest.mark.asyncio
+async def test_route_group_policy_simulation_reports_retries_and_fallbacks(
+    client, test_app, monkeypatch
+):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.model_hot_reload_manager = _FakeHotReload()
+    test_app.state.route_group_runtime_cache = _FakeRouteGroupRuntimeCache()
+    test_app.state.model_registry = {
+        "gpt-4o-mini": [
+            {
+                "deployment_id": "dep-a",
+                "deltallm_params": {"model": "openai/gpt-4o-mini", "api_key": "key"},
+            },
+            {
+                "deployment_id": "dep-b",
+                "deltallm_params": {"model": "openai/gpt-4o-mini", "api_key": "key"},
+            },
+        ]
+    }
+    _publish_test_model_registry(test_app)
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/route-groups",
+        headers=headers,
+        json={"group_key": "sim-route", "mode": "chat", "strategy": "weighted"},
+    )
+    for deployment_id, priority in (("dep-a", 0), ("dep-b", 1)):
+        await client.post(
+            "/ui/api/route-groups/sim-route/members",
+            headers=headers,
+            json={"deployment_id": deployment_id, "weight": 1, "priority": priority},
+        )
+
+    state = test_app.state.routing_runtime_generation_store.require_snapshot().router.state
+    health_reads = 0
+    cooldown_reads = 0
+    get_health_batch = state.get_health_batch
+    get_cooldown_batch = state.get_cooldown_batch
+
+    async def count_health_reads(health_refs):  # noqa: ANN001, ANN202
+        nonlocal health_reads
+        health_reads += 1
+        return await get_health_batch(health_refs)
+
+    async def count_cooldown_reads(health_refs):  # noqa: ANN001, ANN202
+        nonlocal cooldown_reads
+        cooldown_reads += 1
+        return await get_cooldown_batch(health_refs)
+
+    monkeypatch.setattr(state, "get_health_batch", count_health_reads)
+    monkeypatch.setattr(state, "get_cooldown_batch", count_cooldown_reads)
+
+    response = await client.post(
+        "/ui/api/route-groups/sim-route/policy/simulate",
+        headers=headers,
+        json={
+            "iterations": 2,
+            "policy": {
+                "mode": "fallback",
+                "members": [
+                    {"deployment_id": "dep-a", "priority": 0},
+                    {"deployment_id": "dep-b", "priority": 1},
+                ],
+                "retry": {
+                    "max_attempts": 1,
+                    "retryable_error_classes": ["timeout"],
+                },
+            },
+            "outcomes": [{"deployment_id": "dep-a", "outcome": "timeout"}],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"] == {
+        "selected_requests": 2,
+        "no_selection_requests": 0,
+        "served_requests": 2,
+        "failed_requests": 0,
+        "fallback_requests": 2,
+        "timed_out_requests": 0,
+        "total_attempts": 6,
+    }
+    assert payload["served_deployments"] == [{"deployment_id": "dep-b", "count": 2, "ratio": 1.0}]
+    assert [attempt["transition"] for attempt in payload["sample_attempts"][:3]] == [
+        "primary",
+        "retry",
+        "fallback",
+    ]
+    assert health_reads == 1
+    assert cooldown_reads == 1
+
+
+@pytest.mark.asyncio
+async def test_route_group_policy_simulation_replaces_published_policy_fields(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.model_hot_reload_manager = _FakeHotReload()
+    test_app.state.route_group_runtime_cache = _FakeRouteGroupRuntimeCache()
+    test_app.state.model_registry = {
+        "gpt-4o-mini": [
+            {
+                "deployment_id": deployment_id,
+                "deltallm_params": {"model": "openai/gpt-4o-mini", "api_key": "key"},
+            }
+            for deployment_id in ("dep-a", "dep-b")
+        ]
+    }
+    _publish_test_model_registry(test_app)
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/route-groups",
+        headers=headers,
+        json={"group_key": "replace-route", "mode": "chat", "strategy": "weighted"},
+    )
+    for deployment_id, priority in (("dep-a", 0), ("dep-b", 1)):
+        await client.post(
+            "/ui/api/route-groups/replace-route/members",
+            headers=headers,
+            json={"deployment_id": deployment_id, "weight": 1, "priority": priority},
+        )
+    published = await client.put(
+        "/ui/api/route-groups/replace-route/policy",
+        headers=headers,
+        json={
+            "mode": "weighted",
+            "members": [{"deployment_id": "dep-a", "weight": 1}],
+            "timeouts": {"global_ms": 9000},
+            "retry": {
+                "max_attempts": 2,
+                "retryable_error_classes": ["generic"],
+            },
+        },
+    )
+    assert published.status_code == 200
+
+    explicit_replacement = await client.post(
+        "/ui/api/route-groups/replace-route/policy/simulate",
+        headers=headers,
+        json={
+            "iterations": 2,
+            "policy": {
+                "mode": "weighted",
+                "members": [{"deployment_id": "dep-b", "weight": 1}],
+            },
+        },
+    )
+    assert explicit_replacement.status_code == 200
+    explicit_payload = explicit_replacement.json()
+    assert explicit_payload["selections"] == [{"deployment_id": "dep-b", "count": 2, "ratio": 1.0}]
+    assert explicit_payload["sample_decision"]["timeout_seconds"] is None
+    assert explicit_payload["sample_decision"]["retry_max_attempts"] is None
+
+    inherited_replacement = await client.post(
+        "/ui/api/route-groups/replace-route/policy/simulate",
+        headers=headers,
+        json={
+            "iterations": 1,
+            "policy": {"mode": "fallback"},
+            "outcomes": [{"deployment_id": "dep-a", "outcome": "unavailable"}],
+        },
+    )
+    assert inherited_replacement.status_code == 200
+    inherited_payload = inherited_replacement.json()
+    assert inherited_payload["summary"]["total_attempts"] == 2
+    assert inherited_payload["summary"]["fallback_requests"] == 1
+    assert inherited_payload["served_deployments"] == [
+        {"deployment_id": "dep-b", "count": 1, "ratio": 1.0}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_route_group_policy_simulation_rejects_unknown_outcome_target(client, test_app):
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.model_hot_reload_manager = _FakeHotReload()
+    test_app.state.route_group_runtime_cache = _FakeRouteGroupRuntimeCache()
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/route-groups",
+        headers=headers,
+        json={"group_key": "sim-route", "mode": "chat", "strategy": "weighted"},
+    )
+    response = await client.post(
+        "/ui/api/route-groups/sim-route/policy/simulate",
+        headers=headers,
+        json={
+            "iterations": 1,
+            "outcomes": [{"deployment_id": "missing", "outcome": "timeout"}],
+        },
+    )
+
+    assert response.status_code == 400
+    assert "unknown deployment_id" in response.text
 
 
 @pytest.mark.asyncio

--- a/ui/scripts/run-unit-tests.mjs
+++ b/ui/scripts/run-unit-tests.mjs
@@ -28,8 +28,11 @@ const testSources = [
   'tests/reportingRequest.test.ts',
   'tests/reportingRefresh.test.ts',
   'tests/routeGroupsApi.test.ts',
+  'tests/routeGroupsPolicy.test.ts',
+  'tests/routeGroupPolicySimulationPanel.test.ts',
   'tests/usageBreakdown.test.ts',
   'tests/useApi.test.ts',
+  'tests/useRoutePolicySimulation.test.ts',
 ];
 
 await rm(outputDir, { recursive: true, force: true });

--- a/ui/src/components/PolicyGuidedEditor.tsx
+++ b/ui/src/components/PolicyGuidedEditor.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
 import {
+  ArrowDown,
+  ArrowUp,
   BarChart2,
   Clock,
   DollarSign,
@@ -10,25 +11,30 @@ import {
   Tag,
   Zap,
 } from 'lucide-react';
-import type { PolicyGuidedValues } from '../lib/routeGroups';
+import {
+  withGuidedPolicyMode,
+  withGuidedPolicyStrategy,
+  type PolicyGuidedValues,
+  type PolicyMemberOption,
+} from '../lib/routeGroups';
 
 const STRATEGY_META: Record<string, { icon: React.ElementType; label: string }> = {
-  'simple-shuffle':         { icon: Zap,       label: 'Simple Shuffle' },
-  'weighted':               { icon: GitBranch,  label: 'Weighted Split' },
-  'least-busy':             { icon: BarChart2,  label: 'Least Busy' },
-  'latency-based-routing':  { icon: Clock,      label: 'Latency-Based' },
-  'cost-based-routing':     { icon: DollarSign, label: 'Cost-Based' },
-  'usage-based-routing':    { icon: Layers,     label: 'Usage-Based' },
-  'tag-based-routing':      { icon: Tag,        label: 'Tag-Based' },
+  'simple-shuffle': { icon: Zap, label: 'Simple Shuffle' },
+  weighted: { icon: GitBranch, label: 'Weighted Split' },
+  'least-busy': { icon: BarChart2, label: 'Least Busy' },
+  'latency-based-routing': { icon: Clock, label: 'Latency-Based' },
+  'cost-based-routing': { icon: DollarSign, label: 'Cost-Based' },
+  'usage-based-routing': { icon: Layers, label: 'Usage-Based' },
+  'tag-based-routing': { icon: Tag, label: 'Tag-Based' },
   'priority-based-routing': { icon: ListChecks, label: 'Priority-Based' },
-  'rate-limit-aware':       { icon: Shield,     label: 'Rate-Limit Aware' },
+  'rate-limit-aware': { icon: Shield, label: 'Rate-Limit Aware' },
 };
 
 interface PolicyGuidedEditorProps {
   values: PolicyGuidedValues;
   onChange: (next: PolicyGuidedValues) => void;
   strategyOptions: string[];
-  memberOptions: string[];
+  memberOptions: PolicyMemberOption[];
 }
 
 function CheckIcon() {
@@ -45,62 +51,118 @@ export default function PolicyGuidedEditor({
   strategyOptions,
   memberOptions,
 }: PolicyGuidedEditorProps) {
-  const [weights, setWeights] = useState<Record<string, number>>(() =>
-    Object.fromEntries(
-      memberOptions.map((id) => [id, Math.floor(100 / Math.max(memberOptions.length, 1))])
-    )
-  );
+  const enabledMemberIds = memberOptions
+    .filter((member) => member.enabled)
+    .map((member) => member.deployment_id);
+  const optionsById = new Map(memberOptions.map((member) => [member.deployment_id, member]));
+  const orderedOptions = [
+    ...values.memberIds.flatMap((deploymentId) => {
+      const option = optionsById.get(deploymentId);
+      return option ? [option] : [];
+    }),
+    ...memberOptions.filter((member) => !values.memberIds.includes(member.deployment_id)),
+  ];
 
-  useEffect(() => {
-    setWeights((prev) => {
-      const next = { ...prev };
-      memberOptions.forEach((id) => {
-        if (!(id in next)) next[id] = 0;
-      });
-      return next;
+  const updateValue = <K extends keyof PolicyGuidedValues>(
+    key: K,
+    value: PolicyGuidedValues[K],
+  ) => onChange({ ...values, [key]: value });
+
+  const selectExplicitMembers = () => {
+    onChange({
+      ...values,
+      memberSelection: 'explicit',
+      memberIds: values.memberSelection === 'inherit' ? enabledMemberIds : values.memberIds,
     });
-  }, [memberOptions]);
-
-  const updateValue = <K extends keyof PolicyGuidedValues>(key: K, val: PolicyGuidedValues[K]) => {
-    onChange({ ...values, [key]: val });
   };
 
-  const setStrategy = (s: string) => {
-    onChange({ ...values, strategy: s });
+  const toggleMember = (deploymentId: string) => {
+    const startingIds = values.memberSelection === 'inherit'
+      ? enabledMemberIds
+      : values.memberIds;
+    const included = startingIds.includes(deploymentId);
+    onChange({
+      ...values,
+      memberSelection: 'explicit',
+      memberIds: included
+        ? startingIds.filter((item) => item !== deploymentId)
+        : [...startingIds, deploymentId],
+    });
   };
 
-  const toggleMember = (id: string) => {
-    const has = values.memberIds.includes(id);
-    updateValue('memberIds', has ? values.memberIds.filter((m) => m !== id) : [...values.memberIds, id]);
+  const updateWeight = (deploymentId: string, weight: string) => {
+    onChange({
+      ...values,
+      memberSelection: 'explicit',
+      memberIds: values.memberSelection === 'inherit' ? enabledMemberIds : values.memberIds,
+      memberWeights: { ...values.memberWeights, [deploymentId]: weight },
+    });
   };
 
-  const showWeights = values.strategy === 'weighted';
+  const moveMember = (deploymentId: string, delta: -1 | 1) => {
+    const currentIndex = values.memberIds.indexOf(deploymentId);
+    const nextIndex = currentIndex + delta;
+    if (currentIndex < 0 || nextIndex < 0 || nextIndex >= values.memberIds.length) return;
+    const memberIds = [...values.memberIds];
+    [memberIds[currentIndex], memberIds[nextIndex]] = [
+      memberIds[nextIndex],
+      memberIds[currentIndex],
+    ];
+    onChange({ ...values, memberSelection: 'explicit', memberIds });
+  };
+
+  const showWeights = values.mode === 'weighted';
+  const showOrder = values.mode === 'fallback' && values.memberSelection === 'explicit';
 
   return (
     <div className="space-y-6">
-
-      {/* ── Routing Strategy ── */}
       <div>
-        <p className="text-[10px] uppercase tracking-widest font-semibold text-slate-400 mb-3">
-          Routing Strategy
+        <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-slate-400">
+          Policy mode
+        </p>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {([
+            ['weighted', 'Weighted traffic', 'Split requests using integer deployment weights.'],
+            ['fallback', 'Ordered fallback', 'Try enabled deployments in the configured order.'],
+          ] as const).map(([mode, label, description]) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => onChange(withGuidedPolicyMode(values, mode))}
+              className={`rounded-xl border px-4 py-3 text-left transition-colors ${
+                values.mode === mode
+                  ? 'border-brand-primary bg-blue-50'
+                  : 'border-slate-200 bg-white hover:bg-slate-50'
+              }`}
+            >
+              <span className="block text-sm font-semibold text-slate-900">{label}</span>
+              <span className="mt-0.5 block text-xs text-slate-500">{description}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-slate-400">
+          Routing strategy
         </p>
         <div className="flex flex-wrap gap-2">
-          {strategyOptions.map((s) => {
-            const meta = STRATEGY_META[s] ?? { icon: Zap, label: s };
+          {strategyOptions.map((strategy) => {
+            const meta = STRATEGY_META[strategy] ?? { icon: Zap, label: strategy };
             const Icon = meta.icon;
-            const sel = values.strategy === s;
+            const selected = values.strategy === strategy;
             return (
               <button
-                key={s}
+                key={strategy}
                 type="button"
-                onClick={() => setStrategy(s)}
+                onClick={() => onChange(withGuidedPolicyStrategy(values, strategy))}
                 className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-all ${
-                  sel
+                  selected
                     ? 'border-brand-primary bg-blue-50 text-blue-700 shadow-sm'
                     : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50'
                 }`}
               >
-                <Icon className={`h-4 w-4 ${sel ? 'text-brand-primary-ink' : 'text-slate-400'}`} />
+                <Icon className={`h-4 w-4 ${selected ? 'text-brand-primary-ink' : 'text-slate-400'}`} />
                 {meta.label}
               </button>
             );
@@ -108,62 +170,119 @@ export default function PolicyGuidedEditor({
         </div>
       </div>
 
-      {/* ── Target Deployments ── */}
       <div>
-        <p className="text-[10px] uppercase tracking-widest font-semibold text-slate-400 mb-3">
-          Target Deployments
-        </p>
+        <div className="mb-3 flex flex-wrap items-end justify-between gap-2">
+          <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-400">
+            Target deployments
+          </p>
+          <div className="flex rounded-lg border border-slate-200 bg-slate-100 p-1">
+            <button
+              type="button"
+              onClick={() => onChange({
+                ...values,
+                memberSelection: 'inherit',
+                memberIds: enabledMemberIds,
+              })}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium ${
+                values.memberSelection === 'inherit'
+                  ? 'bg-white text-slate-900 shadow-sm'
+                  : 'text-slate-500'
+              }`}
+            >
+              Inherit enabled
+            </button>
+            <button
+              type="button"
+              onClick={selectExplicitMembers}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium ${
+                values.memberSelection === 'explicit'
+                  ? 'bg-white text-slate-900 shadow-sm'
+                  : 'text-slate-500'
+              }`}
+            >
+              Choose subset
+            </button>
+          </div>
+        </div>
+        {values.memberSelection === 'inherit' && (
+          <p className="mb-3 text-xs text-slate-500">
+            The policy follows the group&apos;s enabled membership. Editing a weight or checkbox creates an explicit subset.
+          </p>
+        )}
         {memberOptions.length === 0 ? (
           <p className="rounded-xl border border-dashed border-slate-200 px-4 py-5 text-center text-sm text-slate-500">
             Add group members in the Models tab first.
           </p>
         ) : (
           <div className="space-y-2">
-            {memberOptions.map((id, i) => {
-              const included = values.memberIds.includes(id);
-              const w = weights[id] ?? 0;
+            {orderedOptions.map((member) => {
+              const deploymentId = member.deployment_id;
+              const included = values.memberIds.includes(deploymentId) && member.enabled;
+              const selectedIndex = values.memberIds.indexOf(deploymentId);
               return (
                 <div
-                  key={id}
-                  className={`flex items-center gap-4 rounded-lg border bg-white p-3 shadow-sm transition-all ${
-                    included ? 'border-slate-200' : 'border-slate-100 opacity-50'
+                  key={deploymentId}
+                  className={`flex flex-col gap-3 rounded-lg border bg-white p-3 shadow-sm transition-all md:flex-row md:items-center ${
+                    included ? 'border-slate-200' : 'border-slate-100 opacity-60'
                   }`}
                 >
-                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-slate-100 text-xs font-medium text-slate-600">
-                    {i + 1}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-mono text-slate-900 truncate">{id}</p>
+                  <div className="flex min-w-0 flex-1 items-center gap-3">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-slate-100 text-xs font-medium text-slate-600">
+                      {selectedIndex >= 0 ? selectedIndex + 1 : '—'}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-mono text-sm text-slate-900">{deploymentId}</p>
+                      {!member.enabled && <p className="text-xs text-amber-700">Disabled in group membership</p>}
+                    </div>
                   </div>
                   {showWeights && included && (
-                    <div className="flex items-center gap-3 w-44 shrink-0">
+                    <label className="flex items-center gap-2 md:w-36">
+                      <span className="text-xs font-medium text-slate-500">Weight</span>
                       <input
-                        type="range"
-                        min="0"
-                        max="100"
-                        value={w}
-                        onChange={(e) => setWeights((prev) => ({ ...prev, [id]: Number(e.target.value) }))}
-                        className="w-full accent-brand-primary"
+                        type="number"
+                        min="1"
+                        step="1"
+                        value={values.memberWeights[deploymentId] || ''}
+                        placeholder={member.weight == null ? 'inherit' : String(member.weight)}
+                        onChange={(event) => updateWeight(deploymentId, event.target.value)}
+                        className="min-w-0 flex-1 rounded-md border border-slate-200 px-2 py-1 text-right text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+                        aria-label={`Weight for ${deploymentId}`}
                       />
-                      <div className="relative">
-                        <input
-                          type="number"
-                          value={w}
-                          onChange={(e) => setWeights((prev) => ({ ...prev, [id]: Number(e.target.value) }))}
-                          className="w-16 rounded-md border border-slate-200 py-1 pl-2 pr-6 text-sm text-right focus:border-brand-primary focus:ring-1 focus:ring-brand-primary focus:outline-none"
-                        />
-                        <span className="absolute right-2 top-1.5 text-xs text-slate-400">%</span>
-                      </div>
+                    </label>
+                  )}
+                  {showOrder && included && (
+                    <div className="flex gap-1">
+                      <button
+                        type="button"
+                        onClick={() => moveMember(deploymentId, -1)}
+                        disabled={selectedIndex <= 0}
+                        className="rounded-md border border-slate-200 p-1.5 text-slate-500 hover:bg-slate-50 disabled:opacity-30"
+                        aria-label={`Move ${deploymentId} earlier`}
+                      >
+                        <ArrowUp className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveMember(deploymentId, 1)}
+                        disabled={selectedIndex === values.memberIds.length - 1}
+                        className="rounded-md border border-slate-200 p-1.5 text-slate-500 hover:bg-slate-50 disabled:opacity-30"
+                        aria-label={`Move ${deploymentId} later`}
+                      >
+                        <ArrowDown className="h-3.5 w-3.5" />
+                      </button>
                     </div>
                   )}
                   <button
                     type="button"
                     role="checkbox"
                     aria-checked={included}
-                    onClick={() => toggleMember(id)}
-                    className={`h-5 w-5 shrink-0 rounded border-2 flex items-center justify-center transition-colors ${
-                      included ? 'border-brand-primary bg-brand-primary' : 'border-slate-300 bg-white hover:border-blue-400'
-                    }`}
+                    disabled={!member.enabled}
+                    onClick={() => toggleMember(deploymentId)}
+                    className={`flex h-5 w-5 shrink-0 items-center justify-center self-end rounded border-2 transition-colors md:self-auto ${
+                      included
+                        ? 'border-brand-primary bg-brand-primary'
+                        : 'border-slate-300 bg-white hover:border-blue-400'
+                    } disabled:cursor-not-allowed`}
                   >
                     {included && <CheckIcon />}
                   </button>
@@ -174,43 +293,49 @@ export default function PolicyGuidedEditor({
         )}
       </div>
 
-      {/* ── Timeouts & Retry (collapsible) ── */}
       <details className="rounded-xl border border-slate-200 px-3 py-3">
-        <summary className="cursor-pointer list-none text-sm font-semibold text-slate-900 select-none">
+        <summary className="cursor-pointer list-none select-none text-sm font-semibold text-slate-900">
           Timeouts and retry
         </summary>
         <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
           <label className="space-y-1">
             <span className="text-xs font-medium text-slate-700">Global Timeout (ms)</span>
             <input
+              type="number"
+              min="1"
+              step="1"
               value={values.timeoutMs}
-              onChange={(e) => updateValue('timeoutMs', e.target.value)}
+              onChange={(event) => updateValue('timeoutMs', event.target.value)}
               placeholder="10000"
-              className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-brand-primary focus:border-brand-primary"
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
             />
           </label>
           <label className="space-y-1">
             <span className="text-xs font-medium text-slate-700">Retry Max Attempts</span>
             <input
+              type="number"
+              min="0"
+              step="1"
               value={values.retryMaxAttempts}
-              onChange={(e) => updateValue('retryMaxAttempts', e.target.value)}
+              onChange={(event) => updateValue('retryMaxAttempts', event.target.value)}
               placeholder="2"
-              className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-brand-primary focus:border-brand-primary"
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
             />
           </label>
           <label className="space-y-1 md:col-span-2">
             <span className="text-xs font-medium text-slate-700">Retryable Errors</span>
             <input
               value={values.retryableErrors}
-              onChange={(e) => updateValue('retryableErrors', e.target.value)}
-              placeholder="timeout,5xx,rate_limit"
-              className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-brand-primary focus:border-brand-primary"
+              onChange={(event) => updateValue('retryableErrors', event.target.value)}
+              placeholder="timeout,rate_limit,generic"
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
             />
-            <span className="block text-xs text-slate-500">Comma-separated error classes to retry.</span>
+            <span className="block text-xs text-slate-500">
+              Allowed: timeout, rate_limit, context_window_exceeded, content_policy_violation, generic.
+            </span>
           </label>
         </div>
       </details>
-
     </div>
   );
 }

--- a/ui/src/components/route-groups/RouteGroupAdvancedTab.tsx
+++ b/ui/src/components/route-groups/RouteGroupAdvancedTab.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   Clock,
   Code2,
+  FlaskConical,
   GitBranch,
   ListChecks,
   RotateCcw,
@@ -13,8 +14,18 @@ import {
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import PolicyGuidedEditor from '../PolicyGuidedEditor';
-import { ROUTE_GROUP_STRATEGY_OPTIONS, type PolicyAction, type PolicyGuidedValues } from '../../lib/routeGroups';
-import type { PromptBinding, PromptTemplate, RoutePolicy } from '../../lib/api';
+import RouteGroupPolicySimulationPanel from './RouteGroupPolicySimulationPanel';
+import {
+  ROUTE_GROUP_STRATEGY_OPTIONS,
+  type PolicyAction,
+  type PolicyGuidedValues,
+} from '../../lib/routeGroups';
+import type {
+  PromptBinding,
+  PromptTemplate,
+  RouteGroupMemberDetail,
+  RoutePolicy,
+} from '../../lib/api';
 
 /* ─── AccordionCard shell ─────────────────────────────────────────────────── */
 
@@ -96,9 +107,14 @@ interface RouteGroupAdvancedTabProps {
   onDeleteBinding: (binding: PromptBinding) => void;
 
   /* Routing Policy */
+  groupKey: string;
   guidedPolicy: PolicyGuidedValues;
-  memberIds: string[];
+  members: RouteGroupMemberDetail[];
   guidedPreview: string;
+  simulationPolicy: Record<string, unknown> | null;
+  simulationPolicyError: string | null;
+  simulationPromptRef: Record<string, unknown> | null;
+  canSimulate: boolean;
   policyText: string;
   policyMessage: string | null;
   policyError: string | null;
@@ -146,9 +162,14 @@ export default function RouteGroupAdvancedTab({
   onBindingFormChange,
   onSaveBinding,
   onDeleteBinding,
+  groupKey,
   guidedPolicy,
-  memberIds,
+  members,
   guidedPreview,
+  simulationPolicy,
+  simulationPolicyError,
+  simulationPromptRef,
+  canSimulate,
   policyText,
   policyMessage,
   policyError,
@@ -444,7 +465,7 @@ export default function RouteGroupAdvancedTab({
               values={guidedPolicy}
               onChange={onGuidedPolicyChange}
               strategyOptions={[...ROUTE_GROUP_STRATEGY_OPTIONS]}
-              memberOptions={memberIds}
+              memberOptions={members}
             />
           )}
 
@@ -470,7 +491,36 @@ export default function RouteGroupAdvancedTab({
         </div>
       </AccordionCard>
 
-      {/* ── 3. Policy History ── */}
+      {/* ── 3. Policy Simulation ── */}
+      <AccordionCard
+        id="policy-simulation"
+        open={openSections.has('policy-simulation')}
+        onToggle={() => toggle('policy-simulation')}
+        icon={FlaskConical}
+        iconBg="bg-cyan-100"
+        iconColor="text-cyan-700"
+        title="Policy Simulation"
+        subtitle="Test eligibility, retries, and fallback outcomes without sending provider traffic."
+        borderAccent="border-cyan-200"
+        badge={(
+          <span className="inline-flex items-center rounded-full bg-cyan-50 px-2 py-0.5 text-xs font-medium text-cyan-700 ring-1 ring-inset ring-cyan-600/20">
+            dry run
+          </span>
+        )}
+      >
+        <div className="px-5 py-5">
+          <RouteGroupPolicySimulationPanel
+            groupKey={groupKey}
+            policy={simulationPolicy}
+            policyError={simulationPolicyError}
+            members={members}
+            canSimulate={canSimulate}
+            promptRef={simulationPromptRef}
+          />
+        </div>
+      </AccordionCard>
+
+      {/* ── 4. Policy History ── */}
       <AccordionCard
         id="policy-history"
         open={openSections.has('policy-history')}

--- a/ui/src/components/route-groups/RouteGroupPolicyEditorCard.tsx
+++ b/ui/src/components/route-groups/RouteGroupPolicyEditorCard.tsx
@@ -88,7 +88,12 @@ export default function RouteGroupPolicyEditorCard({
         values={guidedPolicy}
         onChange={onGuidedPolicyChange}
         strategyOptions={[...ROUTE_GROUP_STRATEGY_OPTIONS]}
-        memberOptions={memberIds}
+        memberOptions={memberIds.map((deploymentId) => ({
+          deployment_id: deploymentId,
+          enabled: true,
+          weight: null,
+          priority: null,
+        }))}
       />
 
       {/* Preview + JSON toggle */}

--- a/ui/src/components/route-groups/RouteGroupPolicySimulationPanel.tsx
+++ b/ui/src/components/route-groups/RouteGroupPolicySimulationPanel.tsx
@@ -1,0 +1,359 @@
+import { AlertTriangle, FlaskConical, RefreshCw, ShieldAlert } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import type {
+  RouteGroupMemberDetail,
+  RoutePolicySimulationOutcome,
+  RoutePolicySimulationSelection,
+} from '../../lib/api';
+import { useRoutePolicySimulation } from '../../lib/useRoutePolicySimulation';
+
+interface RouteGroupPolicySimulationPanelProps {
+  groupKey: string;
+  policy: Record<string, unknown> | null;
+  policyError: string | null;
+  members: RouteGroupMemberDetail[];
+  canSimulate: boolean;
+  promptRef?: Record<string, unknown> | null;
+}
+
+const OUTCOME_OPTIONS: Array<{ value: RoutePolicySimulationOutcome; label: string }> = [
+  { value: 'success', label: 'Success' },
+  { value: 'timeout', label: 'Timeout' },
+  { value: 'rate_limit', label: 'Rate limit' },
+  { value: 'unavailable', label: 'Unavailable' },
+];
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : 'Policy simulation failed. Try again.';
+}
+
+function percentage(value: number): string {
+  return `${(value * 100).toFixed(value > 0 && value < 0.01 ? 2 : 1)}%`;
+}
+
+function SelectionList({
+  title,
+  items,
+  emptyLabel,
+}: {
+  title: string;
+  items: RoutePolicySimulationSelection[];
+  emptyLabel: string;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">{title}</h4>
+      {items.length === 0 ? (
+        <p className="mt-3 text-sm text-slate-500">{emptyLabel}</p>
+      ) : (
+        <div className="mt-3 space-y-3">
+          {items.map((item) => (
+            <div key={item.deployment_id}>
+              <div className="flex items-center justify-between gap-3 text-xs">
+                <span className="truncate font-mono text-slate-700">{item.deployment_id}</span>
+                <span className="shrink-0 font-medium text-slate-600">
+                  {item.count} · {percentage(item.ratio)}
+                </span>
+              </div>
+              <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-slate-100">
+                <div
+                  className="h-full rounded-full bg-brand-primary"
+                  style={{ width: `${Math.min(100, item.ratio * 100)}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function RouteGroupPolicySimulationPanel({
+  groupKey,
+  policy,
+  policyError,
+  members,
+  canSimulate,
+  promptRef = null,
+}: RouteGroupPolicySimulationPanelProps) {
+  const [iterations, setIterations] = useState('100');
+  const [tags, setTags] = useState('');
+  const [outcomes, setOutcomes] = useState<Record<string, RoutePolicySimulationOutcome>>({});
+  const [inputError, setInputError] = useState<string | null>(null);
+  const enabledMembers = useMemo(() => members.filter((member) => member.enabled), [members]);
+  const scenarioOutcomes = enabledMembers.map((member) => ({
+    deployment_id: member.deployment_id,
+    outcome: outcomes[member.deployment_id] || 'success' as RoutePolicySimulationOutcome,
+  }));
+  const fingerprint = JSON.stringify({
+    groupKey,
+    policy,
+    promptRef,
+    iterations,
+    tags,
+    outcomes: scenarioOutcomes,
+  });
+  const simulation = useRoutePolicySimulation(groupKey, fingerprint);
+
+  const handleRun = () => {
+    if (!policy) {
+      setInputError(policyError || 'Enter a valid policy before running a simulation.');
+      return;
+    }
+    if (!/^\d+$/.test(iterations)) {
+      setInputError('Iterations must be an integer from 1 to 5000.');
+      return;
+    }
+    const parsedIterations = Number(iterations);
+    if (!Number.isSafeInteger(parsedIterations) || parsedIterations < 1 || parsedIterations > 5000) {
+      setInputError('Iterations must be an integer from 1 to 5000.');
+      return;
+    }
+    const normalizedTags = tags.split(',').map((tag) => tag.trim()).filter(Boolean);
+    setInputError(null);
+    void simulation.run({
+      iterations: parsedIterations,
+      policy,
+      prompt_ref: promptRef,
+      metadata: normalizedTags.length > 0 ? { tags: normalizedTags } : {},
+      outcomes: scenarioOutcomes.filter((item) => item.outcome !== 'success'),
+    });
+  };
+
+  if (!canSimulate) {
+    return (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+        <div className="flex items-start gap-3">
+          <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0" />
+          <div>
+            <p className="font-semibold">Simulation permission required</p>
+            <p className="mt-1 text-amber-800">
+              Your current session cannot access route-group policy simulation.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const result = simulation.data;
+  const visibleError = inputError
+    || (!policy ? policyError || 'Enter a valid policy before running a simulation.' : null)
+    || (simulation.error ? errorMessage(simulation.error) : null);
+
+  return (
+    <div className="space-y-5">
+      <div className="rounded-xl border border-blue-100 bg-blue-50/60 p-4">
+        <div className="flex items-start gap-3">
+          <FlaskConical className="mt-0.5 h-5 w-5 shrink-0 text-brand-primary-ink" />
+          <div>
+            <p className="text-sm font-semibold text-slate-900">Dry-run scenario</p>
+            <p className="mt-1 text-xs leading-5 text-slate-600">
+              Uses one snapshot of current health, cooldown, capacity, usage, and latency. It calls no provider and does not mutate live routing state.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <label className="space-y-1.5">
+          <span className="text-xs font-medium text-slate-700">Requests to simulate</span>
+          <input
+            type="number"
+            min="1"
+            max="5000"
+            step="1"
+            value={iterations}
+            onChange={(event) => setIterations(event.target.value)}
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+          />
+        </label>
+        <label className="space-y-1.5">
+          <span className="text-xs font-medium text-slate-700">Request tags</span>
+          <input
+            value={tags}
+            onChange={(event) => setTags(event.target.value)}
+            placeholder="vip, production"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+          />
+        </label>
+      </div>
+
+      <div>
+        <p className="mb-2 text-xs font-medium text-slate-700">Assumed provider outcomes</p>
+        {enabledMembers.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-slate-200 p-4 text-sm text-slate-500">
+            There are no enabled deployments to simulate.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+            {enabledMembers.map((member) => (
+              <label
+                key={member.deployment_id}
+                className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2"
+              >
+                <span className="truncate font-mono text-xs text-slate-700">
+                  {member.deployment_id}
+                </span>
+                <select
+                  value={outcomes[member.deployment_id] || 'success'}
+                  onChange={(event) => setOutcomes((current) => ({
+                    ...current,
+                    [member.deployment_id]: event.target.value as RoutePolicySimulationOutcome,
+                  }))}
+                  className="shrink-0 rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700"
+                >
+                  {OUTCOME_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleRun}
+          disabled={simulation.loading || !policy || enabledMembers.length === 0}
+          className="inline-flex items-center gap-2 rounded-lg bg-brand-primary px-4 py-2 text-sm font-semibold text-brand-on-primary shadow-sm hover:bg-brand-primary-hover disabled:opacity-50"
+        >
+          <RefreshCw className={`h-4 w-4 ${simulation.loading ? 'animate-spin' : ''}`} />
+          {simulation.loading ? 'Simulating…' : result ? 'Run again' : 'Run simulation'}
+        </button>
+        {result && (
+          <span className="text-xs text-slate-500">
+            {result.iterations} requests · live-state dry run
+          </span>
+        )}
+      </div>
+
+      {visibleError && (
+        <div role="alert" className="flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{visibleError}</span>
+        </div>
+      )}
+
+      {simulation.stale && result && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          These results are stale because the policy or scenario changed. Run the simulation again before relying on them.
+        </div>
+      )}
+
+      {!result && !simulation.loading && !visibleError && (
+        <div className="rounded-xl border border-dashed border-slate-200 px-4 py-8 text-center">
+          <FlaskConical className="mx-auto h-6 w-6 text-slate-300" />
+          <p className="mt-2 text-sm font-medium text-slate-600">No simulation results yet</p>
+          <p className="mt-1 text-xs text-slate-500">
+            Choose any failure assumptions above, then run the current policy.
+          </p>
+        </div>
+      )}
+
+      {result && (
+        <div className={`space-y-4 ${simulation.loading ? 'opacity-60' : ''}`} aria-busy={simulation.loading}>
+          {result.warnings.length > 0 && (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+              {result.warnings.join(' ')}
+            </div>
+          )}
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+            {[
+              ['Selected', result.summary.selected_requests],
+              ['Served', result.summary.served_requests],
+              ['Fallbacks', result.summary.fallback_requests],
+              ['Failed', result.summary.failed_requests],
+              ['Attempts', result.summary.total_attempts],
+            ].map(([label, value]) => (
+              <div key={label} className="rounded-xl border border-slate-200 bg-white p-3">
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">{label}</p>
+                <p className="mt-1 text-xl font-semibold text-slate-900">{value}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <SelectionList title="Initial selection" items={result.selections} emptyLabel="No deployment was eligible." />
+            <SelectionList title="Served by" items={result.served_deployments} emptyLabel="No request reached a successful deployment." />
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Terminal outcomes</h4>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {Object.keys(result.terminal_outcomes).length === 0 ? (
+                  <span className="text-sm text-slate-500">No terminal outcomes.</span>
+                ) : Object.entries(result.terminal_outcomes).map(([outcome, count]) => (
+                  <span key={outcome} className="rounded-full bg-slate-100 px-2.5 py-1 text-xs text-slate-700">
+                    {outcome}: {count}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Eligibility decisions</h4>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {Object.keys(result.reason_counts).length === 0 ? (
+                  <span className="text-sm text-slate-500">No route decision was available.</span>
+                ) : Object.entries(result.reason_counts).map(([reason, count]) => (
+                  <span key={reason} className="rounded-full bg-blue-50 px-2.5 py-1 text-xs text-blue-700">
+                    {reason}: {count}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {result.sample_attempts.length > 0 && (
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Sample attempt trace</h4>
+              <div className="mt-3 space-y-2 md:hidden">
+                {result.sample_attempts.map((attempt, index) => (
+                  <div key={`${attempt.iteration}-${attempt.attempt}-${index}`} className="rounded-lg bg-slate-50 p-3 text-xs">
+                    <div className="flex justify-between gap-3">
+                      <span className="font-mono text-slate-700">{attempt.deployment_id}</span>
+                      <span className="font-medium text-slate-600">{attempt.outcome}</span>
+                    </div>
+                    <p className="mt-1 text-slate-500">
+                      Request {attempt.iteration}, attempt {attempt.attempt} · {attempt.transition}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-3 hidden overflow-x-auto md:block">
+                <table className="min-w-full text-left text-xs">
+                  <thead className="text-slate-400">
+                    <tr>
+                      <th className="pb-2 pr-4 font-medium">Request</th>
+                      <th className="pb-2 pr-4 font-medium">Attempt</th>
+                      <th className="pb-2 pr-4 font-medium">Deployment</th>
+                      <th className="pb-2 pr-4 font-medium">Transition</th>
+                      <th className="pb-2 font-medium">Outcome</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 text-slate-700">
+                    {result.sample_attempts.map((attempt, index) => (
+                      <tr key={`${attempt.iteration}-${attempt.attempt}-${index}`}>
+                        <td className="py-2 pr-4">{attempt.iteration}</td>
+                        <td className="py-2 pr-4">{attempt.attempt}</td>
+                        <td className="py-2 pr-4 font-mono">{attempt.deployment_id}</td>
+                        <td className="py-2 pr-4">{attempt.transition}</td>
+                        <td className="py-2">{attempt.outcome}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -824,6 +824,11 @@ export type {
   RouteGroupWritePayload,
   RoutePolicy,
   RoutePolicyMutationResponse,
+  RoutePolicySimulationAttempt,
+  RoutePolicySimulationOutcome,
+  RoutePolicySimulationRequest,
+  RoutePolicySimulationResponse,
+  RoutePolicySimulationSelection,
 } from './api/routeGroups';
 
 export interface PromptTemplate {

--- a/ui/src/lib/api/routeGroups.ts
+++ b/ui/src/lib/api/routeGroups.ts
@@ -105,6 +105,63 @@ export interface RouteGroupListResponse {
   };
 }
 
+export type RoutePolicySimulationOutcome = 'success' | 'timeout' | 'rate_limit' | 'unavailable';
+
+export interface RoutePolicySimulationRequest {
+  iterations?: number;
+  policy?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown>;
+  user_id?: string;
+  prompt_ref?: Record<string, unknown> | null;
+  outcomes?: Array<{
+    deployment_id: string;
+    outcome: RoutePolicySimulationOutcome;
+  }>;
+}
+
+export interface RoutePolicySimulationSelection {
+  deployment_id: string;
+  count: number;
+  ratio: number;
+}
+
+export interface RoutePolicySimulationAttempt {
+  iteration: number;
+  attempt: number;
+  deployment_id: string;
+  outcome: RoutePolicySimulationOutcome;
+  transition: 'primary' | 'retry' | 'fallback';
+}
+
+export interface RoutePolicySimulationResponse {
+  group_key: string;
+  iterations: number;
+  basis: 'live_state_dry_run';
+  warnings: string[];
+  prompt: {
+    template_key: string;
+    version: number;
+    label: string | null;
+    route_preferences: Record<string, unknown>;
+  } | null;
+  effective_metadata: Record<string, unknown>;
+  summary: {
+    selected_requests: number;
+    no_selection_requests: number;
+    served_requests: number;
+    failed_requests: number;
+    fallback_requests: number;
+    timed_out_requests: number;
+    total_attempts: number;
+  };
+  reason_counts: Record<string, number>;
+  selections: RoutePolicySimulationSelection[];
+  served_deployments: RoutePolicySimulationSelection[];
+  terminal_outcomes: Record<string, number>;
+  sample_decision: Record<string, unknown> | null;
+  sample_attempts: RoutePolicySimulationAttempt[];
+}
+
 export const routeGroups = {
   list: (
     params?: { search?: string; limit?: number; offset?: number },
@@ -201,4 +258,12 @@ export const routeGroups = {
       `/ui/api/route-groups/${encodeURIComponent(groupKey)}/policy/rollback`,
       { method: 'POST', json: { version }, signal },
     ),
+  simulatePolicy: (
+    groupKey: string,
+    payload: RoutePolicySimulationRequest,
+    signal?: AbortSignal,
+  ) => apiFetch<RoutePolicySimulationResponse>(
+    `/ui/api/route-groups/${encodeURIComponent(groupKey)}/policy/simulate`,
+    { method: 'POST', json: payload, signal },
+  ),
 };

--- a/ui/src/lib/routeGroups.ts
+++ b/ui/src/lib/routeGroups.ts
@@ -12,13 +12,32 @@ export const ROUTE_GROUP_STRATEGY_OPTIONS = [
   'rate-limit-aware',
 ] as const;
 
+export const RETRYABLE_ERROR_OPTIONS = [
+  'timeout',
+  'rate_limit',
+  'context_window_exceeded',
+  'content_policy_violation',
+  'generic',
+] as const;
+
 export type PolicyEditorMode = 'guided' | 'json';
 export type PolicyAction = 'validate' | 'save-draft' | 'publish-json' | 'publish-draft' | 'rollback' | null;
+export type GuidedPolicyMode = 'fallback' | 'weighted';
+export type GuidedMemberSelection = 'inherit' | 'explicit';
+
+export interface PolicyMemberOption {
+  deployment_id: string;
+  enabled: boolean;
+  weight: number | null;
+  priority: number | null;
+}
 
 export interface PolicyGuidedValues {
   strategy: string;
-  mode: 'fallback' | 'weighted' | 'conditional' | 'adaptive';
+  mode: GuidedPolicyMode | null;
+  memberSelection: GuidedMemberSelection;
   memberIds: string[];
+  memberWeights: Record<string, string>;
   timeoutMs: string;
   retryMaxAttempts: string;
   retryableErrors: string;
@@ -27,7 +46,9 @@ export interface PolicyGuidedValues {
 export const GUIDED_POLICY_DEFAULTS: PolicyGuidedValues = {
   strategy: 'weighted',
   mode: 'weighted',
+  memberSelection: 'inherit',
   memberIds: [],
+  memberWeights: {},
   timeoutMs: '',
   retryMaxAttempts: '',
   retryableErrors: '',
@@ -39,21 +60,21 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-function toPositiveIntegerString(value: unknown): string {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return '';
-  return String(Math.trunc(value));
+function toIntegerString(value: unknown, minimum: number): string {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < minimum) return '';
+  return String(value);
 }
 
-function parseInteger(value: string): number | null {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+function parseIntegerString(value: string, minimum: number): number | null {
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) return null;
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) return null;
   return parsed;
 }
 
 function memberReferenceFromEntry(entry: unknown): string | null {
-  if (typeof entry === 'string' && entry.trim()) {
-    return entry.trim();
-  }
+  if (typeof entry === 'string' && entry.trim()) return entry.trim();
   if (!isObjectRecord(entry)) return null;
   const candidates = [
     entry.member,
@@ -64,11 +85,31 @@ function memberReferenceFromEntry(entry: unknown): string | null {
     entry.id,
   ];
   for (const candidate of candidates) {
-    if (typeof candidate === 'string' && candidate.trim()) {
-      return candidate.trim();
-    }
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
   }
   return null;
+}
+
+function modeForStrategy(strategy: string): GuidedPolicyMode | null {
+  if (strategy === 'weighted') return 'weighted';
+  if (strategy === 'priority-based-routing') return 'fallback';
+  return null;
+}
+
+function memberWeight(entry: unknown): string {
+  if (!isObjectRecord(entry)) return '';
+  return toIntegerString(entry.weight, 1);
+}
+
+function timeoutMilliseconds(timeoutBlock: Record<string, unknown>): string {
+  const milliseconds = toIntegerString(timeoutBlock.global_ms, 1);
+  if (milliseconds) return milliseconds;
+  if (
+    typeof timeoutBlock.global_seconds !== 'number'
+    || !Number.isFinite(timeoutBlock.global_seconds)
+    || timeoutBlock.global_seconds <= 0
+  ) return '';
+  return String(Math.max(1, Math.round(timeoutBlock.global_seconds * 1000)));
 }
 
 export function parsePolicyTextLoose(raw: string): Record<string, unknown> | null {
@@ -80,76 +121,194 @@ export function parsePolicyTextLoose(raw: string): Record<string, unknown> | nul
   }
 }
 
-export function toGuidedPolicy(policy: Record<string, unknown>, memberIds: string[]): PolicyGuidedValues {
-  const strategy = typeof policy.strategy === 'string' ? policy.strategy : GUIDED_POLICY_DEFAULTS.strategy;
-  const mode = policy.mode;
-  const guidedMode: PolicyGuidedValues['mode'] =
-    mode === 'fallback' || mode === 'weighted' || mode === 'conditional' || mode === 'adaptive' ? mode : GUIDED_POLICY_DEFAULTS.mode;
-
+export function toGuidedPolicy(
+  policy: Record<string, unknown>,
+  memberOptions: PolicyMemberOption[],
+): PolicyGuidedValues {
+  const rawMode = policy.mode;
+  const strategy = typeof policy.strategy === 'string'
+    ? policy.strategy
+    : rawMode === 'fallback'
+      ? 'priority-based-routing'
+      : GUIDED_POLICY_DEFAULTS.strategy;
+  const strategyMode = modeForStrategy(strategy);
+  const declaredMode = rawMode === 'fallback' || rawMode === 'weighted' ? rawMode : null;
+  const mode = strategyMode === null ? null : declaredMode === strategyMode
+    ? declaredMode
+    : strategyMode;
   const timeoutBlock = isObjectRecord(policy.timeouts) ? policy.timeouts : {};
   const retryBlock = isObjectRecord(policy.retry) ? policy.retry : {};
-  const memberEntries = Array.isArray(policy.members) ? policy.members : [];
-  const extractedMembers = memberEntries
-    .map(memberReferenceFromEntry)
-    .filter((value): value is string => !!value);
-  const selectedMembers = extractedMembers.length > 0 ? extractedMembers : memberIds;
-
+  const hasExplicitMembers = Array.isArray(policy.members);
+  const memberEntries = hasExplicitMembers ? policy.members as unknown[] : [];
+  const entriesById = new Map<string, unknown>();
+  for (const entry of memberEntries) {
+    const deploymentId = memberReferenceFromEntry(entry);
+    if (deploymentId) entriesById.set(deploymentId, entry);
+  }
+  const enabledOptionIds = memberOptions
+    .filter((member) => member.enabled)
+    .map((member) => member.deployment_id);
+  const selectedMembers = hasExplicitMembers
+    ? memberEntries.flatMap((entry) => {
+        const deploymentId = memberReferenceFromEntry(entry);
+        if (!deploymentId || (isObjectRecord(entry) && entry.enabled === false)) return [];
+        return [deploymentId];
+      })
+    : enabledOptionIds;
+  const memberWeights = Object.fromEntries(memberOptions.map((member) => {
+    const policyWeight = memberWeight(entriesById.get(member.deployment_id));
+    return [member.deployment_id, policyWeight];
+  }));
   const retryable = Array.isArray(retryBlock.retryable_error_classes)
     ? retryBlock.retryable_error_classes.filter((value): value is string => typeof value === 'string')
     : [];
 
   return {
     strategy,
-    mode: guidedMode,
+    mode,
+    memberSelection: hasExplicitMembers ? 'explicit' : 'inherit',
     memberIds: selectedMembers,
-    timeoutMs: toPositiveIntegerString(timeoutBlock.global_ms),
-    retryMaxAttempts: toPositiveIntegerString(retryBlock.max_attempts),
+    memberWeights,
+    timeoutMs: timeoutMilliseconds(timeoutBlock),
+    retryMaxAttempts: toIntegerString(retryBlock.max_attempts, 0),
     retryableErrors: retryable.join(','),
   };
 }
 
-export function buildPolicyFromGuided(basePolicy: Record<string, unknown>, guided: PolicyGuidedValues): Record<string, unknown> {
-  const policy: Record<string, unknown> = { ...basePolicy };
-  policy.strategy = guided.strategy;
-  policy.mode = guided.mode;
-  if (guided.memberIds.length > 0) {
-    policy.members = guided.memberIds.map((memberId) => ({ deployment_id: memberId }));
+export function reconcileGuidedPolicyMembers(
+  guided: PolicyGuidedValues,
+  memberOptions: PolicyMemberOption[],
+): PolicyGuidedValues {
+  const optionsById = new Map(memberOptions.map((member) => [member.deployment_id, member]));
+  const memberIds = guided.memberSelection === 'inherit'
+    ? memberOptions.filter((member) => member.enabled).map((member) => member.deployment_id)
+    : guided.memberIds.filter((deploymentId) => optionsById.get(deploymentId)?.enabled);
+  const memberWeights = Object.fromEntries(memberOptions.map((member) => [
+    member.deployment_id,
+    guided.memberWeights[member.deployment_id] || '',
+  ]));
+  if (
+    memberIds.length === guided.memberIds.length
+    && memberIds.every((deploymentId, index) => deploymentId === guided.memberIds[index])
+    && Object.keys(memberWeights).length === Object.keys(guided.memberWeights).length
+    && Object.keys(memberWeights).every(
+      (deploymentId) => memberWeights[deploymentId] === guided.memberWeights[deploymentId],
+    )
+  ) {
+    return guided;
+  }
+  return { ...guided, memberIds, memberWeights };
+}
+
+export function withGuidedPolicyStrategy(
+  guided: PolicyGuidedValues,
+  strategy: string,
+): PolicyGuidedValues {
+  return { ...guided, strategy, mode: modeForStrategy(strategy) };
+}
+
+export function withGuidedPolicyMode(
+  guided: PolicyGuidedValues,
+  mode: GuidedPolicyMode,
+): PolicyGuidedValues {
+  return {
+    ...guided,
+    mode,
+    strategy: mode === 'weighted' ? 'weighted' : 'priority-based-routing',
+  };
+}
+
+export function validateGuidedPolicy(
+  guided: PolicyGuidedValues,
+  memberOptions: PolicyMemberOption[],
+): string | null {
+  const enabledIds = new Set(
+    memberOptions.filter((member) => member.enabled).map((member) => member.deployment_id),
+  );
+  if (guided.memberSelection === 'explicit') {
+    if (guided.memberIds.length === 0) return 'Select at least one enabled deployment.';
+    const unavailable = guided.memberIds.find((deploymentId) => !enabledIds.has(deploymentId));
+    if (unavailable) return `Deployment ${unavailable} is disabled or no longer available.`;
+  }
+  for (const deploymentId of guided.memberIds) {
+    const weight = guided.memberWeights[deploymentId]?.trim();
+    if (weight && parseIntegerString(weight, 1) === null) {
+      return `Weight for ${deploymentId} must be an integer greater than or equal to 1.`;
+    }
+  }
+  if (guided.timeoutMs.trim() && parseIntegerString(guided.timeoutMs, 1) === null) {
+    return 'Global timeout must be an integer greater than or equal to 1 ms.';
+  }
+  if (
+    guided.retryMaxAttempts.trim()
+    && parseIntegerString(guided.retryMaxAttempts, 0) === null
+  ) {
+    return 'Retry max attempts must be a non-negative integer.';
+  }
+  const retryClasses = guided.retryableErrors
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const invalidRetryClass = retryClasses.find(
+    (item) => !(RETRYABLE_ERROR_OPTIONS as readonly string[]).includes(item),
+  );
+  if (invalidRetryClass) return `Unsupported retryable error class: ${invalidRetryClass}.`;
+  return null;
+}
+
+export function buildPolicyFromGuided(
+  basePolicy: Record<string, unknown>,
+  guided: PolicyGuidedValues,
+): Record<string, unknown> {
+  const policy: Record<string, unknown> = { ...basePolicy, strategy: guided.strategy };
+  if (guided.mode) policy.mode = guided.mode;
+  else delete policy.mode;
+
+  if (guided.memberSelection === 'explicit') {
+    const baseMembers = Array.isArray(basePolicy.members) ? basePolicy.members : [];
+    const baseById = new Map<string, Record<string, unknown>>();
+    for (const entry of baseMembers) {
+      const deploymentId = memberReferenceFromEntry(entry);
+      if (deploymentId && isObjectRecord(entry)) baseById.set(deploymentId, entry);
+    }
+    policy.members = guided.memberIds.map((deploymentId, index) => {
+      const current = baseById.get(deploymentId) || {};
+      const member = Object.fromEntries(
+        Object.entries(current).filter(
+          ([key]) => !['deployment_id', 'enabled', 'weight', 'priority'].includes(key),
+        ),
+      );
+      member.deployment_id = deploymentId;
+      member.enabled = true;
+      const weight = parseIntegerString(guided.memberWeights[deploymentId] || '', 1);
+      if (weight !== null) member.weight = weight;
+      if (guided.mode === 'fallback') member.priority = index;
+      return member;
+    });
+  } else {
+    delete policy.members;
   }
 
-  const timeoutValue = parseInteger(guided.timeoutMs);
+  const timeoutValue = parseIntegerString(guided.timeoutMs, 1);
   const currentTimeouts = isObjectRecord(policy.timeouts) ? { ...policy.timeouts } : {};
-  if (timeoutValue) {
-    currentTimeouts.global_ms = timeoutValue;
-  } else {
-    delete currentTimeouts.global_ms;
-  }
-  if (Object.keys(currentTimeouts).length > 0) {
-    policy.timeouts = currentTimeouts;
-  } else {
-    delete policy.timeouts;
-  }
+  delete currentTimeouts.global_seconds;
+  if (timeoutValue !== null) currentTimeouts.global_ms = timeoutValue;
+  else delete currentTimeouts.global_ms;
+  if (Object.keys(currentTimeouts).length > 0) policy.timeouts = currentTimeouts;
+  else delete policy.timeouts;
 
-  const retryValue = parseInteger(guided.retryMaxAttempts);
+  const retryValue = parseIntegerString(guided.retryMaxAttempts, 0);
   const retryClasses = guided.retryableErrors
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
   const currentRetry = isObjectRecord(policy.retry) ? { ...policy.retry } : {};
-  if (retryValue) {
-    currentRetry.max_attempts = retryValue;
-  } else {
-    delete currentRetry.max_attempts;
-  }
-  if (retryClasses.length > 0) {
-    currentRetry.retryable_error_classes = retryClasses;
-  } else {
-    delete currentRetry.retryable_error_classes;
-  }
-  if (Object.keys(currentRetry).length > 0) {
-    policy.retry = currentRetry;
-  } else {
-    delete policy.retry;
-  }
+  if (retryValue !== null) currentRetry.max_attempts = retryValue;
+  else delete currentRetry.max_attempts;
+  if (retryClasses.length > 0) currentRetry.retryable_error_classes = retryClasses;
+  else delete currentRetry.retryable_error_classes;
+  if (Object.keys(currentRetry).length > 0) policy.retry = currentRetry;
+  else delete policy.retry;
 
   return policy;
 }

--- a/ui/src/lib/useRoutePolicySimulation.ts
+++ b/ui/src/lib/useRoutePolicySimulation.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  routeGroups,
+  type RoutePolicySimulationRequest,
+  type RoutePolicySimulationResponse,
+} from './api';
+
+interface SimulationIdentity {
+  groupKey: string;
+  fingerprint: string;
+}
+
+interface SimulationResult extends SimulationIdentity {
+  data: RoutePolicySimulationResponse;
+}
+
+function sameIdentity(
+  identity: SimulationIdentity | null,
+  groupKey: string,
+  fingerprint: string,
+): boolean {
+  return identity?.groupKey === groupKey && identity.fingerprint === fingerprint;
+}
+
+export function useRoutePolicySimulation(groupKey: string, fingerprint: string) {
+  const [result, setResult] = useState<SimulationResult | null>(null);
+  const [error, setError] = useState<unknown>(null);
+  const [pending, setPending] = useState<SimulationIdentity | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef(0);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      requestIdRef.current += 1;
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => () => {
+    requestIdRef.current += 1;
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+  }, [groupKey, fingerprint]);
+
+  const run = useCallback(async (request: RoutePolicySimulationRequest) => {
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    const requestId = ++requestIdRef.current;
+    const identity = { groupKey, fingerprint };
+    setPending(identity);
+    setError(null);
+
+    try {
+      const data = await routeGroups.simulatePolicy(groupKey, request, controller.signal);
+      if (
+        requestId !== requestIdRef.current
+        || !mountedRef.current
+        || controller.signal.aborted
+      ) return null;
+      setResult({ ...identity, data });
+      return data;
+    } catch (caught: unknown) {
+      if (
+        requestId === requestIdRef.current
+        && mountedRef.current
+        && !controller.signal.aborted
+      ) setError(caught);
+      return null;
+    } finally {
+      if (requestId === requestIdRef.current && mountedRef.current) setPending(null);
+      if (controllerRef.current === controller) controllerRef.current = null;
+    }
+  }, [fingerprint, groupKey]);
+
+  const reset = useCallback(() => {
+    requestIdRef.current += 1;
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+    setPending(null);
+    setResult(null);
+    setError(null);
+  }, []);
+
+  return {
+    data: result?.data ?? null,
+    error,
+    loading: sameIdentity(pending, groupKey, fingerprint),
+    stale: result !== null && !sameIdentity(result, groupKey, fingerprint),
+    run,
+    reset,
+  };
+}

--- a/ui/src/pages/RouteGroupDetail.tsx
+++ b/ui/src/pages/RouteGroupDetail.tsx
@@ -18,14 +18,18 @@ import {
 } from 'lucide-react';
 import ConfirmDialog from '../components/ConfirmDialog';
 import { useToast } from '../components/ToastProvider';
+import { useAuth } from '../lib/auth';
 import { models, promptRegistry, routeGroups, type PromptBinding } from '../lib/api';
+import { resolveUiAccess } from '../lib/authorization';
 import { useApi } from '../lib/hooks';
 import {
   buildPolicyFromGuided,
   GUIDED_POLICY_DEFAULTS,
   parsePolicyTextLoose,
+  reconcileGuidedPolicyMembers,
   routeGroupMutationOutcome,
   toGuidedPolicy,
+  validateGuidedPolicy,
   type PolicyAction,
   type PolicyGuidedValues,
 } from '../lib/routeGroups';
@@ -97,6 +101,7 @@ export default function RouteGroupDetail() {
   const { groupKey } = useParams<{ groupKey: string }>();
   const navigate = useNavigate();
   const { pushToast } = useToast();
+  const { authMode, session } = useAuth();
 
   const [activeTab, setActiveTab] = useState<TabId>('models');
   const [savingGroup, setSavingGroup] = useState(false);
@@ -148,6 +153,7 @@ export default function RouteGroupDetail() {
   const missingMembers = members.filter((m) => m.healthy == null).length;
   const memberIds = useMemo(() => members.map((m) => m.deployment_id), [members]);
   const isPolicyBusy = policyAction !== null;
+  const canSimulatePolicy = resolveUiAccess(authMode, session).route_groups;
   const publishedPolicy = useMemo(() => policies.find((p) => p.status === 'published') || null, [policies]);
   const draftPolicy = useMemo(() => policies.find((p) => p.status === 'draft') || null, [policies]);
   const winningPrompt = bindingPreview.data?.winner || null;
@@ -187,25 +193,16 @@ export default function RouteGroupDetail() {
         ? preferred.policy_json
         : {};
     setPolicyText(JSON.stringify(policyJson, null, 2));
-    setGuidedPolicy(toGuidedPolicy(policyJson, memberIds));
+    setGuidedPolicy(toGuidedPolicy(policyJson, members));
     const rollbackCandidates = policies
       .filter((p) => p.status === 'archived' || p.status === 'published')
       .sort((a, b) => b.version - a.version);
     setSelectedRollbackVersion(rollbackCandidates[0]?.version ?? null);
-  }, [draftPolicy, memberIds, policies]);
+  }, [draftPolicy, members, policies]);
 
   useEffect(() => {
-    if (memberIds.length === 0) {
-      setGuidedPolicy((cur) => (cur.memberIds.length === 0 ? cur : { ...cur, memberIds: [] }));
-      return;
-    }
-    setGuidedPolicy((cur) => {
-      const filtered = cur.memberIds.filter((id) => memberIds.includes(id));
-      const next = filtered.length > 0 ? filtered : memberIds;
-      if (next.length === cur.memberIds.length && next.every((id, i) => id === cur.memberIds[i])) return cur;
-      return { ...cur, memberIds: next };
-    });
-  }, [memberIds]);
+    setGuidedPolicy((current) => reconcileGuidedPolicyMembers(current, members));
+  }, [members]);
 
   const canRollbackVersions = useMemo(
     () => policies.filter((p) => p.status === 'archived' || p.status === 'published'),
@@ -222,6 +219,18 @@ export default function RouteGroupDetail() {
     const base = parsePolicyTextLoose(policyText) || {};
     return JSON.stringify(buildPolicyFromGuided(base, guidedPolicy), null, 2);
   }, [guidedPolicy, policyText]);
+
+  const simulationPolicy = useMemo(() => {
+    if (showAdvancedJson) return parsePolicyTextLoose(policyText);
+    if (validateGuidedPolicy(guidedPolicy, members)) return null;
+    return buildPolicyFromGuided(parsePolicyTextLoose(policyText) || {}, guidedPolicy);
+  }, [guidedPolicy, members, policyText, showAdvancedJson]);
+  const simulationPolicyError = useMemo(() => {
+    if (showAdvancedJson) {
+      return parsePolicyTextLoose(policyText) ? null : 'Enter valid policy JSON before simulating.';
+    }
+    return validateGuidedPolicy(guidedPolicy, members);
+  }, [guidedPolicy, members, policyText, showAdvancedJson]);
 
   const promptSummary = useMemo(() => {
     if (!winningPrompt || !winningPromptDetail.data) return null;
@@ -245,6 +254,11 @@ export default function RouteGroupDetail() {
   /* ── Handlers ── */
   const parsePolicy = (): Record<string, unknown> | null => {
     if (!showAdvancedJson) {
+      const guidedError = validateGuidedPolicy(guidedPolicy, members);
+      if (guidedError) {
+        setPolicyError(guidedError);
+        return null;
+      }
       const base = parsePolicyTextLoose(policyText) || {};
       const payload = buildPolicyFromGuided(base, guidedPolicy);
       setPolicyText(JSON.stringify(payload, null, 2));
@@ -376,7 +390,7 @@ export default function RouteGroupDetail() {
     try {
       const result = await routeGroups.validatePolicy(groupKey!, parsed);
       setPolicyText(JSON.stringify(result.policy, null, 2));
-      setGuidedPolicy(toGuidedPolicy(result.policy, memberIds));
+      setGuidedPolicy(toGuidedPolicy(result.policy, members));
       setPolicyMessage(result.warnings?.length ? `Valid with warnings: ${result.warnings.join(' ')}` : 'Policy is valid.');
       setPolicyError(null);
     } catch (error: unknown) {
@@ -610,6 +624,7 @@ export default function RouteGroupDetail() {
             />
           ) : activeTab === 'advanced' ? (
             <RouteGroupAdvancedTab
+              groupKey={group.group_key}
               bindings={bindings}
               templates={promptTemplates.data?.data || []}
               bindingForm={bindingForm}
@@ -620,8 +635,15 @@ export default function RouteGroupDetail() {
               onSaveBinding={handleSaveBinding}
               onDeleteBinding={handleDeleteBinding}
               guidedPolicy={guidedPolicy}
-              memberIds={memberIds}
+              members={members}
               guidedPreview={guidedPreview}
+              simulationPolicy={simulationPolicy}
+              simulationPolicyError={simulationPolicyError}
+              simulationPromptRef={promptSummary ? {
+                template_key: promptSummary.templateKey,
+                ...(promptSummary.label ? { label: promptSummary.label } : {}),
+              } : null}
+              canSimulate={canSimulatePolicy}
               policyText={policyText}
               policyMessage={policyMessage}
               policyError={policyError}

--- a/ui/tests/routeGroupPolicySimulationPanel.test.ts
+++ b/ui/tests/routeGroupPolicySimulationPanel.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement } from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import RouteGroupPolicySimulationPanel from '../src/components/route-groups/RouteGroupPolicySimulationPanel';
+
+interface PendingFetch {
+  resolve: (response: Response) => void;
+  reject: (error: Error) => void;
+}
+
+const MEMBERS = [{
+  membership_id: 'member-1',
+  route_group_id: 'group-1',
+  deployment_id: 'dep-a',
+  enabled: true,
+  weight: 1,
+  priority: 0,
+}];
+
+function simulationResponse(): Response {
+  return new Response(JSON.stringify({
+    group_key: 'support',
+    iterations: 100,
+    basis: 'live_state_dry_run',
+    warnings: [],
+    prompt: null,
+    effective_metadata: {},
+    summary: {
+      selected_requests: 100,
+      no_selection_requests: 0,
+      served_requests: 100,
+      failed_requests: 0,
+      fallback_requests: 10,
+      timed_out_requests: 0,
+      total_attempts: 110,
+    },
+    reason_counts: { weighted: 100 },
+    selections: [{ deployment_id: 'dep-a', count: 100, ratio: 1 }],
+    served_deployments: [{ deployment_id: 'dep-a', count: 100, ratio: 1 }],
+    terminal_outcomes: { success: 100 },
+    sample_decision: null,
+    sample_attempts: [{
+      iteration: 1,
+      attempt: 1,
+      deployment_id: 'dep-a',
+      outcome: 'success',
+      transition: 'primary',
+    }],
+  }), { headers: { 'content-type': 'application/json' } });
+}
+
+test('policy simulation panel covers permission, loading, results, stale, error, and responsive states', async () => {
+  const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousFetch = globalThis.fetch;
+  const previousActEnvironment = (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT;
+  Object.defineProperties(globalThis, {
+    window: { configurable: true, value: dom.window },
+    document: { configurable: true, value: dom.window.document },
+    IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+  });
+  const requests: PendingFetch[] = [];
+  globalThis.fetch = (async () => new Promise<Response>((resolve, reject) => {
+    requests.push({ resolve, reject });
+  })) as typeof fetch;
+  const rootNode = document.getElementById('root');
+  assert.ok(rootNode);
+  const root = createRoot(rootNode);
+  const renderPanel = (canSimulate: boolean, policy: Record<string, unknown>) => (
+    root.render(createElement(RouteGroupPolicySimulationPanel, {
+      groupKey: 'support',
+      policy,
+      policyError: null,
+      members: MEMBERS,
+      canSimulate,
+    }))
+  );
+
+  try {
+    await act(async () => renderPanel(false, { mode: 'weighted' }));
+    assert.match(document.body.textContent || '', /Simulation permission required/);
+
+    await act(async () => renderPanel(true, { mode: 'weighted' }));
+    assert.match(document.body.textContent || '', /No simulation results yet/);
+    const runButton = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Run simulation'),
+    );
+    assert.ok(runButton);
+    await act(async () => runButton.click());
+    assert.match(document.body.textContent || '', /Simulating/);
+
+    await act(async () => {
+      requests[0].resolve(simulationResponse());
+      await Promise.resolve();
+    });
+    assert.match(document.body.textContent || '', /Served by/);
+    assert.match(document.body.textContent || '', /Sample attempt trace/);
+    assert.match(document.body.innerHTML, /md:hidden/);
+    assert.match(document.body.innerHTML, /hidden overflow-x-auto md:block/);
+
+    await act(async () => renderPanel(true, { mode: 'weighted', strategy: 'weighted' }));
+    assert.match(document.body.textContent || '', /results are stale/);
+
+    const rerunButton = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Run again'),
+    );
+    assert.ok(rerunButton);
+    await act(async () => rerunButton.click());
+    await act(async () => {
+      requests[1].reject(new Error('simulation unavailable'));
+      await Promise.resolve();
+    });
+    assert.match(document.body.textContent || '', /simulation unavailable/);
+    assert.match(document.body.textContent || '', /Served by/);
+    await act(async () => root.unmount());
+  } finally {
+    globalThis.fetch = previousFetch;
+    dom.window.close();
+    Object.defineProperties(globalThis, {
+      window: { configurable: true, value: previousWindow },
+      document: { configurable: true, value: previousDocument },
+      IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: previousActEnvironment },
+    });
+  }
+});

--- a/ui/tests/routeGroupsApi.test.ts
+++ b/ui/tests/routeGroupsApi.test.ts
@@ -76,3 +76,59 @@ test('route-group policy mutations pass AbortSignal to the shared transport', as
     globalThis.fetch = originalFetch;
   }
 });
+
+test('route-group policy simulation sends the typed scenario and AbortSignal', async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedPath = '';
+  let capturedInit: RequestInit | undefined;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    capturedPath = String(input);
+    capturedInit = init;
+    return new Response(JSON.stringify({
+      group_key: 'support / eu',
+      iterations: 2,
+      basis: 'live_state_dry_run',
+      warnings: [],
+      prompt: null,
+      effective_metadata: { tags: ['vip'] },
+      summary: {
+        selected_requests: 2,
+        no_selection_requests: 0,
+        served_requests: 2,
+        failed_requests: 0,
+        fallback_requests: 2,
+        timed_out_requests: 0,
+        total_attempts: 4,
+      },
+      reason_counts: { priority: 2 },
+      selections: [{ deployment_id: 'dep-a', count: 2, ratio: 1 }],
+      served_deployments: [{ deployment_id: 'dep-b', count: 2, ratio: 1 }],
+      terminal_outcomes: { success: 2 },
+      sample_decision: null,
+      sample_attempts: [],
+    }), { headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+
+  try {
+    const controller = new AbortController();
+    const result = await routeGroups.simulatePolicy('support / eu', {
+      iterations: 2,
+      policy: { mode: 'fallback' },
+      metadata: { tags: ['vip'] },
+      outcomes: [{ deployment_id: 'dep-a', outcome: 'timeout' }],
+    }, controller.signal);
+
+    assert.equal(capturedPath, '/ui/api/route-groups/support%20%2F%20eu/policy/simulate');
+    assert.equal(capturedInit?.method, 'POST');
+    assert.equal(capturedInit?.signal, controller.signal);
+    assert.deepEqual(JSON.parse(String(capturedInit?.body)), {
+      iterations: 2,
+      policy: { mode: 'fallback' },
+      metadata: { tags: ['vip'] },
+      outcomes: [{ deployment_id: 'dep-a', outcome: 'timeout' }],
+    });
+    assert.equal(result.served_deployments[0].deployment_id, 'dep-b');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/ui/tests/routeGroupsPolicy.test.ts
+++ b/ui/tests/routeGroupsPolicy.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildPolicyFromGuided,
+  reconcileGuidedPolicyMembers,
+  toGuidedPolicy,
+  validateGuidedPolicy,
+  withGuidedPolicyMode,
+  withGuidedPolicyStrategy,
+  type PolicyMemberOption,
+} from '../src/lib/routeGroups';
+
+const MEMBERS: PolicyMemberOption[] = [
+  { deployment_id: 'dep-a', enabled: true, weight: 2, priority: 0 },
+  { deployment_id: 'dep-b', enabled: true, weight: 3, priority: 1 },
+  { deployment_id: 'dep-off', enabled: false, weight: 4, priority: 2 },
+];
+
+test('guided policy round-trips weights, fallback order, zero retries, and opaque fields', () => {
+  const base = {
+    mode: 'fallback',
+    members: [
+      { deployment_id: 'dep-b', weight: 7, priority: 0, server_hint: 'keep-me' },
+      { deployment_id: 'dep-a', weight: 5, priority: 1 },
+    ],
+    retry: { max_attempts: 0, server_retry_hint: true },
+    timeouts: { global_ms: 9000, provider_budget_ms: 8000 },
+    server_policy_hint: 'preserved',
+  };
+
+  const guided = toGuidedPolicy(base, MEMBERS);
+  assert.equal(guided.mode, 'fallback');
+  assert.equal(guided.strategy, 'priority-based-routing');
+  assert.equal(guided.memberSelection, 'explicit');
+  assert.deepEqual(guided.memberIds, ['dep-b', 'dep-a']);
+  assert.deepEqual(guided.memberWeights, { 'dep-a': '5', 'dep-b': '7', 'dep-off': '' });
+  assert.equal(guided.retryMaxAttempts, '0');
+
+  const rebuilt = buildPolicyFromGuided(base, {
+    ...guided,
+    memberWeights: { ...guided.memberWeights, 'dep-b': '11' },
+  });
+  assert.deepEqual(rebuilt.members, [
+    {
+      deployment_id: 'dep-b',
+      enabled: true,
+      weight: 11,
+      priority: 0,
+      server_hint: 'keep-me',
+    },
+    { deployment_id: 'dep-a', enabled: true, weight: 5, priority: 1 },
+  ]);
+  assert.deepEqual(rebuilt.retry, { max_attempts: 0, server_retry_hint: true });
+  assert.deepEqual(rebuilt.timeouts, { global_ms: 9000, provider_budget_ms: 8000 });
+  assert.equal(rebuilt.server_policy_hint, 'preserved');
+});
+
+test('explicit empty membership stays empty and is rejected locally', () => {
+  const guided = toGuidedPolicy({ mode: 'weighted', members: [] }, MEMBERS);
+  assert.equal(guided.memberSelection, 'explicit');
+  assert.deepEqual(guided.memberIds, []);
+
+  const reconciled = reconcileGuidedPolicyMembers(guided, MEMBERS);
+  assert.deepEqual(reconciled.memberIds, []);
+  assert.equal(
+    validateGuidedPolicy(reconciled, MEMBERS),
+    'Select at least one enabled deployment.',
+  );
+  assert.deepEqual(buildPolicyFromGuided({}, reconciled).members, []);
+});
+
+test('inherited membership follows enabled group members without serializing a subset', () => {
+  const guided = toGuidedPolicy({ strategy: 'least-busy' }, MEMBERS);
+  assert.equal(guided.memberSelection, 'inherit');
+  assert.deepEqual(guided.memberIds, ['dep-a', 'dep-b']);
+  assert.equal(guided.mode, null);
+
+  const changedMembers = [
+    { ...MEMBERS[0], enabled: false },
+    MEMBERS[1],
+    { deployment_id: 'dep-c', enabled: true, weight: 1, priority: 2 },
+  ];
+  const reconciled = reconcileGuidedPolicyMembers(guided, changedMembers);
+  assert.deepEqual(reconciled.memberIds, ['dep-b', 'dep-c']);
+  assert.equal('members' in buildPolicyFromGuided({}, reconciled), false);
+});
+
+test('guided mode and concrete strategy remain synchronized', () => {
+  const guided = toGuidedPolicy({}, MEMBERS);
+  const fallback = withGuidedPolicyMode(guided, 'fallback');
+  assert.equal(fallback.strategy, 'priority-based-routing');
+  assert.equal(fallback.mode, 'fallback');
+
+  const weighted = withGuidedPolicyStrategy(fallback, 'weighted');
+  assert.equal(weighted.mode, 'weighted');
+  const leastBusy = withGuidedPolicyStrategy(weighted, 'least-busy');
+  assert.equal(leastBusy.mode, null);
+
+  const conflicting = toGuidedPolicy({
+    mode: 'weighted',
+    strategy: 'priority-based-routing',
+  }, MEMBERS);
+  assert.equal(conflicting.mode, 'fallback');
+});
+
+test('guided validation matches backend integer and retry-class constraints', () => {
+  const guided = {
+    ...toGuidedPolicy({ members: [{ deployment_id: 'dep-a' }] }, MEMBERS),
+    memberWeights: { 'dep-a': '0' },
+  };
+  assert.match(validateGuidedPolicy(guided, MEMBERS) || '', /greater than or equal to 1/);
+  assert.match(
+    validateGuidedPolicy(
+      { ...guided, memberWeights: { 'dep-a': '1' }, retryableErrors: '5xx' },
+      MEMBERS,
+    ) || '',
+    /Unsupported retryable error class/,
+  );
+});
+
+test('guided timeout normalizes seconds to its single millisecond control', () => {
+  const guided = toGuidedPolicy({
+    timeouts: { global_seconds: 1.5, server_timeout_hint: true },
+  }, MEMBERS);
+  assert.equal(guided.timeoutMs, '1500');
+  assert.deepEqual(buildPolicyFromGuided({
+    timeouts: { global_seconds: 1.5, server_timeout_hint: true },
+  }, guided).timeouts, {
+    global_ms: 1500,
+    server_timeout_hint: true,
+  });
+});

--- a/ui/tests/useRoutePolicySimulation.test.ts
+++ b/ui/tests/useRoutePolicySimulation.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement } from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { useRoutePolicySimulation } from '../src/lib/useRoutePolicySimulation';
+
+interface PendingFetch {
+  signal: AbortSignal;
+  resolve: (response: Response) => void;
+}
+
+function response(iterations: number): Response {
+  return new Response(JSON.stringify({
+    group_key: 'support',
+    iterations,
+    basis: 'live_state_dry_run',
+    warnings: [],
+    prompt: null,
+    effective_metadata: {},
+    summary: {
+      selected_requests: iterations,
+      no_selection_requests: 0,
+      served_requests: iterations,
+      failed_requests: 0,
+      fallback_requests: 0,
+      timed_out_requests: 0,
+      total_attempts: iterations,
+    },
+    reason_counts: {},
+    selections: [],
+    served_deployments: [],
+    terminal_outcomes: { success: iterations },
+    sample_decision: null,
+    sample_attempts: [],
+  }), { headers: { 'content-type': 'application/json' } });
+}
+
+test('policy simulation aborts changed scenarios and rejects stale completion', async () => {
+  const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousFetch = globalThis.fetch;
+  const previousActEnvironment = (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT;
+  Object.defineProperties(globalThis, {
+    window: { configurable: true, value: dom.window },
+    document: { configurable: true, value: dom.window.document },
+    IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+  });
+  const requests: PendingFetch[] = [];
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => (
+    new Promise<Response>((resolve) => requests.push({
+      signal: init?.signal as AbortSignal,
+      resolve,
+    }))
+  )) as typeof fetch;
+
+  function Probe({ fingerprint, iterations }: { fingerprint: string; iterations: number }) {
+    const simulation = useRoutePolicySimulation('support', fingerprint);
+    return createElement('div', null,
+      createElement('button', {
+        id: 'run',
+        onClick: () => { void simulation.run({ iterations }); },
+      }, 'run'),
+      createElement('span', { id: 'value' }, simulation.data?.iterations ?? 'empty'),
+      createElement('span', { id: 'loading' }, String(simulation.loading)),
+      createElement('span', { id: 'stale' }, String(simulation.stale)),
+    );
+  }
+
+  const rootNode = document.getElementById('root');
+  assert.ok(rootNode);
+  const root = createRoot(rootNode);
+
+  try {
+    await act(async () => root.render(createElement(Probe, { fingerprint: 'old', iterations: 1 })));
+    await act(async () => document.getElementById('run')?.click());
+    assert.equal(document.getElementById('loading')?.textContent, 'true');
+    assert.equal(requests.length, 1);
+
+    await act(async () => root.render(createElement(Probe, { fingerprint: 'new', iterations: 2 })));
+    assert.equal(requests[0].signal.aborted, true);
+    assert.equal(document.getElementById('loading')?.textContent, 'false');
+    await act(async () => document.getElementById('run')?.click());
+    assert.equal(requests.length, 2);
+
+    await act(async () => {
+      requests[1].resolve(response(2));
+      await Promise.resolve();
+    });
+    assert.equal(document.getElementById('value')?.textContent, '2');
+
+    await act(async () => {
+      requests[0].resolve(response(1));
+      await Promise.resolve();
+    });
+    assert.equal(document.getElementById('value')?.textContent, '2');
+
+    await act(async () => root.render(createElement(Probe, { fingerprint: 'changed', iterations: 3 })));
+    assert.equal(document.getElementById('stale')?.textContent, 'true');
+    await act(async () => root.unmount());
+  } finally {
+    globalThis.fetch = previousFetch;
+    dom.window.close();
+    Object.defineProperties(globalThis, {
+      window: { configurable: true, value: previousWindow },
+      document: { configurable: true, value: previousDocument },
+      IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: previousActEnvironment },
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- serialize guided policy weights, authoritative membership subsets, supported modes, retry, and timeout values
- add a typed route-policy simulation API and race-safe UI workflow
- exercise production router and failover decisions against an isolated live-state snapshot
- report initial selection, served deployment, retries, fallback, terminal outcomes, and eligibility reasons
- make simulation policy payloads complete replacements, matching validate and publish semantics

## Engineering contract

- Source of truth: PostgreSQL route-group membership and policy documents, combined with one pinned routing runtime for routing state.
- Tenant and authorization scope: the existing admin `config.read` permission remains authoritative.
- Failure mode: invalid policy and scenario inputs return `400`; missing groups return `404`; unavailable runtime or snapshot state returns `503`.
- Retry boundary: simulation invokes the production retry and failover decision owner, skips provider calls and backoff waits, and keeps attempt effects local.
- Latency impact: control-plane only; no inference-path calls or new data-plane I/O.

## Verification

- `208 passed`: affected backend routing, failover, policy, runtime-generation, admin API, and simulation-state suites
- `146 passed`: full UI unit suite
- touched Python Ruff check and format check passed
- touched UI ESLint passed with zero findings
- production UI build passed; initial bundle output was 435.23 KB gzip
- full UI lint retains the existing unrelated baseline of 139 errors and 4 warnings; touched files are clean
- `git diff --check` passed

Tracks PR 6 in #275.