### PR TITLE
Harden provider error handling and batch error sanitization

### DIFF
--- a/docs/api/messages.md
+++ b/docs/api/messages.md
@@ -56,4 +56,18 @@ Errors use the Anthropic error envelope:
 }
 ```
 
-Gateway-level errors (rate limits, budget exhaustion, upstream failures) return the same status codes as the OpenAI-compatible endpoints.
+Every failure before the response starts—including authentication, request validation, rate
+limits, budget exhaustion, and upstream/provider failures—uses this envelope. Provider response
+bodies and messages are never forwarded. DeltaLLM maps the gateway status to the Anthropic error
+type (`authentication_error`, `permission_error`, `not_found_error`, `rate_limit_error`,
+`overloaded_error`, or `api_error`) and preserves a valid `Retry-After` header for rate limits.
+
+Gateway-level errors return the same HTTP status codes as the OpenAI-compatible endpoints. An
+unclassified upstream `401`, `403`, or `404` is treated as a deployment/configuration failure so
+another healthy deployment can be tried; if failover is exhausted, the client receives a sanitized
+`503 overloaded_error`. A trusted content-policy or context-window classification remains a
+terminal `400 invalid_request_error`.
+
+If a provider fails after a streaming `200` response has already emitted content, DeltaLLM does not
+retry or replace the response. It emits one sanitized Anthropic `event: error` frame and closes the
+stream without a `message_stop` event.

--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -61,6 +61,13 @@ This is the main endpoint most applications should start with.
 
 Chat requests also support DeltaLLM-managed MCP tools through `tools: [{ "type": "mcp", ... }]` on non-streaming requests. See [MCP Gateway & Tooling](mcp.md).
 
+Provider error bodies are bounded and never returned verbatim. Encoded error bodies are kept opaque
+and classified from trusted status and `Retry-After` metadata instead of being decompressed; bounded
+identity bodies may also contribute provider-specific classifications. Before response commit,
+DeltaLLM uses the sanitized classification for retry and failover. After a streaming response has
+emitted content, it never retries: a provider failure closes the OpenAI-compatible stream without a
+`[DONE]` marker, so clients must treat a missing terminal marker as an incomplete response.
+
 ### Completions (Legacy)
 
 ```text

--- a/docs/features/batching.md
+++ b/docs/features/batching.md
@@ -716,7 +716,13 @@ The worker groups only after routing, and only when items share the same deploym
 
 Sync microbatch calls use the same deployment failover path as ordinary chat requests. Before sending a grouped request to any served deployment, the worker checks that deployment's own `chat_batching.mode`, chunk-size limit, token cap, and sync microbatch executor. If the primary deployment fails and a fallback deployment also supports the requested sync microbatch, the fallback response is persisted with the fallback deployment's provider, API base, and pricing metadata. If the served deployment cannot run the requested sync microbatch and no earlier retryable health-affecting microbatch failure occurred, the worker degrades to bounded per-item execution without marking that deployment unhealthy. If the primary deployment already failed with a retryable health-affecting error before failover reaches an unsupported deployment, the worker requeues the chunk using the primary failure so health and retry semantics are preserved.
 
-Successful microbatch results are persisted and billed per item. If a provider result is missing per-item usage, that item fails instead of using aggregate usage. Mixed success and failure results persist successful items and fail or retry only the affected failed items. Structured per-item provider errors with retryable status codes such as `429`, `408`, or `5xx` are classified by the normal batch retry policy; unstructured provider item errors remain terminal invalid-request failures.
+Successful microbatch results are persisted and billed per item. If a provider result is missing per-item usage, that item fails instead of using aggregate usage. Mixed success and failure results persist successful items and fail or retry only the affected failed items. Structured per-item provider errors with retryable status codes such as `429`, `408`, or `5xx` are classified by the normal batch retry policy; unstructured provider item errors remain terminal invalid-request failures. Provider-owned messages and nested payloads are discarded before persistence. Error artifacts and batch UI item responses are assembled from an allowlist of stable fields and messages, including for historical rows, so upstream bodies, credentials, URLs, and arbitrary exception text are not returned through `error_file_id` or the batch detail APIs.
+
+Operators can inspect and then irreversibly sanitize provider-owned text already stored on terminal
+batch items with `scripts/sanitize_batch_item_errors.py`. Supply the database URL through
+`--database-url-file`, run `inspect` first, then run `apply --confirm-sanitize` in bounded pages.
+When `has_more=true`, resume with the reported `next_after_item_id` as `--after-item-id`. Take a
+database backup before `apply`; the discarded historical text cannot be reconstructed by DeltaLLM.
 
 ## Monitoring
 

--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -66,6 +66,7 @@ Core metrics include:
 | `deltallm_deployment_cooldown` | Gauge | Whether a deployment is cooled down |
 | `deltallm_router_health_transitions_total` | Counter | Actual cooldown, manual-cooldown, and recovery transitions |
 | `deltallm_router_health_update_failures_total` | Counter | Post-outcome router health updates that could not be persisted |
+| `deltallm_provider_error_body_discards_total` | Counter | Encoded or oversized provider error bodies excluded from classification |
 | `deltallm_prompt_resolutions_total` | Counter | Prompt registry resolution results |
 | `deltallm_prompt_resolution_latency_seconds` | Histogram | Prompt resolution latency |
 | `deltallm_prompt_singleflight_inflight` | Gauge | Distinct process-owned prompt cold-load tasks currently running |

--- a/docs/features/routing.md
+++ b/docs/features/routing.md
@@ -472,10 +472,14 @@ deployment-health impact, while a trusted adapter classification owns specialize
 selection. A recognized context or policy failure returned with a 5xx status therefore remains
 health-affecting and may try its specialized chain before the general chain. Unclassified 5xx
 responses use the general chain, and 429 remains rate-limit classified regardless of envelope text.
+Provider `408` responses use the timeout path. Unclassified provider `401`, `403`, and `404`
+responses indicate unhealthy deployment credentials, permissions, or model configuration and use
+the general fallback chain; a trusted context-window or content-policy classification still remains
+a terminal request failure.
 Malformed JSON or response schemas behind a nominally successful provider status are also
 health-affecting general failures, and the upstream payload is never returned to the client. Empty
 chat choices, missing or mismatched embedding and rerank results, and empty speech audio are
-malformed successes. Unknown or malformed provider 4xx responses stop immediately and return a
+malformed successes. Other unknown or malformed provider 4xx responses stop immediately and return a
 sanitized, stable gateway error. Anthropic `refusal` and `model_context_window_exceeded` success
 stop reasons select the content-policy and context-window chains respectively. Gemini policy
 terminal reasons select the content-policy chain; unsupported, malformed, and unknown terminal
@@ -490,7 +494,9 @@ terminal events can therefore select a specialized fallback before output. Empty
 and truncated pre-output streams are malformed successes and may use the general fallback chain.
 If a classified stop follows partial output, DeltaLLM completes that committed stream with
 `content_filter` or `length` instead of starting another provider attempt. Any other malformed
-committed stream is aborted, marked unhealthy, and never cached as a complete response.
+committed stream is marked unhealthy and never cached as a complete response. OpenAI-compatible
+streams close without `[DONE]`; Anthropic Messages streams emit one sanitized `event: error` frame.
+Neither path starts another provider attempt after commit.
 
 All three maps are immutable members of one routing-runtime generation. Each replica serializes the
 durable config load, subscriber application, generation publication, and rollback. Publication is

--- a/scripts/sanitize_batch_item_errors.py
+++ b/scripts/sanitize_batch_item_errors.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Inspect or sanitize historical terminal batch-item errors in bounded pages."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from src.batch.error_remediation import remediate_terminal_batch_item_errors
+from src.batch.repositories.error_remediation_repository import BatchErrorRemediationRepository
+
+_MAX_DATABASE_URL_FILE_CHARS = 8_192
+
+
+def _bounded_positive_int(value: str, *, argument: str, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{argument} must be an integer") from exc
+    if not 1 <= parsed <= maximum:
+        raise argparse.ArgumentTypeError(f"{argument} must be between 1 and {maximum}")
+    return parsed
+
+
+def _page_size(value: str) -> int:
+    return _bounded_positive_int(value, argument="--page-size", maximum=1_000)
+
+
+def _max_pages(value: str) -> int:
+    return _bounded_positive_int(value, argument="--max-pages", maximum=10_000)
+
+
+def _read_database_url(path_value: str) -> str:
+    with Path(path_value).open(encoding="utf-8") as database_url_file:
+        database_url = database_url_file.read(_MAX_DATABASE_URL_FILE_CHARS + 1)
+    if len(database_url) > _MAX_DATABASE_URL_FILE_CHARS:
+        raise ValueError("database URL file is too large")
+    database_url = database_url.strip()
+    if not database_url:
+        raise ValueError("database URL file must not be empty")
+    return database_url
+
+
+async def _run(args: argparse.Namespace) -> int:
+    from prisma import Prisma
+
+    database_url = _read_database_url(args.database_url_file)
+    db = Prisma(datasource={"url": database_url})
+    await db.connect()
+    try:
+        result = await remediate_terminal_batch_item_errors(
+            BatchErrorRemediationRepository(db),
+            after_item_id=args.after_item_id,
+            page_size=args.page_size,
+            max_pages=args.max_pages,
+            apply=args.command == "apply",
+        )
+    finally:
+        await db.disconnect()
+    print(
+        f"inspected={result.inspected} updated={result.updated} "
+        f"has_more={str(result.has_more).lower()} "
+        f"next_after_item_id={result.next_after_item_id or ''}"
+    )
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("inspect", "apply"))
+    parser.add_argument("--database-url-file", required=True)
+    parser.add_argument("--after-item-id")
+    parser.add_argument("--page-size", type=_page_size, default=500)
+    parser.add_argument("--max-pages", type=_max_pages, default=100)
+    parser.add_argument("--confirm-sanitize", action="store_true")
+    args = parser.parse_args()
+    if args.command == "apply" and not args.confirm_sanitize:
+        parser.error("apply requires --confirm-sanitize")
+    try:
+        exit_code = asyncio.run(_run(args))
+    except Exception as exc:
+        print(f"batch error sanitization failed: {type(exc).__name__}", file=sys.stderr)
+        raise SystemExit(1) from None
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_migration_paths.py
+++ b/scripts/verify_migration_paths.py
@@ -222,10 +222,27 @@ VALUES
 INSERT INTO deltallm_routepolicy
   (route_policy_id, route_group_id, version, status, policy_json, published_at)
 VALUES
