### PR TITLE
Normalize classified fallbacks across providers

### DIFF
--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -161,6 +161,41 @@ deltallm_settings:
         - claude-3-sonnet
 ```
 
+Provider adapters select the specialized context-window and content-policy maps from known error
+envelope fields for chat, embeddings, images, rerank, speech, and transcription. OpenAI-compatible
+and Azure OpenAI responses or stream events that end with `finish_reason: content_filter` are also
+content-policy failures. Raw exception text and malformed provider bodies never activate a
+specialized chain. Explicit custom providers use generic status mapping unless they are declared as
+one of the supported OpenAI-compatible providers; an omitted provider retains the existing implicit
+OpenAI-compatible behavior. HTTP status still owns the public error type and health impact. A
+recognized context or policy classification on a 5xx response remains health-affecting but may try
+its specialized chain first; an unclassified 5xx uses the general chain, and 429 remains a rate-limit
+failure regardless of envelope text. A malformed JSON or response schema behind a nominally
+successful provider status is a health-affecting provider failure and may use the general
+`fallbacks` map; its upstream payload is never returned to the client. This includes empty chat
+choices, missing or mismatched embedding and rerank results, and empty speech audio. Unknown or
+malformed 4xx responses stop with a sanitized gateway error. Anthropic Messages responses classify
+`refusal` as content policy and `model_context_window_exceeded` as context window before returning a
+nominal success. Gemini accepts only documented success terminal reasons; policy terminals use the
+content-policy chain and unsupported, malformed, or unknown terminal reasons fail closed through
+the general chain. For Bedrock streams, the documented exception type is authoritative: throttling
+and service exceptions cannot be reclassified by message text, while validation exceptions may use
+the bounded provider-specific context/content markers.
+
+No fallback starts after a streaming response frame has been sent. Provider role and metadata
+events are held in a bounded pre-commit buffer until output or a valid terminal event establishes a
+real response. This lets OpenAI-compatible, Azure OpenAI, Anthropic, and Bedrock classified terminal
+events select a specialized fallback when they arrive before output. Empty, terminal-only, and
+truncated pre-output streams are malformed successes and may use the general fallback chain. After
+partial output has committed a response, a classified stop terminates that stream with the compatible
+`content_filter` or `length` finish reason instead of starting another provider attempt. Any other
+malformed committed stream is aborted, marked unhealthy, and never cached as a complete response.
+
+Each replica serializes durable config loads, subscriber application, publication, and rollback.
+Runtime reloads publish all three immutable maps as one generation, and publication is fenced by
+the complete generation identity rather than only the route revision. A failed or superseded reload
+therefore cannot expose mixed fallback configuration or overwrite a newer authorization snapshot.
+
 ## Model Aliases
 
 Aliases let clients request a stable name while you map it to the real group:

--- a/docs/features/routing.md
+++ b/docs/features/routing.md
@@ -453,6 +453,45 @@ deltallm_settings:
 - `context_window_fallbacks`: used when the input is too large for the first model
 - `content_policy_fallbacks`: used when a provider rejects the content for policy reasons
 
+The provider adapter classifies context-window and content-policy failures from documented provider
+error fields before the error reaches the router. The same adapter classifiers are used by chat,
+embeddings, images, rerank, speech, and transcription. OpenAI-compatible and Azure OpenAI response
+envelopes and stream events with `finish_reason: content_filter` are treated as content-policy
+failures rather than successful empty responses. The router does not infer either condition from
+arbitrary exception text or an unstructured response body. Explicit custom providers use generic
+status mapping unless they are in the supported OpenAI-compatible provider set; the existing
+provider-omitted default remains OpenAI-compatible. HTTP status owns the public error type and
+deployment-health impact, while a trusted adapter classification owns specialized fallback
+selection. A recognized context or policy failure returned with a 5xx status therefore remains
+health-affecting and may try its specialized chain before the general chain. Unclassified 5xx
+responses use the general chain, and 429 remains rate-limit classified regardless of envelope text.
+Malformed JSON or response schemas behind a nominally successful provider status are also
+health-affecting general failures, and the upstream payload is never returned to the client. Empty
+chat choices, missing or mismatched embedding and rerank results, and empty speech audio are
+malformed successes. Unknown or malformed provider 4xx responses stop immediately and return a
+sanitized, stable gateway error. Anthropic `refusal` and `model_context_window_exceeded` success
+stop reasons select the content-policy and context-window chains respectively. Gemini policy
+terminal reasons select the content-policy chain; unsupported, malformed, and unknown terminal
+reasons fail closed through the general chain instead of becoming successful empty responses.
+Bedrock stream exception types retain their documented meaning even when their message contains a
+context or policy marker; only validation-like exceptions use those message allowlists.
+
+Streaming fallback is allowed only before the first downstream response frame. Provider role and
+metadata events are held in a bounded pre-commit buffer until output or a valid terminal event
+establishes a real response. OpenAI-compatible, Azure OpenAI, Anthropic, and Bedrock classified
+terminal events can therefore select a specialized fallback before output. Empty, terminal-only,
+and truncated pre-output streams are malformed successes and may use the general fallback chain.
+If a classified stop follows partial output, DeltaLLM completes that committed stream with
+`content_filter` or `length` instead of starting another provider attempt. Any other malformed
+committed stream is aborted, marked unhealthy, and never cached as a complete response.
+
+All three maps are immutable members of one routing-runtime generation. Each replica serializes the
+durable config load, subscriber application, generation publication, and rollback. Publication is
+fenced by the complete generation identity, so a slower reload cannot overwrite a newer grant or
+route snapshot even when both use the same route revision. A validation or subscriber failure leaves
+requests on the previous complete generation. A request that has already started remains pinned to
+the generation it acquired, including all of its fallback maps.
+
 ## Advanced Routing Controls
 
 Use these settings when routing needs a little more control:

--- a/src/audio/elevenlabs_stt.py
+++ b/src/audio/elevenlabs_stt.py
@@ -9,6 +9,7 @@ import httpx
 from fastapi import Request
 
 from src.audio.transcription_formats import render_srt, render_vtt
+from src.providers.base import parse_provider_json_response, validate_provider_success_payload
 from src.providers.resolution import resolve_upstream_model
 from src.router.router import Deployment
 from src.upstream_http import build_upstream_request_timeout_for_request
@@ -27,6 +28,22 @@ ELEVENLABS_STT_FORM_DEFAULT_KEYS = {
 ELEVENLABS_STT_QUERY_DEFAULT_KEYS = {"enable_logging"}
 
 
+def _is_valid_elevenlabs_stt_success_payload(data: Mapping[str, Any]) -> bool:
+    transcripts = data.get("transcripts")
+    if transcripts is not None:
+        return (
+            isinstance(transcripts, list)
+            and bool(transcripts)
+            and all(
+                isinstance(transcript, Mapping)
+                and "text" in transcript
+                and isinstance(transcript.get("text"), str)
+                for transcript in transcripts
+            )
+        )
+    return "text" in data and isinstance(data.get("text"), str)
+
+
 async def execute_elevenlabs_stt(
     *,
     request: Request,
@@ -43,7 +60,9 @@ async def execute_elevenlabs_stt(
     timeout_seconds: float,
 ) -> dict[str, Any]:
     defaults = _model_default_params(deployment.model_info)
-    upstream_model = resolve_upstream_model(deployment.deltallm_params, fallback_model=model) or model
+    upstream_model = (
+        resolve_upstream_model(deployment.deltallm_params, fallback_model=model) or model
+    )
     form_data = _build_elevenlabs_stt_form_data(
         model_id=upstream_model,
         language=language,
@@ -64,26 +83,18 @@ async def execute_elevenlabs_stt(
         timeout=build_upstream_request_timeout_for_request(request, timeout_seconds),
     )
     if response.status_code >= 400:
-        raise httpx.HTTPStatusError(
-            _format_elevenlabs_stt_error(response),
+        status_error = httpx.HTTPStatusError(
+            f"Upstream ElevenLabs STT call failed with status {response.status_code}",
             request=httpx.Request("POST", endpoint),
             response=response,
         )
+        raise request.app.state.provider_error_mapper_registry.map_error("elevenlabs", status_error)
 
-    try:
-        parsed_response = response.json()
-    except ValueError as exc:
-        error_request = httpx.Request("POST", endpoint)
-        error_response = httpx.Response(
-            502,
-            text="Upstream ElevenLabs STT call returned invalid JSON",
-            request=error_request,
-        )
-        raise httpx.HTTPStatusError(
-            "Upstream ElevenLabs STT call returned invalid JSON",
-            request=error_request,
-            response=error_response,
-        ) from exc
+    parsed_response = parse_provider_json_response(response)
+    validate_provider_success_payload(
+        parsed_response,
+        _is_valid_elevenlabs_stt_success_payload,
+    )
 
     data, billing_payload = _reshape_elevenlabs_transcription_response(
         requested_response_format=response_format,
@@ -211,7 +222,11 @@ def _normalize_elevenlabs_transcript_payload(response_payload: dict[str, Any]) -
         segments.extend(_elevenlabs_words_to_segments(words))
 
     if not text_parts and all_words:
-        text_parts.append(_join_elevenlabs_tokens(str(word.get("text") or word.get("word") or "") for word in all_words))
+        text_parts.append(
+            _join_elevenlabs_tokens(
+                str(word.get("text") or word.get("word") or "") for word in all_words
+            )
+        )
 
     normalized: dict[str, Any] = {"text": "\n".join(text_parts)}
     if language:
@@ -407,25 +422,6 @@ def _join_elevenlabs_tokens(tokens: Any) -> str:
         else:
             text = f"{text} {value}"
     return text
-
-
-def _format_elevenlabs_stt_error(response: httpx.Response) -> str:
-    upstream_msg = response.text
-    try:
-        upstream_body = response.json()
-    except Exception:
-        upstream_body = None
-
-    if isinstance(upstream_body, Mapping):
-        detail = upstream_body.get("detail")
-        if isinstance(detail, Mapping):
-            upstream_msg = str(detail.get("message") or detail.get("detail") or upstream_msg)
-        elif detail:
-            upstream_msg = str(detail)
-        else:
-            upstream_msg = str(upstream_body.get("message") or upstream_msg)
-
-    return f"Upstream ElevenLabs STT call failed with status {response.status_code}: {upstream_msg}"
 
 
 def _float_or_none(value: Any) -> float | None:

--- a/src/bootstrap/infrastructure.py
+++ b/src/bootstrap/infrastructure.py
@@ -39,6 +39,7 @@ from src.providers.bedrock import BedrockAdapter
 from src.providers.azure import AzureOpenAIAdapter
 from src.providers.gemini import GeminiAdapter
 from src.providers.openai import OpenAIAdapter
+from src.providers.registry import ProviderErrorMapperRegistry
 from src.services.route_groups import RouteGroupRuntimeCache
 from src.services.ui_branding_assets import UIBrandingAssetService
 from src.services.route_group_mutations import RouteGroupMutationService
@@ -138,6 +139,13 @@ async def init_infrastructure_runtime(app: Any) -> InfrastructureRuntime:
     app.state.anthropic_adapter = AnthropicAdapter(http_client)
     app.state.gemini_adapter = GeminiAdapter(http_client)
     app.state.bedrock_adapter = BedrockAdapter(http_client)
+    app.state.provider_error_mapper_registry = ProviderErrorMapperRegistry(
+        openai=app.state.openai_adapter,
+        azure_openai=app.state.azure_openai_adapter,
+        anthropic=app.state.anthropic_adapter,
+        gemini=app.state.gemini_adapter,
+        bedrock=app.state.bedrock_adapter,
+    )
 
     app.state.model_deployment_repository = ModelDeploymentRepository(prisma_manager.client)
     app.state.named_credential_repository = NamedCredentialRepository(prisma_manager.client)

--- a/src/chat/executor.py
+++ b/src/chat/executor.py
@@ -8,9 +8,11 @@ import asyncio
 import httpx
 from fastapi import Request
 
+from src.chat.stream_validation import validate_first_downstream_stream_frame
 from src.models.errors import ServiceUnavailableError
 from src.models.requests import ChatCompletionRequest
 from src.metrics import observe_request_phase
+from src.providers.base import read_streaming_provider_error_details
 from src.providers.registry import resolve_chat_upstream
 from src.providers.resolution import is_openai_family_provider, resolve_provider
 from src.providers.signing import apply_request_signing
@@ -135,8 +137,7 @@ async def execute_chat(
         )
         raise adapter.map_error(status_exc)
     response_transform_started = perf_counter()
-    data = response.json()
-    canonical = await adapter.translate_response(data, payload.model)
+    canonical = await adapter.translate_success_response(response, payload.model)
     canonical_payload = canonical.model_dump(mode="json")
     observe_request_phase(
         route="chat_completions",
@@ -236,18 +237,20 @@ async def open_stream_with_first_chunk(
         raise
     try:
         if response.status_code >= 400:
+            details = await read_streaming_provider_error_details(response)
             status_exc = httpx.HTTPStatusError(
                 f"Upstream chat call failed with status {response.status_code}",
                 request=httpx.Request("POST", request_url),
                 response=response,
             )
-            raise adapter.map_error(status_exc)
+            raise adapter.map_error(status_exc, details=details)
 
         raw_stream = response.aiter_bytes() if adapter.stream_uses_bytes else response.aiter_lines()
         translated_stream = adapter.translate_stream(raw_stream, model_name=payload.model)
         first_line: str | None = None
         async for line in translated_stream:
             if line:
+                validate_first_downstream_stream_frame(line)
                 first_line = line
                 break
         if first_line is None:

--- a/src/chat/stream_validation.py
+++ b/src/chat/stream_validation.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+from src.providers.base import invalid_provider_response_error
+
+_MAX_CANONICAL_FIRST_FRAME_CHARS = 1_048_576
+
+
+def validate_first_downstream_stream_frame(line: str) -> None:
+    """Require a bounded canonical response frame before failover is committed."""
+
+    if len(line) > _MAX_CANONICAL_FIRST_FRAME_CHARS or not line.startswith("data:"):
+        raise invalid_provider_response_error()
+    raw_payload = line[len("data:") :].strip()
+    if not raw_payload or raw_payload == "[DONE]":
+        raise invalid_provider_response_error()
+    try:
+        payload = json.loads(raw_payload)
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise invalid_provider_response_error() from exc
+    if not isinstance(payload, Mapping) or not isinstance(payload.get("choices"), list):
+        raise invalid_provider_response_error()

--- a/src/config_runtime/dynamic.py
+++ b/src/config_runtime/dynamic.py
@@ -88,6 +88,7 @@ class DynamicConfigManager:
         self._db_config: dict[str, Any] = {}
         self._config = build_app_config(self.file_config, {}, self.secret_resolver)
         self._subscribers: list[ConfigSubscriber] = []
+        self._final_subscriber: ConfigSubscriber | None = None
         self._pubsub_task: asyncio.Task[None] | None = None
         self._poll_task: asyncio.Task[None] | None = None
         self._stopping = False
@@ -127,6 +128,13 @@ class DynamicConfigManager:
 
     def subscribe(self, callback: ConfigSubscriber) -> None:
         self._subscribers.append(callback)
+
+    def subscribe_finalizer(self, callback: ConfigSubscriber) -> None:
+        """Register the sole subscriber that atomically publishes runtime state last."""
+
+        if self._final_subscriber is not None:
+            raise RuntimeError("dynamic config final subscriber is already registered")
+        self._final_subscriber = callback
 
     def get_config(self) -> dict[str, Any]:
         return self._config.model_dump(mode="python", exclude_none=True)
@@ -333,8 +341,15 @@ class DynamicConfigManager:
         return changed
 
     async def _reload_config(self, *, forced_modified_keys: tuple[str, ...] = ()) -> bool:
-        db_config = await self._load_from_db()
-        return await self._apply_db_config(db_config, forced_modified_keys=forced_modified_keys)
+        # Load only after entering the same transaction boundary as direct
+        # updates. Otherwise a poll can capture stale durable state, wait behind
+        # a newer update, and publish the stale candidate afterward.
+        async with self._update_lock:
+            db_config = await self._load_from_db()
+            return await self._apply_db_config(
+                db_config,
+                forced_modified_keys=forced_modified_keys,
+            )
 
     async def _apply_db_config(
         self,
@@ -365,7 +380,10 @@ class DynamicConfigManager:
                 new_app_config,
                 previous_app_config,
             )
-            for callback in list(self._subscribers):
+            callbacks = list(self._subscribers)
+            if self._final_subscriber is not None:
+                callbacks.append(self._final_subscriber)
+            for callback in callbacks:
                 try:
                     result = callback(previous_app_config, rollback_changes)
                     if asyncio.iscoroutine(result):
@@ -422,6 +440,10 @@ class DynamicConfigManager:
     ) -> None:
         for callback in list(self._subscribers):
             result = callback(app_config, changes)
+            if asyncio.iscoroutine(result):
+                await result
+        if self._final_subscriber is not None:
+            result = self._final_subscriber(app_config, changes)
             if asyncio.iscoroutine(result):
                 await result
 

--- a/src/config_runtime/models.py
+++ b/src/config_runtime/models.py
@@ -118,7 +118,7 @@ class ModelHotReloadManager:
             RoutingRuntimeGenerationStore,
         ):
             app.state.routing_runtime_generation_store = RoutingRuntimeGenerationStore()
-        self.dynamic_config.subscribe(self._on_config_change)
+        self.dynamic_config.subscribe_finalizer(self._on_config_change)
 
     def set_routing_authorization_reconciler(
         self,
@@ -263,21 +263,18 @@ class ModelHotReloadManager:
     async def _apply_runtime_config(self, app_config: AppConfig) -> None:
         app = self.app
         settings = app.state.settings
+        generation_store = app.state.routing_runtime_generation_store
 
         async with self._route_reload_lock:
+            publication_base = generation_store.snapshot()
+            publication_base_id = (
+                publication_base.generation_id if publication_base is not None else None
+            )
             await self._invalidate_route_group_cache()
             generation = await self._load_complete_routing_generation(
                 app_config=app_config,
                 settings=settings,
             )
-            current_registry = getattr(app.state.router, "deployment_registry", None)
-            current_deployments = (
-                current_registry.snapshot()
-                if isinstance(current_registry, DeploymentRegistryStore)
-                else current_registry or {}
-            )
-            self._publish_routing_generation(generation)
-        new_deployments = generation.deployment_registry.snapshot()
         salt_key = generation.salt_key
 
         if app_config.deltallm_settings.guardrails:
@@ -384,11 +381,67 @@ class ModelHotReloadManager:
             redis_client=getattr(app.state, "redis", None),
             salt_key=salt_key,
         )
+
+        async with self._route_reload_lock:
+            generation, current_deployments = await self._publish_stable_config_generation(
+                app_config=app_config,
+                settings=settings,
+                candidate=generation,
+                candidate_base_id=publication_base_id,
+            )
+        new_deployments = generation.deployment_registry.snapshot()
         await self._cleanup_replaced_deployment_health(
             current=current_deployments,
             replacement=new_deployments,
         )
-        app.state.app_config = app_config
+
+    async def _publish_stable_config_generation(
+        self,
+        *,
+        app_config: AppConfig,
+        settings: Any,
+        candidate: RoutingRuntimeGeneration,
+        candidate_base_id: str | None,
+    ) -> tuple[RoutingRuntimeGeneration, Mapping[str, Sequence[Any]]]:
+        """Publish only a candidate built from the still-current generation identity."""
+
+        generation_store = self.app.state.routing_runtime_generation_store
+        expected_generation_id = candidate_base_id
+        for attempt in range(_ROUTING_SNAPSHOT_BUILD_ATTEMPTS + 1):
+            current_generation = generation_store.snapshot()
+            current_generation_id = (
+                current_generation.generation_id if current_generation is not None else None
+            )
+            if (
+                current_generation_id == expected_generation_id
+                and candidate.revision >= self._applied_route_revision
+            ):
+                current_registry = (
+                    current_generation.deployment_registry
+                    if current_generation is not None
+                    else getattr(self.app.state.router, "deployment_registry", None)
+                )
+                current_deployments = (
+                    current_registry.snapshot()
+                    if isinstance(current_registry, DeploymentRegistryStore)
+                    else current_registry or {}
+                )
+                # No await is allowed between this identity check and publication.
+                self._publish_routing_generation(candidate)
+                return candidate, current_deployments
+            if attempt == _ROUTING_SNAPSHOT_BUILD_ATTEMPTS:
+                break
+            expected_generation_id = current_generation_id
+            await self._invalidate_route_group_cache()
+            candidate = await self._load_complete_routing_generation(
+                app_config=app_config,
+                settings=settings,
+            )
+
+        self._mark_reconciliation_required()
+        raise StaleRouteGroupSnapshotError(
+            "routing generation changed while config publication was being prepared"
+        )
 
     async def _build_routing_generation(
         self,
@@ -512,9 +565,8 @@ class ModelHotReloadManager:
         """Publish one validated generation without yielding to request tasks."""
 
         app = self.app
-        # Data-plane callers consume this store. The aliases below remain for
-        # control-plane compatibility and are never mixed by a pinned request.
-        app.state.routing_runtime_generation_store.replace(generation)
+        # Data-plane callers consume the store replaced at the end. Prepare the
+        # compatibility aliases first so a failed assignment cannot expose the candidate.
         grant_service = getattr(app.state, "callable_target_grant_service", None)
         if grant_service is not None:
             grant_service.replace_snapshot(generation.authorization_snapshot)
@@ -540,6 +592,7 @@ class ModelHotReloadManager:
             source=generation.source,
             requires_reconciliation=generation.requires_reconciliation,
         )
+        app.state.routing_runtime_generation_store.replace(generation)
 
     async def _cleanup_replaced_deployment_health(
         self,

--- a/src/models/errors.py
+++ b/src/models/errors.py
@@ -2,10 +2,21 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
+from enum import StrEnum
 from math import ceil
 
 
 NO_HEALTHY_DEPLOYMENTS_CODE = "no_healthy_deployments"
+
+
+class FailureClassification(StrEnum):
+    """Stable internal routing classification for a failed upstream attempt."""
+
+    CONTEXT_WINDOW = "context_window_exceeded"
+    CONTENT_POLICY = "content_policy_violation"
+    RATE_LIMIT = "rate_limit"
+    TIMEOUT = "timeout"
+    GENERIC = "generic"
 
 
 def parse_retry_after_header(value: str | None) -> int | None:
@@ -45,11 +56,13 @@ class ProxyError(Exception):
         code: str | None = None,
         *,
         affects_deployment_health: bool | None = None,
+        failure_classification: FailureClassification | None = None,
     ):
         self.message = message or self.message
         self.param = param
         self.code = code
         self.affects_deployment_health = affects_deployment_health
+        self.failure_classification = failure_classification
         super().__init__(self.message)
 
 
@@ -104,7 +117,9 @@ class ApprovalRequiredError(ProxyError):
     error_type = "approval_required"
     message = "Approval required"
 
-    def __init__(self, message: str | None = None, approval_request_id: str | None = None, **kwargs):
+    def __init__(
+        self, message: str | None = None, approval_request_id: str | None = None, **kwargs
+    ):
         super().__init__(message=message, **kwargs)
         self.approval_request_id = approval_request_id
 

--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, Self, TypeAlias
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ChatMessage(BaseModel):
@@ -121,6 +121,12 @@ class EmbeddingRequest(BaseModel):
     dimensions: int | None = Field(default=None, ge=1)
     user: str | None = None
 
+    @model_validator(mode="after")
+    def validate_input_is_not_empty(self) -> Self:
+        if isinstance(self.input, list) and not self.input:
+            raise ValueError("embedding input must not be empty")
+        return self
+
 
 class ImageGenerationRequest(BaseModel):
     model: str
@@ -153,5 +159,11 @@ class RerankRequest(BaseModel):
     model: str
     query: str
     documents: list[str] | list[dict[str, Any]]
-    top_n: int | None = None
+    top_n: int | None = Field(default=None, ge=1)
     return_documents: bool | None = True
+
+    @model_validator(mode="after")
+    def validate_documents_are_not_empty(self) -> Self:
+        if not self.documents:
+            raise ValueError("rerank documents must not be empty")
+        return self

--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -2,21 +2,126 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Mapping
 from typing import Any, AsyncIterator
 
 import httpx
 
-from src.models.errors import InvalidRequestError
+from src.models.errors import FailureClassification, InvalidRequestError, ProxyError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.base import (
+    ProviderAdapter,
+    ProviderErrorDetails,
+    classify_provider_failure,
+    is_valid_provider_token_count,
+    map_standard_provider_error,
+    map_standard_provider_status_error,
+    invalid_provider_response_error,
+    provider_error_details,
+    provider_error_details_from_payload,
+    validate_provider_success_payload,
+)
 from src.providers.healthcheck import is_provider_healthy
 from src.providers.resolution import resolve_upstream_model
+
+_CONTEXT_IDENTIFIERS = frozenset(
+    {
+        "context_length_exceeded",
+        "context_window_exceeded",
+        "model_context_window_exceeded",
+    }
+)
+_CONTENT_IDENTIFIERS = frozenset(
+    {
+        "content_filter",
+        "content_policy_violation",
+        "refusal",
+        "safety",
+    }
+)
+# Anthropic documents context overflow as invalid_request_error with this message,
+# so the adapter owns this narrow fallback when no more specific code is present.
+_CONTEXT_MESSAGE_MARKERS = ("prompt is too long",)
+_CONTENT_MESSAGE_MARKERS = (
+    "blocked by content filtering policy",
+    "violates our usage policies",
+)
+_STREAM_ERROR_STATUS_BY_TYPE = {
+    "invalid_request_error": 400,
+    "authentication_error": 401,
+    "permission_error": 403,
+    "not_found_error": 404,
+    "request_too_large": 413,
+    "rate_limit_error": 429,
+    "api_error": 500,
+    "overloaded_error": 529,
+}
+
+
+def _classify_anthropic_failure(
+    details: ProviderErrorDetails,
+) -> FailureClassification | None:
+    return classify_provider_failure(
+        details,
+        context_identifiers=_CONTEXT_IDENTIFIERS,
+        content_identifiers=_CONTENT_IDENTIFIERS,
+        context_message_markers=_CONTEXT_MESSAGE_MARKERS,
+        content_message_markers=_CONTENT_MESSAGE_MARKERS,
+    )
+
+
+def _map_anthropic_stream_error(event: object) -> ProxyError:
+    details = provider_error_details_from_payload(event, status_code=None)
+    error = event.get("error") if isinstance(event, dict) else None
+    error_type = str(error.get("type") or "") if isinstance(error, dict) else ""
+    return map_standard_provider_status_error(
+        _STREAM_ERROR_STATUS_BY_TYPE.get(error_type.strip().lower(), 500),
+        failure_classification=_classify_anthropic_failure(details),
+    )
+
+
+def _is_valid_anthropic_success_payload(data: Mapping[str, Any]) -> bool:
+    content = data.get("content")
+    stop_reason = data.get("stop_reason")
+    usage = data.get("usage")
+    return (
+        isinstance(content, list)
+        and all(isinstance(block, Mapping) for block in content)
+        and isinstance(stop_reason, str)
+        and bool(stop_reason.strip())
+        and isinstance(usage, Mapping)
+        and is_valid_provider_token_count(usage.get("input_tokens"))
+        and is_valid_provider_token_count(usage.get("output_tokens"))
+    )
+
+
+def _anthropic_stop_failure(stop_reason: object) -> ProxyError | None:
+    if not isinstance(stop_reason, str) or not stop_reason:
+        return None
+    normalized = stop_reason.rsplit("#", 1)[-1].strip().lower()
+    classification = _classify_anthropic_failure(
+        ProviderErrorDetails(status_code=400, identifiers=frozenset({normalized}))
+    )
+    if classification is None:
+        return None
+    return map_standard_provider_status_error(
+        400,
+        failure_classification=classification,
+    )
+
+
+def _stream_index(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise invalid_provider_response_error()
+    return value
 
 
 def _flatten_text_content(content: Any) -> str:
     if isinstance(content, list):
-        return "\n".join(str(part.get("text", "")) if isinstance(part, dict) else str(part) for part in content)
+        return "\n".join(
+            str(part.get("text", "")) if isinstance(part, dict) else str(part) for part in content
+        )
     return str(content or "")
 
 
@@ -67,7 +172,9 @@ class AnthropicAdapter(ProviderAdapter):
     def __init__(self, http_client: httpx.AsyncClient) -> None:
         self.http_client = http_client
 
-    async def translate_request(self, canonical_request: ChatCompletionRequest, provider_config: dict[str, Any]) -> dict[str, Any]:
+    async def translate_request(
+        self, canonical_request: ChatCompletionRequest, provider_config: dict[str, Any]
+    ) -> dict[str, Any]:
         system_messages: list[str] = []
         anthropic_messages: list[dict[str, Any]] = []
 
@@ -90,7 +197,13 @@ class AnthropicAdapter(ProviderAdapter):
             if message.role == "tool":
                 append_blocks(
                     "user",
-                    [{"type": "tool_result", "tool_use_id": message.tool_call_id or "", "content": text}],
+                    [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": message.tool_call_id or "",
+                            "content": text,
+                        }
+                    ],
                 )
                 continue
             role = message.role if message.role in {"user", "assistant"} else "user"
@@ -98,7 +211,10 @@ class AnthropicAdapter(ProviderAdapter):
             if text:
                 blocks.append({"type": "text", "text": text})
             if role == "assistant":
-                blocks.extend(_tool_call_to_tool_use_block(tool_call) for tool_call in message.tool_calls or [])
+                blocks.extend(
+                    _tool_call_to_tool_use_block(tool_call)
+                    for tool_call in message.tool_calls or []
+                )
             append_blocks(role, blocks)
 
         upstream_model = resolve_upstream_model(provider_config)
@@ -106,7 +222,8 @@ class AnthropicAdapter(ProviderAdapter):
         payload: dict[str, Any] = {
             "model": upstream_model or canonical_request.model,
             "messages": anthropic_messages or [{"role": "user", "content": ""}],
-            "max_tokens": canonical_request.max_tokens or int(provider_config.get("max_tokens") or 1024),
+            "max_tokens": canonical_request.max_tokens
+            or int(provider_config.get("max_tokens") or 1024),
         }
         if system_messages:
             payload["system"] = "\n\n".join(system_messages)
@@ -116,18 +233,34 @@ class AnthropicAdapter(ProviderAdapter):
         if "top_p" in fields_set and canonical_request.top_p is not None:
             payload["top_p"] = canonical_request.top_p
         if canonical_request.stop:
-            payload["stop_sequences"] = canonical_request.stop if isinstance(canonical_request.stop, list) else [canonical_request.stop]
+            payload["stop_sequences"] = (
+                canonical_request.stop
+                if isinstance(canonical_request.stop, list)
+                else [canonical_request.stop]
+            )
         if canonical_request.stream:
             payload["stream"] = True
         if canonical_request.tools:
-            payload["tools"] = [_function_tool_to_anthropic_tool(tool) for tool in canonical_request.tools]
+            payload["tools"] = [
+                _function_tool_to_anthropic_tool(tool) for tool in canonical_request.tools
+            ]
             tool_choice = _chat_tool_choice_to_anthropic(canonical_request.tool_choice)
             if tool_choice is not None:
                 payload["tool_choice"] = tool_choice
         return payload
 
-    async def translate_response(self, provider_response: Any, model_name: str) -> ChatCompletionResponse:
-        data = provider_response if isinstance(provider_response, dict) else json.loads(provider_response)
+    async def translate_response(
+        self, provider_response: Any, model_name: str
+    ) -> ChatCompletionResponse:
+        data = (
+            provider_response
+            if isinstance(provider_response, dict)
+            else json.loads(provider_response)
+        )
+        validate_provider_success_payload(data, _is_valid_anthropic_success_payload)
+        stop_reason = data["stop_reason"]
+        if failure := _anthropic_stop_failure(stop_reason):
+            raise failure
         content_blocks = data.get("content") or []
         text_parts: list[str] = []
         tool_calls: list[dict[str, Any]] = []
@@ -156,8 +289,7 @@ class AnthropicAdapter(ProviderAdapter):
             "max_tokens": "length",
             "tool_use": "tool_calls",
         }
-        stop_reason = str(data.get("stop_reason") or "end_turn")
-        finish_reason = finish_reason_map.get(stop_reason, "stop")
+        finish_reason = finish_reason_map.get(str(stop_reason), "stop")
         message: dict[str, Any] = {"role": "assistant", "content": "".join(text_parts)}
         if tool_calls:
             message["tool_calls"] = tool_calls
@@ -192,8 +324,20 @@ class AnthropicAdapter(ProviderAdapter):
         created = int(time.time())
         sent_role = False
         finish_reason: str | None = None
+        saw_message_start = False
+        saw_terminal_delta = False
         # Maps Anthropic content-block indexes to OpenAI tool_calls indexes.
         tool_call_indexes: dict[int, int] = {}
+
+        def role_chunk() -> str:
+            out = {
+                "id": stream_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+            }
+            return f"data: {json.dumps(out, separators=(',', ':'))}"
 
         async for line in provider_stream:
             if not line:
@@ -207,35 +351,42 @@ class AnthropicAdapter(ProviderAdapter):
             if not payload:
                 continue
             if payload == "[DONE]":
-                yield "data: [DONE]"
-                return
+                raise invalid_provider_response_error()
 
             try:
                 event = json.loads(payload)
-            except json.JSONDecodeError:
-                continue
+            except (RecursionError, TypeError, ValueError) as exc:
+                raise invalid_provider_response_error() from exc
+            if not isinstance(event, dict):
+                raise invalid_provider_response_error()
 
             event_type = str(event.get("type") or "")
+            if event_type == "error":
+                raise _map_anthropic_stream_error(event)
+            if event_type == "ping":
+                continue
             if event_type == "message_start":
-                message = event.get("message") or {}
+                if saw_message_start:
+                    raise invalid_provider_response_error()
+                message = event.get("message")
+                if not isinstance(message, Mapping):
+                    raise invalid_provider_response_error()
+                saw_message_start = True
                 stream_id = str(message.get("id") or stream_id)
                 model = str(message.get("model") or model)
-                if not sent_role:
-                    out = {
-                        "id": stream_id,
-                        "object": "chat.completion.chunk",
-                        "created": created,
-                        "model": model,
-                        "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
-                    }
-                    yield f"data: {json.dumps(out, separators=(',', ':'))}"
-                    sent_role = True
                 continue
 
             if event_type == "content_block_start":
-                content_block = event.get("content_block") or {}
+                if not saw_message_start:
+                    raise invalid_provider_response_error()
+                content_block = event.get("content_block")
+                if not isinstance(content_block, Mapping):
+                    raise invalid_provider_response_error()
                 if content_block.get("type") == "tool_use":
-                    block_index = int(event.get("index") or 0)
+                    if not sent_role:
+                        yield role_chunk()
+                        sent_role = True
+                    block_index = _stream_index(event.get("index"))
                     tool_index = len(tool_call_indexes)
                     tool_call_indexes[block_index] = tool_index
                     out = {
@@ -252,7 +403,10 @@ class AnthropicAdapter(ProviderAdapter):
                                             "index": tool_index,
                                             "id": str(content_block.get("id") or ""),
                                             "type": "function",
-                                            "function": {"name": str(content_block.get("name") or ""), "arguments": ""},
+                                            "function": {
+                                                "name": str(content_block.get("name") or ""),
+                                                "arguments": "",
+                                            },
                                         }
                                     ]
                                 },
@@ -264,21 +418,33 @@ class AnthropicAdapter(ProviderAdapter):
                 continue
 
             if event_type == "content_block_delta":
-                delta = event.get("delta") or {}
+                if not saw_message_start:
+                    raise invalid_provider_response_error()
+                delta = event.get("delta")
+                if not isinstance(delta, Mapping):
+                    raise invalid_provider_response_error()
                 text = delta.get("text")
                 if isinstance(text, str) and text:
+                    if not sent_role:
+                        yield role_chunk()
+                        sent_role = True
                     out = {
                         "id": stream_id,
                         "object": "chat.completion.chunk",
                         "created": created,
                         "model": model,
-                        "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+                        "choices": [
+                            {"index": 0, "delta": {"content": text}, "finish_reason": None}
+                        ],
                     }
                     yield f"data: {json.dumps(out, separators=(',', ':'))}"
                 partial_json = delta.get("partial_json")
                 if isinstance(partial_json, str) and partial_json:
-                    tool_index = tool_call_indexes.get(int(event.get("index") or 0))
+                    tool_index = tool_call_indexes.get(_stream_index(event.get("index")))
                     if tool_index is not None:
+                        if not sent_role:
+                            yield role_chunk()
+                            sent_role = True
                         out = {
                             "id": stream_id,
                             "object": "chat.completion.chunk",
@@ -287,7 +453,14 @@ class AnthropicAdapter(ProviderAdapter):
                             "choices": [
                                 {
                                     "index": 0,
-                                    "delta": {"tool_calls": [{"index": tool_index, "function": {"arguments": partial_json}}]},
+                                    "delta": {
+                                        "tool_calls": [
+                                            {
+                                                "index": tool_index,
+                                                "function": {"arguments": partial_json},
+                                            }
+                                        ]
+                                    },
                                     "finish_reason": None,
                                 }
                             ],
@@ -296,37 +469,66 @@ class AnthropicAdapter(ProviderAdapter):
                 continue
 
             if event_type == "message_delta":
-                delta = event.get("delta") or {}
+                if not saw_message_start:
+                    raise invalid_provider_response_error()
+                delta = event.get("delta")
+                if not isinstance(delta, Mapping):
+                    raise invalid_provider_response_error()
                 stop_reason = str(delta.get("stop_reason") or "")
+                if not stop_reason:
+                    continue
+                saw_terminal_delta = True
                 finish_map = {
                     "end_turn": "stop",
                     "stop_sequence": "stop",
                     "max_tokens": "length",
                     "tool_use": "tool_calls",
                 }
-                finish_reason = finish_map.get(stop_reason)
+                if failure := _anthropic_stop_failure(stop_reason):
+                    if not sent_role:
+                        raise failure
+                    finish_reason = (
+                        "content_filter"
+                        if failure.failure_classification is FailureClassification.CONTENT_POLICY
+                        else "length"
+                    )
+                else:
+                    finish_reason = finish_map.get(stop_reason)
                 continue
 
             if event_type == "message_stop":
+                if not saw_message_start or not saw_terminal_delta:
+                    raise invalid_provider_response_error()
+                if not sent_role:
+                    yield role_chunk()
+                    sent_role = True
                 out = {
                     "id": stream_id,
                     "object": "chat.completion.chunk",
                     "created": created,
                     "model": model,
-                    "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason or "stop"}],
+                    "choices": [
+                        {"index": 0, "delta": {}, "finish_reason": finish_reason or "stop"}
+                    ],
                 }
                 yield f"data: {json.dumps(out, separators=(',', ':'))}"
                 yield "data: [DONE]"
                 return
 
-        yield "data: [DONE]"
+        raise invalid_provider_response_error()
 
-    def map_error(self, provider_error: Exception) -> Exception:
-        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
+    def map_error(
+        self,
+        provider_error: Exception,
+        *,
+        details: ProviderErrorDetails | None = None,
+    ) -> ProxyError:
+        classification = _classify_anthropic_failure(
+            details or provider_error_details(provider_error)
+        )
         return map_standard_provider_error(
             provider_error,
-            invalid_request_message=f"Provider rejected request: {status}",
-            rate_limit_message=f"Provider rate limited request: {status}",
+            failure_classification=classification,
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:

--- a/src/providers/azure.py
+++ b/src/providers/azure.py
@@ -5,11 +5,44 @@ from typing import Any, AsyncIterator
 
 import httpx
 
+from src.models.errors import FailureClassification, ProxyError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.base import (
+    ProviderAdapter,
+    ProviderErrorDetails,
+    classify_provider_failure,
+    map_standard_provider_error,
+    provider_error_details,
+    reject_openai_compatible_failure_response,
+)
 from src.providers.healthcheck import is_provider_healthy
-from src.providers.resolution import normalize_openai_chat_payload, resolve_provider, resolve_upstream_model
+from src.providers.openai_compatible import (
+    translate_openai_compatible_stream,
+    validate_openai_compatible_chat_success,
+)
+from src.providers.resolution import (
+    normalize_openai_chat_payload,
+    resolve_provider,
+    resolve_upstream_model,
+)
+
+_CONTEXT_IDENTIFIERS = frozenset(
+    {
+        "context_length_exceeded",
+        "context_window_exceeded",
+        "input_too_long",
+    }
+)
+_CONTENT_IDENTIFIERS = frozenset(
+    {
+        "content_filter",
+        "content_policy_violation",
+        "responsibleaipolicyviolation",
+    }
+)
+_CONTEXT_MESSAGE_MARKERS = ("maximum context length", "too many tokens")
+_CONTENT_MESSAGE_MARKERS = ("content management policy", "responsible ai policy")
 
 
 class AzureOpenAIAdapter(ProviderAdapter):
@@ -18,7 +51,9 @@ class AzureOpenAIAdapter(ProviderAdapter):
     def __init__(self, http_client: httpx.AsyncClient) -> None:
         self.http_client = http_client
 
-    async def translate_request(self, canonical_request: ChatCompletionRequest, provider_config: dict[str, Any]) -> dict[str, Any]:
+    async def translate_request(
+        self, canonical_request: ChatCompletionRequest, provider_config: dict[str, Any]
+    ) -> dict[str, Any]:
         payload = canonical_request.model_dump(exclude_none=True)
         if payload.get("tool_choice") is not None and not payload.get("tools"):
             payload.pop("tool_choice", None)
@@ -26,11 +61,23 @@ class AzureOpenAIAdapter(ProviderAdapter):
         upstream_model = resolve_upstream_model(provider_config)
         if upstream_model:
             payload["model"] = upstream_model
-        normalize_openai_chat_payload(payload, provider=provider, upstream_model=upstream_model or str(payload.get("model") or ""))
+        normalize_openai_chat_payload(
+            payload,
+            provider=provider,
+            upstream_model=upstream_model or str(payload.get("model") or ""),
+        )
         return payload
 
-    async def translate_response(self, provider_response: Any, model_name: str) -> ChatCompletionResponse:
-        data = provider_response if isinstance(provider_response, dict) else json.loads(provider_response)
+    async def translate_response(
+        self, provider_response: Any, model_name: str
+    ) -> ChatCompletionResponse:
+        data = (
+            provider_response
+            if isinstance(provider_response, dict)
+            else json.loads(provider_response)
+        )
+        reject_openai_compatible_failure_response(data)
+        validate_openai_compatible_chat_success(data)
         if "model" not in data:
             data["model"] = model_name
         return ChatCompletionResponse.model_validate(data)
@@ -41,15 +88,32 @@ class AzureOpenAIAdapter(ProviderAdapter):
         *,
         model_name: str | None = None,
     ) -> AsyncIterator[str]:
-        async for chunk in provider_stream:
+        async for chunk in translate_openai_compatible_stream(
+            provider_stream,
+            classify_failure=self._classify_failure,
+        ):
             yield chunk
 
-    def map_error(self, provider_error: Exception) -> Exception:
-        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
+    @staticmethod
+    def _classify_failure(details: ProviderErrorDetails) -> FailureClassification | None:
+        return classify_provider_failure(
+            details,
+            context_identifiers=_CONTEXT_IDENTIFIERS,
+            content_identifiers=_CONTENT_IDENTIFIERS,
+            context_message_markers=_CONTEXT_MESSAGE_MARKERS,
+            content_message_markers=_CONTENT_MESSAGE_MARKERS,
+        )
+
+    def map_error(
+        self,
+        provider_error: Exception,
+        *,
+        details: ProviderErrorDetails | None = None,
+    ) -> ProxyError:
+        classification = self._classify_failure(details or provider_error_details(provider_error))
         return map_standard_provider_error(
             provider_error,
-            invalid_request_message=f"Provider rejected request: {status}",
-            rate_limit_message=f"Provider rate limited request: {status}",
+            failure_classification=classification,
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
+import json
+import math
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
 from typing import Any, AsyncIterator
 
 import httpx
 
 from src.models.errors import (
+    FailureClassification,
     GatewayCapacityError,
     InvalidRequestError,
+    ProxyError,
     RateLimitError,
     ServiceUnavailableError,
     TimeoutError,
@@ -16,65 +22,289 @@ from src.models.errors import (
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 
+_MAX_CLASSIFICATION_MESSAGE_CHARS = 2048
+_PROVIDER_ERROR_READ_CHUNK_BYTES = 8192
+MAX_PROVIDER_ERROR_BODY_BYTES = 65_536
+INVALID_PROVIDER_RESPONSE_MESSAGE = "Provider returned an invalid response"
 
-def provider_http_error_message(provider_error: httpx.HTTPStatusError, *, fallback: str) -> str:
-    response = provider_error.response
+ProviderSuccessValidator = Callable[[Mapping[str, Any]], bool]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderErrorDetails:
+    """Bounded provider metadata used for classification before sanitization."""
+
+    status_code: int | None
+    identifiers: frozenset[str]
+    message: str | None = field(default=None, repr=False)
+
+
+def _mapping(value: object) -> Mapping[str, object] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _normalized_identifier(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.rsplit("#", 1)[-1].strip().lower()
+    if not normalized:
+        return None
+    return normalized.replace("-", "_").replace(" ", "_")
+
+
+def _bounded_message(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    message = value.strip()
+    return message[:_MAX_CLASSIFICATION_MESSAGE_CHARS] if message else None
+
+
+def provider_error_details_from_payload(
+    payload: object,
+    *,
+    status_code: int | None,
+) -> ProviderErrorDetails:
+    """Extract bounded classification fields from a provider-owned JSON value."""
+
+    payload = _mapping(payload)
+    if payload is None:
+        return ProviderErrorDetails(status_code=status_code, identifiers=frozenset())
+
+    nested_error = _mapping(payload.get("error"))
+    error_container = nested_error or payload
+    inner_error = _mapping(error_container.get("innererror"))
+    underscored_inner_error = _mapping(error_container.get("inner_error"))
+    containers = tuple(
+        container
+        for container in (payload, nested_error, inner_error, underscored_inner_error)
+        if container is not None
+    )
+    identifiers = {
+        normalized
+        for container in containers
+        for key in ("code", "type", "status", "reason", "__type")
+        if (normalized := _normalized_identifier(container.get(key))) is not None
+    }
+
+    details = (nested_error or payload).get("details")
+    if isinstance(details, list):
+        for item in details[:16]:
+            detail = _mapping(item)
+            if detail is None:
+                continue
+            reason = _normalized_identifier(detail.get("reason"))
+            if reason is not None:
+                identifiers.add(reason)
+
+    message = next(
+        (
+            bounded
+            for container in containers
+            for key in ("message", "Message")
+            if (bounded := _bounded_message(container.get(key))) is not None
+        ),
+        None,
+    )
+    return ProviderErrorDetails(
+        status_code=status_code,
+        identifiers=frozenset(identifiers),
+        message=message,
+    )
+
+
+def provider_error_details(provider_error: Exception) -> ProviderErrorDetails:
+    """Read known envelope fields without retaining or returning the upstream body."""
+
+    response = getattr(provider_error, "response", None)
+    status_code = getattr(response, "status_code", None)
+    try:
+        payload = response.json() if response is not None else None
+    except (AttributeError, httpx.ResponseNotRead, RecursionError, TypeError, ValueError):
+        payload = None
+    return provider_error_details_from_payload(payload, status_code=status_code)
+
+
+async def read_streaming_provider_error_details(
+    response: httpx.Response,
+    *,
+    max_body_bytes: int = MAX_PROVIDER_ERROR_BODY_BYTES,
+) -> ProviderErrorDetails:
+    """Consume a failed streaming response up to a fixed decoded-body limit."""
+
+    status_code = response.status_code
+    if max_body_bytes <= 0:
+        return ProviderErrorDetails(status_code=status_code, identifiers=frozenset())
+    body = bytearray()
+    try:
+        async for chunk in response.aiter_bytes(
+            chunk_size=min(_PROVIDER_ERROR_READ_CHUNK_BYTES, max_body_bytes + 1)
+        ):
+            if len(body) + len(chunk) > max_body_bytes:
+                return ProviderErrorDetails(status_code=status_code, identifiers=frozenset())
+            body.extend(chunk)
+    except httpx.HTTPError:
+        return ProviderErrorDetails(status_code=status_code, identifiers=frozenset())
+
+    try:
+        payload = json.loads(body) if body else None
+    except (RecursionError, TypeError, ValueError):
+        payload = None
+    return provider_error_details_from_payload(payload, status_code=status_code)
+
+
+def classify_provider_failure(
+    details: ProviderErrorDetails,
+    *,
+    context_identifiers: frozenset[str] = frozenset(),
+    content_identifiers: frozenset[str] = frozenset(),
+    context_message_markers: tuple[str, ...] = (),
+    content_message_markers: tuple[str, ...] = (),
+) -> FailureClassification | None:
+    """Apply adapter-owned allowlists to structured provider error details."""
+
+    if details.identifiers & context_identifiers:
+        return FailureClassification.CONTEXT_WINDOW
+    if details.identifiers & content_identifiers:
+        return FailureClassification.CONTENT_POLICY
+
+    message = (details.message or "").lower()
+    if message and any(marker in message for marker in context_message_markers):
+        return FailureClassification.CONTEXT_WINDOW
+    if message and any(marker in message for marker in content_message_markers):
+        return FailureClassification.CONTENT_POLICY
+    return None
+
+
+def reject_openai_compatible_failure_response(payload: object) -> None:
+    """Reject documented success envelopes that represent content filtering."""
+
+    response = _mapping(payload)
+    if response is None:
+        return
+    choices = response.get("choices")
+    if not isinstance(choices, list):
+        return
+    for choice_value in choices:
+        choice = _mapping(choice_value)
+        if choice is None:
+            continue
+        finish_reason = choice.get("finish_reason")
+        if isinstance(finish_reason, str) and finish_reason.strip().lower() == "content_filter":
+            raise InvalidRequestError(
+                message="Provider rejected request",
+                affects_deployment_health=False,
+                failure_classification=FailureClassification.CONTENT_POLICY,
+            )
+
+
+def invalid_provider_response_error() -> ServiceUnavailableError:
+    """Return the one sanitized error for malformed nominal-success payloads."""
+
+    return ServiceUnavailableError(
+        message=INVALID_PROVIDER_RESPONSE_MESSAGE,
+        affects_deployment_health=True,
+        failure_classification=FailureClassification.GENERIC,
+    )
+
+
+def parse_provider_json_response(response: httpx.Response) -> dict[str, Any]:
+    """Parse a provider success response without exposing provider-owned content."""
+
     try:
         payload = response.json()
-    except (AttributeError, ValueError):
-        payload = None
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise invalid_provider_response_error() from exc
+    if not isinstance(payload, Mapping):
+        raise invalid_provider_response_error()
+    return dict(payload)
 
-    if isinstance(payload, dict):
-        error = payload.get("error")
-        if isinstance(error, dict):
-            message = str(error.get("message") or "").strip()
-            if message:
-                return message
-        for key in ("message", "Message"):
-            message = str(payload.get(key) or "").strip()
-            if message:
-                return message
 
-    body = str(getattr(response, "text", "") or "").strip()
-    if body:
-        return body
-    return fallback
+def validate_provider_success_payload(
+    payload: Mapping[str, Any],
+    validator: ProviderSuccessValidator,
+) -> None:
+    """Apply a bounded schema guard without exposing provider-owned values."""
+
+    try:
+        valid = validator(payload)
+    except ProxyError:
+        raise
+    except Exception as exc:
+        raise invalid_provider_response_error() from exc
+    if not valid:
+        raise invalid_provider_response_error()
+
+
+def is_valid_provider_token_count(value: object) -> bool:
+    """Return whether a provider token count is an exact non-negative integer."""
+
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def is_valid_provider_number(value: object) -> bool:
+    """Return whether a provider numeric value is finite and not boolean."""
+
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
 
 
 def map_standard_provider_error(
     provider_error: Exception,
     *,
-    invalid_request_message: str,
-    unavailable_message: str | None = None,
-    rate_limit_message: str | None = None,
-) -> Exception:
+    failure_classification: FailureClassification | None = None,
+) -> ProxyError:
     if isinstance(provider_error, httpx.PoolTimeout):
         return GatewayCapacityError()
 
     if isinstance(provider_error, httpx.TimeoutException):
-        return TimeoutError(affects_deployment_health=True)
+        return TimeoutError(
+            affects_deployment_health=True,
+            failure_classification=FailureClassification.TIMEOUT,
+        )
 
     if isinstance(provider_error, httpx.HTTPStatusError):
-        status = provider_error.response.status_code
-        if status == 429:
-            return RateLimitError(
-                message=rate_limit_message or invalid_request_message,
-                retry_after=parse_retry_after_header(provider_error.response.headers.get("retry-after")),
-                affects_deployment_health=True,
-            )
-        if status >= 500:
-            return ServiceUnavailableError(
-                message=f"Provider error: {status}",
-                affects_deployment_health=True,
-            )
-        return InvalidRequestError(
-            message=invalid_request_message,
-            affects_deployment_health=False,
+        return map_standard_provider_status_error(
+            provider_error.response.status_code,
+            retry_after_header=provider_error.response.headers.get("retry-after"),
+            failure_classification=failure_classification,
         )
 
     return ServiceUnavailableError(
-        message=unavailable_message or str(provider_error),
+        message="Provider unavailable",
         affects_deployment_health=True,
+        failure_classification=failure_classification or FailureClassification.GENERIC,
+    )
+
+
+def map_standard_provider_status_error(
+    status_code: int,
+    *,
+    retry_after_header: str | None = None,
+    failure_classification: FailureClassification | None = None,
+) -> ProxyError:
+    """Build one stable gateway error from sanitized provider status metadata."""
+
+    if status_code == 429:
+        return RateLimitError(
+            message="Provider rate limited request",
+            retry_after=parse_retry_after_header(retry_after_header),
+            affects_deployment_health=True,
+            failure_classification=FailureClassification.RATE_LIMIT,
+        )
+    if status_code >= 500:
+        return ServiceUnavailableError(
+            message="Provider unavailable",
+            affects_deployment_health=True,
+            failure_classification=(failure_classification or FailureClassification.GENERIC),
+        )
+    resolved_classification = failure_classification or FailureClassification.GENERIC
+    return InvalidRequestError(
+        message="Provider rejected request",
+        affects_deployment_health=False,
+        failure_classification=resolved_classification,
     )
 
 
@@ -95,8 +325,25 @@ class ProviderAdapter(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def translate_response(self, provider_response: Any, model_name: str) -> ChatCompletionResponse:
+    async def translate_response(
+        self, provider_response: Any, model_name: str
+    ) -> ChatCompletionResponse:
         raise NotImplementedError
+
+    async def translate_success_response(
+        self,
+        response: httpx.Response,
+        model_name: str,
+    ) -> ChatCompletionResponse:
+        """Parse and translate a nominal-success response at the provider boundary."""
+
+        payload = parse_provider_json_response(response)
+        try:
+            return await self.translate_response(payload, model_name)
+        except ProxyError:
+            raise
+        except Exception as exc:
+            raise invalid_provider_response_error() from exc
 
     @abstractmethod
     async def translate_stream(
@@ -108,7 +355,12 @@ class ProviderAdapter(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def map_error(self, provider_error: Exception) -> Exception:
+    def map_error(
+        self,
+        provider_error: Exception,
+        *,
+        details: ProviderErrorDetails | None = None,
+    ) -> ProxyError:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/providers/bedrock.py
+++ b/src/providers/bedrock.py
@@ -2,16 +2,51 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Mapping
 from typing import Any, AsyncIterator
 
 import httpx
 from botocore.eventstream import EventStreamBuffer
 
-from src.models.errors import InvalidRequestError, RateLimitError, ServiceUnavailableError
+from src.models.errors import (
+    FailureClassification,
+    InvalidRequestError,
+    ProxyError,
+    RateLimitError,
+    ServiceUnavailableError,
+)
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter, map_standard_provider_error, provider_http_error_message
+from src.providers.base import (
+    ProviderAdapter,
+    ProviderErrorDetails,
+    classify_provider_failure,
+    invalid_provider_response_error,
+    is_valid_provider_token_count,
+    map_standard_provider_error,
+    map_standard_provider_status_error,
+    provider_error_details,
+    validate_provider_success_payload,
+)
 from src.providers.healthcheck import is_provider_healthy
+
+_CONTEXT_IDENTIFIERS = frozenset(
+    {
+        "context_length_exceeded",
+        "context_window_exceeded",
+        "model_context_window_exceeded",
+    }
+)
+_CONTENT_IDENTIFIERS = frozenset(
+    {
+        "content_filtered",
+        "contentpolicyviolationexception",
+        "guardrail_intervened",
+        "guardrailintervenedexception",
+    }
+)
+_CONTEXT_MESSAGE_MARKERS = ("input is too long", "maximum context length")
+_CONTENT_MESSAGE_MARKERS = ("guardrail intervened", "violates content policy")
 
 _STOP_REASON_MAP = {
     "end_turn": "stop",
@@ -22,10 +57,20 @@ _STOP_REASON_MAP = {
     "content_filtered": "content_filter",
 }
 
+_BEDROCK_STREAM_STATUS_BY_EXCEPTION = {
+    "validationexception": 400,
+    "throttlingexception": 429,
+    "modelstreamerrorexception": 424,
+    "internalserverexception": 500,
+    "serviceunavailableexception": 503,
+}
+
 
 def _flatten_text_content(content: Any) -> str:
     if isinstance(content, list):
-        return "\n".join(str(part.get("text", "")) if isinstance(part, dict) else str(part) for part in content)
+        return "\n".join(
+            str(part.get("text", "")) if isinstance(part, dict) else str(part) for part in content
+        )
     return str(content or "")
 
 
@@ -69,13 +114,93 @@ def _chat_tool_choice_to_bedrock(tool_choice: Any) -> dict[str, Any] | None:
     return None
 
 
-def _map_stream_error(exception_type: str, message: str) -> Exception:
-    normalized = exception_type.lower()
-    if "throttling" in normalized:
-        return RateLimitError(message=message, affects_deployment_health=True)
-    if "validation" in normalized:
-        return InvalidRequestError(message=message, affects_deployment_health=False)
-    return ServiceUnavailableError(message=message, affects_deployment_health=True)
+def _map_stream_error(exception_type: str, message: str) -> ProxyError:
+    normalized = exception_type.rsplit("#", 1)[-1].strip().lower()
+    status_code = _BEDROCK_STREAM_STATUS_BY_EXCEPTION.get(normalized, 500)
+    if status_code == 429:
+        return RateLimitError(
+            message="Provider rate limited request",
+            affects_deployment_health=True,
+            failure_classification=FailureClassification.RATE_LIMIT,
+        )
+    if status_code == 400:
+        classification = _classify_bedrock_failure(
+            ProviderErrorDetails(
+                status_code=status_code,
+                identifiers=frozenset({normalized}),
+                message=message,
+            )
+        )
+        return InvalidRequestError(
+            message="Provider rejected request",
+            affects_deployment_health=False,
+            failure_classification=classification or FailureClassification.GENERIC,
+        )
+    return ServiceUnavailableError(
+        message="Provider unavailable",
+        affects_deployment_health=True,
+        failure_classification=FailureClassification.GENERIC,
+    )
+
+
+def _classify_bedrock_failure(
+    details: ProviderErrorDetails,
+) -> FailureClassification | None:
+    return classify_provider_failure(
+        details,
+        context_identifiers=_CONTEXT_IDENTIFIERS,
+        content_identifiers=_CONTENT_IDENTIFIERS,
+        context_message_markers=_CONTEXT_MESSAGE_MARKERS,
+        content_message_markers=_CONTENT_MESSAGE_MARKERS,
+    )
+
+
+def _bedrock_stop_failure(stop_reason: object) -> ProxyError | None:
+    if not isinstance(stop_reason, str) or not stop_reason:
+        return None
+    normalized = stop_reason.rsplit("#", 1)[-1].strip().lower()
+    classification = _classify_bedrock_failure(
+        ProviderErrorDetails(
+            status_code=400,
+            identifiers=frozenset({normalized}),
+        )
+    )
+    if classification is None:
+        return None
+    return map_standard_provider_status_error(
+        400,
+        failure_classification=classification,
+    )
+
+
+def _is_valid_bedrock_success_payload(data: Mapping[str, Any]) -> bool:
+    output = data.get("output")
+    message = output.get("message") if isinstance(output, Mapping) else None
+    content = message.get("content") if isinstance(message, Mapping) else None
+    usage = data.get("usage")
+    stop_reason = data.get("stopReason")
+    return (
+        isinstance(content, list)
+        and all(isinstance(block, Mapping) for block in content)
+        and isinstance(stop_reason, str)
+        and bool(stop_reason.strip())
+        and isinstance(usage, Mapping)
+        and is_valid_provider_token_count(usage.get("inputTokens"))
+        and is_valid_provider_token_count(usage.get("outputTokens"))
+        and is_valid_provider_token_count(usage.get("totalTokens"))
+    )
+
+
+def _stream_index(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise invalid_provider_response_error()
+    return value
+
+
+def _classified_stream_finish_reason(failure: ProxyError) -> str:
+    if failure.failure_classification is FailureClassification.CONTENT_POLICY:
+        return "content_filter"
+    return "length"
 
 
 class BedrockAdapter(ProviderAdapter):
@@ -112,7 +237,14 @@ class BedrockAdapter(ProviderAdapter):
             if message.role == "tool":
                 append_blocks(
                     "user",
-                    [{"toolResult": {"toolUseId": message.tool_call_id or "", "content": [{"text": text}]}}],
+                    [
+                        {
+                            "toolResult": {
+                                "toolUseId": message.tool_call_id or "",
+                                "content": [{"text": text}],
+                            }
+                        }
+                    ],
                 )
                 continue
             role = "assistant" if message.role == "assistant" else "user"
@@ -120,16 +252,23 @@ class BedrockAdapter(ProviderAdapter):
             if text:
                 blocks.append({"text": text})
             if role == "assistant":
-                blocks.extend(_tool_call_to_tool_use_block(tool_call) for tool_call in message.tool_calls or [])
+                blocks.extend(
+                    _tool_call_to_tool_use_block(tool_call)
+                    for tool_call in message.tool_calls or []
+                )
             if not blocks and role == "user":
                 blocks.append({"text": text})
             append_blocks(role, blocks)
 
-        payload: dict[str, Any] = {"messages": messages or [{"role": "user", "content": [{"text": ""}]}]}
+        payload: dict[str, Any] = {
+            "messages": messages or [{"role": "user", "content": [{"text": ""}]}]
+        }
         if system_blocks:
             payload["system"] = system_blocks
         if canonical_request.tools and canonical_request.tool_choice != "none":
-            tool_config: dict[str, Any] = {"tools": [_function_tool_to_tool_spec(tool) for tool in canonical_request.tools]}
+            tool_config: dict[str, Any] = {
+                "tools": [_function_tool_to_tool_spec(tool) for tool in canonical_request.tools]
+            }
             tool_choice = _chat_tool_choice_to_bedrock(canonical_request.tool_choice)
             if tool_choice is not None:
                 tool_config["toolChoice"] = tool_choice
@@ -144,14 +283,25 @@ class BedrockAdapter(ProviderAdapter):
         if "top_p" in fields_set and canonical_request.top_p is not None:
             inference_config["topP"] = canonical_request.top_p
         if canonical_request.stop:
-            inference_config["stopSequences"] = canonical_request.stop if isinstance(canonical_request.stop, list) else [canonical_request.stop]
+            inference_config["stopSequences"] = (
+                canonical_request.stop
+                if isinstance(canonical_request.stop, list)
+                else [canonical_request.stop]
+            )
         if inference_config:
             payload["inferenceConfig"] = inference_config
 
         return payload
 
-    async def translate_response(self, provider_response: Any, model_name: str) -> ChatCompletionResponse:
-        data = provider_response if isinstance(provider_response, dict) else json.loads(provider_response)
+    async def translate_response(
+        self, provider_response: Any, model_name: str
+    ) -> ChatCompletionResponse:
+        data = (
+            provider_response
+            if isinstance(provider_response, dict)
+            else json.loads(provider_response)
+        )
+        validate_provider_success_payload(data, _is_valid_bedrock_success_payload)
         output = data.get("output") or {}
         message = output.get("message") or {}
         contents = message.get("content") or []
@@ -171,7 +321,10 @@ class BedrockAdapter(ProviderAdapter):
                     }
                 )
 
-        finish_reason = _STOP_REASON_MAP.get(str(data.get("stopReason") or "end_turn"), "stop")
+        stop_reason = data.get("stopReason") or "end_turn"
+        if failure := _bedrock_stop_failure(stop_reason):
+            raise failure
+        finish_reason = _STOP_REASON_MAP.get(str(stop_reason), "stop")
         response_message: dict[str, Any] = {"role": "assistant", "content": text}
         if tool_calls:
             response_message["tool_calls"] = tool_calls
@@ -215,6 +368,9 @@ class BedrockAdapter(ProviderAdapter):
         finish_reason = "stop"
         usage: dict[str, int] = {}
         tool_call_indexes: dict[int, int] = {}
+        saw_message_start = False
+        saw_message_stop = False
+        emitted_output = False
 
         def _chunk(delta: dict[str, Any], *, stop: str | None = None) -> str:
             body: dict[str, Any] = {
@@ -237,25 +393,41 @@ class BedrockAdapter(ProviderAdapter):
                 event_type = message.headers.get(":event-type")
                 try:
                     event = json.loads(message.payload) if message.payload else {}
-                except json.JSONDecodeError:
-                    continue
+                except (RecursionError, TypeError, ValueError) as exc:
+                    raise invalid_provider_response_error() from exc
+                if not isinstance(event, Mapping):
+                    raise invalid_provider_response_error()
 
                 if message.headers.get(":message-type") in ("exception", "error"):
                     exception_type = str(message.headers.get(":exception-type") or event_type or "")
                     raise _map_stream_error(
                         exception_type,
-                        str(event.get("message") or f"Bedrock stream error: {exception_type or 'unknown'}"),
+                        str(
+                            event.get("message")
+                            or f"Bedrock stream error: {exception_type or 'unknown'}"
+                        ),
                     )
 
                 if event_type == "messageStart":
-                    if not sent_role:
-                        yield _chunk({"role": "assistant", "content": ""})
-                        sent_role = True
+                    if saw_message_start or saw_message_stop:
+                        raise invalid_provider_response_error()
+                    saw_message_start = True
                 elif event_type == "contentBlockStart":
-                    tool_use = (event.get("start") or {}).get("toolUse")
+                    if not saw_message_start or saw_message_stop:
+                        raise invalid_provider_response_error()
+                    start = event.get("start")
+                    if not isinstance(start, Mapping):
+                        raise invalid_provider_response_error()
+                    tool_use = start.get("toolUse")
                     if isinstance(tool_use, dict):
-                        block_index = int(event.get("contentBlockIndex") or 0)
-                        tool_index = tool_call_indexes.setdefault(block_index, len(tool_call_indexes))
+                        if not sent_role:
+                            yield _chunk({"role": "assistant", "content": ""})
+                            sent_role = True
+                        emitted_output = True
+                        block_index = _stream_index(event.get("contentBlockIndex"))
+                        tool_index = tool_call_indexes.setdefault(
+                            block_index, len(tool_call_indexes)
+                        )
                         yield _chunk(
                             {
                                 "tool_calls": [
@@ -263,33 +435,75 @@ class BedrockAdapter(ProviderAdapter):
                                         "index": tool_index,
                                         "id": tool_use.get("toolUseId") or "",
                                         "type": "function",
-                                        "function": {"name": tool_use.get("name") or "", "arguments": ""},
+                                        "function": {
+                                            "name": tool_use.get("name") or "",
+                                            "arguments": "",
+                                        },
                                     }
                                 ]
                             }
                         )
                 elif event_type == "contentBlockDelta":
-                    delta = event.get("delta") or {}
+                    if not saw_message_start or saw_message_stop:
+                        raise invalid_provider_response_error()
+                    delta = event.get("delta")
+                    if not isinstance(delta, Mapping):
+                        raise invalid_provider_response_error()
                     text = delta.get("text")
                     if isinstance(text, str) and text:
+                        if not sent_role:
+                            yield _chunk({"role": "assistant", "content": ""})
+                            sent_role = True
+                        emitted_output = True
                         yield _chunk({"content": text})
                     tool_use_delta = delta.get("toolUse")
                     if isinstance(tool_use_delta, dict):
                         partial = tool_use_delta.get("input")
                         if isinstance(partial, str) and partial:
-                            block_index = int(event.get("contentBlockIndex") or 0)
+                            block_index = _stream_index(event.get("contentBlockIndex"))
                             tool_index = tool_call_indexes.get(block_index)
                             if tool_index is not None:
-                                yield _chunk({"tool_calls": [{"index": tool_index, "function": {"arguments": partial}}]})
+                                yield _chunk(
+                                    {
+                                        "tool_calls": [
+                                            {
+                                                "index": tool_index,
+                                                "function": {"arguments": partial},
+                                            }
+                                        ]
+                                    }
+                                )
                 elif event_type == "messageStop":
-                    finish_reason = _STOP_REASON_MAP.get(str(event.get("stopReason") or "end_turn"), "stop")
+                    if not saw_message_start or saw_message_stop:
+                        raise invalid_provider_response_error()
+                    stop_reason = event.get("stopReason") or "end_turn"
+                    if failure := _bedrock_stop_failure(stop_reason):
+                        if not emitted_output:
+                            raise failure
+                        finish_reason = _classified_stream_finish_reason(failure)
+                    else:
+                        finish_reason = _STOP_REASON_MAP.get(str(stop_reason), "stop")
+                    saw_message_stop = True
                 elif event_type == "metadata":
-                    usage_data = event.get("usage") or {}
+                    if not saw_message_start or not saw_message_stop:
+                        raise invalid_provider_response_error()
+                    usage_data = event.get("usage")
+                    if not isinstance(usage_data, Mapping) or not all(
+                        is_valid_provider_token_count(usage_data.get(key))
+                        for key in ("inputTokens", "outputTokens", "totalTokens")
+                    ):
+                        raise invalid_provider_response_error()
                     usage = {
-                        "prompt_tokens": int(usage_data.get("inputTokens") or 0),
-                        "completion_tokens": int(usage_data.get("outputTokens") or 0),
-                        "total_tokens": int(usage_data.get("totalTokens") or 0),
+                        "prompt_tokens": int(usage_data["inputTokens"]),
+                        "completion_tokens": int(usage_data["outputTokens"]),
+                        "total_tokens": int(usage_data["totalTokens"]),
                     }
+
+        if not saw_message_start or not saw_message_stop:
+            raise invalid_provider_response_error()
+        if not sent_role:
+            yield _chunk({"role": "assistant", "content": ""})
+            sent_role = True
 
         final: dict[str, Any] = {
             "id": stream_id,
@@ -303,17 +517,18 @@ class BedrockAdapter(ProviderAdapter):
         yield f"data: {json.dumps(final, separators=(',', ':'))}"
         yield "data: [DONE]"
 
-    def map_error(self, provider_error: Exception) -> Exception:
-        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
-        invalid_request_message = (
-            provider_http_error_message(provider_error, fallback=f"Provider rejected request: {status}")
-            if isinstance(provider_error, httpx.HTTPStatusError)
-            else f"Provider rejected request: {status}"
+    def map_error(
+        self,
+        provider_error: Exception,
+        *,
+        details: ProviderErrorDetails | None = None,
+    ) -> ProxyError:
+        classification = _classify_bedrock_failure(
+            details or provider_error_details(provider_error)
         )
         return map_standard_provider_error(
             provider_error,
-            invalid_request_message=invalid_request_message,
-            rate_limit_message=invalid_request_message if status == 429 else f"Provider rate limited request: {status}",
+            failure_classification=classification,
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:

--- a/src/providers/gemini.py
+++ b/src/providers/gemini.py
@@ -2,15 +2,127 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Mapping
 from typing import Any, AsyncIterator
 
 import httpx
 
-from src.models.errors import InvalidRequestError
+from src.models.errors import FailureClassification, InvalidRequestError, ProxyError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.base import (
+    ProviderAdapter,
+    ProviderErrorDetails,
+    classify_provider_failure,
+    invalid_provider_response_error,
+    is_valid_provider_token_count,
+    map_standard_provider_error,
+    map_standard_provider_status_error,
+    provider_error_details,
+    validate_provider_success_payload,
+)
 from src.providers.healthcheck import is_provider_healthy
+
+_CONTEXT_IDENTIFIERS = frozenset(
+    {
+        "context_length_exceeded",
+        "context_window_exceeded",
+        "input_too_long",
+    }
+)
+_CONTENT_IDENTIFIERS = frozenset(
+    {
+        "blocklist",
+        "content_blocked",
+        "escalation",
+        "image_prohibited_content",
+        "image_recitation",
+        "image_safety",
+        "prohibited_content",
+        "recitation",
+        "safety",
+        "spii",
+    }
+)
+_CONTEXT_MESSAGE_MARKERS = ("input context is too long", "prompt is too long")
+_CONTENT_MESSAGE_MARKERS = ("blocked due to safety", "prohibited content")
+_SUCCESS_FINISH_REASONS = frozenset({"max_tokens", "stop"})
+
+
+def _classify_gemini_failure(
+    details: ProviderErrorDetails,
+) -> FailureClassification | None:
+    return classify_provider_failure(
+        details,
+        context_identifiers=_CONTEXT_IDENTIFIERS,
+        content_identifiers=_CONTENT_IDENTIFIERS,
+        context_message_markers=_CONTEXT_MESSAGE_MARKERS,
+        content_message_markers=_CONTENT_MESSAGE_MARKERS,
+    )
+
+
+def _gemini_response_failure(data: dict[str, Any]) -> ProxyError | None:
+    identifiers: set[str] = set()
+    block_reason: str | None = None
+    prompt_feedback = data.get("promptFeedback")
+    if isinstance(prompt_feedback, dict):
+        raw_block_reason = prompt_feedback.get("blockReason")
+        if isinstance(raw_block_reason, str) and raw_block_reason.strip():
+            block_reason = raw_block_reason.strip().lower()
+            identifiers.add(block_reason)
+
+    finish_reason: str | None = None
+    candidates = data.get("candidates")
+    if isinstance(candidates, list) and candidates and isinstance(candidates[0], dict):
+        raw_finish_reason = candidates[0].get("finishReason")
+        if isinstance(raw_finish_reason, str) and raw_finish_reason.strip():
+            finish_reason = raw_finish_reason.strip().lower()
+            identifiers.add(finish_reason)
+
+    classification = _classify_gemini_failure(
+        ProviderErrorDetails(status_code=400, identifiers=frozenset(identifiers))
+    )
+    if classification is not None:
+        return map_standard_provider_status_error(
+            400,
+            failure_classification=classification,
+        )
+    if block_reason is not None or (
+        finish_reason is not None and finish_reason not in _SUCCESS_FINISH_REASONS
+    ):
+        return invalid_provider_response_error()
+    return None
+
+
+def reject_gemini_failure_response(data: dict[str, Any]) -> None:
+    """Reject documented nominal-success envelopes that represent failure."""
+
+    if failure := _gemini_response_failure(data):
+        raise failure
+
+
+def _is_valid_gemini_success_payload(data: Mapping[str, Any]) -> bool:
+    candidates = data.get("candidates")
+    usage = data.get("usageMetadata")
+    if (
+        not isinstance(candidates, list)
+        or not candidates
+        or not isinstance(candidates[0], Mapping)
+        or not isinstance(usage, Mapping)
+    ):
+        return False
+    first = candidates[0]
+    content = first.get("content")
+    parts = content.get("parts") if isinstance(content, Mapping) else None
+    return (
+        isinstance(first.get("finishReason"), str)
+        and bool(str(first["finishReason"]).strip())
+        and isinstance(parts, list)
+        and all(isinstance(part, Mapping) for part in parts)
+        and is_valid_provider_token_count(usage.get("promptTokenCount"))
+        and is_valid_provider_token_count(usage.get("candidatesTokenCount"))
+        and is_valid_provider_token_count(usage.get("totalTokenCount"))
+    )
 
 
 class GeminiAdapter(ProviderAdapter):
@@ -30,7 +142,10 @@ class GeminiAdapter(ProviderAdapter):
             role = message.role
             content = message.content
             if isinstance(content, list):
-                text = "\n".join(str(part.get("text", "")) if isinstance(part, dict) else str(part) for part in content)
+                text = "\n".join(
+                    str(part.get("text", "")) if isinstance(part, dict) else str(part)
+                    for part in content
+                )
             else:
                 text = str(content)
             if role == "system":
@@ -40,7 +155,9 @@ class GeminiAdapter(ProviderAdapter):
             gemini_role = "model" if role == "assistant" else "user"
             contents.append({"role": gemini_role, "parts": [{"text": text}]})
 
-        payload: dict[str, Any] = {"contents": contents or [{"role": "user", "parts": [{"text": ""}]}]}
+        payload: dict[str, Any] = {
+            "contents": contents or [{"role": "user", "parts": [{"text": ""}]}]
+        }
         if system_parts:
             payload["systemInstruction"] = {"parts": system_parts}
 
@@ -52,26 +169,34 @@ class GeminiAdapter(ProviderAdapter):
         if canonical_request.max_tokens is not None:
             generation_config["maxOutputTokens"] = canonical_request.max_tokens
         if canonical_request.stop:
-            generation_config["stopSequences"] = canonical_request.stop if isinstance(canonical_request.stop, list) else [canonical_request.stop]
+            generation_config["stopSequences"] = (
+                canonical_request.stop
+                if isinstance(canonical_request.stop, list)
+                else [canonical_request.stop]
+            )
         if generation_config:
             payload["generationConfig"] = generation_config
 
         return payload
 
-    async def translate_response(self, provider_response: Any, model_name: str) -> ChatCompletionResponse:
-        data = provider_response if isinstance(provider_response, dict) else json.loads(provider_response)
+    async def translate_response(
+        self, provider_response: Any, model_name: str
+    ) -> ChatCompletionResponse:
+        data = (
+            provider_response
+            if isinstance(provider_response, dict)
+            else json.loads(provider_response)
+        )
+        reject_gemini_failure_response(data)
+        validate_provider_success_payload(data, _is_valid_gemini_success_payload)
         candidates = data.get("candidates") or []
         first = candidates[0] if candidates else {}
         content = first.get("content") or {}
         parts = content.get("parts") or []
         text = "".join(str(part.get("text", "")) for part in parts if isinstance(part, dict))
-        finish_reason_map = {
-            "STOP": "stop",
-            "MAX_TOKENS": "length",
-            "SAFETY": "content_filter",
-            "RECITATION": "content_filter",
-        }
-        finish_reason = finish_reason_map.get(str(first.get("finishReason") or "STOP"), "stop")
+        finish_reason = (
+            "length" if first["finishReason"].strip().lower() == "max_tokens" else "stop"
+        )
 
         usage = data.get("usageMetadata") or {}
         prompt_tokens = int(usage.get("promptTokenCount") or 0)
@@ -109,12 +234,16 @@ class GeminiAdapter(ProviderAdapter):
             yield ""
         raise InvalidRequestError(message="Gemini streaming is not supported yet")
 
-    def map_error(self, provider_error: Exception) -> Exception:
-        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
+    def map_error(
+        self,
+        provider_error: Exception,
+        *,
+        details: ProviderErrorDetails | None = None,
+    ) -> ProxyError:
+        classification = _classify_gemini_failure(details or provider_error_details(provider_error))
         return map_standard_provider_error(
             provider_error,
-            invalid_request_message=f"Provider rejected request: {status}",
-            rate_limit_message=f"Provider rate limited request: {status}",
+            failure_classification=classification,
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:

--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -5,11 +5,57 @@ from typing import Any, AsyncIterator
 
 import httpx
 
+from src.models.errors import FailureClassification, ProxyError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
-from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.base import (
+    ProviderAdapter,
+    ProviderErrorDetails,
+    classify_provider_failure,
+    map_standard_provider_error,
+    provider_error_details,
+    reject_openai_compatible_failure_response,
+)
 from src.providers.healthcheck import is_provider_healthy
-from src.providers.resolution import normalize_openai_chat_payload, resolve_provider, resolve_upstream_model
+from src.providers.openai_compatible import (
+    translate_openai_compatible_stream,
+    validate_openai_compatible_chat_success,
+)
+from src.providers.resolution import (
+    normalize_openai_chat_payload,
+    resolve_provider,
+    resolve_upstream_model,
+)
+
+_CONTEXT_IDENTIFIERS = frozenset(
+    {
+        "context_length_exceeded",
+        "context_window_exceeded",
+        "input_too_long",
+        "max_context_length_exceeded",
+    }
+)
+_CONTENT_IDENTIFIERS = frozenset(
+    {
+        "content_blocked",
+        "content_filter",
+        "content_policy_violation",
+        "prohibited_content",
+        "safety",
+    }
+)
+_CONTEXT_MESSAGE_MARKERS = (
+    "context window",
+    "input is too long",
+    "maximum context length",
+    "too many tokens",
+)
+_CONTENT_MESSAGE_MARKERS = (
+    "content management policy",
+    "flagged by our content filter",
+    "responsible ai policy",
+    "violates our usage policies",
+)
 
 
 class OpenAIAdapter(ProviderAdapter):
@@ -30,11 +76,23 @@ class OpenAIAdapter(ProviderAdapter):
         upstream_model = resolve_upstream_model(provider_config)
         if upstream_model:
             payload["model"] = upstream_model
-        normalize_openai_chat_payload(payload, provider=provider, upstream_model=upstream_model or str(payload.get("model") or ""))
+        normalize_openai_chat_payload(
+            payload,
+            provider=provider,
+            upstream_model=upstream_model or str(payload.get("model") or ""),
+        )
         return payload
 
-    async def translate_response(self, provider_response: Any, model_name: str) -> ChatCompletionResponse:
-        data = provider_response if isinstance(provider_response, dict) else json.loads(provider_response)
+    async def translate_response(
+        self, provider_response: Any, model_name: str
+    ) -> ChatCompletionResponse:
+        data = (
+            provider_response
+            if isinstance(provider_response, dict)
+            else json.loads(provider_response)
+        )
+        reject_openai_compatible_failure_response(data)
+        validate_openai_compatible_chat_success(data)
         if "model" not in data:
             data["model"] = model_name
         choices = data.get("choices")
@@ -55,39 +113,32 @@ class OpenAIAdapter(ProviderAdapter):
         *,
         model_name: str | None = None,
     ) -> AsyncIterator[str]:
-        async for chunk in provider_stream:
+        async for chunk in translate_openai_compatible_stream(
+            provider_stream,
+            classify_failure=self._classify_failure,
+        ):
             yield chunk
 
     @staticmethod
-    def _http_error_message(provider_error: httpx.HTTPStatusError) -> str:
-        response = provider_error.response
-        try:
-            payload = response.json()
-        except (AttributeError, ValueError):
-            payload = None
-        if isinstance(payload, dict):
-            error = payload.get("error")
-            if isinstance(error, dict):
-                message = str(error.get("message") or "").strip()
-                if message:
-                    return message
-        body = str(getattr(response, "text", "") or "").strip()
-        if body:
-            return body
-        return f"Provider rejected request: {response.status_code}"
-
-    def map_error(self, provider_error: Exception) -> Exception:
-        status = provider_error.response.status_code if isinstance(provider_error, httpx.HTTPStatusError) else None
-        message = (
-            self._http_error_message(provider_error)
-            if isinstance(provider_error, httpx.HTTPStatusError) and status is not None and status < 500
-            else "Provider unavailable"
+    def _classify_failure(details: ProviderErrorDetails) -> FailureClassification | None:
+        return classify_provider_failure(
+            details,
+            context_identifiers=_CONTEXT_IDENTIFIERS,
+            content_identifiers=_CONTENT_IDENTIFIERS,
+            context_message_markers=_CONTEXT_MESSAGE_MARKERS,
+            content_message_markers=_CONTENT_MESSAGE_MARKERS,
         )
+
+    def map_error(
+        self,
+        provider_error: Exception,
+        *,
+        details: ProviderErrorDetails | None = None,
+    ) -> ProxyError:
+        classification = self._classify_failure(details or provider_error_details(provider_error))
         return map_standard_provider_error(
             provider_error,
-            invalid_request_message=message,
-            unavailable_message="Provider unavailable",
-            rate_limit_message=message if status == 429 else None,
+            failure_classification=classification,
         )
 
     async def health_check(self, provider_config: dict[str, Any]) -> bool:

--- a/src/providers/openai_compatible.py
+++ b/src/providers/openai_compatible.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Callable, Mapping
+
+from src.models.errors import FailureClassification, InvalidRequestError, ProxyError
+from src.providers.base import (
+    ProviderErrorDetails,
+    invalid_provider_response_error,
+    is_valid_provider_token_count,
+    map_standard_provider_status_error,
+    provider_error_details_from_payload,
+    validate_provider_success_payload,
+)
+
+_MAX_PRECOMMIT_STREAM_FRAMES = 32
+_MAX_PRECOMMIT_STREAM_CHARS = 262_144
+_MAX_STREAM_FRAME_CHARS = 1_048_576
+_RATE_LIMIT_IDENTIFIERS = frozenset(
+    {
+        "rate_limit",
+        "rate_limit_error",
+        "rate_limit_exceeded",
+        "requests",
+        "tokens",
+    }
+)
+_CLIENT_ERROR_IDENTIFIERS = frozenset(
+    {
+        "authentication_error",
+        "invalid_api_key",
+        "invalid_request_error",
+        "not_found_error",
+        "permission_denied",
+        "permission_error",
+    }
+)
+_SERVER_ERROR_IDENTIFIERS = frozenset(
+    {
+        "api_error",
+        "internal_error",
+        "overloaded_error",
+        "server_error",
+    }
+)
+
+ProviderFailureClassifier = Callable[[ProviderErrorDetails], FailureClassification | None]
+
+
+def validate_openai_compatible_chat_success(data: Mapping[str, object]) -> None:
+    """Reject nominal chat successes that cannot represent a completion."""
+
+    validate_provider_success_payload(data, _is_valid_openai_compatible_chat_success)
+
+
+def _is_valid_openai_compatible_chat_success(data: Mapping[str, object]) -> bool:
+    choices = data.get("choices")
+    usage = data.get("usage")
+    if not isinstance(choices, list) or not choices or not isinstance(usage, Mapping):
+        return False
+
+    indexes: set[int] = set()
+    for value in choices:
+        if not isinstance(value, Mapping):
+            return False
+        index = value.get("index")
+        message = value.get("message")
+        if (
+            not isinstance(index, int)
+            or isinstance(index, bool)
+            or index < 0
+            or index in indexes
+            or not isinstance(message, Mapping)
+        ):
+            return False
+        indexes.add(index)
+
+    return all(
+        is_valid_provider_token_count(usage.get(key))
+        for key in ("prompt_tokens", "completion_tokens", "total_tokens")
+    )
+
+
+async def translate_openai_compatible_stream(
+    provider_stream: AsyncIterator[str],
+    *,
+    classify_failure: ProviderFailureClassifier,
+) -> AsyncIterator[str]:
+    """Validate an OpenAI-compatible stream before releasing its pre-output frames."""
+
+    pending: list[str] = []
+    pending_chars = 0
+    emitted_output = False
+    saw_terminal = False
+
+    async for line in provider_stream:
+        if not line or line.startswith(":") or line.startswith("event:"):
+            continue
+        if len(line) > _MAX_STREAM_FRAME_CHARS or not line.startswith("data:"):
+            raise invalid_provider_response_error()
+
+        raw_payload = line[len("data:") :].strip()
+        if not raw_payload:
+            continue
+        if raw_payload == "[DONE]":
+            if not emitted_output:
+                raise invalid_provider_response_error()
+            yield line
+            return
+
+        try:
+            payload = json.loads(raw_payload)
+        except (RecursionError, TypeError, ValueError) as exc:
+            raise invalid_provider_response_error() from exc
+        if not isinstance(payload, Mapping):
+            raise invalid_provider_response_error()
+
+        if "error" in payload:
+            raise _map_openai_compatible_stream_error(payload, classify_failure)
+
+        choices = payload.get("choices")
+        if not isinstance(choices, list):
+            raise invalid_provider_response_error()
+        if not _valid_stream_choices(choices):
+            raise invalid_provider_response_error()
+
+        classified_stop = _content_filter_stop(choices)
+        if classified_stop and not emitted_output:
+            raise InvalidRequestError(
+                message="Provider rejected request",
+                affects_deployment_health=False,
+                failure_classification=FailureClassification.CONTENT_POLICY,
+            )
+
+        has_output = _choices_have_output(choices)
+        has_terminal = _choices_have_terminal(choices)
+        if not emitted_output and not has_output and not has_terminal:
+            pending_chars = _buffer_precommit_frame(pending, pending_chars, line)
+            continue
+
+        if not emitted_output:
+            emitted_output = True
+            for buffered in pending:
+                yield buffered
+            pending.clear()
+        yield line
+        saw_terminal = saw_terminal or has_terminal
+
+    if not emitted_output or not saw_terminal:
+        raise invalid_provider_response_error()
+
+
+def _valid_stream_choices(choices: list[object]) -> bool:
+    indexes: set[int] = set()
+    for value in choices:
+        if not isinstance(value, Mapping):
+            return False
+        index = value.get("index")
+        if not isinstance(index, int) or isinstance(index, bool) or index < 0 or index in indexes:
+            return False
+        indexes.add(index)
+        delta = value.get("delta")
+        if delta is not None and not isinstance(delta, Mapping):
+            return False
+        finish_reason = value.get("finish_reason")
+        if finish_reason is not None and not isinstance(finish_reason, str):
+            return False
+    return True
+
+
+def _choices_have_output(choices: list[object]) -> bool:
+    for value in choices:
+        if not isinstance(value, Mapping):
+            continue
+        delta = value.get("delta")
+        if not isinstance(delta, Mapping):
+            continue
+        for key in ("content", "refusal", "function_call", "tool_calls"):
+            output = delta.get(key)
+            if output not in (None, "", [], {}):
+                return True
+    return False
+
+
+def _choices_have_terminal(choices: list[object]) -> bool:
+    return any(
+        isinstance(value, Mapping)
+        and isinstance(value.get("finish_reason"), str)
+        and bool(str(value["finish_reason"]).strip())
+        for value in choices
+    )
+
+
+def _content_filter_stop(choices: list[object]) -> bool:
+    return any(
+        isinstance(value, Mapping)
+        and isinstance(value.get("finish_reason"), str)
+        and str(value["finish_reason"]).strip().lower() == "content_filter"
+        for value in choices
+    )
+
+
+def _buffer_precommit_frame(pending: list[str], pending_chars: int, line: str) -> int:
+    next_chars = pending_chars + len(line)
+    if len(pending) >= _MAX_PRECOMMIT_STREAM_FRAMES or next_chars > _MAX_PRECOMMIT_STREAM_CHARS:
+        raise invalid_provider_response_error()
+    pending.append(line)
+    return next_chars
+
+
+def _map_openai_compatible_stream_error(
+    payload: Mapping[str, object],
+    classify_failure: ProviderFailureClassifier,
+) -> ProxyError:
+    details = provider_error_details_from_payload(payload, status_code=None)
+    classification = classify_failure(details)
+    if classification in {
+        FailureClassification.CONTEXT_WINDOW,
+        FailureClassification.CONTENT_POLICY,
+    }:
+        return map_standard_provider_status_error(400, failure_classification=classification)
+    if details.identifiers & _RATE_LIMIT_IDENTIFIERS:
+        return map_standard_provider_status_error(429)
+    if details.identifiers & _CLIENT_ERROR_IDENTIFIERS:
+        return map_standard_provider_status_error(400)
+    if details.identifiers & _SERVER_ERROR_IDENTIFIERS:
+        return map_standard_provider_status_error(500)
+    return invalid_provider_response_error()

--- a/src/providers/registry.py
+++ b/src/providers/registry.py
@@ -5,11 +5,48 @@ from typing import Any
 
 from fastapi import Request
 
-from src.models.errors import InvalidRequestError
-from src.providers.base import ProviderAdapter
-from src.providers.resolution import is_openai_compatible_provider, resolve_provider, resolve_upstream_model
+from src.models.errors import InvalidRequestError, ProxyError
+from src.providers.base import ProviderAdapter, map_standard_provider_error
+from src.providers.resolution import (
+    is_openai_compatible_provider,
+    resolve_provider,
+    resolve_upstream_model,
+)
 from src.upstream_auth import build_openai_compatible_auth_headers
 from src.upstream_http import configured_timeout_seconds
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderErrorMapperRegistry:
+    """Resolve provider-owned error classifiers for every routed endpoint."""
+
+    openai: ProviderAdapter
+    azure_openai: ProviderAdapter
+    anthropic: ProviderAdapter
+    gemini: ProviderAdapter
+    bedrock: ProviderAdapter
+
+    def resolve(self, provider: str) -> ProviderAdapter | None:
+        normalized = (provider or "").strip().lower()
+        if normalized in {"azure", "azure_openai"}:
+            return self.azure_openai
+        if normalized == "anthropic":
+            return self.anthropic
+        if normalized == "gemini":
+            return self.gemini
+        if normalized == "bedrock":
+            return self.bedrock
+        if normalized == "elevenlabs":
+            return None
+        if normalized in {"", "unknown"} or is_openai_compatible_provider(normalized):
+            return self.openai
+        return None
+
+    def map_error(self, provider: str, error: Exception) -> ProxyError:
+        adapter = self.resolve(provider)
+        if adapter is None:
+            return map_standard_provider_error(error)
+        return adapter.map_error(error)
 
 
 @dataclass
@@ -51,7 +88,9 @@ def resolve_chat_upstream(
             raise InvalidRequestError(message="Provider API key is missing for selected model")
         return ChatUpstream(
             adapter=request.app.state.azure_openai_adapter,
-            api_base=str(params.get("api_base", request.app.state.settings.openai_base_url)).rstrip("/"),
+            api_base=str(params.get("api_base", request.app.state.settings.openai_base_url)).rstrip(
+                "/"
+            ),
             endpoint="/chat/completions",
             headers={"api-key": str(api_key), "Content-Type": "application/json"},
             timeout=timeout,
@@ -66,7 +105,9 @@ def resolve_chat_upstream(
         upstream_model = resolve_upstream_model(params)
         return ChatUpstream(
             adapter=request.app.state.gemini_adapter,
-            api_base=str(params.get("api_base") or "https://generativelanguage.googleapis.com/v1beta").rstrip("/"),
+            api_base=str(
+                params.get("api_base") or "https://generativelanguage.googleapis.com/v1beta"
+            ).rstrip("/"),
             endpoint=f"/models/{upstream_model}:generateContent?key={api_key}",
             headers={"Content-Type": "application/json"},
             timeout=timeout,
@@ -78,7 +119,9 @@ def resolve_chat_upstream(
         endpoint_action = "converse-stream" if is_stream else "converse"
         return ChatUpstream(
             adapter=request.app.state.bedrock_adapter,
-            api_base=str(params.get("api_base") or f"https://bedrock-runtime.{region}.amazonaws.com").rstrip("/"),
+            api_base=str(
+                params.get("api_base") or f"https://bedrock-runtime.{region}.amazonaws.com"
+            ).rstrip("/"),
             endpoint=f"/model/{upstream_model}/{endpoint_action}",
             headers={"Content-Type": "application/json"},
             timeout=timeout,
@@ -92,7 +135,9 @@ def resolve_chat_upstream(
         raise InvalidRequestError(message="Provider API key is missing for selected model")
     return ChatUpstream(
         adapter=request.app.state.openai_adapter,
-        api_base=str(params.get("api_base", request.app.state.settings.openai_base_url)).rstrip("/"),
+        api_base=str(params.get("api_base", request.app.state.settings.openai_base_url)).rstrip(
+            "/"
+        ),
         endpoint="/chat/completions",
         headers=build_openai_compatible_auth_headers(
             provider=provider,

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -5,15 +5,18 @@ import logging
 import math
 import random
 import time
+from collections.abc import Mapping, Sequence
 from collections import deque
 from dataclasses import dataclass, field
 from functools import partial
+from types import MappingProxyType
 from typing import Any, Awaitable, Callable
 
 import httpx
 
 from src.metrics import increment_router_health_update_failure
 from src.models.errors import (
+    FailureClassification,
     GatewayCapacityError,
     InvalidRequestError,
     NO_HEALTHY_DEPLOYMENTS_CODE,
@@ -46,88 +49,64 @@ _ATTEMPT_PERMIT_CLEANUP_MARGIN_SECONDS = 30
 TimeoutForDeployment = Callable[[Deployment], float | int | None]
 
 
-@dataclass
+def _freeze_fallback_map(
+    fallback_map: Mapping[str, Sequence[str]],
+) -> Mapping[str, tuple[str, ...]]:
+    return MappingProxyType({key: tuple(chain) for key, chain in fallback_map.items()})
+
+
+@dataclass(frozen=True, slots=True)
 class FallbackConfig:
     num_retries: int = 0
     retry_after: float = 0.0
     timeout: float = 600.0
-    fallbacks: dict[str, list[str]] = field(default_factory=dict)
-    context_window_fallbacks: dict[str, list[str]] = field(default_factory=dict)
-    content_policy_fallbacks: dict[str, list[str]] = field(default_factory=dict)
+    fallbacks: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    context_window_fallbacks: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    content_policy_fallbacks: Mapping[str, Sequence[str]] = field(default_factory=dict)
     backoff_multiplier: float = 2.0
     backoff_max: float = 30.0
     backoff_jitter: bool = True
     event_history_size: int = 1000
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "fallbacks", _freeze_fallback_map(self.fallbacks))
+        object.__setattr__(
+            self,
+            "context_window_fallbacks",
+            _freeze_fallback_map(self.context_window_fallbacks),
+        )
+        object.__setattr__(
+            self,
+            "content_policy_fallbacks",
+            _freeze_fallback_map(self.content_policy_fallbacks),
+        )
+
+
+def _classify_failure(error: Exception) -> FailureClassification:
+    classification = getattr(error, "failure_classification", None)
+    if isinstance(classification, FailureClassification):
+        return classification
+    if isinstance(error, (httpx.TimeoutException, TimeoutError)):
+        return FailureClassification.TIMEOUT
+
+    status_code = getattr(error, "status_code", None)
+    if status_code == 429 or getattr(error, "error_type", None) == "rate_limit_error":
+        return FailureClassification.RATE_LIMIT
+    return FailureClassification.GENERIC
+
 
 class ErrorClassification:
-    CONTEXT_WINDOW = "context_window_exceeded"
-    CONTENT_POLICY = "content_policy_violation"
-    RATE_LIMIT = "rate_limit"
-    TIMEOUT = "timeout"
-    GENERIC = "generic"
+    """Compatibility facade for the former router-owned classifier."""
 
-    _CONTEXT_WINDOW_PATTERNS = [
-        "context_length_exceeded",
-        "context window",
-        "maximum context length",
-        "max_tokens",
-        "token limit",
-        "too many tokens",
-        "input is too long",
-        "maximum allowed length",
-        "request too large",
-    ]
+    CONTEXT_WINDOW = FailureClassification.CONTEXT_WINDOW
+    CONTENT_POLICY = FailureClassification.CONTENT_POLICY
+    RATE_LIMIT = FailureClassification.RATE_LIMIT
+    TIMEOUT = FailureClassification.TIMEOUT
+    GENERIC = FailureClassification.GENERIC
 
-    _CONTENT_POLICY_PATTERNS = [
-        "content_policy_violation",
-        "content_filter",
-        "content management policy",
-        "safety system",
-        "harmful content",
-        "violates our usage policies",
-        "flagged by our content filter",
-        "responsible ai policy",
-    ]
-
-    @classmethod
-    def classify(cls, error: Exception) -> str:
-        if isinstance(error, (httpx.TimeoutException, TimeoutError)):
-            return cls.TIMEOUT
-
-        status_code = getattr(error, "status_code", None)
-        if status_code == 429 or getattr(error, "error_type", None) == "rate_limit_error":
-            return cls.RATE_LIMIT
-
-        error_body = cls._extract_error_body(error)
-        error_text = error_body.lower() if error_body else str(error).lower()
-
-        for pattern in cls._CONTEXT_WINDOW_PATTERNS:
-            if pattern in error_text:
-                return cls.CONTEXT_WINDOW
-
-        for pattern in cls._CONTENT_POLICY_PATTERNS:
-            if pattern in error_text:
-                return cls.CONTENT_POLICY
-
-        return cls.GENERIC
-
-    @classmethod
-    def _extract_error_body(cls, error: Exception) -> str | None:
-        response = getattr(error, "response", None)
-        if response is None:
-            return None
-        if hasattr(response, "text"):
-            try:
-                return str(response.text)
-            except Exception:
-                pass
-        if hasattr(response, "content"):
-            try:
-                return response.content.decode("utf-8", errors="replace")
-            except Exception:
-                pass
-        return None
+    @staticmethod
+    def classify(error: Exception) -> FailureClassification:
+        return _classify_failure(error)
 
 
 class RetryPolicy:
@@ -183,7 +162,7 @@ class _AttemptExecutionError(Exception):
 @dataclass(frozen=True, slots=True)
 class _NormalizedExecutionError:
     error: Exception
-    classification: str
+    classification: FailureClassification
     allow_classified_fallbacks: bool
     retry_source: Exception
 
@@ -245,8 +224,8 @@ class FailoverManager:
         model_group: str,
         from_id: str,
         to_id: str | None,
-        reason: str,
-        classification: str,
+        reason: str | FailureClassification,
+        classification: str | FailureClassification,
         error_msg: str,
         attempt: int,
         success: bool,
@@ -256,8 +235,8 @@ class FailoverManager:
             model_group=model_group,
             from_deployment_id=from_id,
             to_deployment_id=to_id,
-            reason=reason,
-            error_classification=classification,
+            reason=str(reason),
+            error_classification=str(classification),
             error_message=error_msg,
             attempt=attempt,
             success=success,
@@ -306,66 +285,30 @@ class FailoverManager:
         except Exception:
             logger.warning("failover attempt callback failed", exc_info=True)
 
-    @staticmethod
-    def _http_error_message(error: httpx.HTTPError) -> str:
-        response = getattr(error, "response", None)
-        if response is None:
-            return str(error)
-
-        try:
-            payload = response.json()
-        except Exception:
-            payload = None
-
-        if isinstance(payload, dict):
-            nested_error = payload.get("error")
-            if isinstance(nested_error, dict):
-                for key in ("message", "detail"):
-                    message = nested_error.get(key)
-                    if isinstance(message, str) and message.strip():
-                        return message.strip()
-            if isinstance(nested_error, str) and nested_error.strip():
-                return nested_error.strip()
-            for key in ("message", "detail"):
-                message = payload.get(key)
-                if isinstance(message, str) and message.strip():
-                    return message.strip()
-
-        body = str(getattr(response, "text", "") or "").strip()
-        if body:
-            return body
-
-        content = getattr(response, "content", None)
-        if isinstance(content, bytes):
-            decoded = content.decode("utf-8", errors="replace").strip()
-            if decoded:
-                return decoded
-
-        return str(error)
-
     def _normalize_http_error(self, error: httpx.HTTPError) -> ProxyError:
         if isinstance(error, httpx.PoolTimeout):
             return GatewayCapacityError()
         if isinstance(error, httpx.TimeoutException):
             return TimeoutError(
-                message=str(error) or None,
                 affects_deployment_health=True,
+                failure_classification=FailureClassification.TIMEOUT,
             )
         response = getattr(error, "response", None)
         status_code = getattr(response, "status_code", None)
         if status_code == 429:
             return RateLimitError(
-                message=self._http_error_message(error),
+                message="Provider rate limited request",
                 retry_after=parse_retry_after_header(response.headers.get("retry-after")),
                 affects_deployment_health=True,
+                failure_classification=FailureClassification.RATE_LIMIT,
             )
         if affects_deployment_health(error):
             return ServiceUnavailableError(
-                message=str(error),
+                message="Provider unavailable",
                 affects_deployment_health=True,
             )
         return InvalidRequestError(
-            message=self._http_error_message(error),
+            message="Provider rejected request",
             affects_deployment_health=False,
         )
 
@@ -386,7 +329,7 @@ class FailoverManager:
         if isinstance(error, ProxyError):
             return _NormalizedExecutionError(
                 error=error,
-                classification=ErrorClassification.classify(error),
+                classification=_classify_failure(error),
                 allow_classified_fallbacks=True,
                 retry_source=error,
             )
@@ -395,21 +338,22 @@ class FailoverManager:
             normalized = self._normalize_http_error(error)
             return _NormalizedExecutionError(
                 error=normalized,
-                classification=ErrorClassification.classify(normalized),
+                classification=_classify_failure(normalized),
                 allow_classified_fallbacks=True,
                 retry_source=normalized,
             )
 
         normalized = attach_failover_original_error(
             ServiceUnavailableError(
-                message=str(error),
+                message="Service unavailable",
                 affects_deployment_health=bool(getattr(error, "affects_deployment_health", False)),
+                failure_classification=FailureClassification.GENERIC,
             ),
             error,
         )
         return _NormalizedExecutionError(
             error=normalized,
-            classification=ErrorClassification.classify(normalized),
+            classification=_classify_failure(normalized),
             allow_classified_fallbacks=False,
             retry_source=error,
         )
@@ -718,7 +662,7 @@ class FailoverManager:
 
     async def _get_classified_fallbacks(
         self,
-        classification: str,
+        classification: FailureClassification,
         model_group: str,
         routing_context: dict[str, Any],
         *,
@@ -757,7 +701,7 @@ class FailoverManager:
         model_group: str,
         execute: Callable[[Deployment], Awaitable[Any]],
         from_deployment_id: str,
-        classification: str,
+        classification: FailureClassification,
         routing_context: dict[str, Any],
         visited_ids: set[str],
         attempted_ids: set[str],
@@ -1054,7 +998,7 @@ class FailoverManager:
 
     @staticmethod
     def _should_retry(
-        classification: str,
+        classification: FailureClassification,
         error: Exception,
         retryable_error_classes: set[str] | None,
     ) -> bool:

--- a/src/routers/audio_speech.py
+++ b/src/routers/audio_speech.py
@@ -32,8 +32,10 @@ from src.metrics import (
     observe_api_latency,
     observe_request_latency,
 )
-from src.models.errors import InvalidRequestError
+from src.models.errors import InvalidRequestError, ProxyError
 from src.models.requests import AudioSpeechRequest
+from src.providers.base import invalid_provider_response_error, parse_provider_json_response
+from src.providers.gemini import reject_gemini_failure_response
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.upstream_auth import build_openai_compatible_auth_headers
@@ -160,25 +162,18 @@ async def _execute_tts(
         ),
     )
     if response.status_code >= 400:
-        try:
-            upstream_body = response.json()
-            upstream_msg = upstream_body.get("error", {}).get("message", response.text)
-        except Exception:
-            upstream_msg = response.text
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "upstream TTS %s returned %d: %s", api_base, response.status_code, upstream_msg
-        )
-        raise httpx.HTTPStatusError(
-            f"Upstream TTS call failed with status {response.status_code}: {upstream_msg}",
+        status_error = httpx.HTTPStatusError(
+            f"Upstream TTS call failed with status {response.status_code}",
             request=httpx.Request("POST", f"{api_base}/audio/speech"),
             response=response,
         )
+        raise request.app.state.provider_error_mapper_registry.map_error(provider, status_error)
     audio_bytes = response.content
     billing_payload: dict[str, Any] | None = None
     if upstream_payload.get("stream_format") == "sse":
         audio_bytes, billing_payload = _extract_sse_audio_and_usage(response.content)
+    if not audio_bytes:
+        raise invalid_provider_response_error()
     return {
         "_audio_bytes": audio_bytes,
         "_billing_payload": billing_payload,
@@ -590,17 +585,25 @@ async def _execute_gemini_tts(
         ),
     )
     if response.status_code >= 400:
-        raise httpx.HTTPStatusError(
+        status_error = httpx.HTTPStatusError(
             f"Upstream Gemini TTS call failed with status {response.status_code}",
             request=httpx.Request("POST", endpoint),
             response=response,
         )
+        raise request.app.state.provider_error_mapper_registry.map_error("gemini", status_error)
 
-    data = response.json()
-    audio_bytes = _extract_gemini_audio_bytes(data, response_format=effective_format)
+    data = parse_provider_json_response(response)
+    reject_gemini_failure_response(data)
+    try:
+        audio_bytes = _extract_gemini_audio_bytes(data, response_format=effective_format)
+        billing_payload = _extract_gemini_billing_payload(data)
+    except ProxyError:
+        raise
+    except Exception as exc:
+        raise invalid_provider_response_error() from exc
     return {
         "_audio_bytes": audio_bytes,
-        "_billing_payload": _extract_gemini_billing_payload(data),
+        "_billing_payload": billing_payload,
         "_api_latency_ms": (perf_counter() - upstream_start) * 1000,
         "_api_base": api_base,
         "_deployment_model": deployment.deltallm_params.get("model"),
@@ -646,14 +649,18 @@ async def _execute_elevenlabs_tts(
         ),
     )
     if response.status_code >= 400:
-        raise httpx.HTTPStatusError(
-            _format_elevenlabs_tts_error(response),
+        status_error = httpx.HTTPStatusError(
+            f"Upstream ElevenLabs TTS call failed with status {response.status_code}",
             request=httpx.Request("POST", endpoint),
             response=response,
         )
+        raise request.app.state.provider_error_mapper_registry.map_error("elevenlabs", status_error)
 
+    audio_bytes = response.content
+    if not audio_bytes:
+        raise invalid_provider_response_error()
     return {
-        "_audio_bytes": response.content,
+        "_audio_bytes": audio_bytes,
         "_billing_payload": _extract_elevenlabs_billing_payload(response),
         "_api_latency_ms": (perf_counter() - upstream_start) * 1000,
         "_api_base": api_base,
@@ -804,25 +811,6 @@ def _extract_elevenlabs_billing_payload(response: httpx.Response) -> dict[str, A
     return {"input_characters": character_count}
 
 
-def _format_elevenlabs_tts_error(response: httpx.Response) -> str:
-    upstream_msg = response.text
-    try:
-        upstream_body = response.json()
-    except Exception:
-        upstream_body = None
-
-    if isinstance(upstream_body, Mapping):
-        detail = upstream_body.get("detail")
-        if isinstance(detail, Mapping):
-            upstream_msg = str(detail.get("message") or detail.get("detail") or upstream_msg)
-        elif detail:
-            upstream_msg = str(detail)
-        else:
-            upstream_msg = str(upstream_body.get("message") or upstream_msg)
-
-    return f"Upstream ElevenLabs TTS call failed with status {response.status_code}: {upstream_msg}"
-
-
 def _resolve_gemini_response_format(payload: AudioSpeechRequest) -> str:
     requested_format = (payload.response_format or "mp3").strip().lower()
     if requested_format in GEMINI_SUPPORTED_RESPONSE_FORMATS:
@@ -874,13 +862,18 @@ def _extract_gemini_audio_bytes(response_payload: dict[str, Any], *, response_fo
         encoded_audio = inline_data.get("data")
         if not isinstance(encoded_audio, str) or not encoded_audio:
             continue
-        pcm_bytes = base64.b64decode(encoded_audio)
+        try:
+            pcm_bytes = base64.b64decode(encoded_audio, validate=True)
+        except ValueError as exc:
+            raise invalid_provider_response_error() from exc
+        if not pcm_bytes:
+            raise invalid_provider_response_error()
         if response_format == "pcm":
             return pcm_bytes
         mime_type = str(inline_data.get("mimeType") or inline_data.get("mime_type") or "")
         sample_rate_hz = _extract_pcm_sample_rate(mime_type) or 24000
         return _wrap_pcm_as_wav(pcm_bytes, sample_rate_hz=sample_rate_hz)
-    raise InvalidRequestError(message="Gemini TTS response did not include audio data")
+    raise invalid_provider_response_error()
 
 
 def _extract_gemini_billing_payload(response_payload: dict[str, Any]) -> dict[str, Any] | None:

--- a/src/routers/audio_transcription.py
+++ b/src/routers/audio_transcription.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from time import perf_counter
 from typing import Any
@@ -30,6 +31,7 @@ from src.metrics import (
     observe_request_latency,
 )
 from src.models.errors import InvalidRequestError
+from src.providers.base import parse_provider_json_response, validate_provider_success_payload
 from src.rate_limit_policy import estimate_tokens
 from src.providers.resolution import (
     is_openai_compatible_provider,
@@ -66,6 +68,10 @@ from src.services.preflight_capacity import acquire_preflight_capacity, release_
 DEFAULT_AUDIO_TRANSCRIPTION_TIMEOUT_SECONDS = 600.0
 
 router = APIRouter(prefix="/v1", tags=["audio"])
+
+
+def _is_valid_transcription_success_payload(data: Mapping[str, Any]) -> bool:
+    return "text" in data and isinstance(data.get("text"), str)
 
 
 def _transcription_timeout_seconds(params: dict[str, Any]) -> float:
@@ -151,24 +157,18 @@ async def _execute_stt(
         timeout=build_upstream_request_timeout_for_request(request, timeout_seconds),
     )
     if response.status_code >= 400:
-        try:
-            upstream_body = response.json()
-            upstream_msg = upstream_body.get("error", {}).get("message", response.text)
-        except Exception:
-            upstream_msg = response.text
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "upstream STT %s returned %d: %s", api_base, response.status_code, upstream_msg
-        )
-        raise httpx.HTTPStatusError(
-            f"Upstream transcription failed with status {response.status_code}: {upstream_msg}",
+        status_error = httpx.HTTPStatusError(
+            f"Upstream transcription failed with status {response.status_code}",
             request=httpx.Request("POST", f"{api_base}/audio/transcriptions"),
             response=response,
         )
+        raise request.app.state.provider_error_mapper_registry.map_error(api_provider, status_error)
     parsed_response = (
-        response.json() if "json" in upstream_response_format else {"text": response.text}
+        parse_provider_json_response(response)
+        if "json" in upstream_response_format
+        else {"text": response.text}
     )
+    validate_provider_success_payload(parsed_response, _is_valid_transcription_success_payload)
     data = _reshape_transcription_response(
         requested_response_format=response_format,
         upstream_response_format=upstream_response_format,

--- a/src/routers/embeddings.py
+++ b/src/routers/embeddings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from time import perf_counter
 from typing import Any
@@ -29,6 +30,12 @@ from src.metrics import (
 )
 from src.models.errors import InvalidRequestError
 from src.models.requests import EmbeddingRequest
+from src.providers.base import (
+    is_valid_provider_number,
+    is_valid_provider_token_count,
+    parse_provider_json_response,
+    validate_provider_success_payload,
+)
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.upstream_auth import build_openai_compatible_auth_headers
@@ -56,6 +63,64 @@ from src.audit.actions import AuditAction
 from src.audit.errors import derive_audit_error_code
 
 router = APIRouter(prefix="/v1", tags=["embeddings"])
+
+
+def _is_valid_embedding_success_payload(
+    data: Mapping[str, Any],
+    *,
+    expected_count: int,
+    expected_dimensions: int | None,
+    encoding_format: str,
+) -> bool:
+    embeddings = data.get("data")
+    usage = data.get("usage")
+    if (
+        not isinstance(embeddings, list)
+        or len(embeddings) != expected_count
+        or not isinstance(usage, Mapping)
+    ):
+        return False
+    indexes: set[int] = set()
+    for item in embeddings:
+        if not isinstance(item, Mapping):
+            return False
+        index = item.get("index")
+        embedding = item.get("embedding")
+        if (
+            not isinstance(index, int)
+            or isinstance(index, bool)
+            or index < 0
+            or index >= expected_count
+            or index in indexes
+        ):
+            return False
+        indexes.add(index)
+        if encoding_format == "base64":
+            if not isinstance(embedding, str) or not embedding:
+                return False
+        elif (
+            not isinstance(embedding, list)
+            or not embedding
+            or (expected_dimensions is not None and len(embedding) != expected_dimensions)
+            or not all(is_valid_provider_number(component) for component in embedding)
+        ):
+            return False
+    prompt_tokens = usage.get("prompt_tokens")
+    total_tokens = usage.get("total_tokens")
+    return (
+        indexes == set(range(expected_count))
+        and is_valid_provider_token_count(prompt_tokens)
+        and is_valid_provider_token_count(total_tokens)
+        and total_tokens >= prompt_tokens
+    )
+
+
+def _embedding_input_count(value: str | list[str] | list[int] | list[list[int]]) -> int:
+    if isinstance(value, str):
+        return 1
+    if value and all(isinstance(item, int) and not isinstance(item, bool) for item in value):
+        return 1
+    return len(value)
 
 
 def _request_client_ip(request: Request) -> str | None:
@@ -133,8 +198,9 @@ async def _execute_embedding(
         raise InvalidRequestError(message="Provider API key is missing for selected model")
 
     api_base = params.get("api_base", request.app.state.settings.openai_base_url).rstrip("/")
+    provider = resolve_provider(params)
     headers = build_openai_compatible_auth_headers(
-        provider=resolve_provider(params),
+        provider=provider,
         api_key=str(api_key),
         auth_header_name=params.get("auth_header_name"),
         auth_header_format=params.get("auth_header_format"),
@@ -160,12 +226,22 @@ async def _execute_embedding(
         ),
     )
     if response.status_code >= 400:
-        raise httpx.HTTPStatusError(
+        status_error = httpx.HTTPStatusError(
             f"Upstream embedding call failed with status {response.status_code}",
             request=httpx.Request("POST", f"{api_base}/embeddings"),
             response=response,
         )
-    data = response.json()
+        raise request.app.state.provider_error_mapper_registry.map_error(provider, status_error)
+    data = parse_provider_json_response(response)
+    validate_provider_success_payload(
+        data,
+        lambda response: _is_valid_embedding_success_payload(
+            response,
+            expected_count=_embedding_input_count(payload.input),
+            expected_dimensions=payload.dimensions,
+            encoding_format=payload.encoding_format or "float",
+        ),
+    )
     api_latency_ms = (perf_counter() - upstream_start) * 1000
     data["_api_latency_ms"] = api_latency_ms
     data["_api_base"] = api_base

--- a/src/routers/images.py
+++ b/src/routers/images.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from time import perf_counter
 from typing import Any
@@ -27,6 +28,7 @@ from src.metrics import (
 )
 from src.models.errors import InvalidRequestError
 from src.models.requests import ImageGenerationRequest
+from src.providers.base import parse_provider_json_response, validate_provider_success_payload
 from src.providers.resolution import (
     normalize_openai_image_generation_payload,
     resolve_provider,
@@ -60,6 +62,23 @@ from src.services.model_visibility import (
 from src.services.preflight_capacity import acquire_preflight_capacity, release_preflight_capacity
 
 router = APIRouter(prefix="/v1", tags=["images"])
+
+
+def _is_valid_image_success_payload(data: Mapping[str, Any]) -> bool:
+    images = data.get("data")
+    if not isinstance(images, list) or not images:
+        return False
+    for item in images:
+        if not isinstance(item, Mapping):
+            return False
+        url = item.get("url")
+        encoded_image = item.get("b64_json")
+        if not (
+            (isinstance(url, str) and bool(url))
+            or (isinstance(encoded_image, str) and bool(encoded_image))
+        ):
+            return False
+    return True
 
 
 async def _execute_image_generation(
@@ -105,12 +124,14 @@ async def _execute_image_generation(
         ),
     )
     if response.status_code >= 400:
-        raise httpx.HTTPStatusError(
+        status_error = httpx.HTTPStatusError(
             f"Upstream image generation failed with status {response.status_code}",
             request=httpx.Request("POST", f"{api_base}/images/generations"),
             response=response,
         )
-    data = response.json()
+        raise request.app.state.provider_error_mapper_registry.map_error(provider, status_error)
+    data = parse_provider_json_response(response)
+    validate_provider_success_payload(data, _is_valid_image_success_payload)
     data["_api_latency_ms"] = (perf_counter() - upstream_start) * 1000
     data["_api_base"] = api_base
     data["_deployment_model"] = params.get("model")

--- a/src/routers/rerank.py
+++ b/src/routers/rerank.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from time import perf_counter
 from typing import Any
@@ -30,6 +31,11 @@ from src.metrics import (
 )
 from src.models.errors import InvalidRequestError
 from src.models.requests import RerankRequest
+from src.providers.base import (
+    is_valid_provider_number,
+    parse_provider_json_response,
+    validate_provider_success_payload,
+)
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.router import ROUTING_MODE_CONTEXT_KEY
 from src.upstream_auth import build_openai_compatible_auth_headers
@@ -61,6 +67,33 @@ from src.services.preflight_capacity import acquire_preflight_capacity, release_
 router = APIRouter(prefix="/v1", tags=["rerank"])
 
 
+def _is_valid_rerank_success_payload(
+    data: Mapping[str, Any],
+    *,
+    document_count: int,
+    maximum_count: int,
+) -> bool:
+    results = data.get("results")
+    if not isinstance(results, list) or not results or len(results) > maximum_count:
+        return False
+    indexes: set[int] = set()
+    for item in results:
+        if not isinstance(item, Mapping):
+            return False
+        index = item.get("index")
+        if (
+            not isinstance(index, int)
+            or isinstance(index, bool)
+            or index < 0
+            or index >= document_count
+            or index in indexes
+            or not is_valid_provider_number(item.get("relevance_score"))
+        ):
+            return False
+        indexes.add(index)
+    return len(indexes) == len(results)
+
+
 async def _execute_rerank(
     request: Request,
     payload: RerankRequest,
@@ -72,8 +105,9 @@ async def _execute_rerank(
         raise InvalidRequestError(message="Provider API key is missing for selected model")
 
     api_base = params.get("api_base", request.app.state.settings.openai_base_url).rstrip("/")
+    provider = resolve_provider(params)
     headers = build_openai_compatible_auth_headers(
-        provider=resolve_provider(params),
+        provider=provider,
         api_key=str(api_key),
         auth_header_name=params.get("auth_header_name"),
         auth_header_format=params.get("auth_header_format"),
@@ -99,12 +133,23 @@ async def _execute_rerank(
         ),
     )
     if response.status_code >= 400:
-        raise httpx.HTTPStatusError(
+        status_error = httpx.HTTPStatusError(
             f"Upstream rerank call failed with status {response.status_code}",
             request=httpx.Request("POST", f"{api_base}/rerank"),
             response=response,
         )
-    data = response.json()
+        raise request.app.state.provider_error_mapper_registry.map_error(provider, status_error)
+    data = parse_provider_json_response(response)
+    document_count = len(payload.documents)
+    maximum_count = min(document_count, payload.top_n or document_count)
+    validate_provider_success_payload(
+        data,
+        lambda response: _is_valid_rerank_success_payload(
+            response,
+            document_count=document_count,
+            maximum_count=maximum_count,
+        ),
+    )
     data["_api_latency_ms"] = (perf_counter() - upstream_start) * 1000
     data["_api_base"] = api_base
     data["_deployment_model"] = params.get("model")

--- a/tests/config/test_dynamic.py
+++ b/tests/config/test_dynamic.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from src.billing.spend_ingestion import SpendIngestionConfig
 from src.config import AppConfig, RouterSettings
 from src.config_runtime.dynamic import (
     DynamicConfigManager,
@@ -31,10 +32,14 @@ from src.router import (
     RoutingStrategy,
     build_deployment_registry,
 )
-from src.router.runtime_generation import RoutingRuntimeAppliedState
+from src.router.runtime_generation import (
+    RoutingRuntimeAppliedState,
+    RoutingRuntimeGenerationStore,
+)
 from src.router.health import BackgroundHealthChecker
 from src.services.governance_invalidation import GovernanceInvalidationService
 from src.services.routing_authorization import RoutingAuthorizationReconciler
+from src.services.route_groups import StaleRouteGroupSnapshotError
 
 
 class StaticSecretManager(BaseSecretManager):
@@ -456,6 +461,140 @@ async def test_dynamic_config_merges_db_and_notifies_subscribers(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dynamic_config_candidate_reaches_final_subscriber_only_after_acceptance() -> None:
+    manager = DynamicConfigManager(db_client=FakeDB(), redis_client=None, file_config={})
+    await manager.initialize()
+    candidate_started = asyncio.Event()
+    release_candidate = asyncio.Event()
+    reject_candidate = True
+    observed: list[tuple[str, str]] = []
+
+    async def subscriber(config: AppConfig, _changes: dict[str, list[str]]) -> None:
+        strategy = config.router_settings.routing_strategy
+        observed.append(("subscriber", strategy))
+        if strategy == "weighted" and reject_candidate:
+            candidate_started.set()
+            await release_candidate.wait()
+            raise RuntimeError("candidate rejected")
+
+    async def final_subscriber(config: AppConfig, _changes: dict[str, list[str]]) -> None:
+        observed.append(("final", config.router_settings.routing_strategy))
+
+    manager.subscribe(subscriber)
+    manager.subscribe_finalizer(final_subscriber)
+    update = asyncio.create_task(
+        manager.update_config(
+            {"router_settings": {"routing_strategy": "weighted"}},
+            updated_by="test",
+        )
+    )
+    await candidate_started.wait()
+
+    assert ("final", "weighted") not in observed
+
+    release_candidate.set()
+    with pytest.raises(RuntimeError, match="candidate rejected"):
+        await update
+    assert ("final", "weighted") not in observed
+
+    reject_candidate = False
+    await manager.update_config(
+        {"router_settings": {"routing_strategy": "weighted"}},
+        updated_by="test",
+    )
+    assert observed[-2:] == [("subscriber", "weighted"), ("final", "weighted")]
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_config_serializes_failed_poll_before_later_update() -> None:
+    db = FakeDB()
+    manager = DynamicConfigManager(db_client=db, redis_client=None, file_config={})
+    await manager.initialize()
+    rejected_candidate_started = asyncio.Event()
+    release_rejected_candidate = asyncio.Event()
+    later_update_started = asyncio.Event()
+    runtime_strategy = manager.get_app_config().router_settings.routing_strategy
+
+    async def subscriber(config: AppConfig, _changes: dict[str, list[str]]) -> None:
+        if config.router_settings.routing_strategy == "weighted":
+            rejected_candidate_started.set()
+            await release_rejected_candidate.wait()
+            raise RuntimeError("poll candidate rejected")
+
+    async def final_subscriber(config: AppConfig, _changes: dict[str, list[str]]) -> None:
+        nonlocal runtime_strategy
+        runtime_strategy = config.router_settings.routing_strategy
+
+    async def apply_later_update() -> None:
+        later_update_started.set()
+        await manager.update_config(
+            {"router_settings": {"routing_strategy": "least-busy"}},
+            updated_by="later-update",
+        )
+
+    manager.subscribe(subscriber)
+    manager.subscribe_finalizer(final_subscriber)
+    db.config_value = {"router_settings": {"routing_strategy": "weighted"}}
+    rejected_poll = asyncio.create_task(manager._reload_config_from_source(source="poll"))
+    await rejected_candidate_started.wait()
+    later_update = asyncio.create_task(apply_later_update())
+    await later_update_started.wait()
+
+    assert db.updated_by is None
+    assert runtime_strategy == "simple-shuffle"
+
+    release_rejected_candidate.set()
+    assert await rejected_poll is False
+    await later_update
+
+    assert manager.get_app_config().router_settings.routing_strategy == "least-busy"
+    assert db.config_value["router_settings"]["routing_strategy"] == "least-busy"
+    assert runtime_strategy == "least-busy"
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_config_poll_loads_durable_state_after_waiting_for_update() -> None:
+    db = FakeDB()
+    manager = DynamicConfigManager(db_client=db, redis_client=None, file_config={})
+    await manager.initialize()
+    update_candidate_started = asyncio.Event()
+    release_update_candidate = asyncio.Event()
+    poll_started = asyncio.Event()
+
+    async def subscriber(config: AppConfig, _changes: dict[str, list[str]]) -> None:
+        if config.router_settings.routing_strategy == "weighted":
+            update_candidate_started.set()
+            await release_update_candidate.wait()
+
+    async def run_poll() -> bool:
+        poll_started.set()
+        return await manager._reload_config_from_source(source="poll")
+
+    manager.subscribe(subscriber)
+    update = asyncio.create_task(
+        manager.update_config(
+            {"router_settings": {"routing_strategy": "weighted"}},
+            updated_by="direct-update",
+        )
+    )
+    await update_candidate_started.wait()
+    queries_before_poll = len(db.queries)
+    poll = asyncio.create_task(run_poll())
+    await poll_started.wait()
+
+    assert len(db.queries) == queries_before_poll
+
+    release_update_candidate.set()
+    await update
+    assert await poll is False
+    assert manager.get_app_config().router_settings.routing_strategy == "weighted"
+    assert db.config_value["router_settings"]["routing_strategy"] == "weighted"
+    await manager.close()
+
+
+@pytest.mark.asyncio
 async def test_dynamic_config_model_updated_notifies_subscribers_without_config_diff():
     redis = FakeRedis()
     manager = DynamicConfigManager(db_client=FakeDB(), redis_client=redis, file_config={})
@@ -764,11 +903,16 @@ async def test_dynamic_config_subscriber_failure_restores_last_known_good_config
     db = FakeDB()
     manager = DynamicConfigManager(db_client=db, redis_client=None, file_config={})
     await manager.initialize()
-    observed: list[str] = []
+    observed: list[tuple[str, tuple[list[dict[str, list[str]]], ...]]] = []
 
     async def subscriber(config: AppConfig, _changes: dict[str, list[str]]) -> None:
         strategy = config.router_settings.routing_strategy
-        observed.append(strategy)
+        fallback_maps = (
+            config.deltallm_settings.fallbacks,
+            config.deltallm_settings.context_window_fallbacks,
+            config.deltallm_settings.content_policy_fallbacks,
+        )
+        observed.append((strategy, fallback_maps))
         if strategy == "weighted":
             raise RuntimeError("runtime rejected candidate")
 
@@ -776,13 +920,33 @@ async def test_dynamic_config_subscriber_failure_restores_last_known_good_config
 
     with pytest.raises(RuntimeError, match="runtime rejected candidate"):
         await manager.update_config(
-            {"router_settings": {"routing_strategy": "weighted"}},
+            {
+                "router_settings": {"routing_strategy": "weighted"},
+                "deltallm_settings": {
+                    "fallbacks": [{"primary": ["general"]}],
+                    "context_window_fallbacks": [{"primary": ["context"]}],
+                    "content_policy_fallbacks": [{"primary": ["content"]}],
+                },
+            },
             updated_by="test",
         )
 
     assert manager.get_app_config().router_settings.routing_strategy == "simple-shuffle"
+    assert manager.get_app_config().deltallm_settings.fallbacks == []
+    assert manager.get_app_config().deltallm_settings.context_window_fallbacks == []
+    assert manager.get_app_config().deltallm_settings.content_policy_fallbacks == []
     assert db.config_value == {}
-    assert observed == ["weighted", "simple-shuffle"]
+    assert observed == [
+        (
+            "weighted",
+            (
+                [{"primary": ["general"]}],
+                [{"primary": ["context"]}],
+                [{"primary": ["content"]}],
+            ),
+        ),
+        ("simple-shuffle", ([], [], [])),
+    ]
     await manager.close()
 
 
@@ -945,6 +1109,11 @@ async def test_model_hot_reload_manager_updates_runtime_registries():
                 }
             ],
             "router_settings": {"routing_strategy": "weighted", "num_retries": 2},
+            "deltallm_settings": {
+                "fallbacks": [{"gpt-4.1-mini": ["general-fallback"]}],
+                "context_window_fallbacks": [{"gpt-4.1-mini": ["context-fallback"]}],
+                "content_policy_fallbacks": [{"gpt-4.1-mini": ["content-fallback"]}],
+            },
             "general_settings": {
                 **dynamic.get_app_config().general_settings.model_dump(mode="python"),
                 "instance_name": "Acme AI",
@@ -953,13 +1122,25 @@ async def test_model_hot_reload_manager_updates_runtime_registries():
     )
 
     await manager._on_config_change(
-        updated_cfg, {"added": [], "removed": [], "modified": ["model_list", "router_settings"]}
+        updated_cfg,
+        {
+            "added": [],
+            "removed": [],
+            "modified": ["model_list", "router_settings", "deltallm_settings"],
+        },
     )
 
     assert "gpt-4.1-mini" in app.state.model_registry
     assert app.state.router.strategy == RoutingStrategy.WEIGHTED
     assert app.state.router.config.num_retries == 2
     assert app.state.failover_manager.config.num_retries == 2
+    assert app.state.failover_manager.config.fallbacks == {"gpt-4.1-mini": ("general-fallback",)}
+    assert app.state.failover_manager.config.context_window_fallbacks == {
+        "gpt-4.1-mini": ("context-fallback",)
+    }
+    assert app.state.failover_manager.config.content_policy_fallbacks == {
+        "gpt-4.1-mini": ("content-fallback",)
+    }
     assert app.state.platform_identity_service.totp_issuer == "Acme AI"
     assert app.state.router.deployment_registry["gpt-4.1-mini"][0].deployment_id == "new-dep"
 
@@ -968,6 +1149,8 @@ async def test_model_hot_reload_manager_updates_runtime_registries():
     previous_model_registry = app.state.model_registry
     previous_route_groups = app.state.route_groups
     previous_strategy = app.state.router.strategy
+    previous_generation = app.state.routing_runtime_generation_store.require_snapshot()
+    previous_failover_config = app.state.failover_manager.config
     invalid_cfg = AppConfig.model_validate(
         {
             **updated_cfg.model_dump(mode="python"),
@@ -985,13 +1168,22 @@ async def test_model_hot_reload_manager_updates_runtime_registries():
                 **updated_cfg.general_settings.model_dump(mode="python"),
                 "instance_name": "Must Not Publish",
             },
+            "deltallm_settings": {
+                "fallbacks": [{"gpt-4.1-mini": ["rejected-general"]}],
+                "context_window_fallbacks": [{"gpt-4.1-mini": ["rejected-context"]}],
+                "content_policy_fallbacks": [{"gpt-4.1-mini": ["rejected-content"]}],
+            },
         }
     )
 
     with pytest.raises(ValueError, match="incompatible with members"):
         await manager._on_config_change(
             invalid_cfg,
-            {"added": [], "removed": [], "modified": ["router_settings"]},
+            {
+                "added": [],
+                "removed": [],
+                "modified": ["router_settings", "deltallm_settings"],
+            },
         )
 
     assert app.state.app_config is previous_app_config
@@ -999,9 +1191,224 @@ async def test_model_hot_reload_manager_updates_runtime_registries():
     assert app.state.model_registry is previous_model_registry
     assert app.state.route_groups is previous_route_groups
     assert app.state.router.strategy is previous_strategy
+    assert app.state.failover_manager.config is previous_failover_config
+    assert app.state.routing_runtime_generation_store.require_snapshot() is previous_generation
     assert app.state.platform_identity_service.totp_issuer == "Acme AI"
 
+    def reject_callbacks(**_kwargs) -> None:  # noqa: ANN003
+        raise RuntimeError("callback runtime rejected candidate")
+
+    app.state.callback_manager = SimpleNamespace(load_from_settings=reject_callbacks)
+    valid_but_rejected_cfg = AppConfig.model_validate(
+        {
+            **updated_cfg.model_dump(mode="python"),
+            "deltallm_settings": {
+                "fallbacks": [{"gpt-4.1-mini": ["must-not-publish-general"]}],
+                "context_window_fallbacks": [{"gpt-4.1-mini": ["must-not-publish-context"]}],
+                "content_policy_fallbacks": [{"gpt-4.1-mini": ["must-not-publish-content"]}],
+            },
+        }
+    )
+    with pytest.raises(RuntimeError, match="callback runtime rejected candidate"):
+        await manager._on_config_change(
+            valid_but_rejected_cfg,
+            {
+                "added": [],
+                "removed": [],
+                "modified": ["deltallm_settings"],
+            },
+        )
+
+    assert app.state.app_config is previous_app_config
+    assert app.state.failover_manager.config is previous_failover_config
+    assert app.state.routing_runtime_generation_store.require_snapshot() is previous_generation
+
     await dynamic.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_config_rebuilds_after_same_revision_generation_publish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = object.__new__(ModelHotReloadManager)
+    manager._route_reload_lock = asyncio.Lock()
+    manager._applied_route_revision = 7
+    store = RoutingRuntimeGenerationStore()
+    empty_registry = SimpleNamespace(snapshot=lambda: {})
+    base_generation = SimpleNamespace(
+        generation_id="base",
+        revision=7,
+        deployment_registry=empty_registry,
+    )
+    store.replace(base_generation)  # type: ignore[arg-type]
+    reconfigure_started = asyncio.Event()
+    release_reconfigure = asyncio.Event()
+    rebuild_started = asyncio.Event()
+    release_rebuild = asyncio.Event()
+
+    class PausedSpendService:
+        config = SpendIngestionConfig()
+
+        async def reconfigure(self, _config: SpendIngestionConfig) -> None:
+            reconfigure_started.set()
+            await release_reconfigure.wait()
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            settings=SimpleNamespace(),
+            routing_runtime_generation_store=store,
+            router=SimpleNamespace(deployment_registry={}),
+            guardrail_registry=SimpleNamespace(load_from_config=lambda _: None),
+            callback_manager=SimpleNamespace(load_from_settings=lambda **_: None),
+            spend_tracking_service=PausedSpendService(),
+            turn_off_message_logging=False,
+        )
+    )
+    manager.app = app
+    stale_candidate = SimpleNamespace(
+        generation_id="stale-candidate",
+        revision=7,
+        salt_key="salt",
+        authorization_snapshot="old-grants",
+        deployment_registry=empty_registry,
+    )
+    concurrent_generation = SimpleNamespace(
+        generation_id="same-revision-governance",
+        revision=7,
+        authorization_snapshot="revoked-grants",
+        deployment_registry=empty_registry,
+    )
+    superseded_candidate = SimpleNamespace(
+        generation_id="superseded-candidate",
+        revision=7,
+        salt_key="salt",
+        authorization_snapshot="revoked-grants",
+        deployment_registry=empty_registry,
+    )
+    concurrent_during_rebuild = SimpleNamespace(
+        generation_id="same-revision-governance-v2",
+        revision=7,
+        authorization_snapshot="revoked-grants-v2",
+        deployment_registry=empty_registry,
+    )
+    rebuilt_candidate = SimpleNamespace(
+        generation_id="rebuilt-candidate",
+        revision=7,
+        salt_key="salt",
+        authorization_snapshot="revoked-grants-v2",
+        deployment_registry=empty_registry,
+    )
+    load_count = 0
+    published: list[SimpleNamespace] = []
+
+    async def load_generation(**_kwargs) -> SimpleNamespace:  # noqa: ANN003
+        nonlocal load_count
+        load_count += 1
+        if load_count == 1:
+            return stale_candidate
+        if load_count == 2:
+            rebuild_started.set()
+            await release_rebuild.wait()
+            return superseded_candidate
+        return rebuilt_candidate
+
+    async def no_op(*_args, **_kwargs) -> None:  # noqa: ANN002, ANN003
+        return None
+
+    def publish_generation(generation: SimpleNamespace) -> None:
+        published.append(generation)
+        store.replace(generation)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(manager, "_invalidate_route_group_cache", no_op)
+    monkeypatch.setattr(manager, "_load_complete_routing_generation", load_generation)
+    monkeypatch.setattr(manager, "_publish_routing_generation", publish_generation)
+    monkeypatch.setattr(manager, "_cleanup_replaced_deployment_health", no_op)
+    monkeypatch.setattr("src.config_runtime.models.configure_cache_runtime", lambda *_a, **_k: None)
+
+    apply_candidate = asyncio.create_task(
+        manager._apply_runtime_config(AppConfig.model_validate({}))
+    )
+    await reconfigure_started.wait()
+    async with manager._route_reload_lock:
+        store.replace(concurrent_generation)  # type: ignore[arg-type]
+    release_reconfigure.set()
+    await rebuild_started.wait()
+    store.replace(concurrent_during_rebuild)  # type: ignore[arg-type]
+    release_rebuild.set()
+    await apply_candidate
+
+    assert published == [rebuilt_candidate]
+    assert load_count == 3
+    assert store.require_snapshot() is rebuilt_candidate
+    assert store.require_snapshot().authorization_snapshot == "revoked-grants-v2"
+
+
+@pytest.mark.asyncio
+async def test_runtime_config_publication_contention_is_bounded_and_preserves_latest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = object.__new__(ModelHotReloadManager)
+    manager._applied_route_revision = 7
+    empty_registry = SimpleNamespace(snapshot=lambda: {})
+    store = RoutingRuntimeGenerationStore()
+    latest_generation = SimpleNamespace(
+        generation_id="external-0",
+        revision=7,
+        deployment_registry=empty_registry,
+    )
+    store.replace(latest_generation)  # type: ignore[arg-type]
+    manager.app = SimpleNamespace(
+        state=SimpleNamespace(
+            routing_runtime_generation_store=store,
+            router=SimpleNamespace(deployment_registry={}),
+        )
+    )
+    initial_candidate = SimpleNamespace(
+        generation_id="candidate-0",
+        revision=7,
+        deployment_registry=empty_registry,
+    )
+    load_count = 0
+    published: list[SimpleNamespace] = []
+    reconciliation_marks: list[bool] = []
+
+    async def load_generation(**_kwargs) -> SimpleNamespace:  # noqa: ANN003
+        nonlocal latest_generation, load_count
+        load_count += 1
+        latest_generation = SimpleNamespace(
+            generation_id=f"external-{load_count}",
+            revision=7,
+            deployment_registry=empty_registry,
+        )
+        store.replace(latest_generation)  # type: ignore[arg-type]
+        return SimpleNamespace(
+            generation_id=f"candidate-{load_count}",
+            revision=7,
+            deployment_registry=empty_registry,
+        )
+
+    async def no_op(*_args, **_kwargs) -> None:  # noqa: ANN002, ANN003
+        return None
+
+    monkeypatch.setattr(manager, "_invalidate_route_group_cache", no_op)
+    monkeypatch.setattr(manager, "_load_complete_routing_generation", load_generation)
+    monkeypatch.setattr(manager, "_publish_routing_generation", published.append)
+    monkeypatch.setattr(
+        manager, "_mark_reconciliation_required", lambda: reconciliation_marks.append(True)
+    )
+
+    with pytest.raises(StaleRouteGroupSnapshotError):
+        await manager._publish_stable_config_generation(
+            app_config=AppConfig.model_validate({}),
+            settings=SimpleNamespace(),
+            candidate=initial_candidate,  # type: ignore[arg-type]
+            candidate_base_id="base",
+        )
+
+    assert load_count == 3
+    assert published == []
+    assert reconciliation_marks == [True]
+    assert store.require_snapshot() is latest_generation
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,10 @@ from src.guardrails.registry import GuardrailRegistry
 from src.main import create_app
 from src.providers.bedrock import BedrockAdapter
 from src.providers.azure import AzureOpenAIAdapter
+from src.providers.anthropic import AnthropicAdapter
 from src.providers.gemini import GeminiAdapter
 from src.providers.openai import OpenAIAdapter
+from src.providers.registry import ProviderErrorMapperRegistry
 from src.router import (
     CooldownManager,
     FallbackConfig,
@@ -1269,6 +1271,7 @@ class MockHTTPStreamResponse:
 
     async def aiter_lines(self):
         yield 'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}'
+        yield 'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
         yield "data: [DONE]"
 
 
@@ -1378,8 +1381,16 @@ async def test_app() -> FastAPI:
     app.state.http_client = mock_http
     app.state.openai_adapter = OpenAIAdapter(mock_http)  # type: ignore[arg-type]
     app.state.azure_openai_adapter = AzureOpenAIAdapter(mock_http)  # type: ignore[arg-type]
+    app.state.anthropic_adapter = AnthropicAdapter(mock_http)  # type: ignore[arg-type]
     app.state.gemini_adapter = GeminiAdapter(mock_http)  # type: ignore[arg-type]
     app.state.bedrock_adapter = BedrockAdapter(mock_http)  # type: ignore[arg-type]
+    app.state.provider_error_mapper_registry = ProviderErrorMapperRegistry(
+        openai=app.state.openai_adapter,
+        azure_openai=app.state.azure_openai_adapter,
+        anthropic=app.state.anthropic_adapter,
+        gemini=app.state.gemini_adapter,
+        bedrock=app.state.bedrock_adapter,
+    )
     app.state.app_config = type(
         "Cfg",
         (),

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
 
+import httpx
 import pytest
 
 from src.cache import (
@@ -600,9 +601,7 @@ async def test_streaming_cache_handler_skips_store_when_buffer_limit_exceeded():
 
 
 @pytest.mark.asyncio
-async def test_streaming_cache_skips_store_after_invalid_chunk_without_breaking_stream(
-    client, test_app
-):
+async def test_streaming_cache_discards_committed_stream_after_invalid_chunk(test_app):
     _enable_stream_cache(test_app)
     calls = {"count": 0}
 
@@ -625,17 +624,26 @@ async def test_streaming_cache_skips_store_after_invalid_chunk_without_breaking_
         "stream": True,
     }
 
-    first = await client.post("/v1/chat/completions", headers=headers, json=body)
-    second = await client.post("/v1/chat/completions", headers=headers, json=body)
+    transport = httpx.ASGITransport(app=test_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.post("/v1/chat/completions", headers=headers, json=body)
+        second = await client.post("/v1/chat/completions", headers=headers, json=body)
 
     assert first.status_code == 200
     assert second.status_code == 200
-    assert "data: [DONE]" in first.text
-    assert "data: [DONE]" in second.text
+    assert '"content":"hi"' in first.text
+    assert '"content":"hi"' in second.text
+    assert "data: [DONE]" not in first.text
+    assert "data: [DONE]" not in second.text
     assert calls["count"] == 2
     assert len(test_app.state.cache_backend._cache) == 0
-    assert test_app.state.streaming_cache_handler.disabled_streams_total == 2
+    # The provider validator rejects the malformed frame before it reaches the
+    # cache accumulator, while the stream lifecycle still discards its state.
+    assert test_app.state.streaming_cache_handler.disabled_streams_total == 0
     assert test_app.state.streaming_cache_handler.active_stream_count == 0
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert health["last_error"] == "Provider returned an invalid response"
 
 
 @pytest.mark.asyncio

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json as jsonlib
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any
 from uuid import UUID
@@ -835,9 +836,12 @@ async def test_mcp_tool_is_not_replayed_when_followup_model_retries(client, test
     gateway = _FakeMCPGateway()
     test_app.state.mcp_gateway_service = gateway
     test_app.state.audit_service = _RecordingAuditService()
-    test_app.state.failover_manager.config.num_retries = 1
-    test_app.state.failover_manager.config.retry_after = 0.001
-    test_app.state.failover_manager.config.backoff_jitter = False
+    test_app.state.failover_manager.config = replace(
+        test_app.state.failover_manager.config,
+        num_retries=1,
+        retry_after=0.001,
+        backoff_jitter=False,
+    )
     upstream_phases: list[bool] = []
 
     async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
@@ -1672,7 +1676,7 @@ async def test_chat_upstream_rate_limit_returns_429(client, test_app):
     assert response.status_code == 429
     assert response.headers.get("Retry-After") == "17"
     assert response.json()["error"] == {
-        "message": "provider quota exhausted",
+        "message": "Provider rate limited request",
         "type": "rate_limit_error",
         "param": None,
         "code": None,
@@ -1680,7 +1684,7 @@ async def test_chat_upstream_rate_limit_returns_429(client, test_app):
     health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
     assert health.get("healthy", "true") != "false"
     assert int(health.get("consecutive_failures", 0) or 0) == 1
-    assert health.get("last_error") == "provider quota exhausted"
+    assert health.get("last_error") == "Provider rate limited request"
     assert not await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
 
 
@@ -1757,13 +1761,98 @@ async def test_chat_upstream_bad_request_does_not_mark_deployment_unhealthy(clie
     assert attempted_auths == ["Bearer provider-key", "Bearer provider-key"]
 
 
+@pytest.mark.asyncio
+async def test_chat_malformed_success_uses_general_fallback_without_leaking_payload(
+    client,
+    test_app,
+):
+    registry_store = test_app.state.router.deployment_registry
+    registry = list(registry_store["gpt-4o-mini"])
+    primary = registry[0]
+    primary.deltallm_params["api_key"] = "provider-key"
+    fallback = type(primary)(
+        deployment_id="gpt-4o-mini-malformed-fallback",
+        model_name="gpt-4o-mini",
+        deltallm_params={
+            "model": "openai/gpt-4o-mini",
+            "api_key": "provider-key-fallback",
+        },
+        model_info={},
+    )
+    registry.append(fallback)
+    registry_store.replace({**registry_store.snapshot(), "gpt-4o-mini": registry})
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return primary
+
+    attempted_auths: list[str | None] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del timeout
+        attempted_auths.append(headers.get("Authorization"))
+        request = httpx.Request("POST", url)
+        if headers.get("Authorization") == "Bearer provider-key":
+            return httpx.Response(
+                200,
+                json={"secret": "sk-upstream", "messages": ["private-output"]},
+                request=request,
+            )
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-fallback",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "model": json["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+            request=request,
+        )
+
+    test_app.state.router.select_deployment = choose_primary
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "ok"
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    assert attempted_auths == ["Bearer provider-key", "Bearer provider-key-fallback"]
+    assert "sk-upstream" not in response.text
+    assert "private-output" not in response.text
+    health = await test_app.state.router_state_backend.get_health(primary.deployment_id)
+    assert health["last_error"] == "Provider returned an invalid response"
+
+
 class _StreamContext:
     def __init__(
-        self, status_code: int, lines: list[str], *, line_error: Exception | None = None
+        self,
+        status_code: int,
+        lines: list[str],
+        *,
+        body: bytes = b"",
+        line_error: Exception | None = None,
     ) -> None:
         self.status_code = status_code
         self._lines = lines
+        self._body = body
         self._line_error = line_error
+        self.headers = httpx.Headers()
         self.exited = False
 
     async def __aenter__(self):
@@ -1778,6 +1867,11 @@ class _StreamContext:
             yield line
         if self._line_error is not None:
             raise self._line_error
+
+    async def aiter_bytes(self, chunk_size: int | None = None):
+        del chunk_size
+        if self._body:
+            yield self._body
 
 
 @pytest.mark.asyncio
@@ -2068,6 +2162,7 @@ async def test_stream_retries_before_first_token_with_failover(client, test_app)
             status_code=200,
             lines=[
                 'data: {"id":"chatcmpl-fb","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-fb","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}',
                 "data: [DONE]",
             ],
         )
@@ -2086,6 +2181,194 @@ async def test_stream_retries_before_first_token_with_failover(client, test_app)
     assert calls["count"] == 2
     assert response.headers["x-deltallm-route-deployment"] == "gpt-4o-mini-fallback"
     assert response.headers["x-deltallm-route-fallback-used"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_stream_content_filter_before_output_uses_specialized_fallback(client, test_app):
+    registry_store = test_app.state.router.deployment_registry
+    primary = registry_store["gpt-4o-mini"][0]
+    primary.deltallm_params["api_key"] = "primary-key"
+    fallback = type(primary)(
+        deployment_id="gpt-4o-mini-content-fallback",
+        model_name="gpt-4o-mini-content",
+        deltallm_params={
+            "model": "openai/gpt-4o-mini",
+            "api_key": "content-fallback-key",
+        },
+        model_info={},
+    )
+    registry_store.replace(
+        {
+            **registry_store.snapshot(),
+            "gpt-4o-mini": [primary],
+            "gpt-4o-mini-content": [fallback],
+        }
+    )
+    test_app.state.failover_manager.config = replace(
+        test_app.state.failover_manager.config,
+        content_policy_fallbacks={"gpt-4o-mini": ["gpt-4o-mini-content"]},
+    )
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return primary
+
+    attempted_auths: list[str | None] = []
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
+        del method, url, json, timeout
+        attempted_auths.append(headers.get("Authorization"))
+        if headers.get("Authorization") == "Bearer primary-key":
+            return _StreamContext(
+                status_code=200,
+                lines=[
+                    'data: {"id":"chatcmpl-primary","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+                    'data: {"id":"chatcmpl-primary","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}]}',
+                    "data: [DONE]",
+                ],
+            )
+        return _StreamContext(
+            status_code=200,
+            lines=[
+                'data: {"id":"chatcmpl-content-fallback","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-content-fallback","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"safe answer"},"finish_reason":null}]}',
+                "data: [DONE]",
+            ],
+        )
+
+    test_app.state.router.select_deployment = choose_primary
+    test_app.state.http_client.stream = stream
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "safe answer" in response.text
+    assert "chatcmpl-primary" not in response.text
+    assert attempted_auths == ["Bearer primary-key", "Bearer content-fallback-key"]
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    primary_health = await test_app.state.router_state_backend.get_health(primary.deployment_id)
+    assert int(primary_health.get("consecutive_failures", 0) or 0) == 0
+    assert primary_health.get("last_error") is None
+    primary_usage = await test_app.state.router_state_backend.get_usage(primary.deployment_id)
+    fallback_usage = await test_app.state.router_state_backend.get_usage(fallback.deployment_id)
+    assert int(primary_usage.get("rpm", 0) or 0) == 0
+    assert fallback_usage["rpm"] == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_terminal_only_success_uses_general_fallback(client, test_app):
+    registry_store = test_app.state.router.deployment_registry
+    primary = registry_store["gpt-4o-mini"][0]
+    primary.deltallm_params["api_key"] = "primary-key"
+    fallback = type(primary)(
+        deployment_id="gpt-4o-mini-terminal-fallback",
+        model_name="gpt-4o-mini",
+        deltallm_params={
+            "model": "openai/gpt-4o-mini",
+            "api_key": "general-fallback-key",
+        },
+        model_info={},
+    )
+    registry_store.replace({**registry_store.snapshot(), "gpt-4o-mini": [primary, fallback]})
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return primary
+
+    attempted_auths: list[str | None] = []
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
+        del method, url, json, timeout
+        attempted_auths.append(headers.get("Authorization"))
+        if headers.get("Authorization") == "Bearer primary-key":
+            return _StreamContext(
+                status_code=200,
+                lines=[
+                    'data: {"id":"chatcmpl-terminal-only","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+                    "data: [DONE]",
+                ],
+            )
+        return _StreamContext(
+            status_code=200,
+            lines=[
+                'data: {"id":"chatcmpl-general-fallback","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"fallback answer"},"finish_reason":null}]}',
+                "data: [DONE]",
+            ],
+        )
+
+    test_app.state.router.select_deployment = choose_primary
+    test_app.state.http_client.stream = stream
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "fallback answer" in response.text
+    assert "chatcmpl-terminal-only" not in response.text
+    assert attempted_auths == ["Bearer primary-key", "Bearer general-fallback-key"]
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    primary_health = await test_app.state.router_state_backend.get_health(primary.deployment_id)
+    assert primary_health["last_error"] == "Provider returned an invalid response"
+    primary_usage = await test_app.state.router_state_backend.get_usage(primary.deployment_id)
+    fallback_usage = await test_app.state.router_state_backend.get_usage(fallback.deployment_id)
+    assert int(primary_usage.get("rpm", 0) or 0) == 0
+    assert fallback_usage["rpm"] == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_provider_4xx_body_is_classified_before_response_commit(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params["provider"] = "azure_openai"
+    deployment.deltallm_params["api_base"] = "https://azure.example/openai/v1"
+    deployment.deltallm_params["api_key"] = "azure-provider-key"
+    context = _StreamContext(
+        status_code=400,
+        lines=[],
+        body=jsonlib.dumps(
+            {
+                "error": {
+                    "code": "context_length_exceeded",
+                    "message": "maximum context length sk-upstream",
+                }
+            }
+        ).encode(),
+    )
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
+        del method, url, json, timeout
+        assert headers.get("api-key") == "azure-provider-key"
+        return context
+
+    test_app.state.http_client.stream = stream
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "Provider rejected request"
+    assert "sk-upstream" not in response.text
+    assert context.exited is True
 
 
 @pytest.mark.asyncio
@@ -2212,7 +2495,7 @@ async def test_stream_failure_after_failover_uses_last_attempted_deployment(clie
 
     primary_health = await test_app.state.router_state_backend.get_health(registry[0].deployment_id)
     fallback_health = await test_app.state.router_state_backend.get_health("gpt-4o-mini-fallback")
-    assert primary_health.get("last_error") == "Provider error: 503"
+    assert primary_health.get("last_error") == "Provider unavailable"
     assert fallback_health.get("last_error") == "fallback stream broke"
     assert len(stream_contexts) == 2
     assert all(context.exited for context in stream_contexts)

--- a/tests/test_elevenlabs_stt.py
+++ b/tests/test_elevenlabs_stt.py
@@ -326,7 +326,7 @@ async def test_audio_transcription_elevenlabs_multichannel_uses_billable_channel
 
 
 @pytest.mark.asyncio
-async def test_audio_transcription_elevenlabs_surfaces_upstream_errors(client, test_app):
+async def test_audio_transcription_elevenlabs_sanitizes_upstream_errors(client, test_app):
     test_app.state.spend_tracking_service = _SpendRecorder()
     _configure_elevenlabs_stt_deployment(test_app)
 
@@ -350,7 +350,8 @@ async def test_audio_transcription_elevenlabs_surfaces_upstream_errors(client, t
     )
 
     assert response.status_code == 400
-    assert "bad audio" in response.text
+    assert response.json()["error"]["message"] == "Provider rejected request"
+    assert "bad audio" not in response.text
 
     await asyncio.sleep(0.05)
     last_event = test_app.state.spend_tracking_service.events[-1]
@@ -359,7 +360,7 @@ async def test_audio_transcription_elevenlabs_surfaces_upstream_errors(client, t
 
 
 @pytest.mark.asyncio
-async def test_audio_transcription_elevenlabs_invalid_json_logs_upstream_502(
+async def test_audio_transcription_elevenlabs_invalid_schema_returns_sanitized_error(
     client,
     test_app,
 ):
@@ -372,7 +373,7 @@ async def test_audio_transcription_elevenlabs_invalid_json_logs_upstream_502(
         del headers, files, data, timeout
         return httpx.Response(
             200,
-            content=b"not-json",
+            json={"secret": "sk-upstream"},
             request=httpx.Request("POST", url),
         )
 
@@ -386,7 +387,8 @@ async def test_audio_transcription_elevenlabs_invalid_json_logs_upstream_502(
     )
 
     assert response.status_code == 503
-    assert "invalid JSON" in response.text
+    assert response.json()["error"]["message"] == "Provider returned an invalid response"
+    assert "sk-upstream" not in response.text
 
     await asyncio.sleep(0.05)
     last_event = test_app.state.spend_tracking_service.events[-1]

--- a/tests/test_elevenlabs_tts.py
+++ b/tests/test_elevenlabs_tts.py
@@ -275,7 +275,7 @@ async def test_audio_speech_elevenlabs_rejects_unsupported_openai_formats(
 
 
 @pytest.mark.asyncio
-async def test_audio_speech_elevenlabs_surfaces_upstream_errors(client, test_app):
+async def test_audio_speech_elevenlabs_sanitizes_upstream_errors(client, test_app):
     test_app.state.spend_tracking_service = _SpendRecorder()
     _configure_elevenlabs_deployment(test_app, default_params={"voice_id": "voice-default"})
 
@@ -296,9 +296,37 @@ async def test_audio_speech_elevenlabs_surfaces_upstream_errors(client, test_app
     )
 
     assert response.status_code == 400
-    assert "bad voice" in response.text
+    assert response.json()["error"]["message"] == "Provider rejected request"
+    assert "bad voice" not in response.text
 
     await asyncio.sleep(0.05)
     last_event = test_app.state.spend_tracking_service.events[-1]
     assert last_event["status"] == "error"
     assert last_event["call_type"] == "audio_speech"
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_elevenlabs_rejects_empty_success_audio(client, test_app):
+    test_app.state.spend_tracking_service = _SpendRecorder()
+    _configure_elevenlabs_deployment(test_app, default_params={"voice_id": "voice-default"})
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        return httpx.Response(200, content=b"", request=httpx.Request("POST", url))
+
+    test_app.state.http_client.post = post
+
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "input": "hello world"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["message"] == "Provider returned an invalid response"
+    await asyncio.sleep(0.05)
+    assert not [
+        event
+        for event in test_app.state.spend_tracking_service.events
+        if event["status"] == "success"
+    ]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 
 import httpx
 import pytest
 
 from src.callbacks import CallbackManager, CustomLogger
+from src.router.router import Deployment
 
 
 class RecordingCallback(CustomLogger):
@@ -122,10 +124,11 @@ async def test_embeddings_upstream_rate_limit_returns_429(client, test_app):
     assert response.status_code == 429
     assert response.headers.get("Retry-After") == "11"
     assert response.json()["error"]["type"] == "rate_limit_error"
+    assert response.json()["error"]["message"] == "Provider rate limited request"
     health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
     assert health.get("healthy", "true") != "false"
     assert int(health.get("consecutive_failures", 0) or 0) == 1
-    assert health.get("last_error") == "provider quota exhausted"
+    assert health.get("last_error") == "Provider rate limited request"
     assert not await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
 
 
@@ -151,8 +154,242 @@ async def test_embeddings_upstream_service_unavailable_updates_health_once(clien
     health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
     assert health.get("healthy", "true") != "false"
     assert int(health.get("consecutive_failures", 0) or 0) == 1
-    assert health.get("last_error") == "Upstream embedding call failed with status 503"
+    assert health.get("last_error") == "Provider unavailable"
     assert not await test_app.state.router_state_backend.is_cooled_down(deployment.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_embeddings_provider_classification_selects_content_policy_fallback(client, test_app):
+    registry = test_app.state.router.deployment_registry
+    primary = registry["text-embedding-3-small"][0]
+    primary.deltallm_params["api_key"] = "primary-key"
+    fallback = Deployment(
+        deployment_id="embedding-content-fallback",
+        model_name="embedding-content-fallback",
+        deltallm_params={
+            "provider": "openai",
+            "model": "openai/text-embedding-3-small",
+            "api_key": "fallback-key",
+        },
+        model_info={"mode": "embedding"},
+    )
+    registry.replace(
+        {
+            **registry.snapshot(),
+            "embedding-content-fallback": [fallback],
+        }
+    )
+    manager = test_app.state.failover_manager
+    manager.config = replace(
+        manager.config,
+        content_policy_fallbacks={"text-embedding-3-small": ["embedding-content-fallback"]},
+    )
+    attempts: list[str] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del json, timeout
+        attempts.append(headers["Authorization"])
+        if headers["Authorization"] == "Bearer primary-key":
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "type": "content_policy_violation",
+                        "message": "provider-owned sensitive detail",
+                    }
+                },
+                request=httpx.Request("POST", url),
+            )
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+                "model": "text-embedding-3-small",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/embeddings",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "text-embedding-3-small", "input": "hello"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    assert attempts == ["Bearer primary-key", "Bearer fallback-key"]
+
+
+@pytest.mark.asyncio
+async def test_embeddings_custom_provider_does_not_inherit_openai_classification(client, test_app):
+    registry = test_app.state.router.deployment_registry
+    primary = registry["text-embedding-3-small"][0]
+    primary.deltallm_params.update(
+        {
+            "provider": "custom-gateway",
+            "model": "custom-model",
+            "api_key": "primary-key",
+        }
+    )
+    fallback = Deployment(
+        deployment_id="embedding-context-fallback",
+        model_name="embedding-context-fallback",
+        deltallm_params={
+            "provider": "openai",
+            "model": "openai/text-embedding-3-small",
+            "api_key": "fallback-key",
+        },
+        model_info={"mode": "embedding"},
+    )
+    registry.replace(
+        {
+            **registry.snapshot(),
+            "embedding-context-fallback": [fallback],
+        }
+    )
+    manager = test_app.state.failover_manager
+    manager.config = replace(
+        manager.config,
+        context_window_fallbacks={"text-embedding-3-small": ["embedding-context-fallback"]},
+    )
+    attempts: list[str] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del json, timeout
+        attempts.append(headers["Authorization"])
+        if headers["Authorization"] == "Bearer primary-key":
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "code": "context_length_exceeded",
+                        "message": "maximum context length sk-upstream",
+                    }
+                },
+                request=httpx.Request("POST", url),
+            )
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+                "model": "text-embedding-3-small",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/embeddings",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "text-embedding-3-small", "input": "hello"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "Provider rejected request"
+    assert "sk-upstream" not in response.text
+    assert attempts == ["Bearer primary-key"]
+    health = await test_app.state.router_state_backend.get_health(primary.deployment_id)
+    assert int(health.get("consecutive_failures", 0) or 0) == 0
+    assert health.get("last_error") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "malformed_payload",
+    [
+        {"secret": "sk-upstream"},
+        {"data": [], "usage": {"prompt_tokens": 1, "total_tokens": 1}},
+        {
+            "data": [{"object": "embedding", "index": 0, "embedding": []}],
+            "usage": {"prompt_tokens": 1, "total_tokens": 1},
+        },
+        {
+            "data": [{"object": "embedding", "index": 1, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 1, "total_tokens": 1},
+        },
+    ],
+)
+async def test_embeddings_malformed_success_uses_general_fallback(
+    client,
+    test_app,
+    malformed_payload: dict,
+):
+    registry = test_app.state.router.deployment_registry
+    primary = registry["text-embedding-3-small"][0]
+    primary.deltallm_params["api_key"] = "primary-key"
+    fallback = Deployment(
+        deployment_id="embedding-malformed-fallback",
+        model_name="text-embedding-3-small",
+        deltallm_params={
+            "provider": "openai",
+            "model": "openai/text-embedding-3-small",
+            "api_key": "fallback-key",
+        },
+        model_info={"mode": "embedding"},
+    )
+    registry.replace(
+        {
+            **registry.snapshot(),
+            "text-embedding-3-small": [primary, fallback],
+        }
+    )
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return primary
+
+    attempts: list[str] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del json, timeout
+        attempts.append(headers["Authorization"])
+        request = httpx.Request("POST", url)
+        if headers["Authorization"] == "Bearer primary-key":
+            return httpx.Response(200, json=malformed_payload, request=request)
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+                "model": "text-embedding-3-small",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            },
+            request=request,
+        )
+
+    test_app.state.router.select_deployment = choose_primary
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/embeddings",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "text-embedding-3-small", "input": "hello"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    assert attempts == ["Bearer primary-key", "Bearer fallback-key"]
+    assert "sk-upstream" not in response.text
+    health = await test_app.state.router_state_backend.get_health(primary.deployment_id)
+    assert health["last_error"] == "Provider returned an invalid response"
+
+
+@pytest.mark.asyncio
+async def test_embeddings_rejects_empty_input_before_provider_call(client, test_app):
+    response = await client.post(
+        "/v1/embeddings",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "text-embedding-3-small", "input": []},
+    )
+
+    assert response.status_code == 422
+    assert test_app.state.http_client.post_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_error_middleware.py
+++ b/tests/test_error_middleware.py
@@ -1,10 +1,33 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 from fastapi import FastAPI
 
-from src.middleware.errors import register_exception_handlers
+from src.middleware.errors import proxy_error_response, register_exception_handlers
+from src.models.errors import FailureClassification, InvalidRequestError
+
+
+def test_provider_failure_classification_is_not_serialized() -> None:
+    response = proxy_error_response(
+        InvalidRequestError(
+            message="Provider rejected request",
+            failure_classification=FailureClassification.CONTEXT_WINDOW,
+        )
+    )
+
+    payload = json.loads(response.body)
+
+    assert payload == {
+        "error": {
+            "message": "Provider rejected request",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": None,
+        }
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import FrozenInstanceError
 from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
 
@@ -10,6 +11,7 @@ import pytest
 from src.batch.retry import BatchResponseShapeError
 from src.chat.stream_response import DeadlineStreamingResponse
 from src.models.errors import (
+    FailureClassification,
     GatewayCapacityError,
     InvalidRequestError,
     NO_HEALTHY_DEPLOYMENTS_CODE,
@@ -18,11 +20,18 @@ from src.models.errors import (
     TimeoutError,
     parse_retry_after_header,
 )
+from src.providers.anthropic import AnthropicAdapter
+from src.providers.azure import AzureOpenAIAdapter
+from src.providers.bedrock import BedrockAdapter
+from src.providers.gemini import GeminiAdapter
 from src.providers.healthcheck import HealthProbeResult, probe_provider_health
+from src.providers.openai import OpenAIAdapter
+from src.providers.base import invalid_provider_response_error
 from src.router import (
     AttemptCapacity,
     BackgroundHealthChecker,
     CooldownManager,
+    ErrorClassification,
     FallbackConfig,
     FailoverManager,
     HealthCheckInProgressError,
@@ -42,6 +51,40 @@ from src.router import (
 from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
 from tests.conftest import FakeRedis
+
+
+def test_fallback_config_freezes_all_fallback_maps() -> None:
+    general = {"group-a": ["general"]}
+    context = {"group-a": ["context"]}
+    content = {"group-a": ["content"]}
+
+    config = FallbackConfig(
+        fallbacks=general,
+        context_window_fallbacks=context,
+        content_policy_fallbacks=content,
+    )
+    general["group-a"].append("mutated")
+    context["group-a"].append("mutated")
+    content["group-a"].append("mutated")
+
+    assert config.fallbacks["group-a"] == ("general",)
+    assert config.context_window_fallbacks["group-a"] == ("context",)
+    assert config.content_policy_fallbacks["group-a"] == ("content",)
+    with pytest.raises(TypeError):
+        config.fallbacks["group-a"] = ("replacement",)  # type: ignore[index]
+    with pytest.raises(FrozenInstanceError):
+        config.num_retries = 1  # type: ignore[misc]
+
+
+def test_error_classification_compatibility_facade_uses_typed_metadata_only() -> None:
+    typed = InvalidRequestError(
+        message="Provider rejected request",
+        failure_classification=FailureClassification.CONTEXT_WINDOW,
+    )
+    untyped = InvalidRequestError(message="maximum context length reached")
+
+    assert ErrorClassification.classify(typed) is FailureClassification.CONTEXT_WINDOW
+    assert ErrorClassification.classify(untyped) is FailureClassification.GENERIC
 
 
 def _deployment(
@@ -552,7 +595,10 @@ async def test_classified_fallback_group_reuses_request_tags_and_policy_order():
     async def run(deployment: Deployment) -> str:
         attempts.append(deployment.deployment_id)
         if deployment is primary:
-            raise InvalidRequestError(message="maximum context length reached")
+            raise InvalidRequestError(
+                message="Provider rejected request",
+                failure_classification=FailureClassification.CONTEXT_WINDOW,
+            )
         return "fallback-ok"
 
     data, served = await manager.execute_with_failover(
@@ -566,6 +612,325 @@ async def test_classified_fallback_group_reuses_request_tags_and_policy_order():
     assert data == "fallback-ok"
     assert served is eligible
     assert attempts == ["dep-primary", "dep-eligible"]
+
+
+@pytest.mark.asyncio
+async def test_content_policy_classification_selects_content_fallback_map() -> None:
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary")
+    fallback = _deployment("dep-content-fallback")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            content_policy_fallbacks={"group-a": ["content-group"]},
+        ),
+        candidate_planner=_planner(
+            state,
+            {"group-a": [primary], "content-group": [fallback]},
+        ),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            raise InvalidRequestError(
+                message="Provider rejected request",
+                failure_classification=FailureClassification.CONTENT_POLICY,
+            )
+        return "content-fallback-ok"
+
+    result, served = await manager.execute_with_failover(
+        primary,
+        "group-a",
+        run,
+        return_deployment=True,
+        routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+    )
+
+    assert result == "content-fallback-ok"
+    assert served is fallback
+    assert attempts == ["dep-primary", "dep-content-fallback"]
+
+
+@pytest.mark.asyncio
+async def test_health_affecting_classification_uses_specialized_then_general_fallback() -> None:
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary")
+    context_fallback = _deployment("dep-context-fallback")
+    general_fallback = _deployment("dep-general-fallback")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            fallbacks={"group-a": ["general-group"]},
+            context_window_fallbacks={"group-a": ["context-group"]},
+        ),
+        candidate_planner=_planner(
+            state,
+            {
+                "group-a": [primary],
+                "context-group": [context_fallback],
+                "general-group": [general_fallback],
+            },
+        ),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            raise ServiceUnavailableError(
+                message="Provider unavailable",
+                affects_deployment_health=True,
+                failure_classification=FailureClassification.CONTEXT_WINDOW,
+            )
+        if deployment is context_fallback:
+            raise ServiceUnavailableError(
+                message="Provider unavailable",
+                affects_deployment_health=True,
+                failure_classification=FailureClassification.GENERIC,
+            )
+        return "general-fallback-ok"
+
+    result, served = await manager.execute_with_failover(
+        primary,
+        "group-a",
+        run,
+        return_deployment=True,
+        routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+    )
+
+    assert result == "general-fallback-ok"
+    assert served is general_fallback
+    assert attempts == ["dep-primary", "dep-context-fallback", "dep-general-fallback"]
+    assert await state.is_cooled_down(primary.deployment_id)
+    assert await state.is_cooled_down(context_fallback.deployment_id)
+    assert not await state.is_cooled_down(general_fallback.deployment_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("adapter_type", "provider_response", "expected_fallback"),
+    [
+        (
+            GeminiAdapter,
+            {"promptFeedback": {"blockReason": "SAFETY"}},
+            "dep-content-fallback",
+        ),
+        (
+            AnthropicAdapter,
+            {
+                "content": [],
+                "stop_reason": "refusal",
+                "usage": {"input_tokens": 4, "output_tokens": 0},
+            },
+            "dep-content-fallback",
+        ),
+        (
+            AnthropicAdapter,
+            {
+                "content": [],
+                "stop_reason": "model_context_window_exceeded",
+                "usage": {"input_tokens": 4, "output_tokens": 0},
+            },
+            "dep-context-fallback",
+        ),
+        (
+            BedrockAdapter,
+            {
+                "output": {"message": {"content": []}},
+                "stopReason": "model_context_window_exceeded",
+                "usage": {"inputTokens": 4, "outputTokens": 0, "totalTokens": 4},
+            },
+            "dep-context-fallback",
+        ),
+        (
+            AzureOpenAIAdapter,
+            {
+                "id": "chatcmpl-filtered",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": None},
+                        "finish_reason": "content_filter",
+                    }
+                ],
+            },
+            "dep-content-fallback",
+        ),
+        (
+            OpenAIAdapter,
+            {
+                "id": "chatcmpl-filtered",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": None},
+                        "finish_reason": "content_filter",
+                    }
+                ],
+            },
+            "dep-content-fallback",
+        ),
+    ],
+)
+async def test_documented_provider_response_failure_selects_specialized_fallback(
+    adapter_type,
+    provider_response: dict,
+    expected_fallback: str,
+) -> None:
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary")
+    content_fallback = _deployment("dep-content-fallback")
+    context_fallback = _deployment("dep-context-fallback")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            content_policy_fallbacks={"group-a": ["content-group"]},
+            context_window_fallbacks={"group-a": ["context-group"]},
+        ),
+        candidate_planner=_planner(
+            state,
+            {
+                "group-a": [primary],
+                "content-group": [content_fallback],
+                "context-group": [context_fallback],
+            },
+        ),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    adapter = adapter_type(httpx.AsyncClient())
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            await adapter.translate_response(provider_response, model_name="provider-model")
+            raise AssertionError("provider rejection must not translate as success")
+        return "fallback-ok"
+
+    try:
+        result, served = await manager.execute_with_failover(
+            primary,
+            "group-a",
+            run,
+            return_deployment=True,
+            routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+        )
+    finally:
+        await adapter.http_client.aclose()
+
+    assert result == "fallback-ok"
+    assert served.deployment_id == expected_fallback
+    assert attempts == ["dep-primary", expected_fallback]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_policy_stop_before_first_chunk_selects_specialized_fallback():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary")
+    fallback = _deployment("dep-content-fallback")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            content_policy_fallbacks={"group-a": ["content-group"]},
+        ),
+        candidate_planner=_planner(
+            state,
+            {"group-a": [primary], "content-group": [fallback]},
+        ),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    adapter = AnthropicAdapter(httpx.AsyncClient())
+    attempts: list[str] = []
+
+    async def provider_lines():
+        yield 'data: {"type":"message_start","message":{"id":"msg_1","model":"claude"}}'
+        yield 'data: {"type":"message_delta","delta":{"stop_reason":"refusal"}}'
+        yield 'data: {"type":"message_stop"}'
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            translated = adapter.translate_stream(provider_lines()).__aiter__()
+            return await anext(translated)
+        return "fallback-first-chunk"
+
+    try:
+        result, served = await manager.execute_with_failover(
+            primary,
+            "group-a",
+            run,
+            return_deployment=True,
+            routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+        )
+
+        assert result == "fallback-first-chunk"
+        assert served is fallback
+        assert attempts == [primary.deployment_id, fallback.deployment_id]
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_http_error", [False, True])
+async def test_untyped_error_text_cannot_trigger_classified_fallback(
+    raw_http_error: bool,
+) -> None:
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-primary")
+    fallback = _deployment("dep-context-fallback")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            context_window_fallbacks={"group-a": ["context-group"]},
+        ),
+        candidate_planner=_planner(
+            state,
+            {"group-a": [primary], "context-group": [fallback]},
+        ),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if raw_http_error:
+            response = httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "code": "context_length_exceeded",
+                        "message": "maximum context length sk-upstream",
+                    }
+                },
+                request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+            )
+            raise httpx.HTTPStatusError(
+                "maximum context length",
+                request=response.request,
+                response=response,
+            )
+        raise InvalidRequestError(message="maximum context length reached")
+
+    with pytest.raises(
+        InvalidRequestError,
+        match="Provider rejected request" if raw_http_error else "maximum context length",
+    ):
+        await manager.execute_with_failover(
+            primary,
+            "group-a",
+            run,
+            routing_context={ROUTING_MODE_CONTEXT_KEY: "chat", "metadata": {}},
+        )
+
+    assert attempts == ["dep-primary"]
 
 
 @pytest.mark.asyncio
@@ -828,7 +1193,10 @@ async def test_classified_fallback_excludes_deployments_already_visited_by_reque
     async def run(deployment: Deployment) -> str:
         attempts.append(deployment.deployment_id)
         if deployment is primary:
-            raise InvalidRequestError(message="maximum context length reached")
+            raise InvalidRequestError(
+                message="Provider rejected request",
+                failure_classification=FailureClassification.CONTEXT_WINDOW,
+            )
         return "ok"
 
     result, served = await manager.execute_with_failover(
@@ -1037,12 +1405,12 @@ async def test_failover_records_explicit_health_affecting_execution_failure_once
         exc.affects_deployment_health = True  # type: ignore[attr-defined]
         raise exc
 
-    with pytest.raises(ServiceUnavailableError, match="malformed upstream response") as exc_info:
+    with pytest.raises(ServiceUnavailableError, match="Service unavailable") as exc_info:
         await manager.execute_with_failover(primary, "group-a", run)
 
     health = await state.get_health(primary.deployment_id)
     assert health["consecutive_failures"] == "1"
-    assert health["last_error"] == "malformed upstream response"
+    assert health["last_error"] == "Service unavailable"
     original = get_failover_original_error(exc_info.value)
     assert isinstance(original, RuntimeError)
     assert str(original) == "malformed upstream response"
@@ -1292,7 +1660,7 @@ async def test_failover_http_timeout_maps_to_timeout_error():
     async def run(_deployment: Deployment) -> str:
         raise httpx.ReadTimeout("upstream timed out")
 
-    with pytest.raises(TimeoutError, match="upstream timed out") as exc_info:
+    with pytest.raises(TimeoutError, match="Request timeout") as exc_info:
         await manager.execute_with_failover(
             primary_deployment=primary,
             model_group="group-a",
@@ -1327,7 +1695,7 @@ async def test_failover_local_execution_error_does_not_affect_deployment_health_
             execute=run,
         )
 
-    assert str(exc_info.value) == "local bug"
+    assert str(exc_info.value) == "Service unavailable"
     assert affects_deployment_health(exc_info.value) is False
     assert attempts == ["dep-a"]
     assert not await state.is_cooled_down(primary.deployment_id)
@@ -1361,10 +1729,13 @@ async def test_failover_classified_fallback_local_error_does_not_cool_down_or_tr
     async def run(deployment: Deployment) -> str:
         attempts.append(deployment.deployment_id)
         if deployment.deployment_id == "dep-a":
-            raise InvalidRequestError(message="maximum context length reached")
+            raise InvalidRequestError(
+                message="Provider rejected request",
+                failure_classification=FailureClassification.CONTEXT_WINDOW,
+            )
         raise RuntimeError("local fallback bug")
 
-    with pytest.raises(ServiceUnavailableError, match="local fallback bug"):
+    with pytest.raises(ServiceUnavailableError, match="Service unavailable"):
         await manager.execute_with_failover(
             primary_deployment=primary,
             model_group="group-a",
@@ -1375,6 +1746,40 @@ async def test_failover_classified_fallback_local_error_does_not_cool_down_or_tr
     assert not await state.is_cooled_down(primary.deployment_id)
     assert not await state.is_cooled_down(fallback_a.deployment_id)
     assert not await state.is_cooled_down(fallback_b.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_malformed_provider_success_uses_general_fallback_chain():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback = _deployment("dep-b")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=0,
+            timeout=1.0,
+            fallbacks={"group-a": ["general-fallbacks"]},
+        ),
+        candidate_planner=_planner(
+            state,
+            {"group-a": [primary], "general-fallbacks": [fallback]},
+        ),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment.deployment_id == primary.deployment_id:
+            raise invalid_provider_response_error()
+        return "ok"
+
+    result = await manager.execute_with_failover(primary, "group-a", run)
+
+    assert result == "ok"
+    assert attempts == [primary.deployment_id, fallback.deployment_id]
+    primary_health = await state.get_health(primary.deployment_id)
+    assert primary_health["last_error"] == "Provider returned an invalid response"
 
 
 @pytest.mark.asyncio
@@ -1401,7 +1806,10 @@ async def test_failover_classified_fallback_continues_after_upstream_service_una
     async def run(deployment: Deployment) -> str:
         attempts.append(deployment.deployment_id)
         if deployment.deployment_id == "dep-a":
-            raise InvalidRequestError(message="maximum context length reached")
+            raise InvalidRequestError(
+                message="Provider rejected request",
+                failure_classification=FailureClassification.CONTEXT_WINDOW,
+            )
         if deployment.deployment_id == "dep-b":
             raise httpx.HTTPStatusError(
                 "upstream unavailable",
@@ -1449,7 +1857,10 @@ async def test_failover_applies_timeout_resolver_to_classified_fallbacks():
     async def run(deployment: Deployment) -> str:
         attempts.append(deployment.deployment_id)
         if deployment.deployment_id == "dep-a":
-            raise InvalidRequestError(message="maximum context length reached")
+            raise InvalidRequestError(
+                message="Provider rejected request",
+                failure_classification=FailureClassification.CONTEXT_WINDOW,
+            )
         if deployment.deployment_id == "dep-b":
             await asyncio.sleep(0.05)
             return "late-fallback"

--- a/tests/test_provider_compat.py
+++ b/tests/test_provider_compat.py
@@ -7,13 +7,25 @@ from binascii import crc32
 import httpx
 import pytest
 
-from src.models.errors import InvalidRequestError, RateLimitError, ServiceUnavailableError
+from src.models.errors import (
+    FailureClassification,
+    InvalidRequestError,
+    RateLimitError,
+    ServiceUnavailableError,
+)
 from src.models.requests import ChatCompletionRequest
 from src.providers.anthropic import AnthropicAdapter
 from src.providers.azure import AzureOpenAIAdapter
 from src.providers.bedrock import BedrockAdapter
+from src.providers.base import (
+    INVALID_PROVIDER_RESPONSE_MESSAGE,
+    MAX_PROVIDER_ERROR_BODY_BYTES,
+    parse_provider_json_response,
+    read_streaming_provider_error_details,
+)
 from src.providers.gemini import GeminiAdapter
 from src.providers.openai import OpenAIAdapter
+from src.providers.registry import ProviderErrorMapperRegistry
 
 
 async def _line_stream(lines: list[str]):
@@ -24,6 +36,28 @@ async def _line_stream(lines: list[str]):
 async def _byte_stream(chunks: list[bytes]):
     for chunk in chunks:
         yield chunk
+
+
+class _AsyncBytes(httpx.AsyncByteStream):
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _provider_error_mapper_registry(client: httpx.AsyncClient) -> ProviderErrorMapperRegistry:
+    return ProviderErrorMapperRegistry(
+        openai=OpenAIAdapter(client),
+        azure_openai=AzureOpenAIAdapter(client),
+        anthropic=AnthropicAdapter(client),
+        gemini=GeminiAdapter(client),
+        bedrock=BedrockAdapter(client),
+    )
 
 
 def _encode_eventstream_message(headers: dict[str, str], payload: dict) -> bytes:
@@ -42,7 +76,13 @@ def _encode_eventstream_message(headers: dict[str, str], payload: dict) -> bytes
     prelude_crc = crc32(prelude_no_crc) & 0xFFFFFFFF
     prelude_crc_bytes = struct.pack("!I", prelude_crc)
     message_crc = crc32(prelude_crc_bytes + header_bytes + payload_bytes, prelude_crc) & 0xFFFFFFFF
-    return prelude_no_crc + prelude_crc_bytes + header_bytes + payload_bytes + struct.pack("!I", message_crc)
+    return (
+        prelude_no_crc
+        + prelude_crc_bytes
+        + header_bytes
+        + payload_bytes
+        + struct.pack("!I", message_crc)
+    )
 
 
 def _stream_json_payloads(lines: list[str]) -> list[dict]:
@@ -79,7 +119,9 @@ async def test_openai_adapter_keeps_tool_choice_with_tools() -> None:
         req = ChatCompletionRequest(
             model="gpt-4o-mini",
             messages=[{"role": "user", "content": "hi"}],
-            tools=[{"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}],
+            tools=[
+                {"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}
+            ],
             tool_choice="auto",
         )
         payload = await adapter.translate_request(req, {"model": "openai/gpt-4o-mini"})
@@ -164,7 +206,7 @@ async def test_openai_adapter_allows_tool_call_messages_without_content() -> Non
                                     "type": "function",
                                     "function": {
                                         "name": "docs.search",
-                                        "arguments": "{\"query\":\"DeltaLLM\"}",
+                                        "arguments": '{"query":"DeltaLLM"}',
                                     },
                                 }
                             ],
@@ -178,13 +220,15 @@ async def test_openai_adapter_allows_tool_call_messages_without_content() -> Non
         )
         payload = canonical.model_dump(mode="json")
         assert payload["choices"][0]["message"]["content"] == ""
-        assert payload["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "docs.search"
+        assert (
+            payload["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "docs.search"
+        )
     finally:
         await adapter.http_client.aclose()
 
 
 @pytest.mark.asyncio
-async def test_openai_adapter_surfaces_provider_error_message() -> None:
+async def test_openai_adapter_sanitizes_unclassified_provider_error_message() -> None:
     adapter = OpenAIAdapter(httpx.AsyncClient())
     try:
         response = httpx.Response(
@@ -194,9 +238,564 @@ async def test_openai_adapter_surfaces_provider_error_message() -> None:
         )
         exc = httpx.HTTPStatusError("bad request", request=response.request, response=response)
         mapped = adapter.map_error(exc)
-        assert str(mapped) == "tool_choice is not supported for this model"
+        assert str(mapped) == "Provider rejected request"
+        assert mapped.failure_classification is FailureClassification.GENERIC
+        assert "tool_choice" not in str(mapped)
     finally:
         await adapter.http_client.aclose()
+
+
+def test_provider_success_json_parser_rejects_non_object_without_exposing_body() -> None:
+    response = httpx.Response(
+        200,
+        content=b'["sk-upstream"]',
+        request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+    )
+
+    with pytest.raises(ServiceUnavailableError) as error_info:
+        parse_provider_json_response(response)
+
+    error = error_info.value
+    assert str(error) == INVALID_PROVIDER_RESPONSE_MESSAGE
+    assert error.affects_deployment_health is True
+    assert error.failure_classification is FailureClassification.GENERIC
+    assert "sk-upstream" not in str(error)
+    assert "internal.provider.example" not in str(error)
+
+
+@pytest.mark.asyncio
+async def test_openai_adapter_sanitizes_malformed_success_schema() -> None:
+    adapter = OpenAIAdapter(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            200,
+            json={"secret": "sk-upstream", "messages": ["private-output"]},
+            request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+        )
+
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            await adapter.translate_success_response(response, "provider-model")
+
+        error = error_info.value
+        assert str(error) == INVALID_PROVIDER_RESPONSE_MESSAGE
+        assert error.affects_deployment_health is True
+        assert error.failure_classification is FailureClassification.GENERIC
+        assert "sk-upstream" not in str(error)
+        assert "private-output" not in str(error)
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+async def test_openai_compatible_adapter_rejects_empty_success_choices(adapter_type) -> None:
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-empty",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "model": "provider-model",
+                "choices": [],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            },
+            request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+        )
+
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            await adapter.translate_success_response(response, "provider-model")
+
+        assert str(error_info.value) == INVALID_PROVIDER_RESPONSE_MESSAGE
+        assert error_info.value.affects_deployment_health is True
+        assert error_info.value.failure_classification is FailureClassification.GENERIC
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+async def test_openai_compatible_stream_classifies_filter_before_output(adapter_type) -> None:
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        lines = [
+            'data: {"id":"chatcmpl-filtered","choices":[{"index":0,'
+            '"delta":{"role":"assistant"},"finish_reason":null}]}',
+            'data: {"id":"chatcmpl-filtered","choices":[{"index":0,'
+            '"delta":{},"finish_reason":"content_filter"}]}',
+            "data: [DONE]",
+        ]
+
+        with pytest.raises(InvalidRequestError, match="Provider rejected request") as error_info:
+            async for _ in adapter.translate_stream(_line_stream(lines)):
+                pass
+
+        assert error_info.value.failure_classification is FailureClassification.CONTENT_POLICY
+        assert error_info.value.affects_deployment_health is False
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+async def test_openai_compatible_stream_preserves_filter_after_output(adapter_type) -> None:
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        lines = [
+            'data: {"id":"chatcmpl-filtered","choices":[{"index":0,'
+            '"delta":{"role":"assistant"},"finish_reason":null}]}',
+            'data: {"id":"chatcmpl-filtered","choices":[{"index":0,'
+            '"delta":{"content":"partial"},"finish_reason":null}]}',
+            'data: {"id":"chatcmpl-filtered","choices":[{"index":0,'
+            '"delta":{},"finish_reason":"content_filter"}]}',
+            "data: [DONE]",
+        ]
+
+        out = [line async for line in adapter.translate_stream(_line_stream(lines))]
+
+        assert out == lines
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+@pytest.mark.parametrize(
+    "lines",
+    [
+        ["data: [DONE]"],
+        [
+            'data: {"id":"chatcmpl-truncated","choices":[{"index":0,'
+            '"delta":{"role":"assistant"},"finish_reason":null}]}'
+        ],
+    ],
+)
+async def test_openai_compatible_stream_rejects_terminal_only_or_truncated_input(
+    adapter_type,
+    lines: list[str],
+) -> None:
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            async for _ in adapter.translate_stream(_line_stream(lines)):
+                pass
+
+        assert str(error_info.value) == INVALID_PROVIDER_RESPONSE_MESSAGE
+        assert error_info.value.affects_deployment_health is True
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [AnthropicAdapter, GeminiAdapter, BedrockAdapter])
+async def test_native_adapter_sanitizes_empty_success_schema(adapter_type) -> None:  # noqa: ANN001
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            200,
+            json={"secret": "sk-upstream"},
+            request=httpx.Request("POST", "https://internal.provider.example/native"),
+        )
+
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            await adapter.translate_success_response(response, "provider-model")
+
+        error = error_info.value
+        assert str(error) == INVALID_PROVIDER_RESPONSE_MESSAGE
+        assert error.affects_deployment_health is True
+        assert error.failure_classification is FailureClassification.GENERIC
+        assert "sk-upstream" not in str(error)
+        assert "internal.provider.example" not in str(error)
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_5xx_status_preserves_specialized_envelope_classification() -> None:
+    adapter = OpenAIAdapter(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            500,
+            json={"error": {"code": "content_filter", "message": "sk-upstream"}},
+            request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+        )
+        status_error = httpx.HTTPStatusError(
+            "provider failed",
+            request=response.request,
+            response=response,
+        )
+
+        mapped = adapter.map_error(status_error)
+
+        assert isinstance(mapped, ServiceUnavailableError)
+        assert str(mapped) == "Provider unavailable"
+        assert mapped.affects_deployment_health is True
+        assert mapped.failure_classification is FailureClassification.CONTENT_POLICY
+        assert "sk-upstream" not in str(mapped)
+        assert "internal.provider.example" not in str(mapped)
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_gemini_5xx_context_failure_stays_health_affecting_and_classified() -> None:
+    adapter = GeminiAdapter(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            500,
+            json={
+                "error": {
+                    "status": "INTERNAL",
+                    "message": "The input context is too long sk-upstream",
+                }
+            },
+            request=httpx.Request("POST", "https://internal.provider.example/generateContent"),
+        )
+        status_error = httpx.HTTPStatusError(
+            "provider failed",
+            request=response.request,
+            response=response,
+        )
+
+        mapped = adapter.map_error(status_error)
+
+        assert isinstance(mapped, ServiceUnavailableError)
+        assert mapped.affects_deployment_health is True
+        assert mapped.failure_classification is FailureClassification.CONTEXT_WINDOW
+        assert str(mapped) == "Provider unavailable"
+        assert "sk-upstream" not in str(mapped)
+        assert "internal.provider.example" not in str(mapped)
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_429_status_remains_rate_limit_when_envelope_is_specialized() -> None:
+    adapter = OpenAIAdapter(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            429,
+            json={"error": {"code": "content_filter", "message": "sk-upstream"}},
+            request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+        )
+        status_error = httpx.HTTPStatusError(
+            "provider failed",
+            request=response.request,
+            response=response,
+        )
+
+        mapped = adapter.map_error(status_error)
+
+        assert isinstance(mapped, RateLimitError)
+        assert mapped.affects_deployment_health is True
+        assert mapped.failure_classification is FailureClassification.RATE_LIMIT
+        assert str(mapped) == "Provider rate limited request"
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_unclassified_5xx_remains_generic() -> None:
+    adapter = OpenAIAdapter(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            503,
+            json={"error": {"code": "upstream_unavailable", "message": "sk-upstream"}},
+            request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+        )
+        status_error = httpx.HTTPStatusError(
+            "provider failed",
+            request=response.request,
+            response=response,
+        )
+
+        mapped = adapter.map_error(status_error)
+
+        assert isinstance(mapped, ServiceUnavailableError)
+        assert mapped.affects_deployment_health is True
+        assert mapped.failure_classification is FailureClassification.GENERIC
+        assert str(mapped) == "Provider unavailable"
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("inner_error_key", ["innererror", "inner_error"])
+async def test_provider_error_mapper_registry_reuses_adapter_classification(
+    inner_error_key: str,
+) -> None:
+    client = httpx.AsyncClient()
+    try:
+        registry = _provider_error_mapper_registry(client)
+        response = httpx.Response(
+            400,
+            json={
+                "error": {
+                    "message": "provider-owned sensitive detail",
+                    inner_error_key: {"code": "ResponsibleAIPolicyViolation"},
+                }
+            },
+            request=httpx.Request("POST", "https://provider.invalid/embeddings"),
+        )
+        error = httpx.HTTPStatusError("bad request", request=response.request, response=response)
+
+        mapped = registry.map_error("azure", error)
+
+        assert isinstance(mapped, InvalidRequestError)
+        assert str(mapped) == "Provider rejected request"
+        assert mapped.failure_classification is FailureClassification.CONTENT_POLICY
+        assert "provider-owned sensitive detail" not in str(mapped)
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_error_mapper_registry_limits_openai_rules_to_compatible_providers() -> None:
+    client = httpx.AsyncClient()
+    try:
+        registry = _provider_error_mapper_registry(client)
+
+        assert registry.resolve("openai") is registry.openai
+        assert registry.resolve("vllm") is registry.openai
+        assert registry.resolve("unknown") is registry.openai
+        assert registry.resolve("") is registry.openai
+        assert registry.resolve("custom-gateway") is None
+
+        response = httpx.Response(
+            400,
+            json={
+                "error": {
+                    "code": "context_length_exceeded",
+                    "message": "maximum context length sk-upstream",
+                }
+            },
+            request=httpx.Request("POST", "https://custom.provider.invalid/embeddings"),
+        )
+        error = httpx.HTTPStatusError("bad request", request=response.request, response=response)
+
+        mapped = registry.map_error("custom-gateway", error)
+
+        assert isinstance(mapped, InvalidRequestError)
+        assert mapped.failure_classification is FailureClassification.GENERIC
+        assert str(mapped) == "Provider rejected request"
+        assert "sk-upstream" not in str(mapped)
+        assert "custom.provider.invalid" not in str(mapped)
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+async def test_openai_compatible_adapter_classifies_content_filter_finish_reason(
+    adapter_type,
+) -> None:
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        with pytest.raises(InvalidRequestError, match="Provider rejected request") as error_info:
+            await adapter.translate_response(
+                {
+                    "id": "chatcmpl-filtered",
+                    "object": "chat.completion",
+                    "created": 1700000000,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": None},
+                            "finish_reason": "content_filter",
+                        }
+                    ],
+                },
+                model_name="provider-model",
+            )
+
+        assert error_info.value.failure_classification is FailureClassification.CONTENT_POLICY
+        assert error_info.value.affects_deployment_health is False
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.parametrize(
+    ("adapter_type", "payload", "expected"),
+    [
+        (
+            OpenAIAdapter,
+            {"error": {"code": "context_length_exceeded", "message": "sk-upstream"}},
+            FailureClassification.CONTEXT_WINDOW,
+        ),
+        (
+            OpenAIAdapter,
+            {"error": {"type": "content_policy_violation", "message": "sk-upstream"}},
+            FailureClassification.CONTENT_POLICY,
+        ),
+        (
+            AzureOpenAIAdapter,
+            {"error": {"code": "context_length_exceeded", "message": "sk-upstream"}},
+            FailureClassification.CONTEXT_WINDOW,
+        ),
+        (
+            AzureOpenAIAdapter,
+            {
+                "error": {
+                    "message": "sk-upstream",
+                    "innererror": {"code": "ResponsibleAIPolicyViolation"},
+                }
+            },
+            FailureClassification.CONTENT_POLICY,
+        ),
+        (
+            AnthropicAdapter,
+            {
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "prompt is too long sk-upstream",
+                }
+            },
+            FailureClassification.CONTEXT_WINDOW,
+        ),
+        (
+            AnthropicAdapter,
+            {
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "request blocked by content filtering policy sk-upstream",
+                }
+            },
+            FailureClassification.CONTENT_POLICY,
+        ),
+        (
+            GeminiAdapter,
+            {
+                "error": {
+                    "status": "INVALID_ARGUMENT",
+                    "message": "sk-upstream",
+                    "details": [{"reason": "CONTEXT_LENGTH_EXCEEDED"}],
+                }
+            },
+            FailureClassification.CONTEXT_WINDOW,
+        ),
+        (
+            GeminiAdapter,
+            {"error": {"code": "SAFETY", "message": "sk-upstream"}},
+            FailureClassification.CONTENT_POLICY,
+        ),
+        (
+            BedrockAdapter,
+            {"__type": "ValidationException", "message": "maximum context length sk-upstream"},
+            FailureClassification.CONTEXT_WINDOW,
+        ),
+        (
+            BedrockAdapter,
+            {"__type": "GuardrailIntervenedException", "message": "sk-upstream"},
+            FailureClassification.CONTENT_POLICY,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_provider_adapters_return_typed_sanitized_classified_failures(
+    adapter_type,
+    payload: dict,
+    expected: FailureClassification,
+) -> None:
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            400,
+            json=payload,
+            request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+        )
+        exc = httpx.HTTPStatusError("bad request", request=response.request, response=response)
+
+        mapped = adapter.map_error(exc)
+
+        assert isinstance(mapped, InvalidRequestError)
+        assert str(mapped) == "Provider rejected request"
+        assert mapped.failure_classification is expected
+        assert "sk-upstream" not in str(mapped)
+        assert "internal.provider.example" not in str(mapped)
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_adapter_malformed_error_body_is_sanitized_generic() -> None:
+    adapter = OpenAIAdapter(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            400,
+            content=b"maximum context length sk-upstream",
+            request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+        )
+        exc = httpx.HTTPStatusError("bad request", request=response.request, response=response)
+
+        mapped = adapter.map_error(exc)
+
+        assert str(mapped) == "Provider rejected request"
+        assert mapped.failure_classification is FailureClassification.GENERIC
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_unread_streaming_provider_error_is_bounded_and_classified() -> None:
+    adapter = AzureOpenAIAdapter(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            400,
+            stream=_AsyncBytes(
+                json.dumps(
+                    {
+                        "error": {
+                            "code": "context_length_exceeded",
+                            "message": "maximum context length sk-upstream",
+                        }
+                    }
+                ).encode()
+            ),
+            request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+        )
+        exc = httpx.HTTPStatusError("bad request", request=response.request, response=response)
+
+        details = await read_streaming_provider_error_details(response)
+        mapped = adapter.map_error(exc, details=details)
+
+        assert isinstance(mapped, InvalidRequestError)
+        assert mapped.failure_classification is FailureClassification.CONTEXT_WINDOW
+        assert str(mapped) == "Provider rejected request"
+        assert "sk-upstream" not in str(mapped)
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_oversized_streaming_provider_error_uses_status_only() -> None:
+    response = httpx.Response(
+        400,
+        stream=_AsyncBytes(b"{" + b"x" * MAX_PROVIDER_ERROR_BODY_BYTES),
+        request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+    )
+
+    details = await read_streaming_provider_error_details(response)
+
+    assert details.status_code == 400
+    assert details.identifiers == frozenset()
+    assert details.message is None
+
+
+@pytest.mark.asyncio
+async def test_deeply_nested_streaming_provider_error_uses_status_only() -> None:
+    nested = b"[" * 2048 + b"0" + b"]" * 2048
+    response = httpx.Response(
+        400,
+        stream=_AsyncBytes(nested),
+        request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+    )
+
+    details = await read_streaming_provider_error_details(response)
+
+    assert details.status_code == 400
+    assert details.identifiers == frozenset()
+    assert details.message is None
 
 
 @pytest.mark.asyncio
@@ -263,6 +862,7 @@ async def test_openai_adapter_health_check_defaults_provider_when_missing() -> N
 async def test_openai_adapter_health_check_returns_false_on_unexpected_error() -> None:
     adapter = OpenAIAdapter(httpx.AsyncClient())
     try:
+
         async def fake_get(url, headers, timeout):  # noqa: ANN001, ANN201
             del url, headers, timeout
             raise RuntimeError("unexpected client failure")
@@ -305,7 +905,9 @@ async def test_anthropic_adapter_translate_request_and_response() -> None:
             ],
             max_tokens=32,
         )
-        upstream = await adapter.translate_request(req, {"model": "anthropic/claude-3-5-sonnet-latest"})
+        upstream = await adapter.translate_request(
+            req, {"model": "anthropic/claude-3-5-sonnet-latest"}
+        )
         assert upstream["model"] == "claude-3-5-sonnet-latest"
         assert upstream["system"] == "be concise"
         assert upstream["max_tokens"] == 32
@@ -345,7 +947,10 @@ async def test_anthropic_adapter_forwards_tools_and_tool_messages() -> None:
                             {
                                 "id": "toolu_1",
                                 "type": "function",
-                                "function": {"name": "docs.search", "arguments": json.dumps({"query": "delta"})},
+                                "function": {
+                                    "name": "docs.search",
+                                    "arguments": json.dumps({"query": "delta"}),
+                                },
                             }
                         ],
                     },
@@ -357,7 +962,10 @@ async def test_anthropic_adapter_forwards_tools_and_tool_messages() -> None:
                         "function": {
                             "name": "docs.search",
                             "description": "Search docs",
-                            "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"query": {"type": "string"}},
+                            },
                         },
                     }
                 ],
@@ -376,11 +984,20 @@ async def test_anthropic_adapter_forwards_tools_and_tool_messages() -> None:
         assert upstream["tool_choice"] == {"type": "any"}
         assert upstream["messages"][1] == {
             "role": "assistant",
-            "content": [{"type": "tool_use", "id": "toolu_1", "name": "docs.search", "input": {"query": "delta"}}],
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "docs.search",
+                    "input": {"query": "delta"},
+                }
+            ],
         }
         assert upstream["messages"][2] == {
             "role": "user",
-            "content": [{"type": "tool_result", "tool_use_id": "toolu_1", "content": "delta docs result"}],
+            "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1", "content": "delta docs result"}
+            ],
         }
     finally:
         await adapter.http_client.aclose()
@@ -396,7 +1013,12 @@ async def test_anthropic_adapter_translate_response_maps_tool_use_blocks() -> No
                 "model": "claude-3-5-sonnet-latest",
                 "content": [
                     {"type": "text", "text": "Checking."},
-                    {"type": "tool_use", "id": "toolu_1", "name": "docs.search", "input": {"query": "delta"}},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "docs.search",
+                        "input": {"query": "delta"},
+                    },
                 ],
                 "stop_reason": "tool_use",
                 "usage": {"input_tokens": 4, "output_tokens": 2},
@@ -414,6 +1036,41 @@ async def test_anthropic_adapter_translate_response_maps_tool_use_blocks() -> No
             }
         ]
         assert payload["choices"][0]["finish_reason"] == "tool_calls"
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stop_reason", "expected"),
+    [
+        ("refusal", FailureClassification.CONTENT_POLICY),
+        ("model_context_window_exceeded", FailureClassification.CONTEXT_WINDOW),
+    ],
+)
+async def test_anthropic_adapter_classifies_documented_stop_reason(
+    stop_reason: str,
+    expected: FailureClassification,
+) -> None:
+    adapter = AnthropicAdapter(httpx.AsyncClient())
+    try:
+        response = httpx.Response(
+            200,
+            json={
+                "id": "msg_blocked",
+                "model": "claude-3-5-sonnet-latest",
+                "content": [],
+                "stop_reason": stop_reason,
+                "usage": {"input_tokens": 4, "output_tokens": 0},
+            },
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+        )
+
+        with pytest.raises(InvalidRequestError, match="Provider rejected request") as error_info:
+            await adapter.translate_success_response(response, "anthropic/claude")
+
+        assert error_info.value.failure_classification is expected
+        assert error_info.value.affects_deployment_health is False
     finally:
         await adapter.http_client.aclose()
 
@@ -460,6 +1117,130 @@ async def test_anthropic_adapter_translate_stream_to_openai_chunks() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stop_reason", "expected"),
+    [
+        ("refusal", FailureClassification.CONTENT_POLICY),
+        ("model_context_window_exceeded", FailureClassification.CONTEXT_WINDOW),
+    ],
+)
+async def test_anthropic_stream_classified_stop_before_output_is_typed(
+    stop_reason: str,
+    expected: FailureClassification,
+) -> None:
+    adapter = AnthropicAdapter(httpx.AsyncClient())
+    try:
+        lines = [
+            'data: {"type":"message_start","message":{"id":"msg_1","model":"claude"}}',
+            f'data: {{"type":"message_delta","delta":{{"stop_reason":"{stop_reason}"}}}}',
+            'data: {"type":"message_stop"}',
+        ]
+        translated = adapter.translate_stream(_line_stream(lines)).__aiter__()
+
+        with pytest.raises(InvalidRequestError, match="Provider rejected request") as error_info:
+            await anext(translated)
+
+        assert error_info.value.failure_classification is expected
+        assert error_info.value.affects_deployment_health is False
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stop_reason", "finish_reason"),
+    [
+        ("refusal", "content_filter"),
+        ("model_context_window_exceeded", "length"),
+    ],
+)
+async def test_anthropic_stream_classified_stop_after_output_finishes_without_retry_signal(
+    stop_reason: str,
+    finish_reason: str,
+) -> None:
+    adapter = AnthropicAdapter(httpx.AsyncClient())
+    try:
+        lines = [
+            'data: {"type":"message_start","message":{"id":"msg_1","model":"claude"}}',
+            'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"partial"}}',
+            f'data: {{"type":"message_delta","delta":{{"stop_reason":"{stop_reason}"}}}}',
+            'data: {"type":"message_stop"}',
+        ]
+
+        out = [line async for line in adapter.translate_stream(_line_stream(lines))]
+
+        assert any('"content":"partial"' in line for line in out)
+        assert any(f'"finish_reason":"{finish_reason}"' in line for line in out)
+        assert out[-1] == "data: [DONE]"
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_adapter_stream_error_is_typed_and_sanitized() -> None:
+    adapter = AnthropicAdapter(httpx.AsyncClient())
+    try:
+        lines = [
+            "event: error",
+            'data: {"type":"error","error":{"type":"invalid_request_error",'
+            '"message":"prompt is too long sk-upstream"}}',
+        ]
+
+        with pytest.raises(InvalidRequestError, match="Provider rejected request") as error_info:
+            async for _ in adapter.translate_stream(_line_stream(lines)):
+                pass
+
+        assert error_info.value.failure_classification is FailureClassification.CONTEXT_WINDOW
+        assert "sk-upstream" not in str(error_info.value)
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_adapter_stream_rate_limit_is_retryable() -> None:
+    adapter = AnthropicAdapter(httpx.AsyncClient())
+    try:
+        lines = [
+            'data: {"type":"error","error":{"type":"rate_limit_error",'
+            '"message":"too many requests sk-upstream"}}'
+        ]
+
+        with pytest.raises(RateLimitError, match="Provider rate limited request") as error_info:
+            async for _ in adapter.translate_stream(_line_stream(lines)):
+                pass
+
+        assert error_info.value.failure_classification is FailureClassification.RATE_LIMIT
+        assert error_info.value.affects_deployment_health is True
+        assert "sk-upstream" not in str(error_info.value)
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "lines",
+    [
+        ["data: [DONE]"],
+        ['data: {"type":"message_start","message":{"id":"msg_1","model":"claude"}}'],
+        ["data: not-json"],
+    ],
+)
+async def test_anthropic_stream_rejects_terminal_only_or_truncated_input(
+    lines: list[str],
+) -> None:
+    adapter = AnthropicAdapter(httpx.AsyncClient())
+    try:
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            async for _ in adapter.translate_stream(_line_stream(lines)):
+                pass
+
+        assert str(error_info.value) == INVALID_PROVIDER_RESPONSE_MESSAGE
+        assert error_info.value.affects_deployment_health is True
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_gemini_adapter_translate_request_and_response() -> None:
     adapter = GeminiAdapter(httpx.AsyncClient())
     try:
@@ -485,13 +1266,141 @@ async def test_gemini_adapter_translate_request_and_response() -> None:
                         "finishReason": "STOP",
                     }
                 ],
-                "usageMetadata": {"promptTokenCount": 4, "candidatesTokenCount": 2, "totalTokenCount": 6},
+                "usageMetadata": {
+                    "promptTokenCount": 4,
+                    "candidatesTokenCount": 2,
+                    "totalTokenCount": 6,
+                },
             },
             model_name="gemini/gemini-2.5-flash",
         )
         payload = canonical.model_dump(mode="json")
         assert payload["choices"][0]["message"]["content"] == "Hello"
         assert payload["usage"]["total_tokens"] == 6
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response_payload",
+    [
+        {"promptFeedback": {"blockReason": "SAFETY"}},
+        {
+            "candidates": [
+                {
+                    "content": {"parts": []},
+                    "finishReason": "PROHIBITED_CONTENT",
+                }
+            ]
+        },
+        {
+            "candidates": [
+                {
+                    "content": {"parts": []},
+                    "finishReason": "IMAGE_RECITATION",
+                }
+            ]
+        },
+        {
+            "candidates": [
+                {
+                    "content": {"parts": []},
+                    "finishReason": "ESCALATION",
+                }
+            ]
+        },
+    ],
+)
+async def test_gemini_adapter_classifies_documented_policy_response(
+    response_payload: dict,
+) -> None:
+    adapter = GeminiAdapter(httpx.AsyncClient())
+    try:
+        with pytest.raises(InvalidRequestError, match="Provider rejected request") as error_info:
+            await adapter.translate_response(
+                response_payload,
+                model_name="gemini/gemini-2.5-flash",
+            )
+
+        assert error_info.value.failure_classification is FailureClassification.CONTENT_POLICY
+        assert error_info.value.affects_deployment_health is False
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "finish_reason",
+    [
+        "LANGUAGE",
+        "OTHER",
+        "MALFORMED_FUNCTION_CALL",
+        "IMAGE_OTHER",
+        "NO_IMAGE",
+        "UNEXPECTED_TOOL_CALL",
+        "TOO_MANY_TOOL_CALLS",
+        "MISSING_THOUGHT_SIGNATURE",
+        "MALFORMED_RESPONSE",
+        "FUTURE_PROVIDER_FAILURE",
+    ],
+)
+async def test_gemini_adapter_rejects_non_success_finish_reason_as_malformed(
+    finish_reason: str,
+) -> None:
+    adapter = GeminiAdapter(httpx.AsyncClient())
+    try:
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            await adapter.translate_response(
+                {
+                    "secret": "sk-upstream",
+                    "candidates": [
+                        {
+                            "content": {"parts": []},
+                            "finishReason": finish_reason,
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": 4,
+                        "candidatesTokenCount": 0,
+                        "totalTokenCount": 4,
+                    },
+                },
+                model_name="gemini/gemini-2.5-flash",
+            )
+
+        error = error_info.value
+        assert str(error) == INVALID_PROVIDER_RESPONSE_MESSAGE
+        assert error.affects_deployment_health is True
+        assert error.failure_classification is FailureClassification.GENERIC
+        assert "sk-upstream" not in str(error)
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_gemini_adapter_preserves_max_tokens_as_successful_length_finish() -> None:
+    adapter = GeminiAdapter(httpx.AsyncClient())
+    try:
+        canonical = await adapter.translate_response(
+            {
+                "candidates": [
+                    {
+                        "content": {"parts": [{"text": "partial"}]},
+                        "finishReason": "MAX_TOKENS",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 4,
+                    "candidatesTokenCount": 2,
+                    "totalTokenCount": 6,
+                },
+            },
+            model_name="gemini/gemini-2.5-flash",
+        )
+
+        assert canonical.choices[0].finish_reason == "length"
+        assert canonical.choices[0].message.content == "partial"
     finally:
         await adapter.http_client.aclose()
 
@@ -508,7 +1417,9 @@ async def test_bedrock_adapter_translate_request_and_response() -> None:
             ],
             max_tokens=32,
         )
-        upstream = await adapter.translate_request(req, {"model": "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"})
+        upstream = await adapter.translate_request(
+            req, {"model": "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"}
+        )
         assert upstream["system"][0]["text"] == "be concise"
         assert upstream["messages"][0]["role"] == "user"
         assert upstream["inferenceConfig"]["maxTokens"] == 32
@@ -529,6 +1440,38 @@ async def test_bedrock_adapter_translate_request_and_response() -> None:
         payload = canonical.model_dump(mode="json")
         assert payload["choices"][0]["message"]["content"] == "Hello"
         assert payload["usage"]["total_tokens"] == 6
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stop_reason", "expected"),
+    [
+        ("guardrail_intervened", FailureClassification.CONTENT_POLICY),
+        ("content_filtered", FailureClassification.CONTENT_POLICY),
+        ("model_context_window_exceeded", FailureClassification.CONTEXT_WINDOW),
+    ],
+)
+async def test_bedrock_adapter_classifies_documented_stop_reason(
+    stop_reason: str,
+    expected: FailureClassification,
+) -> None:
+    adapter = BedrockAdapter(httpx.AsyncClient())
+    try:
+        with pytest.raises(InvalidRequestError, match="Provider rejected request") as error_info:
+            await adapter.translate_response(
+                {
+                    "requestId": "req_blocked",
+                    "output": {"message": {"content": []}},
+                    "stopReason": stop_reason,
+                    "usage": {"inputTokens": 4, "outputTokens": 0, "totalTokens": 4},
+                },
+                model_name="bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+            )
+
+        assert error_info.value.failure_classification is expected
+        assert error_info.value.affects_deployment_health is False
     finally:
         await adapter.http_client.aclose()
 
@@ -573,17 +1516,20 @@ async def test_bedrock_adapter_only_sends_explicit_sampling_params() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bedrock_adapter_surfaces_provider_error_message() -> None:
+async def test_bedrock_adapter_sanitizes_provider_error_message() -> None:
     adapter = BedrockAdapter(httpx.AsyncClient())
     try:
         response = httpx.Response(
             400,
             json={"message": "`temperature` and `top_p` cannot both be specified"},
-            request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/model/claude/converse"),
+            request=httpx.Request(
+                "POST", "https://bedrock-runtime.us-east-1.amazonaws.com/model/claude/converse"
+            ),
         )
         exc = httpx.HTTPStatusError("bad request", request=response.request, response=response)
         mapped = adapter.map_error(exc)
-        assert str(mapped) == "`temperature` and `top_p` cannot both be specified"
+        assert str(mapped) == "Provider rejected request"
+        assert mapped.failure_classification is FailureClassification.GENERIC
     finally:
         await adapter.http_client.aclose()
 
@@ -641,6 +1587,77 @@ async def test_bedrock_adapter_translate_stream_to_openai_chunks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_bedrock_adapter_stream_stop_failure_is_not_reported_as_done() -> None:
+    adapter = BedrockAdapter(httpx.AsyncClient())
+    try:
+        frames = b"".join(
+            [
+                _encode_eventstream_message(
+                    {":message-type": "event", ":event-type": "messageStart"},
+                    {"role": "assistant"},
+                ),
+                _encode_eventstream_message(
+                    {":message-type": "event", ":event-type": "messageStop"},
+                    {"stopReason": "guardrail_intervened"},
+                ),
+            ]
+        )
+        translated = adapter.translate_stream(_byte_stream([frames])).__aiter__()
+
+        with pytest.raises(InvalidRequestError, match="Provider rejected request") as error_info:
+            await anext(translated)
+
+        assert error_info.value.failure_classification is FailureClassification.CONTENT_POLICY
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_adapter_stream_classified_stop_after_output_is_terminal() -> None:
+    adapter = BedrockAdapter(httpx.AsyncClient())
+    try:
+        frames = b"".join(
+            [
+                _encode_eventstream_message(
+                    {":message-type": "event", ":event-type": "messageStart"},
+                    {"role": "assistant"},
+                ),
+                _encode_eventstream_message(
+                    {":message-type": "event", ":event-type": "contentBlockDelta"},
+                    {"contentBlockIndex": 0, "delta": {"text": "partial"}},
+                ),
+                _encode_eventstream_message(
+                    {":message-type": "event", ":event-type": "messageStop"},
+                    {"stopReason": "guardrail_intervened"},
+                ),
+            ]
+        )
+
+        out = [line async for line in adapter.translate_stream(_byte_stream([frames]))]
+
+        assert any('"content":"partial"' in line for line in out)
+        assert any('"finish_reason":"content_filter"' in line for line in out)
+        assert out[-1] == "data: [DONE]"
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chunks", [[], [b""]])
+async def test_bedrock_adapter_stream_rejects_empty_input(chunks: list[bytes]) -> None:
+    adapter = BedrockAdapter(httpx.AsyncClient())
+    try:
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            async for _ in adapter.translate_stream(_byte_stream(chunks)):
+                pass
+
+        assert str(error_info.value) == INVALID_PROVIDER_RESPONSE_MESSAGE
+        assert error_info.value.affects_deployment_health is True
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_bedrock_adapter_translate_stream_uses_sequential_tool_call_indexes() -> None:
     adapter = BedrockAdapter(httpx.AsyncClient())
     try:
@@ -656,7 +1673,10 @@ async def test_bedrock_adapter_translate_stream_uses_sequential_tool_call_indexe
                 ),
                 _encode_eventstream_message(
                     {":message-type": "event", ":event-type": "contentBlockStart"},
-                    {"contentBlockIndex": 1, "start": {"toolUse": {"toolUseId": "toolu_1", "name": "docs.search"}}},
+                    {
+                        "contentBlockIndex": 1,
+                        "start": {"toolUse": {"toolUseId": "toolu_1", "name": "docs.search"}},
+                    },
                 ),
                 _encode_eventstream_message(
                     {":message-type": "event", ":event-type": "contentBlockDelta"},
@@ -669,7 +1689,12 @@ async def test_bedrock_adapter_translate_stream_uses_sequential_tool_call_indexe
             ]
         )
 
-        out = [line async for line in adapter.translate_stream(_byte_stream([frames]), model_name="bedrock-public-model")]
+        out = [
+            line
+            async for line in adapter.translate_stream(
+                _byte_stream([frames]), model_name="bedrock-public-model"
+            )
+        ]
         payloads = _stream_json_payloads(out)
         tool_deltas = [
             tool_call
@@ -702,7 +1727,10 @@ async def test_bedrock_adapter_forwards_tools_and_tool_messages() -> None:
                             {
                                 "id": "toolu_1",
                                 "type": "function",
-                                "function": {"name": "docs.search", "arguments": json.dumps({"query": "delta"})},
+                                "function": {
+                                    "name": "docs.search",
+                                    "arguments": json.dumps({"query": "delta"}),
+                                },
                             }
                         ],
                     },
@@ -714,7 +1742,10 @@ async def test_bedrock_adapter_forwards_tools_and_tool_messages() -> None:
                         "function": {
                             "name": "docs.search",
                             "description": "Search docs",
-                            "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"query": {"type": "string"}},
+                            },
                         },
                     }
                 ],
@@ -729,7 +1760,9 @@ async def test_bedrock_adapter_forwards_tools_and_tool_messages() -> None:
                     "toolSpec": {
                         "name": "docs.search",
                         "description": "Search docs",
-                        "inputSchema": {"json": {"type": "object", "properties": {"query": {"type": "string"}}}},
+                        "inputSchema": {
+                            "json": {"type": "object", "properties": {"query": {"type": "string"}}}
+                        },
                     }
                 }
             ],
@@ -737,11 +1770,21 @@ async def test_bedrock_adapter_forwards_tools_and_tool_messages() -> None:
         }
         assert upstream["messages"][1] == {
             "role": "assistant",
-            "content": [{"toolUse": {"toolUseId": "toolu_1", "name": "docs.search", "input": {"query": "delta"}}}],
+            "content": [
+                {
+                    "toolUse": {
+                        "toolUseId": "toolu_1",
+                        "name": "docs.search",
+                        "input": {"query": "delta"},
+                    }
+                }
+            ],
         }
         assert upstream["messages"][2] == {
             "role": "user",
-            "content": [{"toolResult": {"toolUseId": "toolu_1", "content": [{"text": "delta docs result"}]}}],
+            "content": [
+                {"toolResult": {"toolUseId": "toolu_1", "content": [{"text": "delta docs result"}]}}
+            ],
         }
     finally:
         await adapter.http_client.aclose()
@@ -757,7 +1800,13 @@ async def test_bedrock_adapter_translate_response_maps_tool_use_blocks() -> None
                     "message": {
                         "content": [
                             {"text": "Checking."},
-                            {"toolUse": {"toolUseId": "toolu_1", "name": "docs.search", "input": {"query": "delta"}}},
+                            {
+                                "toolUse": {
+                                    "toolUseId": "toolu_1",
+                                    "name": "docs.search",
+                                    "input": {"query": "delta"},
+                                }
+                            },
                         ]
                     }
                 },
@@ -789,9 +1838,10 @@ async def test_bedrock_adapter_translate_stream_raises_on_exception_event() -> N
             {":message-type": "exception", ":exception-type": "validationException"},
             {"message": "Malformed input request"},
         )
-        with pytest.raises(InvalidRequestError, match="Malformed input request"):
+        with pytest.raises(InvalidRequestError, match="Provider rejected request") as error_info:
             async for _ in adapter.translate_stream(_byte_stream([frame])):
                 pass
+        assert error_info.value.failure_classification is FailureClassification.GENERIC
     finally:
         await adapter.http_client.aclose()
 
@@ -804,7 +1854,9 @@ async def test_bedrock_adapter_translate_stream_classifies_retryable_errors() ->
             {":message-type": "exception", ":exception-type": "throttlingException"},
             {"message": "Too many requests"},
         )
-        with pytest.raises(RateLimitError, match="Too many requests") as rate_limit_info:
+        with pytest.raises(
+            RateLimitError, match="Provider rate limited request"
+        ) as rate_limit_info:
             async for _ in adapter.translate_stream(_byte_stream([throttle_frame])):
                 pass
         assert rate_limit_info.value.affects_deployment_health is True
@@ -813,7 +1865,9 @@ async def test_bedrock_adapter_translate_stream_classifies_retryable_errors() ->
             {":message-type": "exception", ":exception-type": "internalServerException"},
             {"message": "Internal failure"},
         )
-        with pytest.raises(ServiceUnavailableError, match="Internal failure") as unavailable_info:
+        with pytest.raises(
+            ServiceUnavailableError, match="Provider unavailable"
+        ) as unavailable_info:
             async for _ in adapter.translate_stream(_byte_stream([server_frame])):
                 pass
         assert unavailable_info.value.affects_deployment_health is True
@@ -822,8 +1876,80 @@ async def test_bedrock_adapter_translate_stream_classifies_retryable_errors() ->
             {":message-type": "error", ":event-type": "somethingUnexpected"},
             {"message": "mystery failure"},
         )
-        with pytest.raises(ServiceUnavailableError, match="mystery failure"):
+        with pytest.raises(ServiceUnavailableError, match="Provider unavailable"):
             async for _ in adapter.translate_stream(_byte_stream([unknown_frame])):
                 pass
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exception_type", "message", "error_type", "classification", "affects_health"),
+    [
+        (
+            "internalServerException",
+            "guardrail intervened",
+            ServiceUnavailableError,
+            FailureClassification.GENERIC,
+            True,
+        ),
+        (
+            "modelStreamErrorException",
+            "guardrail intervened",
+            ServiceUnavailableError,
+            FailureClassification.GENERIC,
+            True,
+        ),
+        (
+            "serviceUnavailableException",
+            "input is too long",
+            ServiceUnavailableError,
+            FailureClassification.GENERIC,
+            True,
+        ),
+        (
+            "throttlingException",
+            "input is too long",
+            RateLimitError,
+            FailureClassification.RATE_LIMIT,
+            True,
+        ),
+        (
+            "validationException",
+            "input is too long",
+            InvalidRequestError,
+            FailureClassification.CONTEXT_WINDOW,
+            False,
+        ),
+        (
+            "validationException",
+            "guardrail intervened",
+            InvalidRequestError,
+            FailureClassification.CONTENT_POLICY,
+            False,
+        ),
+    ],
+)
+async def test_bedrock_stream_exception_type_precedes_message_classification(
+    exception_type: str,
+    message: str,
+    error_type: type[Exception],
+    classification: FailureClassification,
+    affects_health: bool,
+) -> None:
+    adapter = BedrockAdapter(httpx.AsyncClient())
+    try:
+        frame = _encode_eventstream_message(
+            {":message-type": "exception", ":exception-type": exception_type},
+            {"message": message},
+        )
+
+        with pytest.raises(error_type) as error_info:
+            async for _ in adapter.translate_stream(_byte_stream([frame])):
+                pass
+
+        assert error_info.value.failure_classification is classification
+        assert error_info.value.affects_deployment_health is affects_health
     finally:
         await adapter.http_client.aclose()

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -23,7 +23,10 @@ async def _multimodal_success_response(url: str, *args, **kwargs):  # noqa: ANN0
     if url.endswith("/rerank"):
         return httpx.Response(
             200,
-            json={"results": [], "usage": {"prompt_tokens": 1, "total_tokens": 1}},
+            json={
+                "results": [{"index": 0, "relevance_score": 0.9}],
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            },
             request=request,
         )
     if url.endswith("/audio/speech"):

--- a/tests/test_route_decision_multimodal.py
+++ b/tests/test_route_decision_multimodal.py
@@ -1,7 +1,83 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import httpx
 import pytest
+
+from src.router.router import Deployment
+
+
+@pytest.mark.asyncio
+async def test_azure_image_inner_error_selects_content_policy_fallback(client, test_app):
+    registry_store = test_app.state.router.deployment_registry
+    primary = registry_store["gpt-4o-mini"][0]
+    primary.deltallm_params.update(
+        {
+            "provider": "azure_openai",
+            "model": "azure/image-primary",
+            "api_key": "primary-key",
+        }
+    )
+    primary.model_info["mode"] = "image_generation"
+    fallback = Deployment(
+        deployment_id="azure-image-content-fallback",
+        model_name="azure-image-content-fallback",
+        deltallm_params={
+            "provider": "azure_openai",
+            "model": "azure/image-fallback",
+            "api_key": "fallback-key",
+        },
+        model_info={"mode": "image_generation"},
+    )
+    registry_store.replace(
+        {
+            **registry_store.snapshot(),
+            "azure-image-content-fallback": [fallback],
+        }
+    )
+    manager = test_app.state.failover_manager
+    manager.config = replace(
+        manager.config,
+        content_policy_fallbacks={"gpt-4o-mini": ["azure-image-content-fallback"]},
+    )
+    attempts: list[str | None] = []
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del json, timeout
+        attempts.append(headers.get("Authorization"))
+        if headers.get("Authorization") == "Bearer primary-key":
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": "provider-owned sensitive detail sk-upstream",
+                        "inner_error": {"code": "ResponsibleAIPolicyViolation"},
+                    }
+                },
+                request=httpx.Request("POST", url),
+            )
+        return httpx.Response(
+            200,
+            json={"created": 1700000000, "data": [{"url": "https://example.com/image.png"}]},
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/images/generations",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={"model": "gpt-4o-mini", "prompt": "sunset"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    assert attempts == ["Bearer primary-key", "Bearer fallback-key"]
+    assert "sk-upstream" not in response.text
+    primary_health = await test_app.state.router_state_backend.get_health(primary.deployment_id)
+    assert int(primary_health.get("consecutive_failures", 0) or 0) == 0
+    assert primary_health.get("last_error") is None
 
 
 @pytest.mark.asyncio
@@ -202,3 +278,140 @@ async def test_multimodal_endpoints_use_custom_auth_headers_for_openai_compatibl
         "X-Provider-Auth": "Token provider-key",
         "Content-Type": "application/json",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "path", "request_kwargs", "invalid_payload", "valid_payload", "provider"),
+    [
+        (
+            "image_generation",
+            "/v1/images/generations",
+            {"json": {"model": "gpt-4o-mini", "prompt": "sunset"}},
+            {"secret": "sk-upstream"},
+            {"created": 1700000000, "data": [{"url": "https://example.com/image.png"}]},
+            "openai",
+        ),
+        (
+            "rerank",
+            "/v1/rerank",
+            {
+                "json": {
+                    "model": "gpt-4o-mini",
+                    "query": "hello",
+                    "documents": ["hello world"],
+                }
+            },
+            {"results": []},
+            {"results": [{"index": 0, "relevance_score": 0.91}]},
+            "vllm",
+        ),
+        (
+            "rerank",
+            "/v1/rerank",
+            {
+                "json": {
+                    "model": "gpt-4o-mini",
+                    "query": "hello",
+                    "documents": ["hello world"],
+                }
+            },
+            {"results": [{"index": 99, "relevance_score": 0.91}]},
+            {"results": [{"index": 0, "relevance_score": 0.91}]},
+            "vllm",
+        ),
+        (
+            "audio_speech",
+            "/v1/audio/speech",
+            {
+                "json": {
+                    "model": "gpt-4o-mini",
+                    "input": "hello world",
+                    "voice": "alloy",
+                }
+            },
+            {},
+            {},
+            "openai",
+        ),
+        (
+            "audio_transcription",
+            "/v1/audio/transcriptions",
+            {
+                "data": {"model": "gpt-4o-mini", "response_format": "json"},
+                "files": {"file": ("sample.wav", b"RIFFDATA", "audio/wav")},
+            },
+            {"secret": "sk-upstream"},
+            {"text": "hello", "duration": 1.0},
+            "openai",
+        ),
+    ],
+)
+async def test_multimodal_malformed_object_success_uses_general_fallback(
+    client,
+    test_app,
+    mode: str,
+    path: str,
+    request_kwargs: dict,
+    invalid_payload: dict,
+    valid_payload: dict,
+    provider: str,
+):
+    registry_store = test_app.state.router.deployment_registry
+    primary = registry_store["gpt-4o-mini"][0]
+    primary.deltallm_params.update({"api_key": "primary-key", "provider": provider})
+    primary.model_info["mode"] = mode
+    fallback = Deployment(
+        deployment_id=f"{mode}-malformed-fallback",
+        model_name="gpt-4o-mini",
+        deltallm_params={
+            "provider": provider,
+            "model": f"{provider}/provider-model",
+            "api_key": "fallback-key",
+        },
+        model_info={"mode": mode},
+    )
+    registry_store.replace(
+        {
+            **registry_store.snapshot(),
+            "gpt-4o-mini": [primary, fallback],
+        }
+    )
+
+    async def choose_primary(model_group, request_context):  # noqa: ANN001, ANN201
+        del model_group, request_context
+        return primary
+
+    attempts: list[str | None] = []
+
+    async def post(url, headers=None, json=None, timeout=None, files=None, data=None):  # noqa: ANN001, ANN201
+        del json, timeout, files, data
+        attempts.append((headers or {}).get("Authorization"))
+        request = httpx.Request("POST", url)
+        if attempts[-1] == "Bearer primary-key":
+            if mode == "audio_speech":
+                return httpx.Response(200, content=b"", request=request)
+            return httpx.Response(200, json=invalid_payload, request=request)
+        if mode == "audio_speech":
+            return httpx.Response(200, content=b"audio-bytes", request=request)
+        return httpx.Response(200, json=valid_payload, request=request)
+
+    test_app.state.router.select_deployment = choose_primary
+    test_app.state.http_client.post = post
+    response = await client.post(
+        path,
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        **request_kwargs,
+    )
+
+    assert response.status_code == 200
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    assert attempts == ["Bearer primary-key", "Bearer fallback-key"]
+    assert "sk-upstream" not in response.text
+    primary_health = await test_app.state.router_state_backend.get_health(primary.deployment_id)
+    assert primary_health["last_error"] == "Provider returned an invalid response"
+    primary_usage = await test_app.state.router_state_backend.get_usage(primary.deployment_id)
+    fallback_usage = await test_app.state.router_state_backend.get_usage(fallback.deployment_id)
+    assert int(primary_usage.get("rpm", 0) or 0) == 0
+    assert fallback_usage["rpm"] == 1

--- a/tests/test_routing_runtime_generation.py
+++ b/tests/test_routing_runtime_generation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 from types import SimpleNamespace
 
+from src.router.failover import FailoverManager
 from src.router.runtime_authorization import CallableTargetGrantSnapshot
 from src.router.runtime_generation import pin_routing_runtime_generation
 
@@ -13,9 +14,24 @@ def test_operation_keeps_one_generation_after_store_publication(test_app) -> Non
     operation_state = SimpleNamespace()
 
     pinned = pin_routing_runtime_generation(test_app.state, operation_state)
+    replacement_failover_config = replace(
+        first.failover_config,
+        fallbacks={"primary": ["general"]},
+        context_window_fallbacks={"primary": ["context"]},
+        content_policy_fallbacks={"primary": ["content"]},
+    )
+    replacement_failover_manager = FailoverManager(
+        config=replacement_failover_config,
+        candidate_planner=first.router,
+        state_backend=first.failover_manager.state,
+        cooldown_manager=first.cooldown_manager,
+        event_journal=first.failover_manager.event_journal,
+    )
     replacement = replace(
         first,
         generation_id="replacement-generation",
+        failover_config=replacement_failover_config,
+        failover_manager=replacement_failover_manager,
         authorization_snapshot=CallableTargetGrantSnapshot.create(
             enabled_by_scope={("organization", "org-default"): frozenset({"replacement-model"})},
             binding_counts_by_scope={("organization", "org-default"): 1},
@@ -29,4 +45,12 @@ def test_operation_keeps_one_generation_after_store_publication(test_app) -> Non
 
     assert pinned is first
     assert pin_routing_runtime_generation(test_app.state, operation_state) is first
-    assert pin_routing_runtime_generation(test_app.state, SimpleNamespace()) is replacement
+    latest = pin_routing_runtime_generation(test_app.state, SimpleNamespace())
+    assert latest is replacement
+    assert pinned.failover_config.fallbacks == {}
+    assert pinned.failover_config.context_window_fallbacks == {}
+    assert pinned.failover_config.content_policy_fallbacks == {}
+    assert latest.failover_config.fallbacks == {"primary": ("general",)}
+    assert latest.failover_config.context_window_fallbacks == {"primary": ("context",)}
+    assert latest.failover_config.content_policy_fallbacks == {"primary": ("content",)}
+    assert latest.failover_manager.config is latest.failover_config

--- a/tests/test_uniformity_hardening.py
+++ b/tests/test_uniformity_hardening.py
@@ -356,8 +356,8 @@ async def test_embedding_failover_failure_uses_last_attempted_deployment_metadat
 
     primary_health = await test_app.state.router_state_backend.get_health(registry[0].deployment_id)
     fallback_health = await test_app.state.router_state_backend.get_health(fallback.deployment_id)
-    assert primary_health.get("last_error") == "Upstream embedding call failed with status 503"
-    assert fallback_health.get("last_error") == "Upstream embedding call failed with status 502"
+    assert primary_health.get("last_error") == "Provider unavailable"
+    assert fallback_health.get("last_error") == "Provider unavailable"
 
 
 @pytest.mark.asyncio
@@ -810,6 +810,98 @@ async def test_audio_speech_uses_gemini_native_endpoint_and_bills_from_usage_met
     assert billing["cost"] == 12.0
     assert billing["usage_snapshot"]["prompt_tokens"] == 10
     assert billing["usage_snapshot"]["output_audio_tokens"] == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_payload", "expected_status", "expected_message", "expected_failures"),
+    [
+        (
+            {"promptFeedback": {"blockReason": "SAFETY"}},
+            400,
+            "Provider rejected request",
+            0,
+        ),
+        (
+            {
+                "candidates": [
+                    {
+                        "content": {"parts": []},
+                        "finishReason": "IMAGE_RECITATION",
+                    }
+                ]
+            },
+            400,
+            "Provider rejected request",
+            0,
+        ),
+        (
+            {
+                "candidates": [
+                    {
+                        "content": {"parts": []},
+                        "finishReason": "MALFORMED_RESPONSE",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 4,
+                    "candidatesTokenCount": 0,
+                    "totalTokenCount": 4,
+                },
+            },
+            503,
+            "Provider returned an invalid response",
+            1,
+        ),
+    ],
+)
+async def test_audio_speech_gemini_nominal_failure_is_classified_before_audio_extraction(
+    client,
+    test_app,
+    provider_payload: dict,
+    expected_status: int,
+    expected_message: str,
+    expected_failures: int,
+):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params.update(
+        {
+            "provider": "gemini",
+            "model": "gemini/gemini-2.5-flash-preview-tts",
+            "api_base": "https://generativelanguage.googleapis.com/v1beta",
+            "api_key": "gemini-key",
+        }
+    )
+    deployment.model_info = {"mode": "audio_speech"}
+
+    async def post(url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001, ANN201
+        del headers, json, timeout
+        return httpx.Response(
+            200,
+            json=provider_payload,
+            request=httpx.Request("POST", url),
+        )
+
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/audio/speech",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hello world",
+            "voice": "Kore",
+            "response_format": "wav",
+        },
+    )
+
+    assert response.status_code == expected_status
+    assert response.json()["error"]["message"] == expected_message
+    health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+    assert int(health.get("consecutive_failures", 0) or 0) == expected_failures
+    if expected_failures:
+        assert health.get("last_error") == expected_message
+    else:
+        assert health.get("last_error") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- return bounded, typed, sanitized failure classifications from provider adapters
- apply context-window and content-policy fallback selection consistently across OpenAI, Azure OpenAI, Anthropic, Gemini, Bedrock, and supported OpenAI-compatible providers
- preserve authoritative HTTP status semantics while allowing recognized health-affecting 5xx failures to try specialized fallback chains before the general chain
- reject malformed nominal-success payloads and pre-commit streams without exposing provider-owned bodies or retrying after downstream output
- atomically reload general, context-window, and content-policy fallback maps in one validated runtime generation
- keep explicit custom providers on generic status mapping instead of inheriting OpenAI classifications

## Engineering contract

- Source of truth: provider adapters own provider-envelope classification; the immutable routing runtime owns all fallback maps; the failover manager owns attempt ordering and health bookkeeping.
- Tenant and authorization scope: existing authenticated gateway and model-access checks remain unchanged; classification contains no tenant data and never bypasses eligibility.
- Failure mode: provider-owned details are bounded and discarded after classification; public errors remain stable and sanitized. Unknown 4xx failures stop, malformed successes and unclassified 5xx failures use the general chain, recognized context/content failures may use specialized chains, and 429 remains rate-limit classified.
- Retry boundary: failover remains inside the existing bounded total deadline and only before streaming output commits; adapters classify but perform no retry or side effect.
- Latency impact: bounded in-memory envelope/schema validation only; no new SQL, Redis, filesystem, callback, or network work on the data plane.

## Verification

- full backend suite: 3,266 passed, 155 skipped
- repository-wide Ruff lint passed
- Ruff format check passed for all 36 touched Python files
- focused provider, failover, chat, embeddings, multimodal, uniformity, dynamic-config, and runtime-generation suites passed
- `git diff --check` passed
- repository-wide Ruff format retains an existing unrelated baseline of 258 unformatted files; every file touched by this PR is clean

Tracks PR 7 in #275.
