### PR TITLE
Brand MkDocs with shared Delta assets

### DIFF
--- a/docs/stylesheets/brand.css
+++ b/docs/stylesheets/brand.css
@@ -1,0 +1,25 @@
+:root > * {
+  --md-primary-fg-color: #5b50d6;
+  --md-primary-fg-color--light: #8b7cff;
+  --md-primary-fg-color--dark: #4e45b8;
+  --md-accent-fg-color: #5b50d6;
+  --md-accent-fg-color--transparent: rgb(91 80 214 / 0.1);
+}
+
+[data-md-color-scheme="default"] {
+  --md-typeset-a-color: #5b50d6;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-hue: 244;
+  --md-primary-fg-color: #090a16;
+  --md-primary-fg-color--light: #5b50d6;
+  --md-primary-fg-color--dark: #05060d;
+  --md-accent-fg-color: #8b7cff;
+  --md-accent-fg-color--transparent: rgb(139 124 255 / 0.12);
+  --md-typeset-a-color: #a99fff;
+}
+
+::selection {
+  background: rgb(139 124 255 / 0.22);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,16 +6,20 @@ repo_name: deltallm
 
 theme:
   name: material
+  # Reuse the UI's built-in assets so the product and docs have one brand source.
+  custom_dir: ui/public
+  logo: brand/deltallm-delta.svg
+  favicon: favicon.svg
   palette:
     - scheme: default
-      primary: blue
-      accent: blue
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: blue
-      accent: blue
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -44,6 +48,9 @@ markdown_extensions:
       permalink: true
   - attr_list
   - def_list
+
+extra_css:
+  - stylesheets/brand.css
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
- reuse the UI public directory as MkDocs' brand asset source
- apply the Delta mark and favicon to the Material theme
- add accessible light and dark Delta color tokens

## Verification
- MkDocs build completed successfully
- generated root and nested pages resolve the shared logo, favicon, and stylesheet
- generated brand assets match the UI sources byte-for-byte
- git diff --check passed

## Known baseline
- strict MkDocs mode still stops on 151 pre-existing links from internal planning documents; this change adds no branding-related warning