-  ('migration-upgrade-route-policy-1', '{UPGRADE_ROUTE_GROUP_ID}', 1, 'published',
+  ('migration-upgrade-route-policy-1', '{UPGRADE_ROUTE_GROUP_ID}', 1,
+   CASE
+     WHEN to_regclass('public.deltallm_routepolicy_one_published_per_group') IS NULL
+       THEN 'published'
+     ELSE 'archived'
+   END,
    '{{"strategy":"weighted","server_revision":1}}'::jsonb, NOW()),
   ('migration-upgrade-route-policy-2', '{UPGRADE_ROUTE_GROUP_ID}', 2, 'published',
    '{{"strategy":"least-busy","server_revision":2}}'::jsonb, NOW());
+
+DO $migration_fixture$
+BEGIN
+  IF to_regclass('public.deltallm_routeruntimestate') IS NOT NULL THEN
+    UPDATE deltallm_routeruntimestate
+    SET route_groups_initialized = TRUE,
+        updated_at = NOW()
+    WHERE state_key = 'routing_runtime'
+      AND EXISTS (SELECT 1 FROM deltallm_routegroup);
+  END IF;
+END
+$migration_fixture$;
 """,
     )
 

--- a/src/api/admin/endpoints/batches.py
+++ b/src/api/admin/endpoints/batches.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 from src.auth.roles import Permission
 from src.api.admin.endpoints.common import db_or_503, emit_admin_mutation_audit, to_json_value, get_auth_scope
 from src.audit.actions import AuditAction
+from src.batch.error_sanitization import sanitize_batch_item_error_fields
 from src.batch.repository import BatchRepository
 from src.batch.models import BATCH_JOB_STATUS_SET, encode_operator_failed_reason
 from src.batch.scheduling import (
@@ -1047,6 +1048,7 @@ async def get_batch(
             """
             SELECT item_id, line_number, custom_id, status, attempts, provider_cost, billed_cost,
                    last_error,
+                   LEFT(error_body ->> 'retry_category', 64) AS _error_retry_category,
                    request_body IS NOT NULL AS has_request_body,
                    response_body IS NOT NULL AS has_response_body,
                    error_body IS NOT NULL AS has_error_body,
@@ -1065,6 +1067,7 @@ async def get_batch(
             """
             SELECT item_id, line_number, custom_id, status, attempts, provider_cost, billed_cost,
                    last_error,
+                   LEFT(error_body ->> 'retry_category', 64) AS _error_retry_category,
                    request_body IS NOT NULL AS has_request_body,
                    response_body IS NOT NULL AS has_response_body,
                    error_body IS NOT NULL AS has_error_body,
@@ -1079,7 +1082,9 @@ async def get_batch(
             after_line_number,
             fetch_limit,
         )
-    item_rows_page = [dict(r) for r in item_rows[:items_limit]]
+    item_rows_page = [
+        sanitize_batch_item_error_fields(dict(r)) for r in item_rows[:items_limit]
+    ]
     has_more_items = len(item_rows) > items_limit
     next_after_line_number = (
         int(item_rows_page[-1].get("line_number"))
@@ -1184,7 +1189,10 @@ async def get_batch_item(
     rows = await db.query_raw(
         """
         SELECT item_id, batch_id, line_number, custom_id, status, attempts, provider_cost, billed_cost,
-               last_error, request_body, response_body, error_body, usage,
+               last_error, request_body, response_body,
+               error_body IS NOT NULL AS _has_error_body,
+               LEFT(error_body ->> 'retry_category', 64) AS _error_retry_category,
+               usage,
                created_at, started_at, completed_at
         FROM deltallm_batch_item
         WHERE batch_id = $1 AND item_id = $2
@@ -1195,7 +1203,7 @@ async def get_batch_item(
     )
     if not rows:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Batch item not found")
-    return to_json_value(dict(rows[0]))
+    return to_json_value(sanitize_batch_item_error_fields(dict(rows[0])))
 
 
 @router.post("/ui/api/batches/{batch_id}/cancel")

--- a/src/batch/chat_batching.py
+++ b/src/batch/chat_batching.py
@@ -6,17 +6,18 @@ import json
 import operator
 from typing import Any, Literal, Protocol
 
+import httpx
 from pydantic import ValidationError
 
 from src.batch.retry import BatchResponseShapeError
 from src.config import ChatBatchingConfig
-from src.models.errors import (
-    InvalidRequestError,
-    RateLimitError,
-    ServiceUnavailableError,
-    TimeoutError as GatewayTimeoutError,
-)
+from src.models.errors import InvalidRequestError, ProxyError
 from src.models.requests import ChatCompletionRequest, MCPToolDefinition
+from src.providers.base import (
+    map_standard_provider_error,
+    map_standard_provider_status_error,
+    sanitize_provider_proxy_error,
+)
 from src.providers.resolution import resolve_provider
 
 ChatBatchingMode = Literal["disabled", "concurrent", "sync_microbatch"]
@@ -281,13 +282,16 @@ def _result_usage(
 def _normalize_result_error(raw_error: Any) -> Exception | None:
     if raw_error is None:
         return None
+    if isinstance(raw_error, ProxyError):
+        return sanitize_provider_proxy_error(raw_error)
+    if isinstance(raw_error, httpx.HTTPError):
+        return map_standard_provider_error(raw_error)
     if isinstance(raw_error, Exception):
-        return raw_error
+        return InvalidRequestError(message="Provider rejected request")
 
     if not isinstance(raw_error, Mapping):
-        return InvalidRequestError(message=str(raw_error))
+        return InvalidRequestError(message="Provider rejected request")
 
-    message = _error_message(raw_error)
     nested_error = _nested_error_mapping(raw_error)
     status_code = _first_optional_int(
         raw_error.get("status_code"),
@@ -308,19 +312,22 @@ def _normalize_result_error(raw_error: Any) -> Exception | None:
     )
 
     if status_code == 429 or "rate_limit" in error_kind or "rate limit" in error_kind:
-        return RateLimitError(
-            message=message,
-            retry_after=retry_after,
-            affects_deployment_health=True,
+        return map_standard_provider_status_error(
+            429,
+            retry_after_header=str(retry_after) if retry_after is not None else None,
         )
     if status_code == 408 or "timeout" in error_kind or "timed_out" in error_kind:
-        return GatewayTimeoutError(message=message)
+        return map_standard_provider_status_error(408)
     if (status_code is not None and status_code >= 500) or any(
         token in error_kind
         for token in ("service_unavailable", "server_error", "overload", "upstream_5xx")
     ):
-        return ServiceUnavailableError(message=message, affects_deployment_health=True)
-    return InvalidRequestError(message=message)
+        return map_standard_provider_status_error(status_code or 500)
+    if status_code in {401, 403, 404} or any(
+        token in error_kind for token in ("authentication", "permission", "not_found")
+    ):
+        return map_standard_provider_status_error(status_code or 503)
+    return map_standard_provider_status_error(status_code or 400)
 
 
 def _optional_float(value: Any) -> float | None:
@@ -347,15 +354,6 @@ def _first_optional_int(*values: Any) -> int | None:
         if parsed is not None:
             return parsed
     return None
-
-
-def _error_message(raw_error: Mapping[str, Any]) -> str:
-    nested = raw_error.get("error")
-    if isinstance(nested, Mapping):
-        message = nested.get("message") or nested.get("detail")
-    else:
-        message = raw_error.get("message") or raw_error.get("detail") or nested
-    return str(message or raw_error)
 
 
 def _nested_error_mapping(raw_error: Mapping[str, Any]) -> Mapping[str, Any] | None:

--- a/src/batch/chat_worker_execution.py
+++ b/src/batch/chat_worker_execution.py
@@ -16,6 +16,7 @@ from src.batch.chat_batching import (
     resolve_chat_batching_settings,
 )
 from src.batch.endpoints import batch_call_type_for_endpoint, router_usage_mode_for_batch_endpoint
+from src.batch.error_sanitization import persisted_batch_error_message
 from src.batch.policy import record_batch_policy_failure, run_batch_request_preflight
 from src.batch.retry import BatchResponseShapeError, BatchRetryDecision, classify_batch_retry
 from src.batch.worker_constants import COMPLETION_OUTBOX_MAX_ATTEMPTS
@@ -35,9 +36,10 @@ from src.metrics import (
     observe_batch_chat_provider_latency,
     set_batch_worker_saturation,
 )
-from src.models.errors import InvalidRequestError, ServiceUnavailableError
+from src.models.errors import InvalidRequestError, ProxyError, ServiceUnavailableError
 from src.models.request_serialization import dump_request_for_preflight
 from src.models.requests import ChatCompletionRequest, MCPToolDefinition
+from src.providers.base import map_standard_provider_error, sanitize_provider_proxy_error
 from src.providers.resolution import resolve_provider
 from src.router import ProviderAttemptResult, ROUTING_MODE_CONTEXT_KEY
 from src.router.execution import (
@@ -64,6 +66,23 @@ CHAT_MICROBATCH_UNSUPPORTED_REASONS = frozenset(
 
 
 class ChatWorkerExecutionMixin:
+    def _sanitize_chat_microbatch_executor_error(
+        self, deployment: Any, exc: Exception
+    ) -> ProxyError:
+        if self._is_chat_microbatch_unsupported_error(exc):
+            return self._chat_microbatch_unsupported_error(
+                deployment,
+                reason=self._chat_microbatch_unsupported_reason(exc),
+            )
+        if isinstance(exc, ProxyError):
+            return sanitize_provider_proxy_error(exc)
+        registry = getattr(self.app.state, "provider_error_mapper_registry", None)
+        if registry is not None:
+            mapped_error = registry.map_error(resolve_provider(deployment.deltallm_params), exc)
+        else:
+            mapped_error = map_standard_provider_error(exc)
+        return sanitize_provider_proxy_error(mapped_error)
+
     async def prepare_chat_item_for_execution(self, job, item) -> _PreparedChatItem:  # noqa: ANN001
         started_at_monotonic = perf_counter()
         chat_request = ChatCompletionRequest.model_validate(item.request_body)
@@ -513,7 +532,7 @@ class ChatWorkerExecutionMixin:
         failed_size: int,
     ) -> dict[str, Any]:
         return {
-            "message": str(exc),
+            "message": persisted_batch_error_message(exc, decision),
             "type": exc.__class__.__name__,
             "retryable": True,
             "retry_category": decision.category.value,
@@ -587,13 +606,14 @@ class ChatWorkerExecutionMixin:
             original_size=original_size,
             failed_size=chunk_size,
         )
+        safe_error_message = persisted_batch_error_message(exc, decision)
         try:
             released_item_ids = await self.repository.release_items_for_retry(
                 item_ids=item_ids,
                 worker_id=self.config.worker_id,
                 retry_delay_seconds=retry_delay,
                 error_body=error_body,
-                last_error=str(exc),
+                last_error=safe_error_message,
                 item_claim_epochs={
                     prepared.item.item_id: prepared.item.claim_epoch for prepared in prepared_items
                 },
@@ -698,33 +718,38 @@ class ChatWorkerExecutionMixin:
                     deployment=deployment,
                     request_context=request_context,
                 )
-                normalized_results = normalize_chat_microbatch_results(
-                    raw_results,
-                    expected_count=chunk_size,
-                    custom_ids=[prepared.item.custom_id for prepared in prepared_items],
-                )
-                health_errors = [
-                    result.error
-                    for result in normalized_results
-                    if result.error is not None and affects_deployment_health(result.error)
-                ]
-                if len(health_errors) == len(normalized_results):
-                    raise health_errors[0]
-                if health_errors:
-                    return ProviderAttemptResult(
-                        value=normalized_results,
-                        health_error=health_errors[0],
-                    )
-                return normalized_results
             except Exception as exc:
-                retry_decision = classify_batch_retry(exc)
+                mapped_error = self._sanitize_chat_microbatch_executor_error(deployment, exc)
+                retry_decision = classify_batch_retry(mapped_error)
                 if (
-                    not self._is_chat_microbatch_unsupported_error(exc)
+                    not self._is_chat_microbatch_unsupported_error(mapped_error)
                     and retry_decision.retryable
-                    and affects_deployment_health(exc)
+                    and affects_deployment_health(mapped_error)
                 ):
-                    last_retryable_microbatch_exc = exc
-                raise
+                    last_retryable_microbatch_exc = mapped_error
+                if mapped_error is exc:
+                    raise
+                raise mapped_error from exc
+
+            normalized_results = normalize_chat_microbatch_results(
+                raw_results,
+                expected_count=chunk_size,
+                custom_ids=[prepared.item.custom_id for prepared in prepared_items],
+            )
+            health_errors = [
+                result.error
+                for result in normalized_results
+                if result.error is not None and affects_deployment_health(result.error)
+            ]
+            if len(health_errors) == len(normalized_results):
+                last_retryable_microbatch_exc = health_errors[0]
+                raise health_errors[0]
+            if health_errors:
+                return ProviderAttemptResult(
+                    value=normalized_results,
+                    health_error=health_errors[0],
+                )
+            return normalized_results
 
         try:
             for prepared in prepared_items:

--- a/src/batch/embedding_worker_execution.py
+++ b/src/batch/embedding_worker_execution.py
@@ -17,6 +17,7 @@ from src.batch.embedding_microbatch import (
     resolve_effective_upstream_max_batch_inputs,
 )
 from src.batch.endpoints import batch_call_type_for_endpoint, router_usage_mode_for_batch_endpoint
+from src.batch.error_sanitization import persisted_batch_error_message
 from src.batch.policy import record_batch_policy_failure, run_batch_request_preflight
 from src.batch.retry import (
     BatchResponseShapeError,
@@ -260,7 +261,7 @@ class EmbeddingWorkerExecutionMixin:
         result: str,
     ) -> dict[str, Any]:
         return {
-            "message": str(exc),
+            "message": persisted_batch_error_message(exc, decision),
             "type": exc.__class__.__name__,
             "retryable": True,
             "retry_category": decision.category.value,
@@ -380,13 +381,14 @@ class EmbeddingWorkerExecutionMixin:
             next_max_inputs=next_max_inputs,
             result=result,
         )
+        safe_error_message = persisted_batch_error_message(exc, decision)
         try:
             released_item_ids = await self.repository.release_items_for_retry(
                 item_ids=item_ids,
                 worker_id=self.config.worker_id,
                 retry_delay_seconds=retry_delay,
                 error_body=error_body,
-                last_error=str(exc),
+                last_error=safe_error_message,
                 item_claim_epochs={
                     prepared.item.item_id: prepared.item.claim_epoch for prepared in prepared_items
                 },

--- a/src/batch/error_remediation.py
+++ b/src/batch/error_remediation.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from src.batch.error_sanitization import sanitize_batch_artifact_error
+
+
+@dataclass(frozen=True, slots=True)
+class BatchErrorRemediationResult:
+    inspected: int
+    updated: int
+    next_after_item_id: str | None
+    has_more: bool
+
+
+class BatchErrorRemediationStore(Protocol):
+    async def list_terminal_error_rows(
+        self, *, after_item_id: str, limit: int
+    ) -> list[dict[str, Any]]: ...
+
+    async def update_terminal_error_rows(self, updates: list[dict[str, Any]]) -> int: ...
+
+
+async def remediate_terminal_batch_item_errors(
+    store: BatchErrorRemediationStore,
+    *,
+    after_item_id: str | None,
+    page_size: int,
+    max_pages: int,
+    apply: bool,
+) -> BatchErrorRemediationResult:
+    """Inspect or sanitize terminal batch errors in bounded, restartable pages."""
+
+    bounded_page_size = max(1, min(int(page_size), 1_000))
+    bounded_max_pages = max(1, min(int(max_pages), 10_000))
+    cursor = str(after_item_id or "")
+    inspected = 0
+    updated = 0
+    has_more = False
+
+    for _page in range(bounded_max_pages):
+        rows = await store.list_terminal_error_rows(
+            after_item_id=cursor,
+            limit=bounded_page_size,
+        )
+        if not rows:
+            has_more = False
+            break
+
+        updates = [_sanitized_update(dict(row)) for row in rows]
+        inspected += len(updates)
+        cursor = str(updates[-1]["item_id"])
+        has_more = len(updates) == bounded_page_size
+        if apply:
+            updated += await store.update_terminal_error_rows(updates)
+        if not has_more:
+            break
+
+    return BatchErrorRemediationResult(
+        inspected=inspected,
+        updated=updated,
+        next_after_item_id=cursor or None,
+        has_more=has_more,
+    )
+
+
+def _sanitized_update(row: dict[str, Any]) -> dict[str, Any]:
+    retry_category = row.get("retry_category")
+    safe_error = sanitize_batch_artifact_error(
+        {"retry_category": retry_category} if retry_category is not None else None,
+        cancelled=str(row.get("status") or "") == "cancelled",
+    )
+    return {
+        "item_id": str(row["item_id"]),
+        "last_error": safe_error["message"] if row.get("has_last_error") else None,
+        "error_body": safe_error if row.get("has_error_body") else None,
+    }

--- a/src/batch/error_sanitization.py
+++ b/src/batch/error_sanitization.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+from src.batch.retry import (
+    BatchRetryCategory,
+    BatchRetryDecision,
+    BatchRetryTerminalReason,
+)
+from src.models.errors import ProxyError
+
+_PUBLIC_MESSAGES = {
+    BatchRetryCategory.AUTHENTICATION: "Provider authentication failed",
+    BatchRetryCategory.RATE_LIMIT: "Provider rate limited request",
+    BatchRetryCategory.TIMEOUT: "Provider request timed out",
+    BatchRetryCategory.TRANSPORT: "Provider unavailable",
+    BatchRetryCategory.UPSTREAM_5XX: "Provider unavailable",
+    BatchRetryCategory.SERVICE_UNAVAILABLE: "Provider unavailable",
+    BatchRetryCategory.NO_HEALTHY_DEPLOYMENTS: "No healthy deployments available",
+    BatchRetryCategory.INVALID_REQUEST: "Batch request was rejected",
+    BatchRetryCategory.RESPONSE_SHAPE: "Provider returned an invalid response",
+    BatchRetryCategory.BUDGET: "Budget exceeded",
+    BatchRetryCategory.MISSING_MODEL: "Model not found",
+    BatchRetryCategory.PERMISSION: "Permission denied",
+    BatchRetryCategory.UNKNOWN: "Batch request failed",
+}
+
+
+def stable_batch_error_message(category: BatchRetryCategory | str | None) -> str:
+    """Return a public message without consulting persisted or provider-owned text."""
+
+    try:
+        resolved = BatchRetryCategory(str(category))
+    except ValueError:
+        resolved = BatchRetryCategory.UNKNOWN
+    return _PUBLIC_MESSAGES[resolved]
+
+
+def persisted_batch_error_message(exc: Exception, decision: BatchRetryDecision) -> str:
+    """Preserve application failures while sanitizing provider HTTP exceptions."""
+
+    if isinstance(exc, httpx.HTTPError):
+        return stable_batch_error_message(decision.category)
+    if isinstance(exc, ProxyError):
+        return exc.message
+    return str(exc)
+
+
+def sanitize_batch_artifact_error(
+    error_body: Mapping[str, Any] | None,
+    *,
+    cancelled: bool,
+) -> dict[str, Any]:
+    """Build an allowlisted public error from durable, potentially historical state."""
+
+    if cancelled:
+        return {"message": "Batch request cancelled", "type": "BatchItemCancelled"}
+
+    source = error_body or {}
+    category = _retry_category(source.get("retry_category"))
+    sanitized: dict[str, Any] = {
+        "message": stable_batch_error_message(category),
+        "type": "BatchItemError",
+    }
+    _copy_bool(source, sanitized, "retryable")
+    _copy_enum(source, sanitized, "retry_category", BatchRetryCategory)
+    _copy_enum(source, sanitized, "terminal_reason", BatchRetryTerminalReason)
+    for key in ("attempt", "max_attempts", "retry_delay_seconds"):
+        _copy_non_negative_int(source, sanitized, key)
+    return sanitized
+
+
+def sanitize_batch_item_error_fields(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Sanitize durable error fields before returning a batch item through an API."""
+
+    sanitized_item = dict(item)
+    cancelled = str(item.get("status") or "") == "cancelled"
+    error_body_value = item.get("error_body")
+    error_body = error_body_value if isinstance(error_body_value, Mapping) else None
+    retry_category = item.get("_error_retry_category")
+    if retry_category is None and error_body is not None:
+        retry_category = error_body.get("retry_category")
+    safe_error = sanitize_batch_artifact_error(
+        {"retry_category": retry_category} if error_body is None else error_body,
+        cancelled=cancelled,
+    )
+
+    if "_has_error_body" in sanitized_item:
+        sanitized_item["error_body"] = safe_error if item.get("_has_error_body") else None
+    elif "error_body" in sanitized_item and error_body_value is not None:
+        sanitized_item["error_body"] = safe_error
+    if sanitized_item.get("last_error") is not None:
+        sanitized_item["last_error"] = safe_error["message"]
+    sanitized_item.pop("_error_retry_category", None)
+    sanitized_item.pop("_has_error_body", None)
+    return sanitized_item
+
+
+def _retry_category(value: object) -> BatchRetryCategory:
+    try:
+        return BatchRetryCategory(str(value))
+    except ValueError:
+        return BatchRetryCategory.UNKNOWN
+
+
+def _copy_bool(source: Mapping[str, Any], target: dict[str, Any], key: str) -> None:
+    value = source.get(key)
+    if isinstance(value, bool):
+        target[key] = value
+
+
+def _copy_enum(
+    source: Mapping[str, Any],
+    target: dict[str, Any],
+    key: str,
+    enum_type: type[BatchRetryCategory] | type[BatchRetryTerminalReason],
+) -> None:
+    value = source.get(key)
+    try:
+        target[key] = enum_type(str(value)).value
+    except ValueError:
+        return
+
+
+def _copy_non_negative_int(source: Mapping[str, Any], target: dict[str, Any], key: str) -> None:
+    value = source.get(key)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        target[key] = value

--- a/src/batch/repositories/__init__.py
+++ b/src/batch/repositories/__init__.py
@@ -1,4 +1,5 @@
 from src.batch.repositories.completion_outbox_repository import BatchCompletionOutboxRepository
+from src.batch.repositories.error_remediation_repository import BatchErrorRemediationRepository
 from src.batch.repositories.file_repository import BatchFileRepository
 from src.batch.repositories.item_repository import BatchItemRepository
 from src.batch.repositories.job_repository import BatchJobRepository
@@ -8,6 +9,7 @@ from src.batch.repositories.webhook_outbox_repository import BatchWebhookOutboxR
 __all__ = [
     "BatchFileRepository",
     "BatchCompletionOutboxRepository",
+    "BatchErrorRemediationRepository",
     "BatchItemRepository",
     "BatchJobRepository",
     "BatchMaintenanceRepository",

--- a/src/batch/repositories/error_remediation_repository.py
+++ b/src/batch/repositories/error_remediation_repository.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class BatchErrorRemediationRepository:
+    """Bounded data access for the operator-run historical error scrub."""
+
+    def __init__(self, db: Any) -> None:
+        self.db = db
+
+    async def list_terminal_error_rows(
+        self, *, after_item_id: str, limit: int
+    ) -> list[dict[str, Any]]:
+        rows = await self.db.query_raw(
+            """
+            SELECT item_id,
+                   status,
+                   last_error IS NOT NULL AS has_last_error,
+                   error_body IS NOT NULL AS has_error_body,
+                   LEFT(error_body ->> 'retry_category', 64) AS retry_category
+            FROM deltallm_batch_item
+            WHERE item_id > $1
+              AND status IN ('completed', 'failed', 'cancelled')
+              AND (last_error IS NOT NULL OR error_body IS NOT NULL)
+            ORDER BY item_id
+            LIMIT $2
+            """,
+            after_item_id,
+            limit,
+        )
+        return [dict(row) for row in rows]
+
+    async def update_terminal_error_rows(self, updates: list[dict[str, Any]]) -> int:
+        if not updates:
+            return 0
+        return int(
+            await self.db.execute_raw(
+                """
+                UPDATE deltallm_batch_item AS item
+                SET last_error = patch.last_error,
+                    error_body = patch.error_body
+                FROM jsonb_to_recordset($1::jsonb)
+                     AS patch(item_id text, last_error text, error_body jsonb)
+                WHERE item.item_id = patch.item_id
+                  AND item.status IN ('completed', 'failed', 'cancelled')
+                """,
+                json.dumps(updates, separators=(",", ":")),
+            )
+        )

--- a/src/batch/worker_artifacts.py
+++ b/src/batch/worker_artifacts.py
@@ -8,6 +8,7 @@ from time import perf_counter
 from typing import Any, AsyncIterator, Awaitable, Callable
 
 from src.batch.endpoints import BATCH_ENDPOINT_CHAT_COMPLETIONS, BATCH_ENDPOINT_EMBEDDINGS
+from src.batch.error_sanitization import sanitize_batch_artifact_error
 from src.batch.models import BatchJobStatus, is_operator_failed_reason
 from src.batch.repository import BatchRepository
 from src.batch.storage import BatchArtifactStorage
@@ -288,13 +289,10 @@ class BatchArtifactFinalizer:
         }
 
     def _serialize_failed_artifact_row(self, item) -> dict[str, Any]:  # noqa: ANN001
-        error_body = dict(item.error_body) if isinstance(item.error_body, dict) else {}
-        if not error_body.get("message"):
-            error_body["message"] = item.last_error or (
-                "Batch request cancelled" if item.status == "cancelled" else "Batch request failed"
-            )
-        if not error_body.get("type"):
-            error_body["type"] = "BatchItemCancelled" if item.status == "cancelled" else "BatchItemError"
+        error_body = sanitize_batch_artifact_error(
+            item.error_body if isinstance(item.error_body, dict) else None,
+            cancelled=item.status == "cancelled",
+        )
 
         return {
             "id": self._public_batch_row_id(item),

--- a/src/batch/worker_failure_handling.py
+++ b/src/batch/worker_failure_handling.py
@@ -7,6 +7,7 @@ from time import perf_counter
 from typing import Any
 
 from src.batch.backpressure import BatchModelGroupDeferred
+from src.batch.error_sanitization import persisted_batch_error_message
 from src.batch.models import BatchItemRecord, BatchJobRecord
 from src.batch.retry import (
     BatchRetryCategory,
@@ -78,11 +79,12 @@ class WorkerFailureHandlingMixin:
             retry_delay_seconds=retry_delay,
             terminal_reason=terminal_reason,
         )
+        safe_error_message = persisted_batch_error_message(exc, retry_decision)
         updated = await self.repository.mark_item_failed(
             item_id=item.item_id,
             worker_id=self.config.worker_id,
             error_body=error_payload,
-            last_error=str(exc),
+            last_error=safe_error_message,
             retryable=retryable,
             retry_delay_seconds=retry_delay,
             claim_epoch=item.claim_epoch,
@@ -103,7 +105,7 @@ class WorkerFailureHandlingMixin:
                 item_id=item.item_id,
                 worker_id=self.config.worker_id,
                 error_body=error_payload,
-                last_error=str(exc),
+                last_error=safe_error_message,
                 retryable=retryable,
                 retry_delay_seconds=retry_delay,
                 claim_epoch=item.claim_epoch,
@@ -151,7 +153,7 @@ class WorkerFailureHandlingMixin:
         terminal_reason: BatchRetryTerminalReason | None,
     ) -> dict[str, Any]:
         error_payload: dict[str, Any] = {
-            "message": str(exc),
+            "message": persisted_batch_error_message(exc, decision),
             "type": exc.__class__.__name__,
             "retryable": retryable,
             "retry_category": decision.category.value,

--- a/src/chat/executor.py
+++ b/src/chat/executor.py
@@ -12,7 +12,7 @@ from src.chat.stream_validation import validate_first_downstream_stream_frame
 from src.models.errors import ServiceUnavailableError
 from src.models.requests import ChatCompletionRequest
 from src.metrics import observe_request_phase
-from src.providers.base import read_streaming_provider_error_details
+from src.providers.base import ProviderAdapter, read_streaming_provider_error_details
 from src.providers.registry import resolve_chat_upstream
 from src.providers.resolution import is_openai_family_provider, resolve_provider
 from src.providers.signing import apply_request_signing
@@ -27,6 +27,7 @@ class OpenedStream:
     response: Any
     translated_stream: Any
     first_line: str
+    adapter: ProviderAdapter
     deployment: Deployment
     params: dict[str, Any]
     api_base: str
@@ -272,6 +273,7 @@ async def open_stream_with_first_chunk(
             response=response,
             translated_stream=translated_stream,
             first_line=first_line,
+            adapter=adapter,
             deployment=deployment,
             params=params,
             api_base=api_base,

--- a/src/metrics/counters.py
+++ b/src/metrics/counters.py
@@ -130,6 +130,13 @@ deltallm_router_health_update_failures_metric = Counter(
     registry=get_prometheus_registry(),
 )
 
+deltallm_provider_error_body_discards_metric = Counter(
+    "deltallm_provider_error_body_discards_total",
+    "Provider error bodies discarded before classification by bounded reason",
+    ["reason"],
+    registry=get_prometheus_registry(),
+)
+
 deltallm_tier_capacity_fair_share_decisions_metric = Counter(
     "deltallm_tier_capacity_fair_share_decisions_total",
     "Tier capacity fair-share decisions",
@@ -163,6 +170,12 @@ def increment_request_failure(*, model: str, api_provider: str, error_type: str)
         api_provider=sanitize_label(api_provider),
         error_type=sanitize_label(error_type),
     ).inc()
+
+
+def increment_provider_error_body_discard(*, reason: str) -> None:
+    if reason not in {"encoded", "oversized"}:
+        raise ValueError("unsupported provider error body discard reason")
+    deltallm_provider_error_body_discards_metric.labels(reason=reason).inc()
 
 
 def increment_usage(

--- a/src/middleware/errors.py
+++ b/src/middleware/errors.py
@@ -4,17 +4,21 @@ import logging
 
 from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
+from fastapi.exception_handlers import http_exception_handler as fastapi_http_exception_handler
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from src.guardrails.exceptions import GuardrailViolationError
-from src.models.errors import ApprovalRequiredError, ProxyError, RateLimitError
+from src.models.errors import ApprovalRequiredError, InvalidRequestError, ProxyError, RateLimitError
 from src.telemetry.request_failures import (
     maybe_log_proxy_error,
     maybe_log_request_validation_failure,
 )
 
 logger = logging.getLogger(__name__)
+
+_ANTHROPIC_MESSAGES_PATH = "/v1/messages"
 
 
 def _serialize_error(exc: ProxyError) -> dict[str, object]:
@@ -36,28 +40,113 @@ def _serialize_error(exc: ProxyError) -> dict[str, object]:
 def proxy_error_response(exc: ProxyError) -> JSONResponse:
     """Build the canonical HTTP response for a gateway error."""
     headers = {}
-    if isinstance(exc, RateLimitError) and getattr(exc, "retry_after", None):
-        headers["Retry-After"] = str(exc.retry_after)
+    retry_after = getattr(exc, "retry_after", None)
+    if isinstance(exc, RateLimitError) and retry_after is not None:
+        headers["Retry-After"] = str(retry_after)
     return JSONResponse(status_code=exc.status_code, content=_serialize_error(exc), headers=headers)
 
 
+def _anthropic_error_type(status_code: int) -> str:
+    if status_code == 400:
+        return "invalid_request_error"
+    if status_code == 401:
+        return "authentication_error"
+    if status_code == 403:
+        return "permission_error"
+    if status_code == 404:
+        return "not_found_error"
+    if status_code == 413:
+        return "request_too_large"
+    if status_code == 429:
+        return "rate_limit_error"
+    if status_code == 503:
+        return "overloaded_error"
+    return "api_error"
+
+
+def anthropic_error_response(
+    *,
+    status_code: int,
+    message: str,
+    error_type: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    """Render one error envelope for every Anthropic Messages failure boundary."""
+
+    return JSONResponse(
+        status_code=status_code,
+        content=anthropic_error_payload(
+            status_code=status_code,
+            message=message,
+            error_type=error_type,
+        ),
+        headers=headers or {},
+    )
+
+
+def anthropic_error_payload(
+    *, status_code: int, message: str, error_type: str | None = None
+) -> dict[str, object]:
+    return {
+        "type": "error",
+        "error": {
+            "type": error_type or _anthropic_error_type(status_code),
+            "message": message,
+        },
+    }
+
+
+def anthropic_proxy_error_response(exc: ProxyError) -> JSONResponse:
+    """Render a sanitized gateway failure in the Anthropic Messages dialect."""
+
+    headers = {}
+    retry_after = getattr(exc, "retry_after", None)
+    if isinstance(exc, RateLimitError) and retry_after is not None:
+        headers["Retry-After"] = str(retry_after)
+    return anthropic_error_response(
+        status_code=exc.status_code,
+        message=exc.message,
+        headers=headers,
+    )
+
+
+def _uses_anthropic_error_dialect(request: Request) -> bool:
+    return request.url.path.rstrip("/") == _ANTHROPIC_MESSAGES_PATH
+
+
+def _proxy_error_response_for_request(request: Request, exc: ProxyError) -> JSONResponse:
+    if _uses_anthropic_error_dialect(request):
+        return anthropic_proxy_error_response(exc)
+    return proxy_error_response(exc)
+
+
 def register_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(StarletteHTTPException)
+    async def http_error_handler(request: Request, exc: StarletteHTTPException) -> Response:
+        if _uses_anthropic_error_dialect(request):
+            return anthropic_error_response(
+                status_code=exc.status_code,
+                message=str(exc.detail),
+                headers=dict(exc.headers or {}),
+            )
+        return await fastapi_http_exception_handler(request, exc)
+
     @app.exception_handler(ProxyError)
     async def proxy_error_handler(request: Request, exc: ProxyError) -> JSONResponse:
         await maybe_log_proxy_error(request, exc)
-        return proxy_error_response(exc)
+        return _proxy_error_response_for_request(request, exc)
 
     @app.exception_handler(RequestValidationError)
     async def request_validation_error_handler(
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
         await maybe_log_request_validation_failure(request, exc)
+        if _uses_anthropic_error_dialect(request):
+            return anthropic_proxy_error_response(InvalidRequestError(message="Invalid request"))
         return JSONResponse(status_code=422, content={"detail": jsonable_encoder(exc.errors())})
 
     @app.exception_handler(Exception)
-    async def unhandled_error_handler(_: Request, exc: Exception) -> JSONResponse:
+    async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
         logger.error("unhandled exception", extra={"error_type": type(exc).__name__})
         proxy_error = ProxyError()
-        return JSONResponse(
-            status_code=proxy_error.status_code, content=_serialize_error(proxy_error)
-        )
+        return _proxy_error_response_for_request(request, proxy_error)

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -13,6 +13,7 @@ from src.models.errors import (
     FailureClassification,
     GatewayCapacityError,
     InvalidRequestError,
+    NO_HEALTHY_DEPLOYMENTS_CODE,
     ProxyError,
     RateLimitError,
     ServiceUnavailableError,
@@ -21,10 +22,15 @@ from src.models.errors import (
 )
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
+from src.providers.error_body import (
+    MAX_PROVIDER_ERROR_BODY_BYTES,
+    PROVIDER_ERROR_BODY_TRUNCATED_EXTENSION as PROVIDER_ERROR_BODY_TRUNCATED_EXTENSION,
+    bound_provider_error_response_body as bound_provider_error_response_body,
+    provider_error_body_is_unavailable,
+)
 
 _MAX_CLASSIFICATION_MESSAGE_CHARS = 2048
 _PROVIDER_ERROR_READ_CHUNK_BYTES = 8192
-MAX_PROVIDER_ERROR_BODY_BYTES = 65_536
 INVALID_PROVIDER_RESPONSE_MESSAGE = "Provider returned an invalid response"
 
 ProviderSuccessValidator = Callable[[Mapping[str, Any]], bool]
@@ -117,6 +123,8 @@ def provider_error_details(provider_error: Exception) -> ProviderErrorDetails:
 
     response = getattr(provider_error, "response", None)
     status_code = getattr(response, "status_code", None)
+    if provider_error_body_is_unavailable(response):
+        return ProviderErrorDetails(status_code=status_code, identifiers=frozenset())
     try:
         payload = response.json() if response is not None else None
     except (AttributeError, httpx.ResponseNotRead, RecursionError, TypeError, ValueError):
@@ -148,6 +156,8 @@ async def read_streaming_provider_error_details(
     try:
         payload = json.loads(body) if body else None
     except (RecursionError, TypeError, ValueError):
+        payload = None
+    if provider_error_body_is_unavailable(response):
         payload = None
     return provider_error_details_from_payload(payload, status_code=status_code)
 
@@ -294,6 +304,11 @@ def map_standard_provider_status_error(
             affects_deployment_health=True,
             failure_classification=FailureClassification.RATE_LIMIT,
         )
+    if status_code == 408:
+        return TimeoutError(
+            affects_deployment_health=True,
+            failure_classification=FailureClassification.TIMEOUT,
+        )
     if status_code >= 500:
         return ServiceUnavailableError(
             message="Provider unavailable",
@@ -301,10 +316,68 @@ def map_standard_provider_status_error(
             failure_classification=(failure_classification or FailureClassification.GENERIC),
         )
     resolved_classification = failure_classification or FailureClassification.GENERIC
+    if status_code in {401, 403, 404} and failure_classification not in {
+        FailureClassification.CONTEXT_WINDOW,
+        FailureClassification.CONTENT_POLICY,
+    }:
+        return ServiceUnavailableError(
+            message="Provider unavailable",
+            affects_deployment_health=True,
+            failure_classification=resolved_classification,
+        )
     return InvalidRequestError(
         message="Provider rejected request",
         affects_deployment_health=False,
         failure_classification=resolved_classification,
+    )
+
+
+def sanitize_provider_proxy_error(provider_error: ProxyError) -> ProxyError:
+    """Remove provider-owned text while preserving trusted routing semantics."""
+
+    health_impact = provider_error.affects_deployment_health
+    classification = provider_error.failure_classification
+    if isinstance(provider_error, GatewayCapacityError):
+        return GatewayCapacityError(failure_classification=classification)
+    if isinstance(provider_error, RateLimitError):
+        retry_after = getattr(provider_error, "retry_after", None)
+        return RateLimitError(
+            message="Provider rate limited request",
+            retry_after=parse_retry_after_header(
+                str(retry_after) if retry_after is not None else None
+            ),
+            affects_deployment_health=health_impact,
+            failure_classification=classification,
+        )
+    if isinstance(provider_error, TimeoutError):
+        return TimeoutError(
+            affects_deployment_health=health_impact,
+            failure_classification=classification,
+        )
+    if isinstance(provider_error, ServiceUnavailableError):
+        if provider_error.code == NO_HEALTHY_DEPLOYMENTS_CODE:
+            return ServiceUnavailableError(
+                message="No healthy deployments available",
+                code=NO_HEALTHY_DEPLOYMENTS_CODE,
+                affects_deployment_health=health_impact,
+                failure_classification=classification,
+            )
+        return ServiceUnavailableError(
+            message="Provider unavailable",
+            affects_deployment_health=health_impact,
+            failure_classification=classification,
+        )
+    if isinstance(provider_error, InvalidRequestError):
+        return InvalidRequestError(
+            message="Provider rejected request",
+            affects_deployment_health=health_impact,
+            failure_classification=classification,
+        )
+    retry_after = getattr(provider_error, "retry_after", None)
+    return map_standard_provider_status_error(
+        provider_error.status_code,
+        retry_after_header=str(retry_after) if retry_after is not None else None,
+        failure_classification=classification,
     )
 
 

--- a/src/providers/error_body.py
+++ b/src/providers/error_body.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+
+from src.metrics.counters import increment_provider_error_body_discard
+
+MAX_PROVIDER_ERROR_BODY_BYTES = 65_536
+PROVIDER_ERROR_BODY_TRUNCATED_EXTENSION = "deltallm_provider_error_body_truncated"
+PROVIDER_ERROR_BODY_OPAQUE_EXTENSION = "deltallm_provider_error_body_opaque"
+
+
+class _BoundedProviderErrorStream(httpx.AsyncByteStream):
+    """Bound wire bytes before httpx can assemble an upstream error body."""
+
+    def __init__(self, response: httpx.Response, stream: httpx.AsyncByteStream) -> None:
+        self._response = response
+        self._stream = stream
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        remaining = MAX_PROVIDER_ERROR_BODY_BYTES
+        async for chunk in self._stream:
+            if not chunk:
+                continue
+            if len(chunk) <= remaining:
+                remaining -= len(chunk)
+                yield chunk
+                continue
+            if remaining:
+                yield chunk[:remaining]
+            self._response.extensions[PROVIDER_ERROR_BODY_TRUNCATED_EXTENSION] = True
+            increment_provider_error_body_discard(reason="oversized")
+            await self._stream.aclose()
+            return
+
+    async def aclose(self) -> None:
+        await self._stream.aclose()
+
+
+def provider_error_body_is_unavailable(response: object | None) -> bool:
+    extensions = getattr(response, "extensions", {})
+    return bool(
+        extensions.get(PROVIDER_ERROR_BODY_TRUNCATED_EXTENSION, False)
+        or extensions.get(PROVIDER_ERROR_BODY_OPAQUE_EXTENSION, False)
+    )
+
+
+async def bound_provider_error_response_body(response: httpx.Response) -> None:
+    """Bound provider error bytes and never decompress untrusted encoded bodies."""
+
+    if response.status_code < 400 or response.is_closed:
+        return
+    stream = response.stream
+    if not isinstance(stream, httpx.AsyncByteStream):
+        return
+
+    content_encoding = response.headers.get("content-encoding", "").strip().lower()
+    encodings = {value.strip() for value in content_encoding.split(",") if value.strip()}
+    if encodings - {"identity"}:
+        # Removing the header before httpx constructs its decoder keeps a compressed
+        # error body opaque. Status and Retry-After remain available for routing.
+        response.headers.pop("content-encoding", None)
+        response.extensions[PROVIDER_ERROR_BODY_OPAQUE_EXTENSION] = True
+        increment_provider_error_body_discard(reason="encoded")
+
+    response.stream = _BoundedProviderErrorStream(response, stream)

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -41,7 +41,7 @@ from src.mcp.orchestrator import (
     MCPRequestContext,
     chat_request_has_mcp_tools,
 )
-from src.models.errors import InvalidRequestError, ServiceUnavailableError
+from src.models.errors import InvalidRequestError, ProxyError, ServiceUnavailableError
 from src.models.requests import ChatCompletionRequest
 from src.providers.registry import resolve_chat_upstream
 from src.providers.resolution import resolve_provider
@@ -103,6 +103,7 @@ async def handle_chat_like_request(
     request_data: dict[str, Any] | None = None,
     response_transform: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
     stream_line_transform: Callable[[str], str | None] | None = None,
+    stream_error_transform: Callable[[ProxyError], str] | None = None,
     stream_response_object: str = "chat.completion.chunk",
     enable_stream_cache: bool = True,
 ):
@@ -254,8 +255,11 @@ async def handle_chat_like_request(
                         except StopAsyncIteration:
                             break
                         except Exception as exc:
-                            health_error = exc
-                            raise
+                            if isinstance(exc, ProxyError):
+                                health_error = exc
+                                raise
+                            health_error = opened_stream.adapter.map_error(exc)
+                            raise health_error from exc
                         if not line:
                             continue
 
@@ -288,8 +292,10 @@ async def handle_chat_like_request(
                     failure_exc = exc
                     raise
                 except Exception as exc:
-                    failure_exc = exc
-                    stream_error = exc
+                    stream_error = (
+                        exc if isinstance(exc, ProxyError) else health_error or ProxyError()
+                    )
+                    failure_exc = stream_error
                 finally:
                     if (
                         stream_id is not None
@@ -311,25 +317,34 @@ async def handle_chat_like_request(
                 if stream_error is not None:
                     failure_params = opened_stream.params
                     failure_api_base = opened_stream.api_base
-                    await emit_stream_failure(
-                        request=request,
-                        auth=auth,
-                        payload=payload,
-                        request_data=request_data,
-                        callback_manager=callback_manager,
-                        guardrail_middleware=guardrail_middleware,
-                        callback_start=callback_start,
-                        request_start=request_start,
-                        request_id=request_id,
-                        cache_hit=cache_hit,
-                        cache_key=cache_key,
-                        audit_action=audit_action,
-                        primary_deployment=primary,
-                        api_base=failure_api_base,
-                        params=failure_params,
-                        exc=stream_error,
-                    )
-                    raise stream_error
+                    try:
+                        await emit_stream_failure(
+                            request=request,
+                            auth=auth,
+                            payload=payload,
+                            request_data=request_data,
+                            callback_manager=callback_manager,
+                            guardrail_middleware=guardrail_middleware,
+                            callback_start=callback_start,
+                            request_start=request_start,
+                            request_id=request_id,
+                            cache_hit=cache_hit,
+                            cache_key=cache_key,
+                            audit_action=audit_action,
+                            primary_deployment=primary,
+                            api_base=failure_api_base,
+                            params=failure_params,
+                            exc=stream_error,
+                        )
+                    except Exception as reporting_error:
+                        logger.warning(
+                            "post-stream failure reporting failed deployment_id=%s error_type=%s",
+                            served_deployment.deployment_id,
+                            type(reporting_error).__name__,
+                        )
+                    if stream_error_transform is not None:
+                        yield f"{stream_error_transform(stream_error)}\n\n"
+                    return
 
                 if resolved_usage is None:
                     return
@@ -489,7 +504,8 @@ async def handle_chat_like_request(
             status_code=200, content=response_payload, headers=route_decision_headers(request)
         )
     except httpx.HTTPError as exc:
-        status_code = getattr(getattr(exc, "response", None), "status_code", 502)
+        provider_registry = request.app.state.provider_error_mapper_registry
+        mapped_error = provider_registry.map_error(api_provider, exc)
         await emit_nonstream_failure(
             request=request,
             auth=auth,
@@ -506,11 +522,10 @@ async def handle_chat_like_request(
             audit_action=audit_action,
             api_provider=api_provider,
             api_base=api_base,
-            exc=exc,
-            status_code=status_code,
+            exc=mapped_error,
+            status_code=mapped_error.status_code,
         )
-        adapter = request.app.state.openai_adapter
-        raise adapter.map_error(exc) from exc
+        raise mapped_error from exc
     except Exception as exc:
         status_code = int(getattr(exc, "status_code", 500) or 500)
         await emit_nonstream_failure(

--- a/src/routers/messages.py
+++ b/src/routers/messages.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import json
 from json import JSONDecodeError
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
+from src.middleware.errors import anthropic_error_payload, anthropic_error_response
 from src.middleware.auth import require_api_key
-from src.models.errors import InvalidRequestError
+from src.models.errors import InvalidRequestError, ProxyError
 from src.models.requests import AnthropicMessagesRequest
 from src.routers.anthropic_adapters import (
     AnthropicStreamTranslator,
@@ -19,18 +21,20 @@ from src.routers.chat import handle_chat_like_request
 router = APIRouter(prefix="/v1", tags=["messages"])
 
 
-def _anthropic_error_response(*, status_code: int, error_type: str, message: str) -> JSONResponse:
-    return JSONResponse(
-        status_code=status_code,
-        content={"type": "error", "error": {"type": error_type, "message": message}},
-    )
+def _anthropic_stream_error_event(exc: ProxyError) -> str:
+    payload = anthropic_error_payload(status_code=exc.status_code, message=exc.message)
+    return f"event: error\ndata: {json.dumps(payload, separators=(',', ':'))}"
 
 
 def _anthropic_validation_error_response(exc: ValidationError) -> JSONResponse:
     first_error = exc.errors()[0]
     field = ".".join(str(part) for part in first_error["loc"])
     message = f"{field}: {first_error['msg']}" if field else first_error["msg"]
-    return _anthropic_error_response(status_code=400, error_type="invalid_request_error", message=message)
+    return anthropic_error_response(
+        status_code=400,
+        error_type="invalid_request_error",
+        message=message,
+    )
 
 
 @router.post("/messages", dependencies=[Depends(require_api_key)])
@@ -38,7 +42,7 @@ async def messages(request: Request):
     try:
         request_body = await request.json()
     except (JSONDecodeError, UnicodeDecodeError):
-        return _anthropic_error_response(
+        return anthropic_error_response(
             status_code=400,
             error_type="invalid_request_error",
             message="Invalid JSON body",
@@ -52,7 +56,7 @@ async def messages(request: Request):
     try:
         canonical = anthropic_messages_to_chat_request(payload)
     except InvalidRequestError as exc:
-        return _anthropic_error_response(
+        return anthropic_error_response(
             status_code=exc.status_code,
             error_type=exc.error_type,
             message=exc.message,
@@ -63,6 +67,7 @@ async def messages(request: Request):
         canonical,
         response_transform=chat_response_to_anthropic_response,
         stream_line_transform=translator.translate_line,
+        stream_error_transform=_anthropic_stream_error_event,
         stream_response_object="message",
         enable_stream_cache=False,
     )

--- a/src/upstream_http.py
+++ b/src/upstream_http.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import httpx
 
+from src.providers.error_body import bound_provider_error_response_body
+
 
 DEFAULT_UPSTREAM_HTTP_CONNECT_TIMEOUT_SECONDS = 10.0
 DEFAULT_UPSTREAM_HTTP_READ_TIMEOUT_SECONDS = 300.0
@@ -93,6 +95,7 @@ def build_upstream_http_client(general_settings: Any) -> httpx.AsyncClient:
     return httpx.AsyncClient(
         timeout=build_upstream_http_timeout(general_settings),
         limits=build_upstream_http_limits(general_settings),
+        event_hooks={"response": [bound_provider_error_response_body]},
     )
 
 

--- a/tests/bootstrap/test_infrastructure_bootstrap.py
+++ b/tests/bootstrap/test_infrastructure_bootstrap.py
@@ -10,6 +10,7 @@ from src.bootstrap.infrastructure import (
     shutdown_infrastructure_runtime,
 )
 from src.config import GeneralSettings, Settings
+from src.providers.error_body import bound_provider_error_response_body
 
 
 def test_telemetry_startup_mode_uses_env_only_when_config_is_implicit() -> None:
@@ -65,9 +66,10 @@ async def test_init_and_shutdown_infrastructure_runtime(monkeypatch: pytest.Monk
             self.closed = True
 
     class FakeHTTPClient:
-        def __init__(self, *, timeout, limits) -> None:  # noqa: ANN001
+        def __init__(self, *, timeout, limits, event_hooks=None) -> None:  # noqa: ANN001
             self.timeout = timeout
             self.limits = limits
+            self.event_hooks = event_hooks
             self.closed = False
             created.setdefault("http_clients", []).append(self)
 
@@ -223,6 +225,7 @@ async def test_init_and_shutdown_infrastructure_runtime(monkeypatch: pytest.Monk
     assert runtime.http_client.limits.max_connections == 123
     assert runtime.http_client.limits.max_keepalive_connections == 45
     assert runtime.http_client.limits.keepalive_expiry == 12
+    assert runtime.http_client.event_hooks == {"response": [bound_provider_error_response_body]}
     assert app.state.control_http_client is runtime.control_http_client
     assert runtime.control_http_client is not runtime.http_client
     assert runtime.control_http_client.timeout.connect == 5
@@ -232,6 +235,7 @@ async def test_init_and_shutdown_infrastructure_runtime(monkeypatch: pytest.Monk
     assert runtime.control_http_client.limits.max_connections == 100
     assert runtime.control_http_client.limits.max_keepalive_connections == 20
     assert runtime.control_http_client.limits.keepalive_expiry == 30
+    assert runtime.control_http_client.event_hooks is None
     assert app.state.openai_adapter[0] == "openai"
     assert app.state.batch_repository == (
         "batch-repo",

--- a/tests/test_batch_error_remediation.py
+++ b/tests/test_batch_error_remediation.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.sanitize_batch_item_errors import _read_database_url
+from src.batch.error_remediation import remediate_terminal_batch_item_errors
+from src.batch.repositories.error_remediation_repository import BatchErrorRemediationRepository
+
+
+class _FakeDatabase:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self.rows = rows
+        self.update_pages: list[list[dict[str, object]]] = []
+
+    async def list_terminal_error_rows(
+        self, *, after_item_id: str, limit: int
+    ) -> list[dict[str, object]]:
+        return [row for row in self.rows if str(row["item_id"]) > after_item_id][:limit]
+
+    async def update_terminal_error_rows(self, updates: list[dict[str, object]]) -> int:
+        self.update_pages.append(updates)
+        return len(updates)
+
+
+@pytest.mark.asyncio
+async def test_batch_error_remediation_is_bounded_restartable_and_sanitized() -> None:
+    sensitive = "api_key=sk-historical-secret https://provider.internal/private"
+    db = _FakeDatabase(
+        [
+            {
+                "item_id": "item-1",
+                "status": "failed",
+                "has_last_error": True,
+                "has_error_body": True,
+                "retry_category": "upstream_5xx",
+                "last_error": sensitive,
+                "error_body": {
+                    "message": sensitive,
+                    "retry_category": "upstream_5xx",
+                    "provider_payload": {"secret": sensitive},
+                },
+            },
+            {
+                "item_id": "item-2",
+                "status": "cancelled",
+                "has_last_error": True,
+                "has_error_body": True,
+                "retry_category": None,
+                "last_error": sensitive,
+                "error_body": {"message": sensitive},
+            },
+        ]
+    )
+
+    first = await remediate_terminal_batch_item_errors(
+        db,
+        after_item_id=None,
+        page_size=1,
+        max_pages=1,
+        apply=True,
+    )
+    second = await remediate_terminal_batch_item_errors(
+        db,
+        after_item_id=first.next_after_item_id,
+        page_size=1,
+        max_pages=1,
+        apply=True,
+    )
+
+    assert first.inspected == first.updated == 1
+    assert first.has_more is True
+    assert first.next_after_item_id == "item-1"
+    assert second.inspected == second.updated == 1
+    assert db.update_pages == [
+        [
+            {
+                "item_id": "item-1",
+                "last_error": "Provider unavailable",
+                "error_body": {
+                    "message": "Provider unavailable",
+                    "type": "BatchItemError",
+                    "retry_category": "upstream_5xx",
+                },
+            }
+        ],
+        [
+            {
+                "item_id": "item-2",
+                "last_error": "Batch request cancelled",
+                "error_body": {
+                    "message": "Batch request cancelled",
+                    "type": "BatchItemCancelled",
+                },
+            }
+        ],
+    ]
+    assert sensitive not in str(db.update_pages)
+
+
+@pytest.mark.asyncio
+async def test_batch_error_remediation_inspect_mode_does_not_write() -> None:
+    db = _FakeDatabase(
+        [
+            {
+                "item_id": "item-1",
+                "status": "failed",
+                "has_last_error": True,
+                "has_error_body": False,
+                "retry_category": None,
+                "last_error": "provider failure",
+                "error_body": None,
+            }
+        ]
+    )
+
+    result = await remediate_terminal_batch_item_errors(
+        db,
+        after_item_id=None,
+        page_size=10,
+        max_pages=1,
+        apply=False,
+    )
+
+    assert result.inspected == 1
+    assert result.updated == 0
+    assert result.has_more is False
+    assert db.update_pages == []
+
+
+class _RecordingPrisma:
+    def __init__(self) -> None:
+        self.query: tuple[str, tuple[object, ...]] | None = None
+        self.execute: tuple[str, tuple[object, ...]] | None = None
+
+    async def query_raw(self, query: str, *args: object) -> list[dict[str, object]]:
+        self.query = (query, args)
+        return [
+            {
+                "item_id": "item-2",
+                "status": "failed",
+                "has_last_error": True,
+                "has_error_body": True,
+                "retry_category": "upstream_5xx",
+            }
+        ]
+
+    async def execute_raw(self, query: str, *args: object) -> int:
+        self.execute = (query, args)
+        return 1
+
+
+@pytest.mark.asyncio
+async def test_error_remediation_repository_bounds_terminal_row_query() -> None:
+    prisma = _RecordingPrisma()
+    repository = BatchErrorRemediationRepository(prisma)
+
+    rows = await repository.list_terminal_error_rows(after_item_id="item-1", limit=25)
+
+    assert rows == [
+        {
+            "item_id": "item-2",
+            "status": "failed",
+            "has_last_error": True,
+            "has_error_body": True,
+            "retry_category": "upstream_5xx",
+        }
+    ]
+    assert prisma.query is not None
+    query, args = prisma.query
+    assert "last_error IS NOT NULL AS has_last_error" in query
+    assert "LEFT(error_body ->> 'retry_category', 64)" in query
+    assert "SELECT item_id, status, last_error, error_body" not in query
+    assert "status IN ('completed', 'failed', 'cancelled')" in query
+    assert "ORDER BY item_id" in query
+    assert "LIMIT $2" in query
+    assert args == ("item-1", 25)
+
+
+@pytest.mark.asyncio
+async def test_error_remediation_repository_updates_one_terminal_page() -> None:
+    prisma = _RecordingPrisma()
+    repository = BatchErrorRemediationRepository(prisma)
+    updates = [
+        {
+            "item_id": "item-1",
+            "last_error": "Provider unavailable",
+            "error_body": {"message": "Provider unavailable", "type": "BatchItemError"},
+        }
+    ]
+
+    updated = await repository.update_terminal_error_rows(updates)
+
+    assert updated == 1
+    assert prisma.execute is not None
+    query, args = prisma.execute
+    assert "jsonb_to_recordset($1::jsonb)" in query
+    assert "status IN ('completed', 'failed', 'cancelled')" in query
+    assert json.loads(str(args[0])) == updates
+
+
+def test_database_url_file_read_is_bounded(tmp_path) -> None:  # noqa: ANN001
+    oversized = tmp_path / "database-url"
+    oversized.write_text("x" * 8_193, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="too large"):
+        _read_database_url(str(oversized))

--- a/tests/test_batch_retry.py
+++ b/tests/test_batch_retry.py
@@ -8,6 +8,7 @@ from src.batch.chat_batching import normalize_chat_microbatch_results
 from src.batch.retry import BatchResponseShapeError, BatchRetryCategory, classify_batch_retry
 from src.models.errors import (
     BudgetExceededError,
+    GatewayCapacityError,
     InvalidRequestError,
     ModelNotFoundError,
     NO_HEALTHY_DEPLOYMENTS_CODE,
@@ -16,6 +17,7 @@ from src.models.errors import (
     ServiceUnavailableError,
     TimeoutError,
 )
+from src.router.health_policy import affects_deployment_health
 from src.router.execution import attach_failover_original_error
 
 
@@ -199,6 +201,69 @@ def test_chat_microbatch_provider_item_errors_preserve_retry_classification(
     assert decision.category is category
     assert decision.retryable is retryable
     assert decision.retry_after_seconds == retry_after
+
+
+@pytest.mark.parametrize(
+    ("raw_error", "expected_message"),
+    [
+        (
+            {"status_code": 400, "message": "api_key=sk-provider-secret"},
+            "Provider rejected request",
+        ),
+        (
+            ServiceUnavailableError(message="internal provider URL https://provider.local"),
+            "Provider unavailable",
+        ),
+        (RuntimeError("provider api_key=sk-provider-secret"), "Provider rejected request"),
+    ],
+)
+def test_chat_microbatch_provider_item_errors_discard_raw_messages(
+    raw_error: object,
+    expected_message: str,
+) -> None:
+    result = normalize_chat_microbatch_results(
+        [{"index": 0, "error": raw_error}],
+        expected_count=1,
+        custom_ids=["item-1"],
+    )[0]
+
+    assert result.error is not None
+    assert str(result.error) == expected_message
+    assert "sk-provider-secret" not in str(result.error)
+    assert "provider.local" not in str(result.error)
+
+
+def test_chat_microbatch_provider_item_error_preserves_gateway_capacity_semantics() -> None:
+    result = normalize_chat_microbatch_results(
+        [{"index": 0, "error": GatewayCapacityError()}],
+        expected_count=1,
+        custom_ids=["item-1"],
+    )[0]
+
+    assert isinstance(result.error, GatewayCapacityError)
+    assert result.error.code == "upstream_pool_timeout"
+    assert affects_deployment_health(result.error) is False
+
+
+def test_chat_microbatch_provider_item_error_preserves_no_healthy_category() -> None:
+    result = normalize_chat_microbatch_results(
+        [
+            {
+                "index": 0,
+                "error": ServiceUnavailableError(
+                    message="No healthy deployments; api_key=sk-provider-secret",
+                    code=NO_HEALTHY_DEPLOYMENTS_CODE,
+                ),
+            }
+        ],
+        expected_count=1,
+        custom_ids=["item-1"],
+    )[0]
+
+    assert isinstance(result.error, ServiceUnavailableError)
+    assert result.error.code == NO_HEALTHY_DEPLOYMENTS_CODE
+    assert str(result.error) == "No healthy deployments available"
+    assert classify_batch_retry(result.error).category is BatchRetryCategory.NO_HEALTHY_DEPLOYMENTS
 
 
 def _chat_microbatch_success_result(**identity: object) -> dict[str, object]:

--- a/tests/test_batch_worker.py
+++ b/tests/test_batch_worker.py
@@ -1579,7 +1579,7 @@ async def test_batch_worker_sync_microbatch_primary_failure_with_unsupported_fal
     release_call = repo.release_for_retry_calls[0]
     assert release_call["item_ids"] == [f"chat-{index}" for index in range(1, len(contents) + 1)]
     assert release_call["retry_delay_seconds"] == 5
-    assert release_call["last_error"] == "primary unavailable"
+    assert release_call["last_error"] == "Provider unavailable"
     assert release_call["error_body"]["retryable"] is True
     assert release_call["error_body"]["retry_category"] == "service_unavailable"
     assert release_call["error_body"]["microbatch"] == {
@@ -1598,6 +1598,7 @@ async def test_batch_worker_sync_microbatch_unsupported_fallback_respects_max_in
     active = 0
     max_active = 0
     fallback_reasons: list[tuple[str, int]] = []
+    primary_failure_codes: list[str | None] = []
 
     async def _fake_execute_chat(request, payload, deployment, *, record_usage: bool = True):
         del request, deployment, record_usage
@@ -1679,7 +1680,8 @@ async def test_batch_worker_sync_microbatch_unsupported_fallback_respects_max_in
             try:
                 data = await execute(primary_deployment)
                 served_deployment = primary_deployment
-            except ServiceUnavailableError:
+            except ServiceUnavailableError as exc:
+                primary_failure_codes.append(exc.code)
                 data = await execute(fallback)
                 served_deployment = fallback
             if return_deployment:
@@ -1731,6 +1733,7 @@ async def test_batch_worker_sync_microbatch_unsupported_fallback_respects_max_in
     assert len(repo.completed_calls) == 3
     assert repo.release_for_retry_calls == []
     assert fallback_reasons == [("mode=concurrent", 3)]
+    assert primary_failure_codes == ["chat_microbatch_unsupported"]
     assert max_active == 1
 
 
@@ -1862,7 +1865,10 @@ async def test_batch_worker_sync_microbatch_retryable_failure_requeues_chunk_and
     class _ChatMicrobatchExecutor:
         async def execute_chat_microbatch(self, *, requests, deployment, request_context):  # noqa: ANN001
             del requests, deployment, request_context
-            raise ServiceUnavailableError(message="provider down", affects_deployment_health=True)
+            raise ServiceUnavailableError(
+                message="provider api_key=sk-upstream-secret",
+                affects_deployment_health=True,
+            )
 
     repo = _FailureRepository()
     worker, _ = _build_chat_batch_worker(
@@ -1893,7 +1899,8 @@ async def test_batch_worker_sync_microbatch_retryable_failure_requeues_chunk_and
     release_call = repo.release_for_retry_calls[0]
     assert release_call["item_ids"] == ["chat-1", "chat-2"]
     assert release_call["retry_delay_seconds"] == 5
-    assert release_call["last_error"] == "provider down"
+    assert release_call["last_error"] == "Provider unavailable"
+    assert "sk-upstream-secret" not in str(release_call)
     assert release_call["error_body"]["retryable"] is True
     assert release_call["error_body"]["retry_category"] == "service_unavailable"
     assert release_call["error_body"]["microbatch"] == {
@@ -2210,6 +2217,8 @@ async def test_batch_worker_sync_microbatch_persists_mixed_success_and_failure_r
     assert len(repo.failed_calls) == 1
     assert repo.failed_calls[0]["item_id"] == "chat-2"
     assert repo.failed_calls[0]["error_body"]["type"] == "InvalidRequestError"
+    assert repo.failed_calls[0]["error_body"]["message"] == "Provider rejected request"
+    assert "provider rejected this item" not in str(repo.failed_calls[0])
     assert repo.failed_calls[0]["retryable"] is False
     assert worker.app.state.failover_manager.aggregate_health_errors == []
 
@@ -3086,7 +3095,10 @@ async def test_batch_worker_iter_error_lines_emit_openai_batch_error_rows():
                     status="failed",
                     request_body={},
                     response_body=None,
-                    error_body={"message": "boom"},
+                    error_body={
+                        "message": "provider api_key=sk-historical-secret",
+                        "provider_payload": {"url": "https://provider.internal/private"},
+                    },
                     usage=None,
                     provider_cost=0.0,
                     billed_cost=0.0,
@@ -3134,7 +3146,7 @@ async def test_batch_worker_iter_error_lines_emit_openai_batch_error_rows():
             "id": "batch_req_i1",
             "custom_id": "req-1",
             "response": None,
-            "error": {"message": "boom", "type": "BatchItemError"},
+            "error": {"message": "Batch request failed", "type": "BatchItemError"},
         },
         {
             "id": "batch_req_i2",
@@ -5324,7 +5336,7 @@ async def test_batch_worker_finalize_artifacts_writes_openai_compatible_rows(
             "id": "batch_req_i2",
             "custom_id": "req-2",
             "response": None,
-            "error": {"message": "boom", "type": "BatchItemError"},
+            "error": {"message": "Batch request failed", "type": "BatchItemError"},
         }
     ]
     assert repo.attach_calls == [

--- a/tests/test_batch_worker_microbatch.py
+++ b/tests/test_batch_worker_microbatch.py
@@ -1429,7 +1429,11 @@ async def test_worker_requeues_retryable_grouped_http_failures_before_isolation(
     async def _fake_execute_embedding(request, payload, deployment):
         del request, deployment
         execute_inputs.append(payload.input)
-        raise httpx.HTTPStatusError("upstream unavailable", request=http_request, response=response)
+        raise httpx.HTTPStatusError(
+            "provider api_key=sk-upstream-secret",
+            request=http_request,
+            response=response,
+        )
 
     monkeypatch.setattr("src.batch.worker._execute_embedding", _fake_execute_embedding)
 
@@ -1456,7 +1460,8 @@ async def test_worker_requeues_retryable_grouped_http_failures_before_isolation(
     assert release_call["item_ids"] == ["i1", "i2"]
     assert release_call["worker_id"] == "w1"
     assert release_call["retry_delay_seconds"] == 5
-    assert release_call["last_error"] == "upstream unavailable"
+    assert release_call["last_error"] == "Provider unavailable"
+    assert "sk-upstream-secret" not in str(release_call)
     assert release_call["error_body"]["retry_category"] == "upstream_5xx"
     assert release_call["error_body"]["microbatch"] == {
         "retry_count": 1,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2480,8 +2480,11 @@ async def test_stream_failure_after_failover_uses_last_attempted_deployment(clie
         "stream": True,
     }
 
-    with pytest.raises(httpx.ReadError, match="fallback stream broke"):
-        await client.post("/v1/chat/completions", headers=headers, json=body)
+    response = await client.post("/v1/chat/completions", headers=headers, json=body)
+
+    assert response.status_code == 200
+    assert "hi" in response.text
+    assert "data: [DONE]" not in response.text
 
     await asyncio.sleep(0.05)
     assert len(test_app.state.spend_tracking_service.events) == 1
@@ -2489,14 +2492,14 @@ async def test_stream_failure_after_failover_uses_last_attempted_deployment(clie
     metadata = last.get("metadata") or {}
     assert last["status"] == "error"
     assert last["call_type"] == "completion"
-    assert last["error_type"] == "ReadError"
+    assert last["error_type"] == "service_unavailable"
     assert metadata.get("api_base") == "https://fallback.example/v1"
     assert metadata.get("deployment_model") == "openai/gpt-4o-mini"
 
     primary_health = await test_app.state.router_state_backend.get_health(registry[0].deployment_id)
     fallback_health = await test_app.state.router_state_backend.get_health("gpt-4o-mini-fallback")
     assert primary_health.get("last_error") == "Provider unavailable"
-    assert fallback_health.get("last_error") == "fallback stream broke"
+    assert fallback_health.get("last_error") == "Provider unavailable"
     assert len(stream_contexts) == 2
     assert all(context.exited for context in stream_contexts)
     assert (

--- a/tests/test_error_middleware.py
+++ b/tests/test_error_middleware.py
@@ -4,10 +4,19 @@ import json
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
-from src.middleware.errors import proxy_error_response, register_exception_handlers
-from src.models.errors import FailureClassification, InvalidRequestError
+from src.middleware.errors import (
+    anthropic_proxy_error_response,
+    proxy_error_response,
+    register_exception_handlers,
+)
+from src.models.errors import (
+    FailureClassification,
+    InvalidRequestError,
+    RateLimitError,
+    ServiceUnavailableError,
+)
 
 
 def test_provider_failure_classification_is_not_serialized() -> None:
@@ -30,6 +39,13 @@ def test_provider_failure_classification_is_not_serialized() -> None:
     }
 
 
+@pytest.mark.parametrize("response_factory", [proxy_error_response, anthropic_proxy_error_response])
+def test_rate_limit_response_preserves_zero_retry_after(response_factory) -> None:  # noqa: ANN001
+    response = response_factory(RateLimitError(retry_after=0))
+
+    assert response.headers["retry-after"] == "0"
+
+
 @pytest.mark.asyncio
 async def test_unhandled_exception_logging_does_not_include_exception_message(caplog):
     sensitive = "api_key=super-secret-value"
@@ -47,3 +63,41 @@ async def test_unhandled_exception_logging_does_not_include_exception_message(ca
 
     assert response.status_code == 500
     assert sensitive not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_messages_path_renders_proxy_errors_in_anthropic_dialect() -> None:
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    @app.post("/v1/messages")
+    async def messages():
+        raise ServiceUnavailableError(message="Provider unavailable")
+
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/v1/messages")
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "type": "error",
+        "error": {"type": "overloaded_error", "message": "Provider unavailable"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_non_messages_http_errors_keep_fastapi_contract() -> None:
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    @app.get("/ordinary")
+    async def ordinary():
+        raise HTTPException(status_code=418, detail="ordinary detail", headers={"x-test": "yes"})
+
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/ordinary")
+
+    assert response.status_code == 418
+    assert response.json() == {"detail": "ordinary detail"}
+    assert response.headers["x-test"] == "yes"

--- a/tests/test_messages_endpoint.py
+++ b/tests/test_messages_endpoint.py
@@ -269,6 +269,47 @@ async def test_messages_stream_success(client, test_app):
 
 
 @pytest.mark.asyncio
+async def test_messages_stream_provider_failure_emits_sanitized_error_event(client, test_app):
+    sensitive = "provider stream api_key=sk-upstream-secret"
+
+    class _BrokenStream:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: ANN001
+            return None
+
+        async def aiter_lines(self):
+            yield (
+                'data: {"id":"chatcmpl-1","object":"chat.completion.chunk",'
+                '"choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},'
+                '"finish_reason":null}]}'
+            )
+            raise httpx.ReadError(sensitive)
+
+    test_app.state.http_client.stream = lambda *args, **kwargs: _BrokenStream()
+    response = await client.post(
+        "/v1/messages",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "max_tokens": 128,
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "event: error" in response.text
+    assert '"type":"overloaded_error"' in response.text
+    assert "Provider unavailable" in response.text
+    assert sensitive not in response.text
+    assert "event: message_stop" not in response.text
+
+
+@pytest.mark.asyncio
 async def test_messages_tool_use_round_trip(client, test_app):
     async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
         del headers, timeout
@@ -542,3 +583,49 @@ async def test_messages_budget_exceeded_returns_429(client, test_app):
     response = await client.post("/v1/messages", headers=headers, json=body)
 
     assert response.status_code == 429
+    assert response.json()["type"] == "error"
+    assert response.json()["error"]["type"] == "rate_limit_error"
+    assert "budget exceeded" in response.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_messages_provider_failure_returns_sanitized_anthropic_error(client, test_app):
+    sensitive = "provider api_key=sk-upstream-secret"
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del url, headers, json, timeout
+        return httpx.Response(503, json={"error": {"message": sensitive}})
+
+    test_app.state.http_client.post = post
+    response = await client.post(
+        "/v1/messages",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "max_tokens": 128,
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "type": "error",
+        "error": {"type": "overloaded_error", "message": "Provider unavailable"},
+    }
+    assert sensitive not in response.text
+
+
+@pytest.mark.asyncio
+async def test_messages_auth_failure_uses_anthropic_error_envelope(client) -> None:
+    response = await client.post(
+        "/v1/messages",
+        json={
+            "model": "gpt-4o-mini",
+            "max_tokens": 128,
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["type"] == "error"
+    assert response.json()["error"]["type"] == "authentication_error"

--- a/tests/test_migration_verifier.py
+++ b/tests/test_migration_verifier.py
@@ -66,6 +66,31 @@ def test_drop_database_uses_non_transactional_statements(monkeypatch: pytest.Mon
     assert statements[1] == ('DROP DATABASE IF EXISTS "deltallm_migration_verify_abc123_upgrade";')
 
 
+def test_upgrade_fixture_supports_already_applied_routing_invariants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    statements: list[str] = []
+
+    def capture_execute(*_args: object, sql: str, **_kwargs: object) -> None:
+        statements.append(sql)
+
+    monkeypatch.setattr(verify_migration_paths, "_db_execute", capture_execute)
+
+    verify_migration_paths._seed_upgrade_fixture(  # noqa: SLF001
+        "prisma",
+        "postgresql://localhost/upgrade",
+        verify_migration_paths.CURRENT_SCHEMA,
+    )
+
+    assert len(statements) == 1
+    sql = statements[0]
+    assert "deltallm_routepolicy_one_published_per_group" in sql
+    assert "THEN 'published'" in sql
+    assert "ELSE 'archived'" in sql
+    assert "to_regclass('public.deltallm_routeruntimestate')" in sql
+    assert "route_groups_initialized = TRUE" in sql
+
+
 def test_default_base_ref_prefers_environment_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_provider_compat.py
+++ b/tests/test_provider_compat.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import gzip
 import json
 import struct
 from binascii import crc32
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -12,6 +14,7 @@ from src.models.errors import (
     InvalidRequestError,
     RateLimitError,
     ServiceUnavailableError,
+    TimeoutError,
 )
 from src.models.requests import ChatCompletionRequest
 from src.providers.anthropic import AnthropicAdapter
@@ -20,12 +23,17 @@ from src.providers.bedrock import BedrockAdapter
 from src.providers.base import (
     INVALID_PROVIDER_RESPONSE_MESSAGE,
     MAX_PROVIDER_ERROR_BODY_BYTES,
+    PROVIDER_ERROR_BODY_TRUNCATED_EXTENSION,
+    bound_provider_error_response_body,
+    map_standard_provider_status_error,
     parse_provider_json_response,
     read_streaming_provider_error_details,
 )
+from src.providers.error_body import PROVIDER_ERROR_BODY_OPAQUE_EXTENSION
 from src.providers.gemini import GeminiAdapter
 from src.providers.openai import OpenAIAdapter
 from src.providers.registry import ProviderErrorMapperRegistry
+from src.upstream_http import build_upstream_http_client
 
 
 async def _line_stream(lines: list[str]):
@@ -243,6 +251,119 @@ async def test_openai_adapter_sanitizes_unclassified_provider_error_message() ->
         assert "tool_choice" not in str(mapped)
     finally:
         await adapter.http_client.aclose()
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 404])
+def test_provider_configuration_statuses_are_retryable_deployment_failures(
+    status_code: int,
+) -> None:
+    mapped = map_standard_provider_status_error(status_code)
+
+    assert isinstance(mapped, ServiceUnavailableError)
+    assert str(mapped) == "Provider unavailable"
+    assert mapped.affects_deployment_health is True
+    assert mapped.failure_classification is FailureClassification.GENERIC
+
+
+def test_provider_request_timeout_is_retryable_deployment_failure() -> None:
+    mapped = map_standard_provider_status_error(408)
+
+    assert isinstance(mapped, TimeoutError)
+    assert mapped.affects_deployment_health is True
+    assert mapped.failure_classification is FailureClassification.TIMEOUT
+
+
+def test_classified_provider_403_remains_a_terminal_request_failure() -> None:
+    mapped = map_standard_provider_status_error(
+        403,
+        failure_classification=FailureClassification.CONTENT_POLICY,
+    )
+
+    assert isinstance(mapped, InvalidRequestError)
+    assert mapped.affects_deployment_health is False
+    assert mapped.failure_classification is FailureClassification.CONTENT_POLICY
+
+
+@pytest.mark.asyncio
+async def test_nonstream_provider_error_body_is_bounded_before_buffering() -> None:
+    sensitive = b"sk-upstream-secret"
+    response = httpx.Response(
+        500,
+        stream=_AsyncBytes(b'{"error":{"message":"' + sensitive + b'"}}' + b"x" * 70_000),
+        request=httpx.Request("POST", "https://internal.provider.example/v1/chat"),
+    )
+
+    await bound_provider_error_response_body(response)
+    body = await response.aread()
+
+    assert len(body) == MAX_PROVIDER_ERROR_BODY_BYTES
+    assert response.extensions[PROVIDER_ERROR_BODY_TRUNCATED_EXTENSION] is True
+    error = httpx.HTTPStatusError("provider failed", request=response.request, response=response)
+    async with httpx.AsyncClient() as client:
+        mapped = OpenAIAdapter(client).map_error(error)
+    assert isinstance(mapped, ServiceUnavailableError)
+    assert str(mapped) == "Provider unavailable"
+    assert sensitive.decode() not in str(mapped)
+
+
+@pytest.mark.asyncio
+async def test_shared_upstream_client_never_decompresses_encoded_error_body() -> None:
+    decoded_body = b"x" * (8 * 1024 * 1024)
+    encoded_body = gzip.compress(decoded_body)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            503,
+            headers={"content-encoding": "gzip"},
+            stream=_AsyncBytes(encoded_body),
+            request=request,
+        )
+
+    configured_client = build_upstream_http_client(SimpleNamespace())
+    event_hooks = configured_client.event_hooks
+    await configured_client.aclose()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        event_hooks=event_hooks,
+    ) as client:
+        response = await client.get("https://provider.example/v1/chat")
+
+    assert len(encoded_body) < MAX_PROVIDER_ERROR_BODY_BYTES
+    assert response.content == encoded_body
+    assert len(response.content) <= MAX_PROVIDER_ERROR_BODY_BYTES
+    assert response.headers.get("content-encoding") is None
+    assert response.extensions[PROVIDER_ERROR_BODY_OPAQUE_EXTENSION] is True
+    error = httpx.HTTPStatusError("provider failed", request=response.request, response=response)
+    async with httpx.AsyncClient() as adapter_client:
+        mapped = OpenAIAdapter(adapter_client).map_error(error)
+    assert isinstance(mapped, ServiceUnavailableError)
+    assert str(mapped) == "Provider unavailable"
+
+
+@pytest.mark.asyncio
+async def test_shared_upstream_client_still_decodes_success_body() -> None:
+    decoded_body = b'{"ok":true}'
+    encoded_body = gzip.compress(decoded_body)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-encoding": "gzip"},
+            stream=_AsyncBytes(encoded_body),
+            request=request,
+        )
+
+    configured_client = build_upstream_http_client(SimpleNamespace())
+    event_hooks = configured_client.event_hooks
+    await configured_client.aclose()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        event_hooks=event_hooks,
+    ) as client:
+        response = await client.get("https://provider.example/v1/chat")
+
+    assert response.content == decoded_body
+    assert PROVIDER_ERROR_BODY_OPAQUE_EXTENSION not in response.extensions
 
 
 def test_provider_success_json_parser_rejects_non_object_without_exposing_body() -> None:

--- a/tests/test_stream_response.py
+++ b/tests/test_stream_response.py
@@ -174,6 +174,7 @@ async def test_opened_stream_close_can_retry_after_interrupted_cleanup() -> None
         response=None,
         translated_stream=None,
         first_line="data: first",
+        adapter=None,  # type: ignore[arg-type]
         deployment=_deployment(),
         params={},
         api_base="https://example.test",

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -174,11 +174,18 @@ class FakeAuthorizationDB:
             if "WHERE batch_id = $1 AND item_id = $2" in query:
                 batch_id = str(params[0])
                 item_id = str(params[1])
-                return [
-                    item
+                rows = [
+                    dict(item)
                     for item in self.batch_items
                     if item.get("item_id") == item_id and self.batches.get(batch_id)
                 ]
+                for row in rows:
+                    error_body = row.pop("error_body", None)
+                    row["_has_error_body"] = error_body is not None
+                    row["_error_retry_category"] = (error_body or {}).get(
+                        "retry_category"
+                    )
+                return rows
             if "request_body IS NOT NULL AS has_request_body" in query:
                 if "line_number > $2" in query:
                     after_line_number = int(params[1])
@@ -202,6 +209,9 @@ class FakeAuthorizationDB:
                         "provider_cost": item["provider_cost"],
                         "billed_cost": item["billed_cost"],
                         "last_error": item["last_error"],
+                        "_error_retry_category": (
+                            item.get("error_body") or {}
+                        ).get("retry_category"),
                         "has_request_body": item.get("request_body") is not None,
                         "has_response_body": item.get("response_body") is not None,
                         "has_error_body": item.get("error_body") is not None,
@@ -666,6 +676,68 @@ async def test_get_batch_item_returns_payload_on_demand(client, test_app, monkey
     assert payload["request_body"] == {"model": "gpt-4o-mini", "input": "large prompt"}
     assert payload["response_body"] == {"object": "embedding", "data": [{"embedding": [0.1]}]}
     assert payload["usage"] == {"prompt_tokens": 3, "total_tokens": 3}
+
+
+@pytest.mark.asyncio
+async def test_batch_ui_endpoints_sanitize_historical_provider_errors(
+    client, test_app, monkeypatch
+):
+    fake_db = FakeAuthorizationDB()
+    sensitive = "provider api_key=sk-historical-secret https://provider.internal/private"
+    fake_db.batch_items[0].update(
+        status="failed",
+        last_error=sensitive,
+        response_body=None,
+        error_body={
+            "message": sensitive,
+            "type": "HTTPStatusError",
+            "retry_category": "upstream_5xx",
+            "provider_payload": {"secret": sensitive},
+        },
+    )
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.batches.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=False,
+            org_ids=[],
+            team_ids=["team-1"],
+            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ}},
+        ),
+    )
+
+    headers = {"Authorization": "Bearer mk-test"}
+    list_response = await client.get(
+        "/ui/api/batches/batch-1?items_limit=1&items_offset=0",
+        headers=headers,
+    )
+    detail_response = await client.get(
+        "/ui/api/batches/batch-1/items/item-1",
+        headers=headers,
+    )
+
+    assert list_response.status_code == 200
+    assert detail_response.status_code == 200
+    list_item = list_response.json()["items"]["data"][0]
+    detail_item = detail_response.json()
+    assert list_item["last_error"] == "Provider unavailable"
+    assert detail_item["last_error"] == "Provider unavailable"
+    assert detail_item["error_body"] == {
+        "message": "Provider unavailable",
+        "type": "BatchItemError",
+        "retry_category": "upstream_5xx",
+    }
+    detail_query = next(
+        query
+        for query, _params in fake_db.queries
+        if "WHERE batch_id = $1 AND item_id = $2" in query
+    )
+    assert "error_body IS NOT NULL AS _has_error_body" in detail_query
+    assert "response_body, error_body" not in detail_query
+    assert sensitive not in list_response.text
+    assert sensitive not in detail_response.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- bound provider error bodies before HTTPX can assemble or decompress untrusted content
- map provider failures to stable sanitized gateway errors while preserving retry, failover, and `Retry-After` semantics
- return Anthropic-compatible error envelopes and committed-stream error framing for `/v1/messages`
- sanitize new and historical batch item errors across persistence, artifacts, and admin UI responses
- add bounded remediation tooling, discard metrics, regression tests, and operator documentation

## Verification

- affected Python integration suite: 543 passed
- Ruff check across touched Python paths: passed
- `git diff --check origin/main...HEAD`: passed
- Ruff format check still reports the same five baseline files that fail on `main`: `src/api/admin/endpoints/batches.py`, `src/batch/worker_artifacts.py`, `src/upstream_http.py`, `tests/test_messages_endpoint.py`, and `tests/test_ui_authorization.py`

## Review blockers before ready

- required audit persistence failures are currently swallowed in committed-stream failure reporting
- a non-`ProxyError` usage-processing failure can bypass the Anthropic `event: error` frame
- batch UI and historical remediation retain only retry category and discard other safe allowlisted retry metadata
- the remediation mutation still needs real PostgreSQL integration coverage

This PR is intentionally draft until the review blockers above are resolved.