### PR TITLE
Clarify and enforce organization lifecycle state

### DIFF
--- a/docs/admin-ui/organizations.md
+++ b/docs/admin-ui/organizations.md
@@ -30,6 +30,15 @@ Platform administrators see a **Danger zone** on the organization overview. **De
 
 The same panel shows cleanup progress, restore while the operation remains reversible, and retry if automatic cleanup exhausts its attempts. Organization owners and organization administrators cannot use these controls. See [Organization Deletion](../features/organization-deletion.md) for retained history and operational behavior.
 
+The organization header and list show the authoritative lifecycle state:
+
+- **Active** — runtime access and administrative changes are available according to the viewer's permissions.
+- **Deletion pending** — access and administrative changes are disabled immediately. The displayed “no earlier than” time is the beginning of permanent cleanup, not the time at which access is disabled. A platform administrator can restore the organization while cleanup remains reversible.
+- **Purging** — irreversible permanent cleanup has started and restore is no longer available.
+- **Deletion failed** — access remains disabled and a platform administrator must retry cleanup from the Danger zone.
+
+Mutation controls such as Edit, Add Team, Add Member, Asset Access, and tier assignment changes are unavailable whenever the lifecycle state is not **Active**.
+
 ## Rate limit fields
 
 | Field | Description |

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1483,6 +1483,47 @@
         "title": "ModelMutationResponse",
         "type": "object"
       },
+      "OrganizationCapabilitiesResponse": {
+        "properties": {
+          "add_team": {
+            "default": false,
+            "title": "Add Team",
+            "type": "boolean"
+          },
+          "edit": {
+            "default": false,
+            "title": "Edit",
+            "type": "boolean"
+          },
+          "manage_assets": {
+            "default": false,
+            "title": "Manage Assets",
+            "type": "boolean"
+          },
+          "manage_members": {
+            "default": false,
+            "title": "Manage Members",
+            "type": "boolean"
+          },
+          "manage_service_policy": {
+            "default": false,
+            "title": "Manage Service Policy",
+            "type": "boolean"
+          },
+          "view": {
+            "default": true,
+            "title": "View",
+            "type": "boolean"
+          },
+          "view_usage": {
+            "default": false,
+            "title": "View Usage",
+            "type": "boolean"
+          }
+        },
+        "title": "OrganizationCapabilitiesResponse",
+        "type": "object"
+      },
       "OrganizationDeletionCountsResponse": {
         "properties": {
           "active_batches": {
@@ -1909,14 +1950,7 @@
             "type": "integer"
           },
           "lifecycle_state": {
-            "enum": [
-              "active",
-              "deletion_pending",
-              "purging",
-              "deletion_failed"
-            ],
-            "title": "Lifecycle State",
-            "type": "string"
+            "$ref": "#/components/schemas/OrganizationLifecycleState"
           },
           "lifecycle_version": {
             "title": "Lifecycle Version",
@@ -2010,6 +2044,355 @@
           "acknowledge_running_work_cancellation"
         ],
         "title": "OrganizationDeletionRequest",
+        "type": "object"
+      },
+      "OrganizationLifecycleState": {
+        "enum": [
+          "active",
+          "deletion_pending",
+          "purging",
+          "deletion_failed"
+        ],
+        "title": "OrganizationLifecycleState",
+        "type": "string"
+      },
+      "OrganizationListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationResponse"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/OrganizationPaginationResponse"
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "title": "OrganizationListResponse",
+        "type": "object"
+      },
+      "OrganizationPaginationResponse": {
+        "properties": {
+          "has_more": {
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "limit": {
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "minimum": 0.0,
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "limit",
+          "offset",
+          "has_more"
+        ],
+        "title": "OrganizationPaginationResponse",
+        "type": "object"
+      },
+      "OrganizationResponse": {
+        "additionalProperties": true,
+        "description": "Typed core of the organization UI contract; extension fields remain compatible.",
+        "properties": {
+          "audit_content_storage_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audit Content Storage Enabled"
+          },
+          "budget_duration": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Duration"
+          },
+          "budget_reset_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Reset At"
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/OrganizationCapabilitiesResponse"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "deletion_not_before_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deletion Not Before At"
+          },
+          "deletion_requested_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deletion Requested At"
+          },
+          "lifecycle_state": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OrganizationLifecycleState"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Budget"
+          },
+          "member_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Member Count"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "model_rpm_limit": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Rpm Limit"
+          },
+          "model_tpm_limit": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Tpm Limit"
+          },
+          "organization_id": {
+            "minLength": 1,
+            "title": "Organization Id",
+            "type": "string"
+          },
+          "organization_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization Name"
+          },
+          "rpd_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rpd Limit"
+          },
+          "rph_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rph Limit"
+          },
+          "rpm_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rpm Limit"
+          },
+          "service_policy": {
+            "additionalProperties": true,
+            "title": "Service Policy",
+            "type": "object"
+          },
+          "soft_budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Soft Budget"
+          },
+          "spend": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spend"
+          },
+          "team_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Team Count"
+          },
+          "tpd_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tpd Limit"
+          },
+          "tpm_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tpm Limit"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "user_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Count"
+          }
+        },
+        "required": [
+          "organization_id",
+          "lifecycle_state",
+          "service_policy"
+        ],
+        "title": "OrganizationResponse",
         "type": "object"
       },
       "OrganizationTierAssignmentCreateRequest": {
@@ -17971,9 +18354,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response List Organizations Ui Api Organizations Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/OrganizationListResponse"
                 }
               }
             },
@@ -18080,9 +18461,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Create Organization Ui Api Organizations Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/OrganizationResponse"
                 }
               }
             },
@@ -18179,9 +18558,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Get Organization Ui Api Organizations  Organization Id  Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/OrganizationResponse"
                 }
               }
             },
@@ -18288,9 +18665,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Update Organization Ui Api Organizations  Organization Id  Put",
-                  "type": "object"
+                  "$ref": "#/components/schemas/OrganizationResponse"
                 }
               }
             },

--- a/src/api/admin/endpoints/invitations.py
+++ b/src/api/admin/endpoints/invitations.py
@@ -6,8 +6,11 @@ from typing import Any
 from fastapi import APIRouter, Header, HTTPException, Query, Request, status
 
 from src.api.admin.endpoints.common import emit_admin_mutation_audit, get_auth_scope
+from src.api.admin.organization_mutations import organization_mutation_http_error
 from src.audit.actions import AuditAction
 from src.auth.roles import Permission, validate_organization_role, validate_team_role
+from src.services.organization_mutation_policy import OrganizationMutationError
+
 router = APIRouter(tags=["Admin Invitations"])
 
 
@@ -36,21 +39,33 @@ def _can_manage_invitation(scope, invitation: dict[str, Any]) -> bool:  # noqa: 
     metadata = invitation.get("metadata")
     org_permissions = getattr(scope, "org_permissions_by_id", {}) or {}
     team_permissions = getattr(scope, "team_permissions_by_id", {}) or {}
-    organization_invites = [item for item in list((metadata or {}).get("organization_invites") or []) if isinstance(item, dict)]
-    team_invites = [item for item in list((metadata or {}).get("team_invites") or []) if isinstance(item, dict)]
+    organization_invites = [
+        item
+        for item in list((metadata or {}).get("organization_invites") or [])
+        if isinstance(item, dict)
+    ]
+    team_invites = [
+        item for item in list((metadata or {}).get("team_invites") or []) if isinstance(item, dict)
+    ]
     if not organization_invites and not team_invites:
         return False
 
     for item in organization_invites:
         organization_id = str(item.get("organization_id") or "")
-        if not organization_id or Permission.ORG_UPDATE not in org_permissions.get(organization_id, set()):
+        if not organization_id or Permission.ORG_UPDATE not in org_permissions.get(
+            organization_id, set()
+        ):
             return False
 
     for item in team_invites:
         team_id = str(item.get("team_id") or "")
         organization_id = str(item.get("organization_id") or "")
-        team_allowed = bool(team_id and Permission.TEAM_UPDATE in team_permissions.get(team_id, set()))
-        org_allowed = bool(organization_id and Permission.ORG_UPDATE in org_permissions.get(organization_id, set()))
+        team_allowed = bool(
+            team_id and Permission.TEAM_UPDATE in team_permissions.get(team_id, set())
+        )
+        org_allowed = bool(
+            organization_id and Permission.ORG_UPDATE in org_permissions.get(organization_id, set())
+        )
         if not (team_allowed or org_allowed):
             return False
     return True
@@ -81,12 +96,18 @@ async def list_invitations(
     scope = get_auth_scope(request, authorization, x_master_key)
     service = getattr(request.app.state, "invitation_service", None)
     if service is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable"
+        )
     normalized_status = None if status_filter == "active" else status_filter
     invitations = await service.list_invitations(status=normalized_status, search=search)
     if status_filter == "active":
         invitations = [item for item in invitations if item.get("status") in {"pending", "sent"}]
-    visible = invitations if scope.is_platform_admin else [item for item in invitations if _can_manage_invitation(scope, item)]
+    visible = (
+        invitations
+        if scope.is_platform_admin
+        else [item for item in invitations if _can_manage_invitation(scope, item)]
+    )
     page = visible[offset : offset + limit]
     return {
         "data": page,
@@ -111,18 +132,24 @@ async def create_invitation(
     service = getattr(request.app.state, "invitation_service", None)
     db = getattr(getattr(request.app.state, "prisma_manager", None), "client", None)
     if service is None or db is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable"
+        )
 
     organization_id = str(payload.get("organization_id") or "").strip() or None
     team_id = str(payload.get("team_id") or "").strip() or None
     try:
         organization_role = (
-            validate_organization_role(str(payload.get("organization_role") or payload.get("role") or "org_member"))
+            validate_organization_role(
+                str(payload.get("organization_role") or payload.get("role") or "org_member")
+            )
             if organization_id
             else "org_member"
         )
         team_role = (
-            validate_team_role(str(payload.get("team_role") or payload.get("role") or "team_viewer"))
+            validate_team_role(
+                str(payload.get("team_role") or payload.get("role") or "team_viewer")
+            )
             if team_id
             else "team_viewer"
         )
@@ -133,18 +160,29 @@ async def create_invitation(
     if team_id and not team_org_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="team not found")
     if organization_id and team_org_id and team_org_id != organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="team_id does not belong to organization_id")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="team_id does not belong to organization_id",
+        )
 
     if not scope.is_platform_admin:
         org_permissions = scope.org_permissions_by_id or {}
         team_permissions = scope.team_permissions_by_id or {}
-        if organization_id and Permission.ORG_UPDATE not in org_permissions.get(organization_id, set()):
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+        if organization_id and Permission.ORG_UPDATE not in org_permissions.get(
+            organization_id, set()
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+            )
         if team_id:
             team_allowed = Permission.TEAM_UPDATE in team_permissions.get(team_id, set())
-            org_allowed = bool(team_org_id and Permission.ORG_UPDATE in org_permissions.get(team_org_id, set()))
+            org_allowed = bool(
+                team_org_id and Permission.ORG_UPDATE in org_permissions.get(team_org_id, set())
+            )
             if not (team_allowed or org_allowed):
-                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+                )
 
     try:
         response = await service.create_invitation(
@@ -155,9 +193,13 @@ async def create_invitation(
             team_id=team_id,
             team_role=team_role,
         )
+    except OrganizationMutationError as exc:
+        raise organization_mutation_http_error(exc) from exc
     except ValueError as exc:
         detail = str(exc)
-        status_code = status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        status_code = (
+            status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        )
         raise HTTPException(status_code=status_code, detail=detail) from exc
 
     await emit_admin_mutation_audit(
@@ -184,19 +226,29 @@ async def resend_invitation(
     scope = get_auth_scope(request, authorization, x_master_key)
     service = getattr(request.app.state, "invitation_service", None)
     if service is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable"
+        )
 
     invitation = await service.get_invitation(invitation_id)
     if invitation is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="invitation not found")
     if not _can_manage_invitation(scope, invitation):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+        )
 
     try:
-        response = await service.resend_invitation(invitation_id=invitation_id, invited_by_account_id=scope.account_id)
+        response = await service.resend_invitation(
+            invitation_id=invitation_id, invited_by_account_id=scope.account_id
+        )
+    except OrganizationMutationError as exc:
+        raise organization_mutation_http_error(exc) from exc
     except ValueError as exc:
         detail = str(exc)
-        status_code = status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        status_code = (
+            status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        )
         raise HTTPException(status_code=status_code, detail=detail) from exc
 
     await emit_admin_mutation_audit(
@@ -222,19 +274,27 @@ async def cancel_invitation(
     scope = get_auth_scope(request, authorization, x_master_key)
     service = getattr(request.app.state, "invitation_service", None)
     if service is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable"
+        )
 
     invitation = await service.get_invitation(invitation_id)
     if invitation is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="invitation not found")
     if not _can_manage_invitation(scope, invitation):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+        )
 
     try:
         cancelled = await service.cancel_invitation(invitation_id=invitation_id)
+    except OrganizationMutationError as exc:
+        raise organization_mutation_http_error(exc) from exc
     except ValueError as exc:
         detail = str(exc)
-        status_code = status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        status_code = (
+            status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        )
         raise HTTPException(status_code=status_code, detail=detail) from exc
 
     response = {"cancelled": cancelled, "invitation_id": invitation_id}

--- a/src/api/admin/endpoints/keys.py
+++ b/src/api/admin/endpoints/keys.py
@@ -19,9 +19,15 @@ from src.api.admin.endpoints.common import (
     to_json_value,
     validate_runtime_user_scope,
 )
+from src.api.admin.organization_mutations import require_active_organization_mutation
+from src.db.callable_target_access_groups import CallableTargetAccessGroupBindingRepository
+from src.db.callable_target_policies import CallableTargetScopePolicyRepository
+from src.db.callable_targets import CallableTargetBindingRepository
+from src.db.route_groups import RouteGroupRepository
 from src.middleware.platform_auth import get_platform_auth_context
+from src.services.asset_binding_mirror import reload_callable_target_grants
 from src.services.asset_visibility_preview import build_asset_visibility_preview
-from src.services.scoped_asset_access import apply_scope_asset_access, build_scope_asset_access
+from src.services.scoped_asset_access import build_scope_asset_access, sync_scope_asset_access_state
 
 router = APIRouter(tags=["Admin Keys"])
 logger = logging.getLogger(__name__)
@@ -32,6 +38,15 @@ _SELF_SERVICE_RATE_LIMIT_FIELDS = ("rpm_limit", "tpm_limit", "rph_limit", "rpd_l
 _ADMIN_KEY_LIST_PERMISSIONS = frozenset({Permission.KEY_UPDATE, Permission.KEY_REVOKE})
 _READ_KEY_LIST_PERMISSIONS = frozenset({Permission.KEY_READ})
 _OWNER_KEY_LIST_PERMISSIONS = frozenset({Permission.KEY_CREATE_SELF})
+
+
+def _transaction_repository(
+    request: Request, state_name: str, repository_type: type, db: Any
+) -> Any:
+    repository = getattr(request.app.state, state_name, None)
+    if isinstance(repository, repository_type):
+        return repository_type(db)
+    return repository
 
 
 def _normalize_lock_part(value: object) -> str:
@@ -62,13 +77,19 @@ def _normalize_self_service_budget(max_budget: Any) -> float | None:
     if max_budget is None:
         return None
     if isinstance(max_budget, bool):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be a valid number")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be a valid number"
+        )
     try:
         budget_val = float(max_budget)
     except (TypeError, ValueError):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be a valid number")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be a valid number"
+        )
     if not math.isfinite(budget_val):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be a finite number")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be a finite number"
+        )
     return budget_val
 
 
@@ -76,12 +97,18 @@ def _normalize_self_service_limit(value: Any, field_name: str) -> int | None:
     if value is None:
         return None
     if isinstance(value, bool):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{field_name} must be a positive integer",
+        )
     if isinstance(value, int):
         parsed = value
     elif isinstance(value, float):
         if not value.is_integer():
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{field_name} must be a positive integer",
+            )
         parsed = int(value)
     elif isinstance(value, str):
         stripped = value.strip()
@@ -90,12 +117,21 @@ def _normalize_self_service_limit(value: Any, field_name: str) -> int | None:
         try:
             parsed = int(stripped)
         except ValueError:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{field_name} must be a positive integer",
+            )
     else:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{field_name} must be a positive integer",
+        )
 
     if parsed <= 0:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} must be a positive integer")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{field_name} must be a positive integer",
+        )
     return parsed
 
 
@@ -104,11 +140,17 @@ def _parse_self_service_expiry(expires: str | None) -> datetime | None:
         return None
     raw = expires.strip()
     if not raw:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="expires must be a valid ISO 8601 datetime string")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="expires must be a valid ISO 8601 datetime string",
+        )
     try:
         exp_dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="expires must be a valid ISO 8601 datetime string")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="expires must be a valid ISO 8601 datetime string",
+        )
     if exp_dt.tzinfo is None:
         exp_dt = exp_dt.replace(tzinfo=UTC)
     return exp_dt.astimezone(UTC)
@@ -171,7 +213,9 @@ async def _notify_key_lifecycle(
             record=record,
         )
     except Exception:  # pragma: no cover - defensive guard
-        logger.exception("failed to enqueue key lifecycle notification", extra={"notification_kind": event_kind})
+        logger.exception(
+            "failed to enqueue key lifecycle notification", extra={"notification_kind": event_kind}
+        )
 
 
 async def _get_self_service_policy(db: Any, team_id: str) -> dict[str, Any]:
@@ -236,7 +280,10 @@ async def _validate_self_service_constraints(
 
     budget_val = _normalize_self_service_budget(max_budget)
     if budget_val is not None and budget_val < 0:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="max_budget must be greater than or equal to 0")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="max_budget must be greater than or equal to 0",
+        )
     budget_ceiling = policy.get("budget_ceiling")
     if budget_ceiling is not None:
         if budget_val is None:
@@ -411,7 +458,9 @@ def _resolve_key_read_access_mode(
         return "admin"
 
     owner_only_read = False
-    for permissions in _target_scope_permission_sets(scope, organization_id=organization_id, team_id=team_id):
+    for permissions in _target_scope_permission_sets(
+        scope, organization_id=organization_id, team_id=team_id
+    ):
         if permissions.intersection(_ADMIN_KEY_LIST_PERMISSIONS):
             return "admin"
         if Permission.KEY_READ in permissions and Permission.KEY_CREATE_SELF not in permissions:
@@ -484,7 +533,9 @@ def _ordered_unique_scope_ids(*groups: list[str]) -> list[str]:
     return ordered
 
 
-def _append_key_list_scope_clause(scope: Any, clauses: list[str], params: list[Any], *, my_keys: bool) -> bool:
+def _append_key_list_scope_clause(
+    scope: Any, clauses: list[str], params: list[Any], *, my_keys: bool
+) -> bool:
     owner_account_id = str(getattr(scope, "account_id", "") or "").strip() or None
     owner_param_index: int | None = None
     if my_keys:
@@ -511,7 +562,9 @@ def _append_key_list_scope_clause(scope: Any, clauses: list[str], params: list[A
     ]
     owner_team_ids = [
         scope_id
-        for scope_id in _scope_ids_with_any_permission(team_permissions, _OWNER_KEY_LIST_PERMISSIONS)
+        for scope_id in _scope_ids_with_any_permission(
+            team_permissions, _OWNER_KEY_LIST_PERMISSIONS
+        )
         if scope_id not in admin_team_id_set
     ]
     owner_org_id_set = set(owner_org_ids)
@@ -543,10 +596,14 @@ def _append_key_list_scope_clause(scope: Any, clauses: list[str], params: list[A
             owner_param_index = len(params)
         owner_org_predicate = _append_in_predicate("t.organization_id", owner_org_ids, params)
         if owner_org_predicate is not None:
-            scope_parts.append(f"({owner_org_predicate} AND vt.owner_account_id = ${owner_param_index})")
+            scope_parts.append(
+                f"({owner_org_predicate} AND vt.owner_account_id = ${owner_param_index})"
+            )
         owner_team_predicate = _append_in_predicate("vt.team_id", owner_team_ids, params)
         if owner_team_predicate is not None:
-            scope_parts.append(f"({owner_team_predicate} AND vt.owner_account_id = ${owner_param_index})")
+            scope_parts.append(
+                f"({owner_team_predicate} AND vt.owner_account_id = ${owner_param_index})"
+            )
 
     if not scope_parts:
         return False
@@ -584,6 +641,28 @@ async def _get_team_row(db: Any, team_id: str) -> dict[str, Any]:
     return dict(rows[0])
 
 
+async def _lock_team_organization_for_key_mutation(
+    db: Any,
+    team_id: str,
+) -> dict[str, Any]:
+    rows = await db.query_raw(
+        """
+        SELECT team_id, team_alias, organization_id
+        FROM deltallm_teamtable
+        WHERE team_id = $1
+        FOR SHARE
+        """,
+        team_id,
+    )
+    if not rows:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+    team = dict(rows[0])
+    organization_id = str(team.get("organization_id") or "").strip()
+    if organization_id:
+        await require_active_organization_mutation(db, organization_id)
+    return team
+
+
 async def _get_key_scope_row(db: Any, token_hash: str) -> dict[str, Any]:
     rows = await db.query_raw(
         """
@@ -605,6 +684,38 @@ async def _get_key_scope_row(db: Any, token_hash: str) -> dict[str, Any]:
     return dict(rows[0])
 
 
+async def _lock_key_organization_for_mutation(
+    db: Any,
+    token_hash: str,
+) -> dict[str, Any]:
+    rows = await db.query_raw(
+        """
+        SELECT
+            vt.token,
+            vt.user_id,
+            COALESCE(vt.team_id, u.team_id, sa.team_id) AS team_id,
+            t.organization_id
+        FROM deltallm_verificationtoken vt
+        LEFT JOIN deltallm_usertable u ON u.user_id = vt.user_id
+        LEFT JOIN deltallm_serviceaccount sa
+          ON sa.service_account_id = vt.owner_service_account_id
+        LEFT JOIN deltallm_teamtable t
+          ON t.team_id = COALESCE(vt.team_id, u.team_id, sa.team_id)
+        WHERE vt.token = $1
+        LIMIT 1
+        FOR UPDATE OF vt
+        """,
+        token_hash,
+    )
+    if not rows:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Key not found")
+    row = dict(rows[0])
+    organization_id = str(row.get("organization_id") or "").strip()
+    if organization_id:
+        await require_active_organization_mutation(db, organization_id)
+    return row
+
+
 async def _validate_runtime_user(db: Any, user_id: str, team_id: str | None) -> None:
     await validate_runtime_user_scope(db, user_id, team_id=team_id)
 
@@ -619,7 +730,10 @@ async def _validate_owner_references(
     require_owner: bool,
 ) -> tuple[str | None, str | None]:
     if owner_account_id and owner_service_account_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Select either 'You' or a service account, not both")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Select either 'You' or a service account, not both",
+        )
 
     ctx = get_platform_auth_context(request)
     if owner_account_id:
@@ -628,9 +742,14 @@ async def _validate_owner_references(
             owner_account_id,
         )
         if not rows:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="owner_account_id not found")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="owner_account_id not found"
+            )
         if ctx is not None and str(ctx.account_id) != owner_account_id:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="owner_account_id must match the current account")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="owner_account_id must match the current account",
+            )
         return owner_account_id, None
 
     if owner_service_account_id:
@@ -644,12 +763,20 @@ async def _validate_owner_references(
             owner_service_account_id,
         )
         if not rows:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="owner_service_account_id not found")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="owner_service_account_id not found"
+            )
         row = rows[0]
         if str(row.get("team_id") or "") != team_id:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Service account must belong to the selected team")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Service account must belong to the selected team",
+            )
         if not bool(row.get("is_active", True)):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Selected service account is inactive")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Selected service account is inactive",
+            )
         return None, owner_service_account_id
 
     if not require_owner:
@@ -713,14 +840,22 @@ async def list_keys(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, any_permission=[Permission.KEY_READ, Permission.KEY_CREATE_SELF])
+    scope = get_auth_scope(
+        request,
+        authorization,
+        x_master_key,
+        any_permission=[Permission.KEY_READ, Permission.KEY_CREATE_SELF],
+    )
     db = db_or_503(request)
 
     clauses: list[str] = []
     params: list[Any] = []
 
     if not _append_key_list_scope_clause(scope, clauses, params, my_keys=my_keys):
-        return {"data": [], "pagination": {"total": 0, "limit": limit, "offset": offset, "has_more": False}}
+        return {
+            "data": [],
+            "pagination": {"total": 0, "limit": limit, "offset": offset, "has_more": False},
+        }
 
     if search:
         params.append(f"%{search}%")
@@ -776,7 +911,12 @@ async def list_keys(
 
     return {
         "data": [_key_response_payload(dict(row)) for row in rows],
-        "pagination": {"total": total, "limit": limit, "offset": offset, "has_more": offset + limit < total},
+        "pagination": {
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + limit < total,
+        },
     }
 
 
@@ -789,8 +929,14 @@ async def create_key(
 ) -> dict[str, Any]:
     request_start = perf_counter()
     _reject_legacy_models_field(payload)
-    scope = get_auth_scope(request, authorization, x_master_key, any_permission=[Permission.KEY_UPDATE, Permission.KEY_CREATE_SELF])
+    scope = get_auth_scope(
+        request,
+        authorization,
+        x_master_key,
+        any_permission=[Permission.KEY_UPDATE, Permission.KEY_CREATE_SELF],
+    )
     db = db_or_503(request)
+    tx_factory = getattr(db, "tx", None)
 
     key_name = str(payload.get("key_name") or "").strip()
     user_id = str(payload.get("user_id") or "").strip() or None
@@ -805,7 +951,9 @@ async def create_key(
     tpd_limit = payload.get("tpd_limit")
     expires = payload.get("expires")
     if expires is not None and not isinstance(expires, str):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="expires must be a string datetime")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="expires must be a string datetime"
+        )
 
     if not key_name:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="key_name is required")
@@ -823,11 +971,21 @@ async def create_key(
         allow_self_service=True,
     )
     self_service_only = access_mode == "self_service"
+    if not callable(tx_factory):
+        detail = (
+            "Database transactions are required for self-service key creation"
+            if self_service_only
+            else "Key mutation requires transaction support"
+        )
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail)
 
     account_email: str | None = None
     if self_service_only:
         if not scope.account_id:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Self-service key creation requires an account context")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Self-service key creation requires an account context",
+            )
         owner_account_id = scope.account_id
         owner_service_account_id = None
         ctx = get_platform_auth_context(request)
@@ -847,19 +1005,30 @@ async def create_key(
     raw_key = f"sk-{secrets.token_urlsafe(24)}"
     key_service = request.app.state.key_service
     token_hash = key_service.hash_key(raw_key)
-    audit_action = AuditAction.ADMIN_KEY_SELF_CREATE if self_service_only else AuditAction.ADMIN_KEY_CREATE
+    audit_action = (
+        AuditAction.ADMIN_KEY_SELF_CREATE if self_service_only else AuditAction.ADMIN_KEY_CREATE
+    )
 
     try:
-        if self_service_only:
-            tx_factory = getattr(db, "tx", None)
-            if not callable(tx_factory):
+        async with tx_factory() as tx:
+            team = await _lock_team_organization_for_key_mutation(tx, team_id)
+            team_org = str(team.get("organization_id") or "").strip() or None
+            locked_access_mode = _resolve_key_access_mode(
+                scope,
+                organization_id=team_org,
+                team_id=team_id,
+                admin_permission=Permission.KEY_UPDATE,
+                allow_self_service=True,
+            )
+            if locked_access_mode != access_mode:
                 raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail="Database transactions are required for self-service key creation",
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Key authorization changed; retry the request",
                 )
-
-            async with tx_factory() as tx:
-                await _acquire_self_service_key_create_lock(tx, team_id=team_id, account_id=scope.account_id)
+            if self_service_only:
+                await _acquire_self_service_key_create_lock(
+                    tx, team_id=team_id, account_id=scope.account_id
+                )
                 policy = await _get_self_service_policy(tx, team_id)
                 normalized_self_service_values = await _validate_self_service_constraints(
                     tx,
@@ -903,23 +1072,23 @@ async def create_key(
                     tpd_limit=tpd_limit,
                     expires=expires,
                 )
-        else:
-            await _insert_key_row(
-                db,
-                token_hash=token_hash,
-                key_name=key_name,
-                user_id=user_id,
-                team_id=team_id,
-                owner_account_id=owner_account_id,
-                owner_service_account_id=owner_service_account_id,
-                max_budget=max_budget,
-                rpm_limit=rpm_limit,
-                tpm_limit=tpm_limit,
-                rph_limit=rph_limit,
-                rpd_limit=rpd_limit,
-                tpd_limit=tpd_limit,
-                expires=expires,
-            )
+            else:
+                await _insert_key_row(
+                    tx,
+                    token_hash=token_hash,
+                    key_name=key_name,
+                    user_id=user_id,
+                    team_id=team_id,
+                    owner_account_id=owner_account_id,
+                    owner_service_account_id=owner_service_account_id,
+                    max_budget=max_budget,
+                    rpm_limit=rpm_limit,
+                    tpm_limit=tpm_limit,
+                    rph_limit=rph_limit,
+                    rpd_limit=rpd_limit,
+                    tpd_limit=tpd_limit,
+                    expires=expires,
+                )
 
         response = {
             "token": token_hash,
@@ -991,8 +1160,16 @@ async def update_key(
 ) -> dict[str, Any]:
     request_start = perf_counter()
     _reject_legacy_models_field(payload)
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.KEY_UPDATE)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.KEY_UPDATE
+    )
     db = db_or_503(request)
+    tx_factory = getattr(db, "tx", None)
+    if not callable(tx_factory):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Key mutation requires transaction support",
+        )
     await _require_key_access(scope, db, token_hash, admin_permission=Permission.KEY_UPDATE)
     rows = await db.query_raw(
         """
@@ -1009,13 +1186,22 @@ async def update_key(
     existing = dict(rows[0])
     expires = payload.get("expires", existing.get("expires"))
     if expires is not None and not isinstance(expires, str):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="expires must be a string datetime")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="expires must be a string datetime"
+        )
 
     key_name = str(payload.get("key_name", existing.get("key_name")) or "").strip()
     user_id = str(payload.get("user_id", existing.get("user_id")) or "").strip() or None
     team_id = str(payload.get("team_id", existing.get("team_id")) or "").strip()
-    owner_account_id = str(payload.get("owner_account_id", existing.get("owner_account_id")) or "").strip() or None
-    owner_service_account_id = str(payload.get("owner_service_account_id", existing.get("owner_service_account_id")) or "").strip() or None
+    owner_account_id = (
+        str(payload.get("owner_account_id", existing.get("owner_account_id")) or "").strip() or None
+    )
+    owner_service_account_id = (
+        str(
+            payload.get("owner_service_account_id", existing.get("owner_service_account_id")) or ""
+        ).strip()
+        or None
+    )
     max_budget = payload.get("max_budget", existing.get("max_budget"))
     rpm_limit = payload.get("rpm_limit", existing.get("rpm_limit"))
     tpm_limit = payload.get("tpm_limit", existing.get("tpm_limit"))
@@ -1032,7 +1218,10 @@ async def update_key(
     if not scope.is_platform_admin:
         team_org = team.get("organization_id")
         if not team_org or team_org not in scope.org_ids:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only manage keys for teams in your organizations")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only manage keys for teams in your organizations",
+            )
     if user_id:
         await _validate_runtime_user(db, user_id, team_id)
     owner_account_id, owner_service_account_id = await _validate_owner_references(
@@ -1045,77 +1234,93 @@ async def update_key(
     )
 
     try:
-        await db.execute_raw(
-            """
-            UPDATE deltallm_verificationtoken
-            SET key_name = $1,
-                user_id = $2,
-                team_id = $3,
-                owner_account_id = $4,
-                owner_service_account_id = $5,
-                max_budget = $6,
-                rpm_limit = $7,
-                tpm_limit = $8,
-                rph_limit = $9,
-                rpd_limit = $10,
-                tpd_limit = $11,
-                expires = $12::timestamp,
-                updated_at = NOW()
-            WHERE token = $13
-            """,
-            key_name,
-            user_id,
-            team_id,
-            owner_account_id,
-            owner_service_account_id,
-            max_budget,
-            rpm_limit,
-            tpm_limit,
-            rph_limit,
-            rpd_limit,
-            tpd_limit,
-            expires,
-            token_hash,
-        )
+        async with tx_factory() as tx:
+            await _lock_key_organization_for_mutation(tx, token_hash)
+            await _require_key_access(
+                scope,
+                tx,
+                token_hash,
+                admin_permission=Permission.KEY_UPDATE,
+            )
+            locked_team = await _lock_team_organization_for_key_mutation(tx, team_id)
+            _resolve_key_access_mode(
+                scope,
+                organization_id=str(locked_team.get("organization_id") or "").strip() or None,
+                team_id=team_id,
+                admin_permission=Permission.KEY_UPDATE,
+            )
+            await tx.execute_raw(
+                """
+                UPDATE deltallm_verificationtoken
+                SET key_name = $1,
+                    user_id = $2,
+                    team_id = $3,
+                    owner_account_id = $4,
+                    owner_service_account_id = $5,
+                    max_budget = $6,
+                    rpm_limit = $7,
+                    tpm_limit = $8,
+                    rph_limit = $9,
+                    rpd_limit = $10,
+                    tpd_limit = $11,
+                    expires = $12::timestamp,
+                    updated_at = NOW()
+                WHERE token = $13
+                """,
+                key_name,
+                user_id,
+                team_id,
+                owner_account_id,
+                owner_service_account_id,
+                max_budget,
+                rpm_limit,
+                tpm_limit,
+                rph_limit,
+                rpd_limit,
+                tpd_limit,
+                expires,
+                token_hash,
+            )
+
+            updated_rows = await tx.query_raw(
+                """
+                SELECT
+                    vt.token,
+                    vt.key_name,
+                    vt.user_id,
+                    vt.team_id,
+                    t.team_alias,
+                    vt.owner_account_id,
+                    pa.email AS owner_account_email,
+                    vt.owner_service_account_id,
+                    sa.name AS owner_service_account_name,
+                    vt.spend,
+                    vt.max_budget,
+                    vt.rpm_limit,
+                    vt.tpm_limit,
+                    vt.rph_limit,
+                    vt.rpd_limit,
+                    vt.tpd_limit,
+                    vt.expires,
+                    vt.created_at,
+                    vt.updated_at
+                FROM deltallm_verificationtoken vt
+                LEFT JOIN deltallm_teamtable t ON vt.team_id = t.team_id
+                LEFT JOIN deltallm_platformaccount pa ON vt.owner_account_id = pa.account_id
+                LEFT JOIN deltallm_serviceaccount sa
+                  ON vt.owner_service_account_id = sa.service_account_id
+                WHERE token = $1
+                LIMIT 1
+                """,
+                token_hash,
+            )
+            if not updated_rows:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Key not found")
+            updated = _key_response_payload(dict(updated_rows[0]))
 
         key_service = getattr(request.app.state, "key_service", None)
         if key_service:
             await key_service.invalidate_key_cache_by_hash(token_hash)
-
-        updated_rows = await db.query_raw(
-            """
-            SELECT
-                vt.token,
-                vt.key_name,
-                vt.user_id,
-                vt.team_id,
-                t.team_alias,
-                vt.owner_account_id,
-                pa.email AS owner_account_email,
-                vt.owner_service_account_id,
-                sa.name AS owner_service_account_name,
-                vt.spend,
-                vt.max_budget,
-                vt.rpm_limit,
-                vt.tpm_limit,
-                vt.rph_limit,
-                vt.rpd_limit,
-                vt.tpd_limit,
-                vt.expires,
-                vt.created_at,
-                vt.updated_at
-            FROM deltallm_verificationtoken vt
-            LEFT JOIN deltallm_teamtable t ON vt.team_id = t.team_id
-            LEFT JOIN deltallm_platformaccount pa ON vt.owner_account_id = pa.account_id
-            LEFT JOIN deltallm_serviceaccount sa ON vt.owner_service_account_id = sa.service_account_id
-            WHERE token = $1
-            LIMIT 1
-            """,
-            token_hash,
-        )
-        if not updated_rows:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Key not found")
-        updated = _key_response_payload(dict(updated_rows[0]))
         await emit_admin_mutation_audit(
             request=request,
             request_start=request_start,
@@ -1156,7 +1361,9 @@ async def _require_key_access(
     organization_id = str(row.get("organization_id") or "").strip() or None
     team_id = str(row.get("team_id") or "").strip() or None
     if admin_permission == Permission.KEY_READ:
-        access_mode = _resolve_key_read_access_mode(scope, organization_id=organization_id, team_id=team_id)
+        access_mode = _resolve_key_read_access_mode(
+            scope, organization_id=organization_id, team_id=team_id
+        )
     else:
         access_mode = _resolve_key_access_mode(
             scope,
@@ -1173,7 +1380,9 @@ async def _require_key_access(
         )
         if owner_rows and str(owner_rows[0].get("owner_account_id") or "") == scope.account_id:
             return access_mode
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only manage your own keys")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="You can only manage your own keys"
+        )
 
     return access_mode
 
@@ -1189,7 +1398,9 @@ async def get_key_asset_visibility(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.KEY_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.KEY_READ
+    )
     db = db_or_503(request)
     await _require_key_access(scope, db, token_hash, admin_permission=Permission.KEY_READ)
     key_row = await _get_key_scope_row(db, token_hash)
@@ -1197,7 +1408,10 @@ async def get_key_asset_visibility(
     team_id = str(key_row.get("team_id") or "").strip() or None
     user_id = str(key_row.get("user_id") or "").strip() or None
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Key team organization is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Key team organization is not configured",
+        )
     return await build_asset_visibility_preview(
         request,
         organization_id=organization_id,
@@ -1222,7 +1436,9 @@ async def get_key_asset_access(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.KEY_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.KEY_READ
+    )
     db = db_or_503(request)
     await _require_key_access(scope, db, token_hash, admin_permission=Permission.KEY_READ)
     key_row = await _get_key_scope_row(db, token_hash)
@@ -1230,7 +1446,10 @@ async def get_key_asset_access(
     team_id = str(key_row.get("team_id") or "").strip() or None
     user_id = str(key_row.get("user_id") or "").strip() or None
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Key team organization is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Key team organization is not configured",
+        )
     return await build_scope_asset_access(
         request,
         scope_type="api_key",
@@ -1255,7 +1474,9 @@ async def update_key_asset_access(
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
     request_start = perf_counter()
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.KEY_UPDATE)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.KEY_UPDATE
+    )
     db = db_or_503(request)
     await _require_key_access(scope, db, token_hash, admin_permission=Permission.KEY_UPDATE)
     key_row = await _get_key_scope_row(db, token_hash)
@@ -1263,7 +1484,10 @@ async def update_key_asset_access(
     team_id = str(key_row.get("team_id") or "").strip() or None
     user_id = str(key_row.get("user_id") or "").strip() or None
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Key team organization is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Key team organization is not configured",
+        )
     asset_access_payload = {
         "scope_type": "api_key",
         "scope_id": token_hash,
@@ -1277,7 +1501,69 @@ async def update_key_asset_access(
     }
     if "selected_access_group_keys" in payload:
         asset_access_payload["selected_access_group_keys"] = payload["selected_access_group_keys"]
-    response = await apply_scope_asset_access(request, **asset_access_payload)
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Key asset-access mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        locked_key = await _lock_key_organization_for_mutation(tx, token_hash)
+        await _require_key_access(
+            scope,
+            tx,
+            token_hash,
+            admin_permission=Permission.KEY_UPDATE,
+        )
+        locked_organization_id = str(locked_key.get("organization_id") or "").strip()
+        if not locked_organization_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Key team organization is not configured",
+            )
+        locked_team_id = str(locked_key.get("team_id") or "").strip() or None
+        locked_user_id = str(locked_key.get("user_id") or "").strip() or None
+        asset_access_payload["organization_id"] = locked_organization_id
+        asset_access_payload["team_id"] = locked_team_id
+        asset_access_payload["user_id"] = locked_user_id
+        await sync_scope_asset_access_state(
+            request,
+            **asset_access_payload,
+            binding_repository=_transaction_repository(
+                request,
+                "callable_target_binding_repository",
+                CallableTargetBindingRepository,
+                tx,
+            ),
+            access_group_repository=_transaction_repository(
+                request,
+                "callable_target_access_group_repository",
+                CallableTargetAccessGroupBindingRepository,
+                tx,
+            ),
+            policy_repository=_transaction_repository(
+                request,
+                "callable_target_scope_policy_repository",
+                CallableTargetScopePolicyRepository,
+                tx,
+            ),
+            route_group_repository=_transaction_repository(
+                request,
+                "route_group_repository",
+                RouteGroupRepository,
+                tx,
+            ),
+            reload_after_write=False,
+        )
+    await reload_callable_target_grants(request)
+    response = await build_scope_asset_access(
+        request,
+        scope_type="api_key",
+        scope_id=token_hash,
+        organization_id=locked_organization_id,
+        team_id=locked_team_id,
+        api_key_id=token_hash,
+        user_id=locked_user_id,
+    )
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -1299,34 +1585,47 @@ async def regenerate_key(
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
     request_start = perf_counter()
-    scope = get_auth_scope(request, authorization, x_master_key, any_permission=[Permission.KEY_UPDATE, Permission.KEY_CREATE_SELF])
-    db = db_or_503(request)
-    access_mode = await _require_key_access(
-        scope,
-        db,
-        token_hash,
-        admin_permission=Permission.KEY_UPDATE,
-        allow_self_service=True,
+    scope = get_auth_scope(
+        request,
+        authorization,
+        x_master_key,
+        any_permission=[Permission.KEY_UPDATE, Permission.KEY_CREATE_SELF],
     )
-
-    rows = await db.query_raw("SELECT token FROM deltallm_verificationtoken WHERE token = $1 LIMIT 1", token_hash)
-    if not rows:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Key not found")
-    notification_row = await _get_key_notification_row(db, token_hash)
+    db = db_or_503(request)
+    tx_factory = getattr(db, "tx", None)
+    if not callable(tx_factory):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Key mutation requires transaction support",
+        )
 
     raw_key = f"sk-{secrets.token_urlsafe(24)}"
     new_hash = request.app.state.key_service.hash_key(raw_key)
-    await db.execute_raw(
-        "UPDATE deltallm_verificationtoken SET token = $1, updated_at = NOW() WHERE token = $2",
-        new_hash,
-        token_hash,
-    )
+    async with tx_factory() as tx:
+        await _lock_key_organization_for_mutation(tx, token_hash)
+        access_mode = await _require_key_access(
+            scope,
+            tx,
+            token_hash,
+            admin_permission=Permission.KEY_UPDATE,
+            allow_self_service=True,
+        )
+        notification_row = await _get_key_notification_row(tx, token_hash)
+        await tx.execute_raw(
+            "UPDATE deltallm_verificationtoken SET token = $1, updated_at = NOW() WHERE token = $2",
+            new_hash,
+            token_hash,
+        )
     try:
         await request.app.state.key_service.invalidate_key_cache_by_hash(token_hash)
         await request.app.state.key_service.invalidate_key_cache_by_hash(new_hash)
     except Exception:
         logger.exception("failed to invalidate key auth cache after regenerate")
-    audit_action = AuditAction.ADMIN_KEY_SELF_ROTATE if access_mode == "self_service" else AuditAction.ADMIN_KEY_REGENERATE
+    audit_action = (
+        AuditAction.ADMIN_KEY_SELF_ROTATE
+        if access_mode == "self_service"
+        else AuditAction.ADMIN_KEY_REGENERATE
+    )
     response = {"token": new_hash, "raw_key": raw_key}
     if notification_row is not None:
         notification_row["token"] = new_hash
@@ -1357,17 +1656,31 @@ async def revoke_key(
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, bool]:
     request_start = perf_counter()
-    scope = get_auth_scope(request, authorization, x_master_key, any_permission=[Permission.KEY_REVOKE, Permission.KEY_CREATE_SELF])
-    db = db_or_503(request)
-    access_mode = await _require_key_access(
-        scope,
-        db,
-        token_hash,
-        admin_permission=Permission.KEY_REVOKE,
-        allow_self_service=True,
+    scope = get_auth_scope(
+        request,
+        authorization,
+        x_master_key,
+        any_permission=[Permission.KEY_REVOKE, Permission.KEY_CREATE_SELF],
     )
-    notification_row = await _get_key_notification_row(db, token_hash)
-    deleted = await db.execute_raw("DELETE FROM deltallm_verificationtoken WHERE token = $1", token_hash)
+    db = db_or_503(request)
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Key mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        await _lock_key_organization_for_mutation(tx, token_hash)
+        access_mode = await _require_key_access(
+            scope,
+            tx,
+            token_hash,
+            admin_permission=Permission.KEY_REVOKE,
+            allow_self_service=True,
+        )
+        notification_row = await _get_key_notification_row(tx, token_hash)
+        deleted = await tx.execute_raw(
+            "DELETE FROM deltallm_verificationtoken WHERE token = $1", token_hash
+        )
     if int(deleted or 0) > 0:
         try:
             await request.app.state.key_service.invalidate_key_cache_by_hash(token_hash)
@@ -1380,7 +1693,11 @@ async def revoke_key(
                 actor_account_id=scope.account_id,
                 record=_notification_record(notification_row),
             )
-    audit_action = AuditAction.ADMIN_KEY_SELF_REVOKE if access_mode == "self_service" else AuditAction.ADMIN_KEY_REVOKE
+    audit_action = (
+        AuditAction.ADMIN_KEY_SELF_REVOKE
+        if access_mode == "self_service"
+        else AuditAction.ADMIN_KEY_REVOKE
+    )
     response = {"revoked": int(deleted or 0) > 0}
     await emit_admin_mutation_audit(
         request=request,
@@ -1402,17 +1719,31 @@ async def delete_key(
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, bool]:
     request_start = perf_counter()
-    scope = get_auth_scope(request, authorization, x_master_key, any_permission=[Permission.KEY_REVOKE, Permission.KEY_CREATE_SELF])
-    db = db_or_503(request)
-    access_mode = await _require_key_access(
-        scope,
-        db,
-        token_hash,
-        admin_permission=Permission.KEY_REVOKE,
-        allow_self_service=True,
+    scope = get_auth_scope(
+        request,
+        authorization,
+        x_master_key,
+        any_permission=[Permission.KEY_REVOKE, Permission.KEY_CREATE_SELF],
     )
-    notification_row = await _get_key_notification_row(db, token_hash)
-    deleted = await db.execute_raw("DELETE FROM deltallm_verificationtoken WHERE token = $1", token_hash)
+    db = db_or_503(request)
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Key mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        await _lock_key_organization_for_mutation(tx, token_hash)
+        access_mode = await _require_key_access(
+            scope,
+            tx,
+            token_hash,
+            admin_permission=Permission.KEY_REVOKE,
+            allow_self_service=True,
+        )
+        notification_row = await _get_key_notification_row(tx, token_hash)
+        deleted = await tx.execute_raw(
+            "DELETE FROM deltallm_verificationtoken WHERE token = $1", token_hash
+        )
     if int(deleted or 0) > 0:
         try:
             await request.app.state.key_service.invalidate_key_cache_by_hash(token_hash)
@@ -1425,7 +1756,11 @@ async def delete_key(
                 actor_account_id=scope.account_id,
                 record=_notification_record(notification_row),
             )
-    audit_action = AuditAction.ADMIN_KEY_SELF_REVOKE if access_mode == "self_service" else AuditAction.ADMIN_KEY_DELETE
+    audit_action = (
+        AuditAction.ADMIN_KEY_SELF_REVOKE
+        if access_mode == "self_service"
+        else AuditAction.ADMIN_KEY_DELETE
+    )
     response = {"deleted": int(deleted or 0) > 0}
     await emit_admin_mutation_audit(
         request=request,

--- a/src/api/admin/endpoints/organization_deletion_schemas.py
+++ b/src/api/admin/endpoints/organization_deletion_schemas.py
@@ -5,13 +5,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.models.organization_lifecycle import OrganizationLifecycleState
 
-OrganizationLifecycleState = Literal[
-    "active",
-    "deletion_pending",
-    "purging",
-    "deletion_failed",
-]
 OrganizationDeletionStatus = Literal[
     "pending",
     "processing",

--- a/src/api/admin/endpoints/organization_schemas.py
+++ b/src/api/admin/endpoints/organization_schemas.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.models.organization_lifecycle import OrganizationLifecycleState
+
+
+class OrganizationCapabilitiesResponse(BaseModel):
+    view: bool = True
+    edit: bool = False
+    add_team: bool = False
+    manage_members: bool = False
+    manage_assets: bool = False
+    manage_service_policy: bool = False
+    view_usage: bool = False
+
+
+class OrganizationResponse(BaseModel):
+    """Typed core of the organization UI contract; extension fields remain compatible."""
+
+    model_config = ConfigDict(extra="allow")
+
+    organization_id: str = Field(min_length=1)
+    organization_name: str | None = None
+    lifecycle_state: OrganizationLifecycleState | None
+    deletion_requested_at: str | None = None
+    deletion_not_before_at: str | None = None
+    max_budget: float | None = None
+    soft_budget: float | None = None
+    spend: float | None = None
+    budget_duration: str | None = None
+    budget_reset_at: str | None = None
+    rpm_limit: int | None = None
+    tpm_limit: int | None = None
+    rph_limit: int | None = None
+    rpd_limit: int | None = None
+    tpd_limit: int | None = None
+    model_rpm_limit: dict[str, int] | None = None
+    model_tpm_limit: dict[str, int] | None = None
+    audit_content_storage_enabled: bool | None = None
+    metadata: dict[str, Any] | None = None
+    service_policy: dict[str, Any]
+    capabilities: OrganizationCapabilitiesResponse = Field(
+        default_factory=OrganizationCapabilitiesResponse
+    )
+    team_count: int | None = Field(default=None, ge=0)
+    member_count: int | None = Field(default=None, ge=0)
+    user_count: int | None = Field(default=None, ge=0)
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class OrganizationPaginationResponse(BaseModel):
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    has_more: bool
+
+
+class OrganizationListResponse(BaseModel):
+    data: list[OrganizationResponse]
+    pagination: OrganizationPaginationResponse
+
+
+__all__ = [
+    "OrganizationCapabilitiesResponse",
+    "OrganizationListResponse",
+    "OrganizationPaginationResponse",
+    "OrganizationResponse",
+]

--- a/src/api/admin/endpoints/organizations.py
+++ b/src/api/admin/endpoints/organizations.py
@@ -28,6 +28,11 @@ from src.api.admin.endpoints.common import (
     to_json_value,
     validate_runtime_user_scope,
 )
+from src.api.admin.endpoints.organization_schemas import (
+    OrganizationListResponse,
+    OrganizationResponse,
+)
+from src.api.admin.organization_mutations import require_active_organization_mutation
 from src.db.callable_target_access_groups import CallableTargetAccessGroupBindingRepository
 from src.db.callable_targets import CallableTargetBindingRepository
 from src.db.organization_admin import (
@@ -1006,7 +1011,7 @@ async def _build_org_asset_visibility_preview(
     return await build_asset_visibility_preview(request, organization_id=organization_id)
 
 
-@router.get("/ui/api/organizations")
+@router.get("/ui/api/organizations", response_model=OrganizationListResponse)
 async def list_organizations(
     request: Request,
     search: str | None = Query(default=None),
@@ -1045,7 +1050,9 @@ async def list_organizations(
     select_cols = """o.organization_id, o.organization_name, o.max_budget, o.soft_budget, o.spend, o.budget_duration, o.budget_reset_at, o.rpm_limit, o.tpm_limit,
                    o.rph_limit, o.rpd_limit, o.tpd_limit,
                    o.model_rpm_limit, o.model_tpm_limit,
-                   o.audit_content_storage_enabled, o.metadata, o.created_at, o.updated_at,
+                   o.audit_content_storage_enabled, o.metadata,
+                   o.lifecycle_state, o.deletion_requested_at, o.deletion_not_before_at,
+                   o.created_at, o.updated_at,
                    (SELECT COUNT(*) FROM deltallm_teamtable t WHERE t.organization_id = o.organization_id) AS team_count"""
 
     count_rows = await db.query_raw(
@@ -1095,6 +1102,7 @@ async def list_organizations(
 @router.get(
     "/ui/api/organizations/{organization_id}",
     dependencies=[Depends(require_admin_permission(Permission.ORG_READ))],
+    response_model=OrganizationResponse,
 )
 async def get_organization(
     request: Request,
@@ -1108,7 +1116,7 @@ async def get_organization(
     db = db_or_503(request)
     rows = await db.query_raw(
         """
-        SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
+        SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, lifecycle_state, deletion_requested_at, deletion_not_before_at, created_at, updated_at
         FROM deltallm_organizationtable
         WHERE organization_id = $1
         LIMIT 1
@@ -1265,6 +1273,7 @@ async def update_organization_asset_access(
         access_group_repository,
         route_repository,
     ) -> None:  # noqa: ANN001, ANN202
+        await require_active_organization_mutation(db_client, organization_id)
         asset_access_payload = {
             "scope_type": "organization",
             "scope_id": organization_id,
@@ -1288,24 +1297,21 @@ async def update_organization_asset_access(
             enabled=auto_follow_catalog,
         )
 
-    if hasattr(db, "tx"):
-        async with db.tx() as tx:
-            await _apply_asset_access(
-                tx,
-                callable_repository=_callable_target_binding_repository_for_request(
-                    request, db_client=tx
-                ),
-                access_group_repository=_callable_target_access_group_repository_for_request(
-                    request, db_client=tx
-                ),
-                route_repository=_route_group_repository_for_request(request, db_client=tx),
-            )
-    else:
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Organization asset-access mutation requires transaction support",
+        )
+    async with db.tx() as tx:
         await _apply_asset_access(
-            db,
-            callable_repository=_callable_target_binding_repository_for_request(request),
-            access_group_repository=_callable_target_access_group_repository_for_request(request),
-            route_repository=_route_group_repository_for_request(request),
+            tx,
+            callable_repository=_callable_target_binding_repository_for_request(
+                request, db_client=tx
+            ),
+            access_group_repository=_callable_target_access_group_repository_for_request(
+                request, db_client=tx
+            ),
+            route_repository=_route_group_repository_for_request(request, db_client=tx),
         )
     await reload_callable_target_grants(request)
     response = await build_scope_asset_access(
@@ -1333,10 +1339,22 @@ async def update_organization_asset_access(
 @router.post(
     "/ui/api/organizations",
     dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+    response_model=OrganizationResponse,
 )
-async def create_organization(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
+async def create_organization(
+    request: Request,
+    payload: dict[str, Any],
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
+) -> dict[str, Any]:
     request_start = perf_counter()
     db = db_or_503(request)
+    scope = get_auth_scope(
+        request,
+        authorization,
+        x_master_key,
+        required_permission=Permission.PLATFORM_ADMIN,
+    )
     tier_policy_mode = get_tier_policy_mode_from_app(request.app)
     organization_id = str(payload.get("organization_id") or "").strip()
     if not organization_id:
@@ -1442,7 +1460,6 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
         )
     _validate_route_group_callable_target_overlap(route_group_bindings, callable_target_bindings)
     route_repo = _route_group_repository_for_request(request)
-    callable_binding_repo = _callable_target_binding_repository_for_request(request)
     catalog = callable_catalog(request)
     await _validate_org_route_group_binding_payloads(
         route_repo, binding_payloads=route_group_bindings
@@ -1465,6 +1482,17 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
             )
 
     async def _apply_create(db_client: Any, *, route_repository, callable_repository):  # noqa: ANN001, ANN202
+        current_rows = await db_client.query_raw(
+            """
+            SELECT organization_id
+            FROM deltallm_organizationtable
+            WHERE organization_id = $1
+            LIMIT 1
+            """,
+            organization_id,
+        )
+        if current_rows:
+            await require_active_organization_mutation(db_client, organization_id)
         persisted_organization = await OrganizationAdminRepository(db_client).upsert(
             OrganizationPersistenceValues(
                 organization_id=organization_id,
@@ -1561,30 +1589,23 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
         )
 
     try:
-        if hasattr(db, "tx"):
-            async with db.tx() as tx:
-                (
-                    response,
-                    primary_tier_assignment,
-                    scheduled_cache_invalidation,
-                    shadow_access_mirrored,
-                ) = await _apply_create(
-                    tx,
-                    route_repository=_route_group_repository_for_request(request, db_client=tx),
-                    callable_repository=_callable_target_binding_repository_for_request(
-                        request, db_client=tx
-                    ),
-                )
-        else:
+        if not hasattr(db, "tx"):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Organization mutation requires transaction support",
+            )
+        async with db.tx() as tx:
             (
                 response,
                 primary_tier_assignment,
                 scheduled_cache_invalidation,
                 shadow_access_mirrored,
             ) = await _apply_create(
-                db,
-                route_repository=route_repo,
-                callable_repository=callable_binding_repo,
+                tx,
+                route_repository=_route_group_repository_for_request(request, db_client=tx),
+                callable_repository=_callable_target_binding_repository_for_request(
+                    request, db_client=tx
+                ),
             )
     except ValueError as exc:
         if primary_tier_fields is not None:
@@ -1606,6 +1627,7 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
         assignment_rows=[],
         tier_policy_mode=tier_policy_mode,
     )
+    response["capabilities"] = build_organization_capabilities(scope, response)
     if primary_tier_assignment is not None and scheduled_cache_invalidation is not None:
         cache_invalidation_service = getattr(request.app.state, "cache_invalidation_service", None)
         await apply_best_effort_org_cache_invalidation(
@@ -1664,6 +1686,7 @@ async def create_organization(request: Request, payload: dict[str, Any]) -> dict
 @router.put(
     "/ui/api/organizations/{organization_id}",
     dependencies=[Depends(require_admin_permission(Permission.ORG_UPDATE))],
+    response_model=OrganizationResponse,
 )
 async def update_organization(
     request: Request,
@@ -1683,7 +1706,7 @@ async def update_organization(
     )
     rows = await db.query_raw(
         """
-        SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
+        SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, lifecycle_state, deletion_requested_at, deletion_not_before_at, created_at, updated_at
         FROM deltallm_organizationtable
         WHERE organization_id = $1
         LIMIT 1
@@ -1777,7 +1800,6 @@ async def update_organization(
             detail="Only platform admins can update asset bootstrap bindings",
         )
     route_repo = _route_group_repository_for_request(request)
-    callable_binding_repo = _callable_target_binding_repository_for_request(request)
     catalog = callable_catalog(request)
     if route_group_bindings is not None:
         await _validate_org_route_group_binding_payloads(
@@ -1804,6 +1826,7 @@ async def update_organization(
     )
 
     async def _apply_update(db_client: Any, *, route_repository, callable_repository):  # noqa: ANN001, ANN202
+        await require_active_organization_mutation(db_client, organization_id)
         updated_organization = await OrganizationAdminRepository(db_client).update(
             OrganizationPersistenceValues(
                 organization_id=organization_id,
@@ -1860,20 +1883,18 @@ async def update_organization(
             )
         return updated_payload
 
-    if hasattr(db, "tx"):
-        async with db.tx() as tx:
-            updated = await _apply_update(
-                tx,
-                route_repository=_route_group_repository_for_request(request, db_client=tx),
-                callable_repository=_callable_target_binding_repository_for_request(
-                    request, db_client=tx
-                ),
-            )
-    else:
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Organization mutation requires transaction support",
+        )
+    async with db.tx() as tx:
         updated = await _apply_update(
-            db,
-            route_repository=route_repo,
-            callable_repository=callable_binding_repo,
+            tx,
+            route_repository=_route_group_repository_for_request(request, db_client=tx),
+            callable_repository=_callable_target_binding_repository_for_request(
+                request, db_client=tx
+            ),
         )
     if route_group_bindings is not None or callable_target_bindings is not None:
         await reload_callable_target_grants(request)
@@ -2053,28 +2074,35 @@ async def add_organization_member(
     if not account_rows:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
 
-    await db.execute_raw(
-        """
-        INSERT INTO deltallm_organizationmembership (membership_id, account_id, organization_id, role, created_at, updated_at)
-        VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
-        ON CONFLICT (account_id, organization_id)
-        DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
-        """,
-        account_id,
-        organization_id,
-        role,
-    )
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Organization membership mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        await require_active_organization_mutation(tx, organization_id)
+        await tx.execute_raw(
+            """
+            INSERT INTO deltallm_organizationmembership (membership_id, account_id, organization_id, role, created_at, updated_at)
+            VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
+            ON CONFLICT (account_id, organization_id)
+            DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
+            """,
+            account_id,
+            organization_id,
+            role,
+        )
 
-    rows = await db.query_raw(
-        """
-        SELECT membership_id, account_id, organization_id, role, created_at, updated_at
-        FROM deltallm_organizationmembership
-        WHERE account_id = $1 AND organization_id = $2
-        LIMIT 1
-        """,
-        account_id,
-        organization_id,
-    )
+        rows = await tx.query_raw(
+            """
+            SELECT membership_id, account_id, organization_id, role, created_at, updated_at
+            FROM deltallm_organizationmembership
+            WHERE account_id = $1 AND organization_id = $2
+            LIMIT 1
+            """,
+            account_id,
+            organization_id,
+        )
     if not rows:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="membership upsert failed"
@@ -2101,38 +2129,47 @@ async def remove_organization_member(
 ) -> dict[str, Any]:
     request_start = perf_counter()
     db = db_or_503(request)
-    rows = await db.query_raw(
-        """
-        SELECT membership_id, account_id
-        FROM deltallm_organizationmembership
-        WHERE membership_id = $1 AND organization_id = $2
-        LIMIT 1
-        """,
-        membership_id,
-        organization_id,
-    )
-    if not rows:
+    if not hasattr(db, "tx"):
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Organization membership not found"
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Organization membership mutation requires transaction support",
         )
-    account_id = rows[0].get("account_id")
-    removed_team_memberships = await db.execute_raw(
-        """
-        DELETE FROM deltallm_teammembership
-        WHERE account_id = $1
-          AND team_id IN (
-            SELECT team_id
-            FROM deltallm_teamtable
-            WHERE organization_id = $2
-          )
-        """,
-        account_id,
-        organization_id,
-    )
-    deleted = await db.execute_raw(
-        "DELETE FROM deltallm_organizationmembership WHERE membership_id = $1",
-        membership_id,
-    )
+    async with db.tx() as tx:
+        await require_active_organization_mutation(tx, organization_id)
+        rows = await tx.query_raw(
+            """
+            SELECT membership_id, account_id
+            FROM deltallm_organizationmembership
+            WHERE membership_id = $1 AND organization_id = $2
+            LIMIT 1
+            FOR UPDATE
+            """,
+            membership_id,
+            organization_id,
+        )
+        if not rows:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Organization membership not found",
+            )
+        account_id = rows[0].get("account_id")
+        removed_team_memberships = await tx.execute_raw(
+            """
+            DELETE FROM deltallm_teammembership
+            WHERE account_id = $1
+              AND team_id IN (
+                SELECT team_id
+                FROM deltallm_teamtable
+                WHERE organization_id = $2
+              )
+            """,
+            account_id,
+            organization_id,
+        )
+        deleted = await tx.execute_raw(
+            "DELETE FROM deltallm_organizationmembership WHERE membership_id = $1",
+            membership_id,
+        )
     response = {
         "deleted": int(deleted or 0) > 0,
         "team_memberships_removed": int(removed_team_memberships or 0),

--- a/src/api/admin/endpoints/rbac.py
+++ b/src/api/admin/endpoints/rbac.py
@@ -6,9 +6,19 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
-from src.auth.roles import Permission, PlatformRole, validate_organization_role, validate_platform_role, validate_team_role
+from src.auth.roles import (
+    Permission,
+    PlatformRole,
+    validate_organization_role,
+    validate_platform_role,
+    validate_team_role,
+)
 from src.audit import AuditAction
 from src.api.admin.endpoints.common import db_or_503, emit_admin_mutation_audit, to_json_value
+from src.api.admin.organization_mutations import (
+    require_active_organization_mutation,
+    require_active_organization_mutations,
+)
 from src.middleware.admin import require_admin_permission
 from src.services.access_provisioning_service import AccessProvisioningService
 
@@ -44,12 +54,17 @@ def _self_registration_account_metadata(metadata: Any) -> dict[str, Any]:
     registration = metadata_obj.get(_ACCOUNT_SELF_REGISTRATION_METADATA_KEY)
     if not isinstance(registration, dict):
         return {}
-    if registration.get("source") != _SELF_REGISTRATION_SOURCE or registration.get("registered") is not True:
+    if (
+        registration.get("source") != _SELF_REGISTRATION_SOURCE
+        or registration.get("registered") is not True
+    ):
         return {}
     return registration
 
 
-def _empty_self_registration_payload(account_metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+def _empty_self_registration_payload(
+    account_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     registration = account_metadata or {}
     return {
         "is_self_registered": bool(registration),
@@ -70,8 +85,10 @@ def _merge_account_self_registration(
 
     return {
         **runtime_payload,
-        "is_self_registered": bool(account_metadata) or bool(runtime_payload.get("is_self_registered")),
-        "sandbox_team_id": runtime_payload.get("sandbox_team_id") or account_metadata.get("default_team_id"),
+        "is_self_registered": bool(account_metadata)
+        or bool(runtime_payload.get("is_self_registered")),
+        "sandbox_team_id": runtime_payload.get("sandbox_team_id")
+        or account_metadata.get("default_team_id"),
         "sandbox_organization_id": runtime_payload.get("sandbox_organization_id")
         or account_metadata.get("default_organization_id"),
     }
@@ -133,13 +150,18 @@ def _runtime_user_context(row: dict[str, Any]) -> dict[str, Any]:
             "seeded_team": team_default,
             "seeded_organization": organization_default,
             "sandbox_team_id": item.get("team_id") if team_default else None,
-            "sandbox_organization_id": item.get("organization_id") if organization_default else None,
+            "sandbox_organization_id": item.get("organization_id")
+            if organization_default
+            else None,
         },
         "self_service_policy": _self_service_policy_payload(item),
     }
 
 
-@router.get("/ui/api/rbac/accounts", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.get(
+    "/ui/api/rbac/accounts",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def list_rbac_accounts(request: Request) -> list[dict[str, Any]]:
     db = db_or_503(request)
     rows = await db.query_raw(
@@ -152,7 +174,10 @@ async def list_rbac_accounts(request: Request) -> list[dict[str, Any]]:
     return [to_json_value(dict(row)) for row in rows]
 
 
-@router.get("/ui/api/principals", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.get(
+    "/ui/api/principals",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def list_principals(
     request: Request,
     search: str | None = Query(default=None),
@@ -164,7 +189,9 @@ async def list_principals(
     params: list[Any] = []
     if search and search.strip():
         params.append(f"%{search.strip()}%")
-        clauses.append(f"(email ILIKE ${len(params)} OR role ILIKE ${len(params)} OR account_id::text ILIKE ${len(params)})")
+        clauses.append(
+            f"(email ILIKE ${len(params)} OR role ILIKE ${len(params)} OR account_id::text ILIKE ${len(params)})"
+        )
     where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
 
     count_rows = await db.query_raw(
@@ -185,11 +212,18 @@ async def list_principals(
         """,
         *page_params,
     )
-    account_ids = [str(row.get("account_id") or "") for row in account_rows if row.get("account_id")]
+    account_ids = [
+        str(row.get("account_id") or "") for row in account_rows if row.get("account_id")
+    ]
     if not account_ids:
         return {
             "data": [],
-            "pagination": {"total": total, "limit": limit, "offset": offset, "has_more": offset + limit < total},
+            "pagination": {
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+                "has_more": offset + limit < total,
+            },
         }
 
     account_ph = ", ".join(f"${i + 1}" for i in range(len(account_ids)))
@@ -229,7 +263,9 @@ async def list_principals(
             continue
         placeholder_index = len(runtime_params) + 1
         runtime_params.extend([account_id, str(row.get("email") or "").strip().lower()])
-        runtime_account_values.append(f"(${placeholder_index}::text, ${placeholder_index + 1}::text)")
+        runtime_account_values.append(
+            f"(${placeholder_index}::text, ${placeholder_index + 1}::text)"
+        )
 
     runtime_user_rows = await db.query_raw(
         f"""
@@ -341,7 +377,9 @@ async def list_principals(
         principals.append(
             {
                 **base,
-                "runtime_user_id": runtime_user.get("user_id") if isinstance(runtime_user, dict) else None,
+                "runtime_user_id": runtime_user.get("user_id")
+                if isinstance(runtime_user, dict)
+                else None,
                 "runtime_user": runtime_user,
                 "self_registration": self_registration,
                 "self_service_policy": runtime_context.get("self_service_policy")
@@ -354,11 +392,19 @@ async def list_principals(
 
     return {
         "data": principals,
-        "pagination": {"total": total, "limit": limit, "offset": offset, "has_more": offset + limit < total},
+        "pagination": {
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + limit < total,
+        },
     }
 
 
-@router.get("/ui/api/principals/summary", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.get(
+    "/ui/api/principals/summary",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def principals_summary(request: Request) -> dict[str, int]:
     db = db_or_503(request)
     rows = await db.query_raw(
@@ -391,13 +437,18 @@ async def principals_summary(request: Request) -> dict[str, int]:
     }
 
 
-@router.post("/ui/api/rbac/accounts", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.post(
+    "/ui/api/rbac/accounts",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def upsert_rbac_account(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
     request_start = perf_counter()
     db = db_or_503(request)
     service = getattr(request.app.state, "platform_identity_service", None)
     if service is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Auth service unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Auth service unavailable"
+        )
 
     email = str(payload.get("email") or "").strip().lower()
     if not email:
@@ -436,11 +487,18 @@ async def upsert_rbac_account(request: Request, payload: dict[str, Any]) -> dict
         )
         if rows:
             try:
-                updated = await service.admin_set_password(account_id=rows[0]["account_id"], new_password=password)
+                updated = await service.admin_set_password(
+                    account_id=rows[0]["account_id"], new_password=password
+                )
             except ValueError as exc:
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+                ) from exc
             if not updated:
-                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="failed to set account password")
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="failed to set account password",
+                )
 
     rows = await db.query_raw(
         """
@@ -452,7 +510,9 @@ async def upsert_rbac_account(request: Request, payload: dict[str, Any]) -> dict
         email,
     )
     if not rows:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="account upsert failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="account upsert failed"
+        )
     response = to_json_value(dict(rows[0]))
     await emit_admin_mutation_audit(
         request=request,
@@ -466,18 +526,26 @@ async def upsert_rbac_account(request: Request, payload: dict[str, Any]) -> dict
     return response
 
 
-@router.post("/ui/api/rbac/provision", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.post(
+    "/ui/api/rbac/provision",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def provision_person(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
     request_start = perf_counter()
     db = db_or_503(request)
     identity_service = getattr(request.app.state, "platform_identity_service", None)
     invitation_service = getattr(request.app.state, "invitation_service", None)
     if identity_service is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Provisioning service unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Provisioning service unavailable",
+        )
 
     mode = str(payload.get("mode") or "").strip()
     if mode == "invite_email" and invitation_service is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable"
+        )
 
     service = AccessProvisioningService(
         db_client=db,
@@ -489,26 +557,41 @@ async def provision_person(request: Request, payload: dict[str, Any]) -> dict[st
         response = await service.provision_person(
             email=str(payload.get("email") or ""),
             mode=mode,
-            platform_role=str(payload.get("platform_role") or payload.get("role") or PlatformRole.ORG_USER),
+            platform_role=str(
+                payload.get("platform_role") or payload.get("role") or PlatformRole.ORG_USER
+            ),
             password=str(payload.get("password") or "") or None,
             is_active=bool(payload.get("is_active", True)),
             organization_id=str(payload.get("organization_id") or "").strip() or None,
             organization_role=str(payload.get("organization_role") or "") or None,
             team_id=str(payload.get("team_id") or "").strip() or None,
             team_role=str(payload.get("team_role") or "") or None,
-            invited_by_account_id=getattr(getattr(request.state, "platform_auth", None), "account_id", None),
+            invited_by_account_id=getattr(
+                getattr(request.state, "platform_auth", None), "account_id", None
+            ),
         )
     except ValueError as exc:
         detail = str(exc)
-        status_code = status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        status_code = (
+            status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        )
         raise HTTPException(status_code=status_code, detail=detail) from exc
     except RuntimeError as exc:
         if "invitation service unavailable" in str(exc):
-            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invitation service unavailable") from exc
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Provisioning failed") from exc
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Invitation service unavailable",
+            ) from exc
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Provisioning failed"
+        ) from exc
 
     mode = str(response.get("mode") or "")
-    action = AuditAction.ADMIN_INVITATION_CREATE if mode == "invite_email" else AuditAction.ADMIN_RBAC_ACCOUNT_UPSERT
+    action = (
+        AuditAction.ADMIN_INVITATION_CREATE
+        if mode == "invite_email"
+        else AuditAction.ADMIN_RBAC_ACCOUNT_UPSERT
+    )
     resource_type = "invitation" if mode == "invite_email" else "platform_account"
     resource_id = str(response.get("invitation_id") or response.get("account_id") or "")
     await emit_admin_mutation_audit(
@@ -523,28 +606,69 @@ async def provision_person(request: Request, payload: dict[str, Any]) -> dict[st
     return response
 
 
-@router.delete("/ui/api/rbac/accounts/{account_id}", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.delete(
+    "/ui/api/rbac/accounts/{account_id}",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def delete_rbac_account(request: Request, account_id: str) -> dict[str, bool]:
     request_start = perf_counter()
     db = db_or_503(request)
-    existing = await db.query_raw(
-        """
-        SELECT account_id, email, role, is_active
-        FROM deltallm_platformaccount
-        WHERE account_id = $1
-        LIMIT 1
-        """,
-        account_id,
-    )
-    if not existing:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="RBAC mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        existing = await tx.query_raw(
+            """
+            SELECT account_id, email, role, is_active
+            FROM deltallm_platformaccount
+            WHERE account_id = $1
+            LIMIT 1
+            FOR UPDATE
+            """,
+            account_id,
+        )
+        if not existing:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+        organization_rows = await tx.query_raw(
+            """
+            SELECT DISTINCT organization_id
+            FROM (
+                SELECT organization_id
+                FROM deltallm_organizationmembership
+                WHERE account_id = $1
+                UNION
+                SELECT t.organization_id
+                FROM deltallm_teammembership tm
+                JOIN deltallm_teamtable t ON t.team_id = tm.team_id
+                WHERE tm.account_id = $1
+            ) account_organizations
+            WHERE organization_id IS NOT NULL
+            """,
+            account_id,
+        )
+        await require_active_organization_mutations(
+            tx,
+            {str(row.get("organization_id") or "") for row in organization_rows},
+        )
 
-    # Manual delete order keeps behavior deterministic regardless of FK cascade configuration.
-    await db.execute_raw("DELETE FROM deltallm_teammembership WHERE account_id = $1", account_id)
-    await db.execute_raw("DELETE FROM deltallm_organizationmembership WHERE account_id = $1", account_id)
-    await db.execute_raw("DELETE FROM deltallm_platformsession WHERE account_id = $1", account_id)
-    await db.execute_raw("DELETE FROM deltallm_platformidentity WHERE account_id = $1", account_id)
-    deleted = await db.execute_raw("DELETE FROM deltallm_platformaccount WHERE account_id = $1", account_id)
+        # Manual delete order keeps behavior deterministic regardless of FK cascade configuration.
+        await tx.execute_raw(
+            "DELETE FROM deltallm_teammembership WHERE account_id = $1", account_id
+        )
+        await tx.execute_raw(
+            "DELETE FROM deltallm_organizationmembership WHERE account_id = $1", account_id
+        )
+        await tx.execute_raw(
+            "DELETE FROM deltallm_platformsession WHERE account_id = $1", account_id
+        )
+        await tx.execute_raw(
+            "DELETE FROM deltallm_platformidentity WHERE account_id = $1", account_id
+        )
+        deleted = await tx.execute_raw(
+            "DELETE FROM deltallm_platformaccount WHERE account_id = $1", account_id
+        )
     response = {"deleted": int(deleted or 0) > 0}
     await emit_admin_mutation_audit(
         request=request,
@@ -558,8 +682,13 @@ async def delete_rbac_account(request: Request, account_id: str) -> dict[str, bo
     return response
 
 
-@router.get("/ui/api/rbac/organization-memberships", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
-async def list_org_memberships(request: Request, account_id: str | None = None) -> list[dict[str, Any]]:
+@router.get(
+    "/ui/api/rbac/organization-memberships",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
+async def list_org_memberships(
+    request: Request, account_id: str | None = None
+) -> list[dict[str, Any]]:
     db = db_or_503(request)
     if account_id:
         rows = await db.query_raw(
@@ -582,7 +711,10 @@ async def list_org_memberships(request: Request, account_id: str | None = None) 
     return [to_json_value(dict(row)) for row in rows]
 
 
-@router.post("/ui/api/rbac/organization-memberships", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.post(
+    "/ui/api/rbac/organization-memberships",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def upsert_org_membership(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
     request_start = perf_counter()
     db = db_or_503(request)
@@ -595,39 +727,55 @@ async def upsert_org_membership(request: Request, payload: dict[str, Any]) -> di
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="organization_id is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="organization_id is required"
+        )
 
     if not account_id and email:
-        rows = await db.query_raw("SELECT account_id FROM deltallm_platformaccount WHERE lower(email)=lower($1) LIMIT 1", email)
+        rows = await db.query_raw(
+            "SELECT account_id FROM deltallm_platformaccount WHERE lower(email)=lower($1) LIMIT 1",
+            email,
+        )
         if rows:
             account_id = rows[0].get("account_id")
     if not account_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="account_id or known email is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="account_id or known email is required"
+        )
 
-    await db.execute_raw(
-        """
-        INSERT INTO deltallm_organizationmembership (membership_id, account_id, organization_id, role, created_at, updated_at)
-        VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
-        ON CONFLICT (account_id, organization_id)
-        DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
-        """,
-        account_id,
-        organization_id,
-        role,
-    )
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Organization membership mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        await require_active_organization_mutation(tx, organization_id)
+        await tx.execute_raw(
+            """
+            INSERT INTO deltallm_organizationmembership (membership_id, account_id, organization_id, role, created_at, updated_at)
+            VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
+            ON CONFLICT (account_id, organization_id)
+            DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
+            """,
+            account_id,
+            organization_id,
+            role,
+        )
 
-    rows = await db.query_raw(
-        """
-        SELECT membership_id, account_id, organization_id, role, created_at, updated_at
-        FROM deltallm_organizationmembership
-        WHERE account_id = $1 AND organization_id = $2
-        LIMIT 1
-        """,
-        account_id,
-        organization_id,
-    )
+        rows = await tx.query_raw(
+            """
+            SELECT membership_id, account_id, organization_id, role, created_at, updated_at
+            FROM deltallm_organizationmembership
+            WHERE account_id = $1 AND organization_id = $2
+            LIMIT 1
+            """,
+            account_id,
+            organization_id,
+        )
     if not rows:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="membership upsert failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="membership upsert failed"
+        )
     response = to_json_value(dict(rows[0]))
     await emit_admin_mutation_audit(
         request=request,
@@ -641,43 +789,56 @@ async def upsert_org_membership(request: Request, payload: dict[str, Any]) -> di
     return response
 
 
-@router.delete("/ui/api/rbac/organization-memberships/{membership_id}", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.delete(
+    "/ui/api/rbac/organization-memberships/{membership_id}",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def delete_org_membership(request: Request, membership_id: str) -> dict[str, Any]:
     request_start = perf_counter()
     db = db_or_503(request)
-    existing_rows = await db.query_raw(
-        """
-        SELECT membership_id, account_id, organization_id, role, created_at, updated_at
-        FROM deltallm_organizationmembership
-        WHERE membership_id = $1
-        LIMIT 1
-        """,
-        membership_id,
-    )
-    if not existing_rows:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization membership not found")
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Organization membership mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        existing_rows = await tx.query_raw(
+            """
+            SELECT membership_id, account_id, organization_id, role, created_at, updated_at
+            FROM deltallm_organizationmembership
+            WHERE membership_id = $1
+            LIMIT 1
+            FOR UPDATE
+            """,
+            membership_id,
+        )
+        if not existing_rows:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Organization membership not found"
+            )
 
-    existing = dict(existing_rows[0])
-    account_id = str(existing.get("account_id") or "")
-    organization_id = str(existing.get("organization_id") or "")
-    removed_team_memberships = await db.execute_raw(
-        """
-        DELETE FROM deltallm_teammembership
-        WHERE account_id = $1
-          AND team_id IN (
-            SELECT team_id
-            FROM deltallm_teamtable
-            WHERE organization_id = $2
-          )
-        """,
-        account_id,
-        organization_id,
-    )
+        existing = dict(existing_rows[0])
+        account_id = str(existing.get("account_id") or "")
+        organization_id = str(existing.get("organization_id") or "")
+        await require_active_organization_mutation(tx, organization_id)
+        removed_team_memberships = await tx.execute_raw(
+            """
+            DELETE FROM deltallm_teammembership
+            WHERE account_id = $1
+              AND team_id IN (
+                SELECT team_id
+                FROM deltallm_teamtable
+                WHERE organization_id = $2
+              )
+            """,
+            account_id,
+            organization_id,
+        )
 
-    deleted = await db.execute_raw(
-        "DELETE FROM deltallm_organizationmembership WHERE membership_id = $1",
-        membership_id,
-    )
+        deleted = await tx.execute_raw(
+            "DELETE FROM deltallm_organizationmembership WHERE membership_id = $1",
+            membership_id,
+        )
     response = {
         "deleted": int(deleted or 0) > 0,
         "team_memberships_removed": int(removed_team_memberships or 0),
@@ -694,8 +855,13 @@ async def delete_org_membership(request: Request, membership_id: str) -> dict[st
     return response
 
 
-@router.get("/ui/api/rbac/team-memberships", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
-async def list_team_memberships(request: Request, account_id: str | None = None) -> list[dict[str, Any]]:
+@router.get(
+    "/ui/api/rbac/team-memberships",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
+async def list_team_memberships(
+    request: Request, account_id: str | None = None
+) -> list[dict[str, Any]]:
     db = db_or_503(request)
     if account_id:
         rows = await db.query_raw(
@@ -718,7 +884,10 @@ async def list_team_memberships(request: Request, account_id: str | None = None)
     return [to_json_value(dict(row)) for row in rows]
 
 
-@router.post("/ui/api/rbac/team-memberships", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.post(
+    "/ui/api/rbac/team-memberships",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def upsert_team_membership(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
     request_start = perf_counter()
     db = db_or_503(request)
@@ -734,65 +903,82 @@ async def upsert_team_membership(request: Request, payload: dict[str, Any]) -> d
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="team_id is required")
 
     if not account_id and email:
-        rows = await db.query_raw("SELECT account_id FROM deltallm_platformaccount WHERE lower(email)=lower($1) LIMIT 1", email)
+        rows = await db.query_raw(
+            "SELECT account_id FROM deltallm_platformaccount WHERE lower(email)=lower($1) LIMIT 1",
+            email,
+        )
         if rows:
             account_id = rows[0].get("account_id")
     if not account_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="account_id or known email is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="account_id or known email is required"
+        )
 
-    account_rows = await db.query_raw(
-        "SELECT account_id FROM deltallm_platformaccount WHERE account_id = $1 LIMIT 1",
-        account_id,
-    )
-    if not account_rows:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Team membership mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        account_rows = await tx.query_raw(
+            "SELECT account_id FROM deltallm_platformaccount WHERE account_id = $1 LIMIT 1",
+            account_id,
+        )
+        if not account_rows:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
 
-    team_rows = await db.query_raw(
-        "SELECT team_id, organization_id FROM deltallm_teamtable WHERE team_id = $1 LIMIT 1",
-        team_id,
-    )
-    if not team_rows:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+        team_rows = await tx.query_raw(
+            "SELECT team_id, organization_id FROM deltallm_teamtable WHERE team_id = $1 LIMIT 1 FOR SHARE",
+            team_id,
+        )
+        if not team_rows:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
 
-    organization_id = team_rows[0].get("organization_id")
-    if organization_id:
-        org_membership_rows = await db.query_raw(
+        organization_id = str(team_rows[0].get("organization_id") or "").strip()
+        if organization_id:
+            await require_active_organization_mutation(tx, organization_id)
+            org_membership_rows = await tx.query_raw(
+                """
+                SELECT membership_id
+                FROM deltallm_organizationmembership
+                WHERE account_id = $1 AND organization_id = $2
+                LIMIT 1
+                """,
+                account_id,
+                organization_id,
+            )
+            if not org_membership_rows:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Account must be a member of the team's organization",
+                )
+
+        await tx.execute_raw(
             """
-            SELECT membership_id
-            FROM deltallm_organizationmembership
-            WHERE account_id = $1 AND organization_id = $2
+            INSERT INTO deltallm_teammembership (membership_id, account_id, team_id, role, created_at, updated_at)
+            VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
+            ON CONFLICT (account_id, team_id)
+            DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
+            """,
+            account_id,
+            team_id,
+            role,
+        )
+
+        rows = await tx.query_raw(
+            """
+            SELECT membership_id, account_id, team_id, role, created_at, updated_at
+            FROM deltallm_teammembership
+            WHERE account_id = $1 AND team_id = $2
             LIMIT 1
             """,
             account_id,
-            organization_id,
+            team_id,
         )
-        if not org_membership_rows:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Account must be a member of the team's organization")
-
-    await db.execute_raw(
-        """
-        INSERT INTO deltallm_teammembership (membership_id, account_id, team_id, role, created_at, updated_at)
-        VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
-        ON CONFLICT (account_id, team_id)
-        DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
-        """,
-        account_id,
-        team_id,
-        role,
-    )
-
-    rows = await db.query_raw(
-        """
-        SELECT membership_id, account_id, team_id, role, created_at, updated_at
-        FROM deltallm_teammembership
-        WHERE account_id = $1 AND team_id = $2
-        LIMIT 1
-        """,
-        account_id,
-        team_id,
-    )
     if not rows:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="membership upsert failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="membership upsert failed"
+        )
     response = to_json_value(dict(rows[0]))
     await emit_admin_mutation_audit(
         request=request,
@@ -806,14 +992,41 @@ async def upsert_team_membership(request: Request, payload: dict[str, Any]) -> d
     return response
 
 
-@router.delete("/ui/api/rbac/team-memberships/{membership_id}", dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))])
+@router.delete(
+    "/ui/api/rbac/team-memberships/{membership_id}",
+    dependencies=[Depends(require_admin_permission(Permission.PLATFORM_ADMIN))],
+)
 async def delete_team_membership(request: Request, membership_id: str) -> dict[str, bool]:
     request_start = perf_counter()
     db = db_or_503(request)
-    deleted = await db.execute_raw(
-        "DELETE FROM deltallm_teammembership WHERE membership_id = $1",
-        membership_id,
-    )
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Team membership mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        existing_rows = await tx.query_raw(
+            """
+            SELECT tm.membership_id, t.organization_id
+            FROM deltallm_teammembership tm
+            JOIN deltallm_teamtable t ON t.team_id = tm.team_id
+            WHERE tm.membership_id = $1
+            FOR UPDATE OF tm
+            FOR SHARE OF t
+            """,
+            membership_id,
+        )
+        if existing_rows:
+            await require_active_organization_mutation(
+                tx,
+                str(existing_rows[0].get("organization_id") or ""),
+            )
+            deleted = await tx.execute_raw(
+                "DELETE FROM deltallm_teammembership WHERE membership_id = $1",
+                membership_id,
+            )
+        else:
+            deleted = 0
     response = {"deleted": int(deleted or 0) > 0}
     await emit_admin_mutation_audit(
         request=request,

--- a/src/api/admin/endpoints/service_accounts.py
+++ b/src/api/admin/endpoints/service_accounts.py
@@ -8,7 +8,13 @@ from fastapi import APIRouter, Header, HTTPException, Query, Request, status
 
 from src.auth.roles import Permission
 from src.audit.actions import AuditAction
-from src.api.admin.endpoints.common import db_or_503, emit_admin_mutation_audit, get_auth_scope, to_json_value
+from src.api.admin.endpoints.common import (
+    db_or_503,
+    emit_admin_mutation_audit,
+    get_auth_scope,
+    to_json_value,
+)
+from src.api.admin.organization_mutations import require_active_organization_mutation
 from src.middleware.platform_auth import get_platform_auth_context
 
 router = APIRouter(tags=["Admin Service Accounts"])
@@ -33,7 +39,10 @@ async def _validate_team_access(scope: Any, db: Any, team_id: str) -> dict[str, 
 
     organization_id = str(team.get("organization_id") or "")
     if not organization_id or organization_id not in scope.org_ids:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only manage service accounts for teams in your organizations")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only manage service accounts for teams in your organizations",
+        )
     return team
 
 
@@ -47,7 +56,9 @@ async def list_service_accounts(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.KEY_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.KEY_READ
+    )
     db = db_or_503(request)
 
     clauses: list[str] = []
@@ -59,7 +70,10 @@ async def list_service_accounts(
             params.extend(scope.org_ids)
             clauses.append(f"t.organization_id IN ({placeholders})")
         else:
-            return {"data": [], "pagination": {"total": 0, "limit": limit, "offset": offset, "has_more": False}}
+            return {
+                "data": [],
+                "pagination": {"total": 0, "limit": limit, "offset": offset, "has_more": False},
+            }
 
     if team_id:
         params.append(team_id)
@@ -67,7 +81,9 @@ async def list_service_accounts(
 
     if search:
         params.append(f"%{search.strip()}%")
-        clauses.append(f"(sa.name ILIKE ${len(params)} OR sa.service_account_id ILIKE ${len(params)})")
+        clauses.append(
+            f"(sa.name ILIKE ${len(params)} OR sa.service_account_id ILIKE ${len(params)})"
+        )
 
     where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
 
@@ -107,7 +123,12 @@ async def list_service_accounts(
 
     return {
         "data": [to_json_value(dict(row)) for row in rows],
-        "pagination": {"total": total, "limit": limit, "offset": offset, "has_more": offset + limit < total},
+        "pagination": {
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + limit < total,
+        },
     }
 
 
@@ -119,7 +140,9 @@ async def create_service_account(
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
     request_start = perf_counter()
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.TEAM_UPDATE)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.TEAM_UPDATE
+    )
     db = db_or_503(request)
 
     team_id = str(payload.get("team_id") or "").strip()
@@ -132,36 +155,51 @@ async def create_service_account(
     if not name:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="name is required")
 
-    team = await _validate_team_access(scope, db, team_id)
-    existing = await db.query_raw(
-        """
-        SELECT service_account_id
-        FROM deltallm_serviceaccount
-        WHERE team_id = $1 AND lower(name) = lower($2)
-        LIMIT 1
-        """,
-        team_id,
-        name,
-    )
-    if existing:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="A service account with this name already exists in the selected team")
-
     ctx = get_platform_auth_context(request)
     created_by_account_id = getattr(ctx, "account_id", None)
-
-    await db.execute_raw(
-        """
-        INSERT INTO deltallm_serviceaccount (
-            service_account_id, team_id, name, description, is_active, metadata, created_by_account_id, created_at, updated_at
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service-account mutation requires transaction support",
         )
-        VALUES ($1, $2, $3, $4, true, '{}'::jsonb, $5, NOW(), NOW())
-        """,
-        service_account_id,
-        team_id,
-        name,
-        description,
-        created_by_account_id,
-    )
+    async with db.tx() as tx:
+        team = await _validate_team_access(scope, tx, team_id)
+        organization_id = str(team.get("organization_id") or "").strip()
+        if not organization_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Team organization is not configured",
+            )
+        await require_active_organization_mutation(tx, organization_id)
+        existing = await tx.query_raw(
+            """
+            SELECT service_account_id
+            FROM deltallm_serviceaccount
+            WHERE team_id = $1 AND lower(name) = lower($2)
+            LIMIT 1
+            """,
+            team_id,
+            name,
+        )
+        if existing:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=("A service account with this name already exists in the selected team"),
+            )
+
+        await tx.execute_raw(
+            """
+            INSERT INTO deltallm_serviceaccount (
+                service_account_id, team_id, name, description, is_active, metadata, created_by_account_id, created_at, updated_at
+            )
+            VALUES ($1, $2, $3, $4, true, '{}'::jsonb, $5, NOW(), NOW())
+            """,
+            service_account_id,
+            team_id,
+            name,
+            description,
+            created_by_account_id,
+        )
 
     response = {
         "service_account_id": service_account_id,

--- a/src/api/admin/endpoints/teams.py
+++ b/src/api/admin/endpoints/teams.py
@@ -7,7 +7,13 @@ from typing import Any
 
 from fastapi import APIRouter, Header, HTTPException, Query, Request, status
 
-from src.auth.roles import Permission, ORG_ROLE_PERMISSIONS, TEAM_ROLE_PERMISSIONS, TeamRole, validate_team_role
+from src.auth.roles import (
+    Permission,
+    ORG_ROLE_PERMISSIONS,
+    TEAM_ROLE_PERMISSIONS,
+    TeamRole,
+    validate_team_role,
+)
 from src.audit import AuditAction
 from src.api.admin.endpoints.common import (
     AuthScope,
@@ -18,15 +24,35 @@ from src.api.admin.endpoints.common import (
     to_json_value,
     validate_runtime_user_scope,
 )
+from src.api.admin.organization_mutations import (
+    require_active_organization_mutation,
+    require_active_organization_mutations,
+)
+from src.db.callable_target_access_groups import CallableTargetAccessGroupBindingRepository
+from src.db.callable_target_policies import CallableTargetScopePolicyRepository
+from src.db.callable_targets import CallableTargetBindingRepository
+from src.db.route_groups import RouteGroupRepository
 from src.middleware.platform_auth import get_platform_auth_context
+from src.services.asset_binding_mirror import reload_callable_target_grants
 from src.services.asset_visibility_preview import build_asset_visibility_preview
-from src.services.scoped_asset_access import apply_scope_asset_access, build_scope_asset_access
+from src.services.scoped_asset_access import build_scope_asset_access, sync_scope_asset_access_state
 from src.services.ui_authorization import build_team_capabilities
 
 router = APIRouter(tags=["Admin Teams"])
 
 
-def _team_response_payload(team: dict[str, Any], *, capabilities: dict[str, bool] | None = None) -> dict[str, Any]:
+def _transaction_repository(
+    request: Request, state_name: str, repository_type: type, db: Any
+) -> Any:
+    repository = getattr(request.app.state, state_name, None)
+    if isinstance(repository, repository_type):
+        return repository_type(db)
+    return repository
+
+
+def _team_response_payload(
+    team: dict[str, Any], *, capabilities: dict[str, bool] | None = None
+) -> dict[str, Any]:
     payload = to_json_value(dict(team))
     if isinstance(payload, dict):
         payload.pop("models", None)
@@ -54,13 +80,22 @@ def _validate_model_limit_dict(value: Any, field_name: str) -> dict[str, int] | 
     result: dict[str, int] = {}
     for k, v in value.items():
         if not isinstance(k, str) or not k.strip():
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} keys must be non-empty strings")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{field_name} keys must be non-empty strings",
+            )
         try:
             int_val = int(v)
         except (TypeError, ValueError):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} values must be integers")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{field_name} values must be integers",
+            )
         if int_val < 0:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{field_name} values must be non-negative")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{field_name} values must be non-negative",
+            )
         result[k.strip()] = int_val
     return result if result else None
 
@@ -71,22 +106,40 @@ def _resolve_self_service_policy(
     existing_team: dict[str, Any] | None = None,
     default_enabled: bool,
 ) -> tuple[bool, int | None, float | None, bool, int | None]:
-    enabled_default = existing_team.get("self_service_keys_enabled", default_enabled) if existing_team is not None else default_enabled
-    max_keys_default = existing_team.get("self_service_max_keys_per_user") if existing_team is not None else None
-    budget_default = existing_team.get("self_service_budget_ceiling") if existing_team is not None else None
-    require_expiry_default = (
-        existing_team.get("self_service_require_expiry", False) if existing_team is not None else False
+    enabled_default = (
+        existing_team.get("self_service_keys_enabled", default_enabled)
+        if existing_team is not None
+        else default_enabled
     )
-    max_expiry_days_default = existing_team.get("self_service_max_expiry_days") if existing_team is not None else None
+    max_keys_default = (
+        existing_team.get("self_service_max_keys_per_user") if existing_team is not None else None
+    )
+    budget_default = (
+        existing_team.get("self_service_budget_ceiling") if existing_team is not None else None
+    )
+    require_expiry_default = (
+        existing_team.get("self_service_require_expiry", False)
+        if existing_team is not None
+        else False
+    )
+    max_expiry_days_default = (
+        existing_team.get("self_service_max_expiry_days") if existing_team is not None else None
+    )
 
     enabled = bool(payload.get("self_service_keys_enabled", enabled_default))
-    max_keys = optional_int(payload.get("self_service_max_keys_per_user", max_keys_default), "self_service_max_keys_per_user")
+    max_keys = optional_int(
+        payload.get("self_service_max_keys_per_user", max_keys_default),
+        "self_service_max_keys_per_user",
+    )
     budget_ceiling = payload.get("self_service_budget_ceiling", budget_default)
     if budget_ceiling is not None:
         try:
             budget_ceiling = float(budget_ceiling)
         except (TypeError, ValueError):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="self_service_budget_ceiling must be a number")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="self_service_budget_ceiling must be a number",
+            )
     require_expiry = bool(payload.get("self_service_require_expiry", require_expiry_default))
     max_expiry_days = optional_int(
         payload.get("self_service_max_expiry_days", max_expiry_days_default),
@@ -105,13 +158,16 @@ async def _require_team_access(
 ) -> dict[str, Any]:
     rows = await db.query_raw(
         """
-        SELECT team_id, team_alias, organization_id, max_budget, spend, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit,
-               model_rpm_limit, model_tpm_limit, blocked,
-               self_service_keys_enabled, self_service_max_keys_per_user, self_service_budget_ceiling,
-               self_service_require_expiry, self_service_max_expiry_days,
-               created_at, updated_at
-        FROM deltallm_teamtable
-        WHERE team_id = $1
+        SELECT t.team_id, t.team_alias, t.organization_id, t.max_budget, t.spend,
+               t.rpm_limit, t.tpm_limit, t.rph_limit, t.rpd_limit, t.tpd_limit,
+               t.model_rpm_limit, t.model_tpm_limit, t.blocked,
+               t.self_service_keys_enabled, t.self_service_max_keys_per_user,
+               t.self_service_budget_ceiling, t.self_service_require_expiry,
+               t.self_service_max_expiry_days, o.lifecycle_state AS organization_lifecycle_state,
+               t.created_at, t.updated_at
+        FROM deltallm_teamtable t
+        LEFT JOIN deltallm_organizationtable o ON o.organization_id = t.organization_id
+        WHERE t.team_id = $1
         LIMIT 1
         """,
         team_id,
@@ -145,6 +201,26 @@ async def _require_team_access(
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
 
 
+async def _lock_team_for_mutation(
+    request: Request,
+    scope: AuthScope,
+    db: Any,
+    team_id: str,
+) -> dict[str, Any]:
+    rows = await db.query_raw(
+        """
+        SELECT team_id
+        FROM deltallm_teamtable
+        WHERE team_id = $1
+        FOR UPDATE
+        """,
+        team_id,
+    )
+    if not rows:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+    return await _require_team_access(request, scope, db, team_id, write=True)
+
+
 @router.get("/ui/api/teams")
 async def list_teams(
     request: Request,
@@ -155,7 +231,9 @@ async def list_teams(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.TEAM_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.TEAM_READ
+    )
     db = db_or_503(request)
 
     clauses: list[str] = []
@@ -172,7 +250,10 @@ async def list_teams(
             params.extend(scope.team_ids)
             scope_clauses.append(f"t.team_id IN ({ph})")
         if not scope_clauses:
-            return {"data": [], "pagination": {"total": 0, "limit": limit, "offset": offset, "has_more": False}}
+            return {
+                "data": [],
+                "pagination": {"total": 0, "limit": limit, "offset": offset, "has_more": False},
+            }
         clauses.append("(" + " OR ".join(scope_clauses) + ")")
 
     if search:
@@ -189,6 +270,7 @@ async def list_teams(
                    t.model_rpm_limit, t.model_tpm_limit, t.blocked,
                    t.self_service_keys_enabled, t.self_service_max_keys_per_user,
                    t.self_service_budget_ceiling, t.self_service_require_expiry, t.self_service_max_expiry_days,
+                   o.lifecycle_state AS organization_lifecycle_state,
                    t.created_at, t.updated_at,
                    (SELECT COUNT(*) FROM deltallm_teammembership tm WHERE tm.team_id = t.team_id) AS member_count"""
 
@@ -204,6 +286,7 @@ async def list_teams(
         f"""
         SELECT {select_cols}
         FROM deltallm_teamtable t
+        LEFT JOIN deltallm_organizationtable o ON o.organization_id = t.organization_id
         {where_sql}
         ORDER BY t.created_at DESC
         LIMIT ${len(params) - 1} OFFSET ${len(params)}
@@ -219,7 +302,12 @@ async def list_teams(
             )
             for row in rows
         ],
-        "pagination": {"total": total, "limit": limit, "offset": offset, "has_more": offset + limit < total},
+        "pagination": {
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + limit < total,
+        },
     }
 
 
@@ -248,12 +336,16 @@ async def get_team_asset_visibility(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.TEAM_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.TEAM_READ
+    )
     db = db_or_503(request)
     team = await _require_team_access(request, scope, db, team_id)
     organization_id = str(team.get("organization_id") or "").strip()
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Team organization is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Team organization is not configured"
+        )
     user_row = (
         await validate_runtime_user_scope(db, user_id, team_id=team_id)
         if user_id is not None and str(user_id).strip()
@@ -282,12 +374,16 @@ async def get_team_asset_access(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.TEAM_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.TEAM_READ
+    )
     db = db_or_503(request)
     team = await _require_team_access(request, scope, db, team_id)
     organization_id = str(team.get("organization_id") or "").strip()
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Team organization is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Team organization is not configured"
+        )
     return await build_scope_asset_access(
         request,
         scope_type="team",
@@ -310,12 +406,16 @@ async def update_team_asset_access(
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
     request_start = perf_counter()
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.TEAM_UPDATE)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.TEAM_UPDATE
+    )
     db = db_or_503(request)
     team = await _require_team_access(request, scope, db, team_id, write=True)
     organization_id = str(team.get("organization_id") or "").strip()
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Team organization is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Team organization is not configured"
+        )
     asset_access_payload = {
         "scope_type": "team",
         "scope_id": team_id,
@@ -327,7 +427,69 @@ async def update_team_asset_access(
     }
     if "selected_access_group_keys" in payload:
         asset_access_payload["selected_access_group_keys"] = payload["selected_access_group_keys"]
-    response = await apply_scope_asset_access(request, **asset_access_payload)
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Team asset-access mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        locked_rows = await tx.query_raw(
+            """
+            SELECT team_id, organization_id
+            FROM deltallm_teamtable
+            WHERE team_id = $1
+            FOR SHARE
+            """,
+            team_id,
+        )
+        if not locked_rows:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+        locked_team = await _require_team_access(request, scope, tx, team_id, write=True)
+        locked_organization_id = str(locked_team.get("organization_id") or "").strip()
+        if not locked_organization_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Team organization is not configured",
+            )
+        await require_active_organization_mutation(tx, locked_organization_id)
+        asset_access_payload["organization_id"] = locked_organization_id
+        await sync_scope_asset_access_state(
+            request,
+            **asset_access_payload,
+            binding_repository=_transaction_repository(
+                request,
+                "callable_target_binding_repository",
+                CallableTargetBindingRepository,
+                tx,
+            ),
+            access_group_repository=_transaction_repository(
+                request,
+                "callable_target_access_group_repository",
+                CallableTargetAccessGroupBindingRepository,
+                tx,
+            ),
+            policy_repository=_transaction_repository(
+                request,
+                "callable_target_scope_policy_repository",
+                CallableTargetScopePolicyRepository,
+                tx,
+            ),
+            route_group_repository=_transaction_repository(
+                request,
+                "route_group_repository",
+                RouteGroupRepository,
+                tx,
+            ),
+            reload_after_write=False,
+        )
+    await reload_callable_target_grants(request)
+    response = await build_scope_asset_access(
+        request,
+        scope_type="team",
+        scope_id=team_id,
+        organization_id=locked_organization_id,
+        team_id=team_id,
+    )
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,
@@ -350,13 +512,20 @@ async def create_team(
 ) -> dict[str, Any]:
     request_start = perf_counter()
     _reject_legacy_models_field(payload)
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.TEAM_UPDATE)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.TEAM_UPDATE
+    )
     organization_id = payload.get("organization_id")
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="organization_id is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="organization_id is required"
+        )
     if not scope.is_platform_admin:
         if organization_id not in scope.org_ids:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only create teams in your own organizations")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only create teams in your own organizations",
+            )
     db = db_or_503(request)
     team_id = str(payload.get("team_id") or f"team-{secrets.token_hex(6)}")
     team_alias = payload.get("team_alias")
@@ -368,40 +537,49 @@ async def create_team(
     tpd_limit = optional_int(payload.get("tpd_limit"), "tpd_limit")
     model_rpm_limit = _validate_model_limit_dict(payload.get("model_rpm_limit"), "model_rpm_limit")
     model_tpm_limit = _validate_model_limit_dict(payload.get("model_tpm_limit"), "model_tpm_limit")
-    ss_keys_enabled, ss_max_keys, ss_budget_ceiling, ss_require_expiry, ss_max_expiry_days = _resolve_self_service_policy(
-        payload,
-        default_enabled=True,
+    ss_keys_enabled, ss_max_keys, ss_budget_ceiling, ss_require_expiry, ss_max_expiry_days = (
+        _resolve_self_service_policy(
+            payload,
+            default_enabled=True,
+        )
     )
 
-    await db.execute_raw(
-        """
-        INSERT INTO deltallm_teamtable (
-            team_id, team_alias, organization_id, max_budget, spend,
-            rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit,
-            model_rpm_limit, model_tpm_limit, blocked,
-            self_service_keys_enabled, self_service_max_keys_per_user,
-            self_service_budget_ceiling, self_service_require_expiry, self_service_max_expiry_days,
-            created_at, updated_at
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Team mutation requires transaction support",
         )
-        VALUES ($1, $2, $3, $4, 0, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, false, $12, $13, $14, $15, $16, NOW(), NOW())
-        """,
-        team_id,
-        team_alias,
-        organization_id,
-        max_budget,
-        rpm_limit,
-        tpm_limit,
-        rph_limit,
-        rpd_limit,
-        tpd_limit,
-        json.dumps(model_rpm_limit) if model_rpm_limit else None,
-        json.dumps(model_tpm_limit) if model_tpm_limit else None,
-        ss_keys_enabled,
-        ss_max_keys,
-        ss_budget_ceiling,
-        ss_require_expiry,
-        ss_max_expiry_days,
-    )
+    async with db.tx() as tx:
+        await require_active_organization_mutation(tx, str(organization_id))
+        await tx.execute_raw(
+            """
+            INSERT INTO deltallm_teamtable (
+                team_id, team_alias, organization_id, max_budget, spend,
+                rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit,
+                model_rpm_limit, model_tpm_limit, blocked,
+                self_service_keys_enabled, self_service_max_keys_per_user,
+                self_service_budget_ceiling, self_service_require_expiry, self_service_max_expiry_days,
+                created_at, updated_at
+            )
+            VALUES ($1, $2, $3, $4, 0, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, false, $12, $13, $14, $15, $16, NOW(), NOW())
+            """,
+            team_id,
+            team_alias,
+            organization_id,
+            max_budget,
+            rpm_limit,
+            tpm_limit,
+            rph_limit,
+            rpd_limit,
+            tpd_limit,
+            json.dumps(model_rpm_limit) if model_rpm_limit else None,
+            json.dumps(model_tpm_limit) if model_tpm_limit else None,
+            ss_keys_enabled,
+            ss_max_keys,
+            ss_budget_ceiling,
+            ss_require_expiry,
+            ss_max_expiry_days,
+        )
 
     response = {
         "team_id": team_id,
@@ -421,6 +599,7 @@ async def create_team(
         "self_service_require_expiry": ss_require_expiry,
         "self_service_max_expiry_days": ss_max_expiry_days,
         "blocked": False,
+        "organization_lifecycle_state": "active",
     }
     response["capabilities"] = build_team_capabilities(scope, response)
     await emit_admin_mutation_audit(
@@ -453,9 +632,14 @@ async def update_team(
     team_alias = payload.get("team_alias", existing_team.get("team_alias"))
     organization_id = payload.get("organization_id", existing_team.get("organization_id"))
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="organization_id is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="organization_id is required"
+        )
     if not scope.is_platform_admin and organization_id not in scope.org_ids:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cannot move team to an organization you don't manage")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot move team to an organization you don't manage",
+        )
     max_budget = payload.get("max_budget", existing_team.get("max_budget"))
     rpm_limit = optional_int(payload.get("rpm_limit", existing_team.get("rpm_limit")), "rpm_limit")
     tpm_limit = optional_int(payload.get("tpm_limit", existing_team.get("tpm_limit")), "tpm_limit")
@@ -468,63 +652,88 @@ async def update_team(
     model_tpm_limit = _validate_model_limit_dict(
         payload.get("model_tpm_limit", existing_team.get("model_tpm_limit")), "model_tpm_limit"
     )
-    ss_keys_enabled, ss_max_keys, ss_budget_ceiling, ss_require_expiry, ss_max_expiry_days = _resolve_self_service_policy(
-        payload,
-        existing_team=existing_team,
-        default_enabled=False,
+    ss_keys_enabled, ss_max_keys, ss_budget_ceiling, ss_require_expiry, ss_max_expiry_days = (
+        _resolve_self_service_policy(
+            payload,
+            existing_team=existing_team,
+            default_enabled=False,
+        )
     )
 
-    await db.execute_raw(
-        """
-        UPDATE deltallm_teamtable
-        SET team_alias = $1,
-            organization_id = $2,
-            max_budget = $3,
-            rpm_limit = $4,
-            tpm_limit = $5,
-            rph_limit = $6,
-            rpd_limit = $7,
-            tpd_limit = $8,
-            model_rpm_limit = $9::jsonb,
-            model_tpm_limit = $10::jsonb,
-            self_service_keys_enabled = $11,
-            self_service_max_keys_per_user = $12,
-            self_service_budget_ceiling = $13,
-            self_service_require_expiry = $14,
-            self_service_max_expiry_days = $15,
-            updated_at = NOW()
-        WHERE team_id = $16
-        """,
-        team_alias,
-        organization_id,
-        max_budget,
-        rpm_limit,
-        tpm_limit,
-        rph_limit,
-        rpd_limit,
-        tpd_limit,
-        json.dumps(model_rpm_limit) if model_rpm_limit else None,
-        json.dumps(model_tpm_limit) if model_tpm_limit else None,
-        ss_keys_enabled,
-        ss_max_keys,
-        ss_budget_ceiling,
-        ss_require_expiry,
-        ss_max_expiry_days,
-        team_id,
-    )
-    updated_rows = await db.query_raw(
-        """
-        SELECT team_id, team_alias, organization_id, max_budget, spend, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit,
-               model_rpm_limit, model_tpm_limit, blocked,
-               self_service_keys_enabled, self_service_max_keys_per_user, self_service_budget_ceiling,
-               self_service_require_expiry, self_service_max_expiry_days,
-               created_at, updated_at
-        FROM deltallm_teamtable
-        WHERE team_id = $1
-        LIMIT 1
-        """,
-        team_id,
-    )
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Team mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        locked_existing_team = await _lock_team_for_mutation(
+            request,
+            scope,
+            tx,
+            team_id,
+        )
+        await require_active_organization_mutations(
+            tx,
+            {
+                str(locked_existing_team.get("organization_id") or ""),
+                str(organization_id),
+            },
+        )
+        await tx.execute_raw(
+            """
+            UPDATE deltallm_teamtable
+            SET team_alias = $1,
+                organization_id = $2,
+                max_budget = $3,
+                rpm_limit = $4,
+                tpm_limit = $5,
+                rph_limit = $6,
+                rpd_limit = $7,
+                tpd_limit = $8,
+                model_rpm_limit = $9::jsonb,
+                model_tpm_limit = $10::jsonb,
+                self_service_keys_enabled = $11,
+                self_service_max_keys_per_user = $12,
+                self_service_budget_ceiling = $13,
+                self_service_require_expiry = $14,
+                self_service_max_expiry_days = $15,
+                updated_at = NOW()
+            WHERE team_id = $16
+            """,
+            team_alias,
+            organization_id,
+            max_budget,
+            rpm_limit,
+            tpm_limit,
+            rph_limit,
+            rpd_limit,
+            tpd_limit,
+            json.dumps(model_rpm_limit) if model_rpm_limit else None,
+            json.dumps(model_tpm_limit) if model_tpm_limit else None,
+            ss_keys_enabled,
+            ss_max_keys,
+            ss_budget_ceiling,
+            ss_require_expiry,
+            ss_max_expiry_days,
+            team_id,
+        )
+        updated_rows = await tx.query_raw(
+            """
+            SELECT t.team_id, t.team_alias, t.organization_id, t.max_budget, t.spend,
+                   t.rpm_limit, t.tpm_limit, t.rph_limit, t.rpd_limit, t.tpd_limit,
+                   t.model_rpm_limit, t.model_tpm_limit, t.blocked,
+                   t.self_service_keys_enabled, t.self_service_max_keys_per_user,
+                   t.self_service_budget_ceiling, t.self_service_require_expiry,
+                   t.self_service_max_expiry_days,
+                   o.lifecycle_state AS organization_lifecycle_state,
+                   t.created_at, t.updated_at
+            FROM deltallm_teamtable t
+            LEFT JOIN deltallm_organizationtable o ON o.organization_id = t.organization_id
+            WHERE t.team_id = $1
+            LIMIT 1
+            """,
+            team_id,
+        )
     if not updated_rows:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
     updated_team = dict(updated_rows[0])
@@ -593,7 +802,9 @@ async def list_team_member_candidates(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> list[dict[str, Any]]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.TEAM_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.TEAM_READ
+    )
     db = db_or_503(request)
     team = await _require_team_access(request, scope, db, team_id)
     organization_id = team.get("organization_id")
@@ -606,7 +817,9 @@ async def list_team_member_candidates(
     params: list[Any] = [organization_id, team_id]
     if search and search.strip():
         params.append(f"%{search.strip()}%")
-        clauses.append(f"(pa.email ILIKE ${len(params)} OR pa.account_id::text ILIKE ${len(params)})")
+        clauses.append(
+            f"(pa.email ILIKE ${len(params)} OR pa.account_id::text ILIKE ${len(params)})"
+        )
     params.append(limit)
 
     where_sql = " AND ".join(clauses)
@@ -656,7 +869,9 @@ async def add_team_member(
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     if not account_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="account_id is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="account_id is required"
+        )
 
     account_rows = await db.query_raw(
         "SELECT account_id, email FROM deltallm_platformaccount WHERE account_id = $1 LIMIT 1",
@@ -665,27 +880,43 @@ async def add_team_member(
     if not account_rows:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
 
-    organization_id = team.get("organization_id")
-    if organization_id:
-        org_membership_rows = await db.query_raw(
+    organization_id = str(team.get("organization_id") or "").strip()
+    if not organization_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Team organization is not configured",
+        )
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Team membership mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        locked_team = await _lock_team_for_mutation(request, scope, tx, team_id)
+        organization_id = str(locked_team.get("organization_id") or "").strip()
+        await require_active_organization_mutation(tx, organization_id)
+        org_membership_rows = await tx.query_raw(
             "SELECT membership_id FROM deltallm_organizationmembership WHERE organization_id = $1 AND account_id = $2 LIMIT 1",
             organization_id,
             account_id,
         )
         if not org_membership_rows:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Account is not a member of this team's organization")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Account is not a member of this team's organization",
+            )
 
-    await db.execute_raw(
-        """
-        INSERT INTO deltallm_teammembership (membership_id, account_id, team_id, role, created_at, updated_at)
-        VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
-        ON CONFLICT (account_id, team_id)
-        DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
-        """,
-        account_id,
-        team_id,
-        user_role,
-    )
+        await tx.execute_raw(
+            """
+            INSERT INTO deltallm_teammembership (membership_id, account_id, team_id, role, created_at, updated_at)
+            VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
+            ON CONFLICT (account_id, team_id)
+            DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
+            """,
+            account_id,
+            team_id,
+            user_role,
+        )
     response = {
         "user_id": account_id,
         "user_email": account_rows[0].get("email"),
@@ -715,25 +946,41 @@ async def delete_team(
     request_start = perf_counter()
     scope = get_auth_scope(request, authorization, x_master_key)
     db = db_or_503(request)
-    await _require_team_access(request, scope, db, team_id, write=True)
-    key_count = await db.query_raw(
-        "SELECT COUNT(*) AS cnt FROM deltallm_verificationtoken WHERE team_id = $1",
-        team_id,
-    )
-    if key_count and int(key_count[0].get("cnt", 0)) > 0:
-        raise HTTPException(status_code=409, detail=f"Cannot delete team: {key_count[0]['cnt']} API key(s) still assigned. Reassign or revoke them first.")
-    await db.execute_raw(
-        "DELETE FROM deltallm_teammembership WHERE team_id = $1",
-        team_id,
-    )
-    await db.execute_raw(
-        "UPDATE deltallm_usertable SET team_id = NULL, updated_at = NOW() WHERE team_id = $1",
-        team_id,
-    )
-    deleted = await db.execute_raw(
-        "DELETE FROM deltallm_teamtable WHERE team_id = $1",
-        team_id,
-    )
+    team = await _require_team_access(request, scope, db, team_id, write=True)
+    organization_id = str(team.get("organization_id") or "").strip()
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Team mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        locked_team = await _lock_team_for_mutation(request, scope, tx, team_id)
+        organization_id = str(locked_team.get("organization_id") or "").strip()
+        await require_active_organization_mutation(tx, organization_id)
+        key_count = await tx.query_raw(
+            "SELECT COUNT(*) AS cnt FROM deltallm_verificationtoken WHERE team_id = $1",
+            team_id,
+        )
+        if key_count and int(key_count[0].get("cnt", 0)) > 0:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Cannot delete team: {key_count[0]['cnt']} API key(s) still assigned. "
+                    "Reassign or revoke them first."
+                ),
+            )
+        await tx.execute_raw(
+            "DELETE FROM deltallm_teammembership WHERE team_id = $1",
+            team_id,
+        )
+        await tx.execute_raw(
+            "UPDATE deltallm_usertable SET team_id = NULL, updated_at = NOW() WHERE team_id = $1",
+            team_id,
+        )
+        deleted = await tx.execute_raw(
+            "DELETE FROM deltallm_teamtable WHERE team_id = $1",
+            team_id,
+        )
     response = {"deleted": int(deleted or 0) > 0}
     await emit_admin_mutation_audit(
         request=request,
@@ -758,47 +1005,61 @@ async def remove_team_member(
     request_start = perf_counter()
     scope = get_auth_scope(request, authorization, x_master_key)
     db = db_or_503(request)
-    await _require_team_access(request, scope, db, team_id, write=True)
-    removed = await db.execute_raw(
-        "DELETE FROM deltallm_teammembership WHERE team_id = $1 AND account_id = $2",
-        team_id,
-        user_id,
-    )
-
+    team = await _require_team_access(request, scope, db, team_id, write=True)
+    organization_id = str(team.get("organization_id") or "").strip()
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Team membership mutation requires transaction support",
+        )
+    owned_key_rows: list[dict[str, Any]] = []
     revoked_keys = 0
-    if int(removed or 0) > 0:
-        owned_key_rows = await db.query_raw(
-            "SELECT token FROM deltallm_verificationtoken WHERE team_id = $1 AND owner_account_id = $2",
+    async with db.tx() as tx:
+        locked_team = await _lock_team_for_mutation(request, scope, tx, team_id)
+        organization_id = str(locked_team.get("organization_id") or "").strip()
+        await require_active_organization_mutation(tx, organization_id)
+        removed = await tx.execute_raw(
+            "DELETE FROM deltallm_teammembership WHERE team_id = $1 AND account_id = $2",
             team_id,
             user_id,
         )
-        if owned_key_rows:
-            revoked_keys = int(
-                await db.execute_raw(
-                    "DELETE FROM deltallm_verificationtoken WHERE team_id = $1 AND owner_account_id = $2",
-                    team_id,
-                    user_id,
-                )
-                or 0
+        if int(removed or 0) > 0:
+            owned_key_rows = await tx.query_raw(
+                "SELECT token FROM deltallm_verificationtoken WHERE team_id = $1 AND owner_account_id = $2",
+                team_id,
+                user_id,
             )
-            if revoked_keys > 0:
-                try:
-                    key_service = request.app.state.key_service
-                    for kr in owned_key_rows:
-                        await key_service.invalidate_key_cache_by_hash(str(kr["token"]))
-                except Exception:
-                    import logging
-                    logging.getLogger(__name__).exception("failed to invalidate key cache after membership removal auto-revoke")
-                for kr in owned_key_rows:
-                    await emit_admin_mutation_audit(
-                        request=request,
-                        request_start=request_start,
-                        action=AuditAction.ADMIN_KEY_AUTO_REVOKE_MEMBERSHIP_REMOVED,
-                        scope=scope,
-                        resource_type="api_key",
-                        resource_id=str(kr["token"]),
-                        response_payload={"team_id": team_id, "removed_account_id": user_id},
+            if owned_key_rows:
+                revoked_keys = int(
+                    await tx.execute_raw(
+                        "DELETE FROM deltallm_verificationtoken WHERE team_id = $1 AND owner_account_id = $2",
+                        team_id,
+                        user_id,
                     )
+                    or 0
+                )
+
+    if revoked_keys > 0:
+        try:
+            key_service = request.app.state.key_service
+            for key_row in owned_key_rows:
+                await key_service.invalidate_key_cache_by_hash(str(key_row["token"]))
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).exception(
+                "failed to invalidate key cache after membership removal auto-revoke"
+            )
+        for key_row in owned_key_rows:
+            await emit_admin_mutation_audit(
+                request=request,
+                request_start=request_start,
+                action=AuditAction.ADMIN_KEY_AUTO_REVOKE_MEMBERSHIP_REMOVED,
+                scope=scope,
+                resource_type="api_key",
+                resource_id=str(key_row["token"]),
+                response_payload={"team_id": team_id, "removed_account_id": user_id},
+            )
 
     response = {"removed": int(removed or 0) > 0, "revoked_keys": revoked_keys}
     await emit_admin_mutation_audit(

--- a/src/api/admin/endpoints/users.py
+++ b/src/api/admin/endpoints/users.py
@@ -12,12 +12,27 @@ from src.api.admin.endpoints.common import (
     get_auth_scope,
     validate_runtime_user_scope,
 )
+from src.api.admin.organization_mutations import require_active_organization_mutation
 from src.auth.roles import Permission
 from src.audit.actions import AuditAction
+from src.db.callable_target_access_groups import CallableTargetAccessGroupBindingRepository
+from src.db.callable_target_policies import CallableTargetScopePolicyRepository
+from src.db.callable_targets import CallableTargetBindingRepository
+from src.db.route_groups import RouteGroupRepository
+from src.services.asset_binding_mirror import reload_callable_target_grants
 from src.services.asset_visibility_preview import build_asset_visibility_preview
-from src.services.scoped_asset_access import apply_scope_asset_access, build_scope_asset_access
+from src.services.scoped_asset_access import build_scope_asset_access, sync_scope_asset_access_state
 
 router = APIRouter(tags=["Admin Users"])
+
+
+def _transaction_repository(
+    request: Request, state_name: str, repository_type: type, db: Any
+) -> Any:
+    repository = getattr(request.app.state, state_name, None)
+    if isinstance(repository, repository_type):
+        return repository_type(db)
+    return repository
 
 
 async def _require_runtime_user_access(
@@ -40,7 +55,9 @@ async def _require_runtime_user_access(
         return row
 
     required = Permission.USER_UPDATE if write else Permission.USER_READ
-    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Insufficient permissions for {required}")
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN, detail=f"Insufficient permissions for {required}"
+    )
 
 
 def _optional_int(val: Any, name: str) -> int | None:
@@ -49,9 +66,13 @@ def _optional_int(val: Any, name: str) -> int | None:
     try:
         v = int(val)
     except (ValueError, TypeError):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{name} must be an integer")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"{name} must be an integer"
+        )
     if v < 0:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{name} must be non-negative")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"{name} must be non-negative"
+        )
     return v
 
 
@@ -62,7 +83,9 @@ async def get_user(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.USER_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.USER_READ
+    )
     db = db_or_503(request)
     rows = await db.query_raw(
         """
@@ -83,7 +106,9 @@ async def get_user(
         org_id = str(user.get("organization_id") or "").strip()
         team_id = str(user.get("team_id") or "").strip()
         if org_id not in scope.org_ids and team_id not in scope.team_ids:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+            )
     return user
 
 
@@ -96,7 +121,9 @@ async def update_user(
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
     request_start = perf_counter()
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.USER_UPDATE)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.USER_UPDATE
+    )
     db = db_or_503(request)
     await _require_runtime_user_access(request, scope, db, user_id, write=True)
 
@@ -118,54 +145,89 @@ async def update_user(
 
     rpm_limit = _optional_int(payload.get("rpm_limit", existing.get("rpm_limit")), "rpm_limit")
     tpm_limit = _optional_int(payload.get("tpm_limit", existing.get("tpm_limit")), "tpm_limit")
-    max_parallel_requests = _optional_int(payload.get("max_parallel_requests", existing.get("max_parallel_requests")), "max_parallel_requests")
+    max_parallel_requests = _optional_int(
+        payload.get("max_parallel_requests", existing.get("max_parallel_requests")),
+        "max_parallel_requests",
+    )
     rph_limit = _optional_int(payload.get("rph_limit", existing.get("rph_limit")), "rph_limit")
     rpd_limit = _optional_int(payload.get("rpd_limit", existing.get("rpd_limit")), "rpd_limit")
     tpd_limit = _optional_int(payload.get("tpd_limit", existing.get("tpd_limit")), "tpd_limit")
     max_budget = payload.get("max_budget", existing.get("max_budget"))
     blocked = payload.get("blocked", existing.get("blocked", False))
 
-    await db.execute_raw(
-        """
-        UPDATE deltallm_usertable SET
-            rpm_limit = $2,
-            tpm_limit = $3,
-            max_parallel_requests = $4,
-            rph_limit = $5,
-            rpd_limit = $6,
-            tpd_limit = $7,
-            max_budget = $8,
-            blocked = $9,
-            updated_at = NOW()
-        WHERE user_id = $1
-        """,
-        user_id,
-        rpm_limit,
-        tpm_limit,
-        max_parallel_requests,
-        rph_limit,
-        rpd_limit,
-        tpd_limit,
-        max_budget,
-        blocked,
-    )
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="User mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        locked_rows = await tx.query_raw(
+            """
+            SELECT user_id
+            FROM deltallm_usertable
+            WHERE user_id = $1
+            FOR UPDATE
+            """,
+            user_id,
+        )
+        if not locked_rows:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+        locked_user = await _require_runtime_user_access(
+            request,
+            scope,
+            tx,
+            user_id,
+            write=True,
+        )
+        organization_id = str(locked_user.get("organization_id") or "").strip()
+        if not organization_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="User organization is not configured",
+            )
+        await require_active_organization_mutation(tx, organization_id)
+        await tx.execute_raw(
+            """
+            UPDATE deltallm_usertable SET
+                rpm_limit = $2,
+                tpm_limit = $3,
+                max_parallel_requests = $4,
+                rph_limit = $5,
+                rpd_limit = $6,
+                tpd_limit = $7,
+                max_budget = $8,
+                blocked = $9,
+                updated_at = NOW()
+            WHERE user_id = $1
+            """,
+            user_id,
+            rpm_limit,
+            tpm_limit,
+            max_parallel_requests,
+            rph_limit,
+            rpd_limit,
+            tpd_limit,
+            max_budget,
+            blocked,
+        )
+
+        updated_rows = await tx.query_raw(
+            """
+            SELECT user_id, team_id, organization_id, max_budget, spend,
+                   rpm_limit, tpm_limit, max_parallel_requests,
+                   rph_limit, rpd_limit, tpd_limit,
+                   blocked, created_at, updated_at
+            FROM deltallm_usertable
+            WHERE user_id = $1
+            LIMIT 1
+            """,
+            user_id,
+        )
 
     key_service = getattr(request.app.state, "key_service", None)
     if key_service:
         await key_service.invalidate_keys_for_user(user_id)
 
-    updated_rows = await db.query_raw(
-        """
-        SELECT user_id, team_id, organization_id, max_budget, spend,
-               rpm_limit, tpm_limit, max_parallel_requests,
-               rph_limit, rpd_limit, tpd_limit,
-               blocked, created_at, updated_at
-        FROM deltallm_usertable
-        WHERE user_id = $1
-        LIMIT 1
-        """,
-        user_id,
-    )
     result = dict(updated_rows[0]) if updated_rows else {}
 
     await emit_admin_mutation_audit(
@@ -192,13 +254,17 @@ async def get_user_asset_visibility(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.USER_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.USER_READ
+    )
     db = db_or_503(request)
     row = await _require_runtime_user_access(request, scope, db, user_id)
     organization_id = str(row.get("organization_id") or "").strip()
     team_id = str(row.get("team_id") or "").strip() or None
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User organization is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="User organization is not configured"
+        )
     return await build_asset_visibility_preview(
         request,
         organization_id=organization_id,
@@ -222,13 +288,17 @@ async def get_user_asset_access(
     authorization: str | None = Header(default=None, alias="Authorization"),
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.USER_READ)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.USER_READ
+    )
     db = db_or_503(request)
     row = await _require_runtime_user_access(request, scope, db, user_id)
     organization_id = str(row.get("organization_id") or "").strip()
     team_id = str(row.get("team_id") or "").strip() or None
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User organization is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="User organization is not configured"
+        )
     return await build_scope_asset_access(
         request,
         scope_type="user",
@@ -252,13 +322,17 @@ async def update_user_asset_access(
     x_master_key: str | None = Header(default=None, alias="X-Master-Key"),
 ) -> dict[str, Any]:
     request_start = perf_counter()
-    scope = get_auth_scope(request, authorization, x_master_key, required_permission=Permission.USER_UPDATE)
+    scope = get_auth_scope(
+        request, authorization, x_master_key, required_permission=Permission.USER_UPDATE
+    )
     db = db_or_503(request)
     row = await _require_runtime_user_access(request, scope, db, user_id, write=True)
     organization_id = str(row.get("organization_id") or "").strip()
     team_id = str(row.get("team_id") or "").strip() or None
     if not organization_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User organization is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="User organization is not configured"
+        )
     asset_access_payload = {
         "scope_type": "user",
         "scope_id": user_id,
@@ -271,7 +345,77 @@ async def update_user_asset_access(
     }
     if "selected_access_group_keys" in payload:
         asset_access_payload["selected_access_group_keys"] = payload["selected_access_group_keys"]
-    response = await apply_scope_asset_access(request, **asset_access_payload)
+    if not hasattr(db, "tx"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="User asset-access mutation requires transaction support",
+        )
+    async with db.tx() as tx:
+        locked_rows = await tx.query_raw(
+            """
+            SELECT user_id
+            FROM deltallm_usertable
+            WHERE user_id = $1
+            FOR SHARE
+            """,
+            user_id,
+        )
+        if not locked_rows:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+        locked_user = await _require_runtime_user_access(
+            request,
+            scope,
+            tx,
+            user_id,
+            write=True,
+        )
+        locked_organization_id = str(locked_user.get("organization_id") or "").strip()
+        if not locked_organization_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="User organization is not configured",
+            )
+        await require_active_organization_mutation(tx, locked_organization_id)
+        asset_access_payload["organization_id"] = locked_organization_id
+        asset_access_payload["team_id"] = str(locked_user.get("team_id") or "").strip() or None
+        await sync_scope_asset_access_state(
+            request,
+            **asset_access_payload,
+            binding_repository=_transaction_repository(
+                request,
+                "callable_target_binding_repository",
+                CallableTargetBindingRepository,
+                tx,
+            ),
+            access_group_repository=_transaction_repository(
+                request,
+                "callable_target_access_group_repository",
+                CallableTargetAccessGroupBindingRepository,
+                tx,
+            ),
+            policy_repository=_transaction_repository(
+                request,
+                "callable_target_scope_policy_repository",
+                CallableTargetScopePolicyRepository,
+                tx,
+            ),
+            route_group_repository=_transaction_repository(
+                request,
+                "route_group_repository",
+                RouteGroupRepository,
+                tx,
+            ),
+            reload_after_write=False,
+        )
+    await reload_callable_target_grants(request)
+    response = await build_scope_asset_access(
+        request,
+        scope_type="user",
+        scope_id=user_id,
+        organization_id=locked_organization_id,
+        team_id=str(locked_user.get("team_id") or "").strip() or None,
+        user_id=user_id,
+    )
     await emit_admin_mutation_audit(
         request=request,
         request_start=request_start,

--- a/src/api/admin/organization_mutations.py
+++ b/src/api/admin/organization_mutations.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from src.db.organization_mutation_guard import OrganizationMutationGuardDatabase
+from src.services.organization_mutation_policy import (
+    OrganizationMutationError,
+    OrganizationMutationInactiveError,
+    OrganizationMutationNotFoundError,
+    OrganizationMutationPolicy,
+)
+
+
+async def require_active_organization_mutation(
+    db: OrganizationMutationGuardDatabase,
+    organization_id: str,
+) -> None:
+    try:
+        await OrganizationMutationPolicy.for_database(db).require_active(organization_id)
+    except OrganizationMutationError as exc:
+        raise organization_mutation_http_error(exc) from exc
+
+
+async def require_active_organization_mutations(
+    db: OrganizationMutationGuardDatabase,
+    organization_ids: list[str] | tuple[str, ...] | set[str],
+) -> None:
+    for organization_id in sorted(
+        {str(value or "").strip() for value in organization_ids if str(value or "").strip()}
+    ):
+        await require_active_organization_mutation(db, organization_id)
+
+
+def organization_mutation_http_error(exc: OrganizationMutationError) -> HTTPException:
+    if isinstance(exc, OrganizationMutationInactiveError):
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.detail())
+    if isinstance(exc, OrganizationMutationNotFoundError):
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": exc.code,
+                "message": "Organization not found",
+            },
+        )
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail={
+            "code": exc.code,
+            "message": "Organization lifecycle state could not be checked",
+        },
+    )
+
+
+__all__ = [
+    "organization_mutation_http_error",
+    "require_active_organization_mutation",
+    "require_active_organization_mutations",
+]

--- a/src/db/organization_admin.py
+++ b/src/db/organization_admin.py
@@ -190,7 +190,7 @@ class OrganizationAdminRepository:
     async def get(self, organization_id: str) -> dict[str, object] | None:
         rows = await self.db.query_raw(
             """
-            SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, created_at, updated_at
+            SELECT organization_id, organization_name, max_budget, soft_budget, spend, budget_duration, budget_reset_at, rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit, model_rpm_limit, model_tpm_limit, audit_content_storage_enabled, metadata, lifecycle_state, deletion_requested_at, deletion_not_before_at, created_at, updated_at
             FROM deltallm_organizationtable
             WHERE organization_id = $1
             LIMIT 1

--- a/src/db/organization_mutation_guard.py
+++ b/src/db/organization_mutation_guard.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.models.organization_lifecycle import OrganizationLifecycleState
+
+
+class OrganizationMutationGuardDatabase(Protocol):
+    async def query_raw(
+        self,
+        query: str,
+        *params: object,
+    ) -> list[dict[str, object]]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class OrganizationMutationSnapshot:
+    organization_id: str
+    lifecycle_state: OrganizationLifecycleState
+
+
+class OrganizationMutationGuardRepository:
+    """Locks the durable organization lifecycle row for a tenant mutation."""
+
+    def __init__(self, db: OrganizationMutationGuardDatabase) -> None:
+        self.db = db
+
+    async def lock_organization(
+        self,
+        organization_id: str,
+    ) -> OrganizationMutationSnapshot | None:
+        rows = await self.db.query_raw(
+            """
+            SELECT organization_id, lifecycle_state
+            FROM deltallm_organizationtable
+            WHERE organization_id = $1
+            FOR SHARE
+            """,
+            organization_id,
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        return OrganizationMutationSnapshot(
+            organization_id=str(row.get("organization_id") or ""),
+            lifecycle_state=OrganizationLifecycleState(
+                str(row.get("lifecycle_state") or "").strip().lower()
+            ),
+        )
+
+
+__all__ = [
+    "OrganizationMutationGuardDatabase",
+    "OrganizationMutationGuardRepository",
+    "OrganizationMutationSnapshot",
+]

--- a/src/models/organization_lifecycle.py
+++ b/src/models/organization_lifecycle.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 
 ORGANIZATION_LIFECYCLE_PROTOCOL_VERSION = 2
+
+
+class OrganizationLifecycleState(StrEnum):
+    ACTIVE = "active"
+    DELETION_PENDING = "deletion_pending"
+    PURGING = "purging"
+    DELETION_FAILED = "deletion_failed"
+
+
+def parse_organization_lifecycle_state(value: object) -> OrganizationLifecycleState | None:
+    try:
+        return OrganizationLifecycleState(str(value or "").strip().lower())
+    except ValueError:
+        return None
 
 
 @dataclass(frozen=True, slots=True)
@@ -12,4 +27,9 @@ class TeamOrganizationLifecycle:
     lifecycle_state: str
 
 
-__all__ = ["ORGANIZATION_LIFECYCLE_PROTOCOL_VERSION", "TeamOrganizationLifecycle"]
+__all__ = [
+    "ORGANIZATION_LIFECYCLE_PROTOCOL_VERSION",
+    "OrganizationLifecycleState",
+    "TeamOrganizationLifecycle",
+    "parse_organization_lifecycle_state",
+]

--- a/src/services/invitation_service.py
+++ b/src/services/invitation_service.py
@@ -19,6 +19,7 @@ from src.db.email_tokens import EmailTokenRepository
 from src.db.invitations import InvitationRepository, PlatformInvitationRecord
 from src.services.email_token_service import EmailTokenService
 from src.services.email_outbox_service import EmailOutboxService
+from src.services.organization_mutation_policy import OrganizationMutationPolicy
 from src.services.platform_identity_service import LoginResult, PlatformIdentityService
 
 
@@ -197,6 +198,15 @@ class InvitationService:
                 != str(organization_context.get("organization_id") or "").strip()
             ):
                 raise ValueError("team_id does not belong to organization_id")
+        organization_ids = {
+            str(context.get("organization_id") or "").strip()
+            for context in (organization_context, team_context)
+            if context is not None and str(context.get("organization_id") or "").strip()
+        }
+        for scoped_organization_id in sorted(organization_ids):
+            await OrganizationMutationPolicy.for_database(db_client).require_active(
+                scoped_organization_id
+            )
 
         account = await identity_service.ensure_account(
             email=normalized_email,
@@ -317,13 +327,45 @@ class InvitationService:
         )
 
     async def cancel_invitation(self, *, invitation_id: str) -> bool:
-        invitation = await self._require_manageable_invitation(invitation_id)
-        await self.token_service.invalidate_active_tokens(
-            purpose="invite_accept",
-            account_id=invitation.account_id,
-            invitation_id=invitation.invitation_id,
-        )
-        return await self.repository.mark_cancelled(invitation.invitation_id)
+        if self.db is None or not hasattr(self.db, "tx"):
+            raise RuntimeError("invitation cancellation requires transaction support")
+        async with self.db.tx() as tx:
+            repository, token_service, _outbox_service, _identity_service = (
+                self._transactional_dependencies(tx)
+            )
+            invitation = await repository.get_by_id(invitation_id)
+            if invitation is None:
+                raise ValueError("invitation not found")
+            await self._require_active_invitation_scopes(tx, invitation.metadata)
+            invitation = await self._expire_if_needed(
+                invitation,
+                repository=repository,
+                token_service=token_service,
+            )
+            if invitation.status == "accepted":
+                raise ValueError("accepted invitations cannot be modified")
+            if invitation.status == "cancelled":
+                raise ValueError("cancelled invitations cannot be modified")
+            await token_service.invalidate_active_tokens(
+                purpose="invite_accept",
+                account_id=invitation.account_id,
+                invitation_id=invitation.invitation_id,
+            )
+            return await repository.mark_cancelled(invitation.invitation_id)
+
+    async def _require_active_invitation_scopes(
+        self,
+        db_client: Any,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        organization_ids = {
+            str(item.get("organization_id") or "").strip()
+            for key in ("organization_invites", "team_invites")
+            for item in list((metadata or {}).get(key) or [])
+            if isinstance(item, dict) and str(item.get("organization_id") or "").strip()
+        }
+        for organization_id in sorted(organization_ids):
+            await OrganizationMutationPolicy.for_database(db_client).require_active(organization_id)
 
     async def describe_invitation_token(self, raw_token: str) -> InvitationContext | None:
         token = await self.token_service.validate_token(
@@ -501,7 +543,6 @@ class InvitationService:
             SELECT organization_id, organization_name
             FROM deltallm_organizationtable
             WHERE organization_id = $1
-              AND lifecycle_state = 'active'
             LIMIT 1
             """,
             organization_id,
@@ -523,7 +564,6 @@ class InvitationService:
             LEFT JOIN deltallm_organizationtable AS o
               ON o.organization_id = t.organization_id
             WHERE t.team_id = $1
-              AND (t.organization_id IS NULL OR o.lifecycle_state = 'active')
             LIMIT 1
             """,
             team_id,

--- a/src/services/organization_mutation_policy.py
+++ b/src/services/organization_mutation_policy.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from src.db.organization_mutation_guard import (
+    OrganizationMutationGuardDatabase,
+    OrganizationMutationGuardRepository,
+)
+from src.models.organization_lifecycle import OrganizationLifecycleState
+
+
+class OrganizationMutationError(RuntimeError):
+    code = "organization_mutation_error"
+
+
+class OrganizationMutationNotFoundError(OrganizationMutationError):
+    code = "organization_not_found"
+
+
+class OrganizationMutationUnavailableError(OrganizationMutationError):
+    code = "organization_lifecycle_unavailable"
+
+
+class OrganizationMutationInactiveError(OrganizationMutationError):
+    code = "organization_inactive"
+
+    def __init__(
+        self,
+        *,
+        organization_id: str,
+        lifecycle_state: OrganizationLifecycleState,
+    ) -> None:
+        self.organization_id = organization_id
+        self.lifecycle_state = lifecycle_state
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        return f"organization {self.organization_id} is {self.lifecycle_state.value}"
+
+    def detail(self) -> dict[str, str]:
+        return {
+            "code": self.code,
+            "message": "Organization administrative changes are disabled",
+            "lifecycle_state": self.lifecycle_state.value,
+        }
+
+
+class OrganizationMutationPolicy:
+    """Authoritative policy for human/admin organization-scoped mutations."""
+
+    def __init__(self, repository: OrganizationMutationGuardRepository) -> None:
+        self.repository = repository
+
+    @classmethod
+    def for_database(
+        cls,
+        db: OrganizationMutationGuardDatabase,
+    ) -> OrganizationMutationPolicy:
+        return cls(OrganizationMutationGuardRepository(db))
+
+    async def require_active(self, organization_id: str) -> None:
+        normalized_id = str(organization_id or "").strip()
+        if not normalized_id:
+            raise OrganizationMutationNotFoundError("Organization not found")
+        try:
+            snapshot = await self.repository.lock_organization(normalized_id)
+        except ValueError as exc:
+            raise OrganizationMutationUnavailableError(
+                "Organization lifecycle state is invalid"
+            ) from exc
+        except OrganizationMutationError:
+            raise
+        except Exception as exc:
+            raise OrganizationMutationUnavailableError(
+                "Organization lifecycle state could not be checked"
+            ) from exc
+        if snapshot is None:
+            raise OrganizationMutationNotFoundError("Organization not found")
+        if snapshot.lifecycle_state is not OrganizationLifecycleState.ACTIVE:
+            raise OrganizationMutationInactiveError(
+                organization_id=snapshot.organization_id,
+                lifecycle_state=snapshot.lifecycle_state,
+            )
+
+
+__all__ = [
+    "OrganizationMutationError",
+    "OrganizationMutationInactiveError",
+    "OrganizationMutationNotFoundError",
+    "OrganizationMutationPolicy",
+    "OrganizationMutationUnavailableError",
+]

--- a/src/services/tier_assignment_admin.py
+++ b/src/services/tier_assignment_admin.py
@@ -25,6 +25,12 @@ from src.services.tier_assignment_cache_invalidation import (
     enqueue_org_tier_assignment_cache_invalidation,
 )
 from src.services.tier_assignment_admin_serialization import serialize_tier_assignment
+from src.services.organization_mutation_policy import (
+    OrganizationMutationError,
+    OrganizationMutationInactiveError,
+    OrganizationMutationNotFoundError,
+    OrganizationMutationPolicy,
+)
 
 
 class TierAssignmentAdminService:
@@ -59,10 +65,10 @@ class TierAssignmentAdminService:
         payload: Mapping[str, Any],
     ) -> TierAssignmentCreateResult:
         organization_id = self._normalize_organization_id(organization_id)
-        await self._require_organization(organization_id)
         try:
             fields = normalize_assignment_create(payload)
             async with self._transaction() as tx:
+                await OrganizationMutationPolicy.for_database(tx).require_active(organization_id)
                 repository = self._repository_for_transaction(tx)
                 record = await repository.upsert_org_assignment_in_current_transaction(
                     organization_id=organization_id,
@@ -77,6 +83,8 @@ class TierAssignmentAdminService:
                     metadata={"assignment_id": record.assignment_id},
                     max_attempts=self.cache_invalidation_max_attempts,
                 )
+        except OrganizationMutationError as exc:
+            raise _organization_mutation_admin_error(exc) from exc
         except ValueError as exc:
             raise _assignment_admin_error(exc) from exc
         except TierAdminError:
@@ -107,9 +115,9 @@ class TierAssignmentAdminService:
     ) -> TierAssignmentUpdateResult:
         organization_id = self._normalize_organization_id(organization_id)
         assignment_id = self._normalize_assignment_id(assignment_id)
-        await self._require_organization(organization_id)
         try:
             async with self._transaction() as tx:
+                await OrganizationMutationPolicy.for_database(tx).require_active(organization_id)
                 repository = self._repository_for_transaction(tx)
                 before = await repository.get_org_assignment_for_update(
                     assignment_id=assignment_id,
@@ -132,6 +140,8 @@ class TierAssignmentAdminService:
                     metadata={"assignment_id": assignment_id},
                     max_attempts=self.cache_invalidation_max_attempts,
                 )
+        except OrganizationMutationError as exc:
+            raise _organization_mutation_admin_error(exc) from exc
         except ValueError as exc:
             raise _assignment_admin_error(exc) from exc
         except TierAdminError:
@@ -162,9 +172,9 @@ class TierAssignmentAdminService:
     ) -> TierAssignmentDeleteResult:
         organization_id = self._normalize_organization_id(organization_id)
         assignment_id = self._normalize_assignment_id(assignment_id)
-        await self._require_organization(organization_id)
         try:
             async with self._transaction() as tx:
+                await OrganizationMutationPolicy.for_database(tx).require_active(organization_id)
                 repository = self._repository_for_transaction(tx)
                 before = await repository.get_org_assignment_for_update(
                     assignment_id=assignment_id,
@@ -185,6 +195,8 @@ class TierAssignmentAdminService:
                     metadata={"assignment_id": assignment_id},
                     max_attempts=self.cache_invalidation_max_attempts,
                 )
+        except OrganizationMutationError as exc:
+            raise _organization_mutation_admin_error(exc) from exc
         except TierAdminError:
             raise
         except Exception as exc:
@@ -274,6 +286,14 @@ def _assignment_admin_error(exc: ValueError) -> TierAdminError:
     if "existing tier" in lowered or "existing tier version" in lowered:
         return TierAdminNotFoundError(detail)
     return TierAdminValidationError(detail)
+
+
+def _organization_mutation_admin_error(exc: OrganizationMutationError) -> TierAdminError:
+    if isinstance(exc, OrganizationMutationInactiveError):
+        return TierAdminConflictError(exc.detail())
+    if isinstance(exc, OrganizationMutationNotFoundError):
+        return TierAdminNotFoundError("Organization not found")
+    return TierAdminUnavailableError("Organization lifecycle state could not be checked")
 
 
 def _assignment_storage_error(exc: Exception) -> TierAdminError | None:

--- a/src/services/ui_authorization.py
+++ b/src/services/ui_authorization.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from src.auth.roles import ORG_ROLE_PERMISSIONS, PLATFORM_ROLE_PERMISSIONS, TEAM_ROLE_PERMISSIONS, Permission
+from src.auth.roles import (
+    ORG_ROLE_PERMISSIONS,
+    PLATFORM_ROLE_PERMISSIONS,
+    TEAM_ROLE_PERMISSIONS,
+    Permission,
+)
 
 
 def effective_permissions_for_context(context: Any | None) -> list[str]:
@@ -38,7 +43,9 @@ def build_ui_access(
         or Permission.KEY_UPDATE in permissions
         or Permission.KEY_CREATE_SELF in permissions
     )
-    can_view_dashboard = authenticated and (is_platform_admin or Permission.SPEND_READ in permissions)
+    can_view_dashboard = authenticated and (
+        is_platform_admin or Permission.SPEND_READ in permissions
+    )
     can_create_team = is_platform_admin
     if not can_create_team:
         for membership in list(organization_memberships or []):
@@ -65,9 +72,11 @@ def build_ui_access(
         "route_groups": is_platform_admin,
         "prompts": is_platform_admin,
         "mcp_servers": authenticated and (is_platform_admin or Permission.KEY_READ in permissions),
-        "mcp_approvals": authenticated and (is_platform_admin or Permission.KEY_UPDATE in permissions),
+        "mcp_approvals": authenticated
+        and (is_platform_admin or Permission.KEY_UPDATE in permissions),
         "keys": authenticated and (is_platform_admin or can_read_keys),
-        "organizations": authenticated and (is_platform_admin or Permission.ORG_READ in permissions),
+        "organizations": authenticated
+        and (is_platform_admin or Permission.ORG_READ in permissions),
         "organization_create": is_platform_admin,
         "teams": authenticated and (is_platform_admin or Permission.TEAM_READ in permissions),
         "team_create": authenticated and can_create_team,
@@ -103,9 +112,14 @@ def _scope_has_team_permission(scope: Any, team_id: str | None, permission: str)
 
 def build_organization_capabilities(scope: Any, organization: dict[str, Any]) -> dict[str, bool]:
     organization_id = str(organization.get("organization_id") or "").strip()
-    can_edit = _scope_has_org_permission(scope, organization_id, Permission.ORG_UPDATE)
-    can_add_team = _scope_has_org_permission(scope, organization_id, Permission.TEAM_UPDATE)
-    can_manage_assets = bool(getattr(scope, "is_platform_admin", False))
+    is_active = str(organization.get("lifecycle_state") or "").strip().lower() == "active"
+    can_edit = is_active and _scope_has_org_permission(
+        scope, organization_id, Permission.ORG_UPDATE
+    )
+    can_add_team = is_active and _scope_has_org_permission(
+        scope, organization_id, Permission.TEAM_UPDATE
+    )
+    can_manage_assets = is_active and bool(getattr(scope, "is_platform_admin", False))
 
     return {
         "view": True,
@@ -113,6 +127,7 @@ def build_organization_capabilities(scope: Any, organization: dict[str, Any]) ->
         "add_team": can_add_team,
         "manage_members": can_edit,
         "manage_assets": can_manage_assets,
+        "manage_service_policy": can_manage_assets,
         "view_usage": _scope_has_org_permission(scope, organization_id, Permission.SPEND_READ),
     }
 
@@ -120,7 +135,8 @@ def build_organization_capabilities(scope: Any, organization: dict[str, Any]) ->
 def build_team_capabilities(scope: Any, team: dict[str, Any]) -> dict[str, bool]:
     team_id = str(team.get("team_id") or "").strip()
     organization_id = str(team.get("organization_id") or "").strip()
-    can_edit = (
+    is_active = str(team.get("organization_lifecycle_state") or "").strip().lower() == "active"
+    can_edit = is_active and (
         _scope_has_team_permission(scope, team_id, Permission.TEAM_UPDATE)
         or _scope_has_org_permission(scope, organization_id, Permission.TEAM_UPDATE)
     )
@@ -132,7 +148,9 @@ def build_team_capabilities(scope: Any, team: dict[str, Any]) -> dict[str, bool]
         "manage_members": can_edit,
         "manage_assets": can_edit,
         "manage_self_service_policy": can_edit,
-        "create_self_key": bool(team.get("self_service_keys_enabled")) and _scope_has_team_permission(
+        "create_self_key": is_active
+        and bool(team.get("self_service_keys_enabled"))
+        and _scope_has_team_permission(
             scope,
             team_id,
             Permission.KEY_CREATE_SELF,
@@ -149,10 +167,9 @@ def build_batch_capabilities(
     team_id = str(batch.get("created_by_team_id") or "").strip()
     organization_id = str(batch.get("organization_id") or "").strip()
     status = str(batch.get("status") or "").strip().lower()
-    can_update = (
-        _scope_has_team_permission(scope, team_id, Permission.KEY_UPDATE)
-        or _scope_has_org_permission(scope, organization_id, Permission.KEY_UPDATE)
-    )
+    can_update = _scope_has_team_permission(
+        scope, team_id, Permission.KEY_UPDATE
+    ) or _scope_has_org_permission(scope, organization_id, Permission.KEY_UPDATE)
 
     capabilities = {
         "view": True,
@@ -176,10 +193,9 @@ def build_archived_batch_webhook_capabilities(
 
     team_id = str(ownership.get("created_by_team_id") or "").strip()
     organization_id = str(ownership.get("organization_id") or "").strip()
-    can_update = (
-        _scope_has_team_permission(scope, team_id, Permission.KEY_UPDATE)
-        or _scope_has_org_permission(scope, organization_id, Permission.KEY_UPDATE)
-    )
+    can_update = _scope_has_team_permission(
+        scope, team_id, Permission.KEY_UPDATE
+    ) or _scope_has_org_permission(scope, organization_id, Permission.KEY_UPDATE)
     return {
         "view": True,
         "cancel": False,
@@ -199,13 +215,14 @@ def build_batch_create_session_capabilities(
     team_id = str(session.get("created_by_team_id") or "").strip()
     organization_id = str(session.get("organization_id") or "").strip()
     status = str(session.get("status") or "").strip().lower()
-    can_update = (
-        _scope_has_team_permission(scope, team_id, Permission.KEY_UPDATE)
-        or _scope_has_org_permission(scope, organization_id, Permission.KEY_UPDATE)
-    )
+    can_update = _scope_has_team_permission(
+        scope, team_id, Permission.KEY_UPDATE
+    ) or _scope_has_org_permission(scope, organization_id, Permission.KEY_UPDATE)
 
     return {
         "view": True,
         "retry": admin_actions_enabled and can_update and status in {"staged", "failed_retryable"},
-        "expire": admin_actions_enabled and can_update and status in {"staged", "failed_retryable", "failed_permanent"},
+        "expire": admin_actions_enabled
+        and can_update
+        and status in {"staged", "failed_retryable", "failed_permanent"},
     }

--- a/tests/db/tier_repository_fakes.py
+++ b/tests/db/tier_repository_fakes.py
@@ -20,6 +20,7 @@ class _FakePrisma:
         next_transition_at: object = None,
         assignment_rows: dict[str, dict[str, object]] | None = None,
         organization_exists: bool = True,
+        organization_lifecycle_state: str = "active",
     ) -> None:
         self.calls: list[tuple[str, tuple[object, ...]]] = []
         self.executions: list[tuple[str, tuple[object, ...]]] = []
@@ -38,6 +39,7 @@ class _FakePrisma:
         self.next_transition_at = next_transition_at
         self.assignment_rows = dict(assignment_rows or {})
         self.organization_exists = organization_exists
+        self.organization_lifecycle_state = organization_lifecycle_state
         self.tx_clients: list[_FakePrisma] = []
         self.tx_started = 0
         self.tx_committed = 0
@@ -67,7 +69,16 @@ class _FakePrisma:
                 else []
             )
         if "FROM deltallm_organizationtable" in sql and "WHERE organization_id = $1" in sql:
-            return [{"organization_id": params[0]}] if self.organization_exists else []
+            return (
+                [
+                    {
+                        "organization_id": params[0],
+                        "lifecycle_state": self.organization_lifecycle_state,
+                    }
+                ]
+                if self.organization_exists
+                else []
+            )
         if "MIN(transition_at) AS next_transition_at" in sql:
             return [{"next_transition_at": self.next_transition_at}]
         if "resolved_version.tier_version_id AS effective_tier_version_id" in sql:
@@ -297,7 +308,10 @@ class _FakePrisma:
                 return []
             if "a.organization_id = $2" in sql:
                 organization_id = str(params[1])
-                if fields is not None and str(fields.get("organization_id") or "") != organization_id:
+                if (
+                    fields is not None
+                    and str(fields.get("organization_id") or "") != organization_id
+                ):
                     return []
             return [
                 _assignment_row(
@@ -338,6 +352,7 @@ class _FakeTxContext:
             next_transition_at=self.root.next_transition_at,
             assignment_rows=self.root.assignment_rows,
             organization_exists=self.root.organization_exists,
+            organization_lifecycle_state=self.root.organization_lifecycle_state,
         )
         self.root.tx_clients.append(self.client)
         return self.client

--- a/tests/services/test_invitation_service.py
+++ b/tests/services/test_invitation_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -8,6 +9,7 @@ import pytest
 
 from src.db.invitations import PlatformInvitationRecord
 from src.services.invitation_service import InvitationService
+from src.services.organization_mutation_policy import OrganizationMutationInactiveError
 from src.services.platform_identity_service import LoginResult
 
 
@@ -17,14 +19,21 @@ class FakeInvitationRepository:
 
     async def create(self, record: PlatformInvitationRecord) -> PlatformInvitationRecord:
         invitation_id = record.invitation_id or f"inv-{len(self.records) + 1}"
-        stored = replace(record, invitation_id=invitation_id, created_at=datetime.now(tz=UTC), updated_at=datetime.now(tz=UTC))
+        stored = replace(
+            record,
+            invitation_id=invitation_id,
+            created_at=datetime.now(tz=UTC),
+            updated_at=datetime.now(tz=UTC),
+        )
         self.records[invitation_id] = stored
         return stored
 
     async def get_by_id(self, invitation_id: str) -> PlatformInvitationRecord | None:
         return self.records.get(invitation_id)
 
-    async def get_latest_pending_by_account_id(self, account_id: str) -> PlatformInvitationRecord | None:
+    async def get_latest_pending_by_account_id(
+        self, account_id: str
+    ) -> PlatformInvitationRecord | None:
         for record in self.records.values():
             if record.account_id == account_id and record.status in {"pending", "sent"}:
                 return record
@@ -66,12 +75,16 @@ class FakeInvitationRepository:
 
     async def mark_accepted(self, invitation_id: str) -> bool:
         record = self.records[invitation_id]
-        self.records[invitation_id] = replace(record, status="accepted", accepted_at=datetime.now(tz=UTC))
+        self.records[invitation_id] = replace(
+            record, status="accepted", accepted_at=datetime.now(tz=UTC)
+        )
         return True
 
     async def mark_cancelled(self, invitation_id: str) -> bool:
         record = self.records[invitation_id]
-        self.records[invitation_id] = replace(record, status="cancelled", cancelled_at=datetime.now(tz=UTC))
+        self.records[invitation_id] = replace(
+            record, status="cancelled", cancelled_at=datetime.now(tz=UTC)
+        )
         return True
 
     async def mark_expired(self, invitation_id: str) -> bool:
@@ -106,11 +119,21 @@ class FakeTokenService:
         self.invalidated.append((purpose, account_id, invitation_id))
         return 1
 
-    async def issue_invitation_token(self, *, account_id: str, email: str, invitation_id: str, created_by_account_id: str | None):  # noqa: ANN001, ANN201
+    async def issue_invitation_token(
+        self, *, account_id: str, email: str, invitation_id: str, created_by_account_id: str | None
+    ):  # noqa: ANN001, ANN201
         del created_by_account_id
         raw = f"raw-{invitation_id}"
-        record = SimpleNamespace(token_id=f"tok-{invitation_id}", expires_at=datetime.now(tz=UTC) + timedelta(hours=72))
-        self.by_raw_token[raw] = SimpleNamespace(token_id=record.token_id, account_id=account_id, email=email, invitation_id=invitation_id, expires_at=record.expires_at)
+        record = SimpleNamespace(
+            token_id=f"tok-{invitation_id}", expires_at=datetime.now(tz=UTC) + timedelta(hours=72)
+        )
+        self.by_raw_token[raw] = SimpleNamespace(
+            token_id=record.token_id,
+            account_id=account_id,
+            email=email,
+            invitation_id=invitation_id,
+            expires_at=record.expires_at,
+        )
         return SimpleNamespace(raw_token=raw, record=record)
 
     async def validate_token(self, *, purpose: str, raw_token: str):  # noqa: ANN201
@@ -180,7 +203,9 @@ class FakePlatformIdentityService:
             self.accounts[account_id] = account
         return account
 
-    async def upsert_organization_membership(self, *, account_id: str, organization_id: str, role: str) -> None:
+    async def upsert_organization_membership(
+        self, *, account_id: str, organization_id: str, role: str
+    ) -> None:
         self.org_memberships.append((account_id, organization_id, role))
 
     async def upsert_team_membership(self, *, account_id: str, team_id: str, role: str) -> None:
@@ -228,11 +253,24 @@ class FakePlatformIdentityService:
 
 
 class FakeDB:
+    def __init__(self, *, lifecycle_state: str = "active") -> None:
+        self.lifecycle_state = lifecycle_state
+
+    @asynccontextmanager
+    async def tx(self):
+        yield self
+
     async def query_raw(self, query: str, *params):  # noqa: ANN001, ANN201
         if "FROM deltallm_teamtable" in query:
             return [{"team_id": params[0], "team_alias": "Engineering", "organization_id": "org-1"}]
         if "FROM deltallm_organizationtable" in query:
-            return [{"organization_id": params[0], "organization_name": "Acme"}]
+            return [
+                {
+                    "organization_id": params[0],
+                    "organization_name": "Acme",
+                    "lifecycle_state": self.lifecycle_state,
+                }
+            ]
         if "SELECT email FROM deltallm_platformaccount" in query:
             return [{"email": "admin@example.com"}]
         if "SELECT account_id, email FROM deltallm_platformaccount" in query:
@@ -241,7 +279,9 @@ class FakeDB:
 
 
 def _config():
-    return SimpleNamespace(general_settings=SimpleNamespace(instance_name="DeltaLLM", invitation_token_ttl_hours=72))
+    return SimpleNamespace(
+        general_settings=SimpleNamespace(instance_name="DeltaLLM", invitation_token_ttl_hours=72)
+    )
 
 
 @pytest.mark.asyncio
@@ -269,6 +309,59 @@ async def test_create_invitation_creates_pending_account_memberships_and_email()
     assert response["status"] == "sent"
     assert identity_service.org_memberships == []
     assert identity_service.team_memberships == []
+
+
+@pytest.mark.asyncio
+async def test_create_invitation_rejects_inactive_organization_before_writes() -> None:
+    identity_service = FakePlatformIdentityService()
+    repository = FakeInvitationRepository()
+    service = InvitationService(
+        db_client=FakeDB(lifecycle_state="deletion_pending"),
+        repository=repository,
+        token_service=FakeTokenService(),
+        outbox_service=FakeOutboxService(),
+        platform_identity_service=identity_service,
+        config_getter=_config,
+    )
+
+    with pytest.raises(OrganizationMutationInactiveError):
+        await service.create_invitation(
+            email="user@example.com",
+            invited_by_account_id="acct-admin",
+            organization_id="org-1",
+        )
+
+    assert repository.records == {}
+    assert identity_service.accounts == {}
+
+
+@pytest.mark.asyncio
+async def test_cancel_invitation_rejects_inactive_organization() -> None:
+    repository = FakeInvitationRepository()
+    invitation = await repository.create(
+        PlatformInvitationRecord(
+            invitation_id="inv-1",
+            account_id="acct-1",
+            email="user@example.com",
+            status="sent",
+            invite_scope_type="organization",
+            expires_at=datetime.now(tz=UTC) + timedelta(hours=1),
+            metadata={"organization_invites": [{"organization_id": "org-1", "role": "org_member"}]},
+        )
+    )
+    service = InvitationService(
+        db_client=FakeDB(lifecycle_state="deletion_pending"),
+        repository=repository,
+        token_service=FakeTokenService(),
+        outbox_service=FakeOutboxService(),
+        platform_identity_service=FakePlatformIdentityService(),
+        config_getter=_config,
+    )
+
+    with pytest.raises(OrganizationMutationInactiveError):
+        await service.cancel_invitation(invitation_id=invitation.invitation_id)
+
+    assert repository.records[invitation.invitation_id].status == "sent"
 
 
 @pytest.mark.asyncio
@@ -302,7 +395,9 @@ async def test_create_invitation_keeps_distinct_pending_records_per_scope() -> N
 
 
 @pytest.mark.asyncio
-async def test_create_invitation_rejects_suppressed_recipient_delivery_and_consumes_new_token() -> None:
+async def test_create_invitation_rejects_suppressed_recipient_delivery_and_consumes_new_token() -> (
+    None
+):
     repository = FakeInvitationRepository()
     token_service = FakeTokenService()
     outbox_service = FakeOutboxService(status="cancelled")
@@ -680,7 +775,9 @@ async def test_accept_invitation_applies_team_and_org_memberships_on_accept() ->
             expires_at=datetime.now(tz=UTC) + timedelta(hours=1),
             metadata={
                 "organization_invites": [{"organization_id": "org-1", "role": "org_admin"}],
-                "team_invites": [{"team_id": "team-1", "organization_id": "org-1", "role": "team_developer"}],
+                "team_invites": [
+                    {"team_id": "team-1", "organization_id": "org-1", "role": "team_developer"}
+                ],
             },
         )
     )

--- a/tests/services/test_organization_mutation_policy.py
+++ b/tests/services/test_organization_mutation_policy.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+from src.db.organization_mutation_guard import OrganizationMutationGuardRepository
+from src.models.organization_lifecycle import OrganizationLifecycleState
+from src.services.organization_mutation_policy import (
+    OrganizationMutationInactiveError,
+    OrganizationMutationNotFoundError,
+    OrganizationMutationPolicy,
+    OrganizationMutationUnavailableError,
+)
+
+
+class _LifecycleDatabase:
+    def __init__(self, row: dict[str, object] | None) -> None:
+        self.row = row
+        self.queries: list[tuple[str, tuple[object, ...]]] = []
+
+    async def query_raw(self, query: str, *params: object) -> list[dict[str, object]]:
+        self.queries.append((query, params))
+        return [self.row] if self.row is not None else []
+
+
+@pytest.mark.asyncio
+async def test_active_organization_mutation_locks_authoritative_row() -> None:
+    db = _LifecycleDatabase({"organization_id": "org-1", "lifecycle_state": "active"})
+
+    await OrganizationMutationPolicy(OrganizationMutationGuardRepository(db)).require_active(
+        "org-1"
+    )
+
+    assert db.queries[0][1] == ("org-1",)
+    assert "FOR SHARE" in db.queries[0][0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        OrganizationLifecycleState.DELETION_PENDING,
+        OrganizationLifecycleState.PURGING,
+        OrganizationLifecycleState.DELETION_FAILED,
+    ],
+)
+async def test_inactive_organization_mutation_fails_closed(
+    state: OrganizationLifecycleState,
+) -> None:
+    db = _LifecycleDatabase({"organization_id": "org-1", "lifecycle_state": state.value})
+
+    with pytest.raises(OrganizationMutationInactiveError) as exc_info:
+        await OrganizationMutationPolicy.for_database(db).require_active("org-1")
+
+    assert exc_info.value.detail() == {
+        "code": "organization_inactive",
+        "message": "Organization administrative changes are disabled",
+        "lifecycle_state": state.value,
+    }
+
+
+@pytest.mark.asyncio
+async def test_missing_organization_mutation_is_not_found() -> None:
+    with pytest.raises(OrganizationMutationNotFoundError):
+        await OrganizationMutationPolicy.for_database(_LifecycleDatabase(None)).require_active(
+            "org-1"
+        )
+
+
+@pytest.mark.asyncio
+async def test_unknown_lifecycle_state_is_unavailable() -> None:
+    db = _LifecycleDatabase({"organization_id": "org-1", "lifecycle_state": "future_state"})
+
+    with pytest.raises(OrganizationMutationUnavailableError):
+        await OrganizationMutationPolicy.for_database(db).require_active("org-1")

--- a/tests/test_ui_asset_access.py
+++ b/tests/test_ui_asset_access.py
@@ -18,7 +18,11 @@ from src.services.callable_targets import CallableTarget
 class _FakeScopeDB:
     def __init__(self) -> None:
         self.organizations = {
-            "org-1": {"organization_id": "org-1", "metadata": None},
+            "org-1": {
+                "organization_id": "org-1",
+                "lifecycle_state": "active",
+                "metadata": None,
+            },
         }
         self.teams = {
             "team-1": {
@@ -49,7 +53,9 @@ class _FakeScopeDB:
             return [row] if row else []
         if "FROM deltallm_organizationtable" in query:
             return list(self.organizations.values())
-        if "FROM deltallm_teamtable" in query and "WHERE team_id = $1" in query:
+        if "FROM deltallm_teamtable" in query and (
+            "WHERE team_id = $1" in query or "WHERE t.team_id = $1" in query
+        ):
             row = self.teams.get(str(params[0]))
             return [row] if row else []
         if "FROM deltallm_verificationtoken vt" in query and "WHERE vt.token = $1" in query:

--- a/tests/test_ui_authorization.py
+++ b/tests/test_ui_authorization.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
 from src.api.admin.endpoints.common import AuthScope
 from src.auth.roles import Permission
 from src.models.platform_auth import PlatformAuthContext
-from src.services.ui_authorization import build_batch_create_session_capabilities
+from src.services.ui_authorization import (
+    build_batch_create_session_capabilities,
+    build_organization_capabilities,
+    build_team_capabilities,
+)
 
 
 class FakeAuthorizationDB:
@@ -30,6 +34,9 @@ class FakeAuthorizationDB:
                 "model_tpm_limit": None,
                 "audit_content_storage_enabled": False,
                 "metadata": {},
+                "lifecycle_state": "active",
+                "deletion_requested_at": None,
+                "deletion_not_before_at": None,
                 "created_at": now,
                 "updated_at": now,
             },
@@ -39,6 +46,7 @@ class FakeAuthorizationDB:
                 "team_id": "team-1",
                 "team_alias": "Team One",
                 "organization_id": "org-1",
+                "organization_lifecycle_state": "active",
                 "max_budget": None,
                 "spend": 0.0,
                 "rpm_limit": None,
@@ -143,18 +151,36 @@ class FakeAuthorizationDB:
             return [row] if row else []
         if "COUNT(*) AS total FROM deltallm_batch_job j" in query:
             return [{"total": 1}]
-        if "COUNT(*) FILTER (WHERE status IN ('in_progress', 'finalizing')) AS in_progress" in query:
-            return [{"total": 1, "queued": 0, "in_progress": 1, "completed": 0, "failed": 0, "cancelled": 0}]
-        if "FROM deltallm_batch_job" in query and "WHERE batch_id = $1" in query and "LEFT JOIN" not in query:
+        if (
+            "COUNT(*) FILTER (WHERE status IN ('in_progress', 'finalizing')) AS in_progress"
+            in query
+        ):
+            return [
+                {
+                    "total": 1,
+                    "queued": 0,
+                    "in_progress": 1,
+                    "completed": 0,
+                    "failed": 0,
+                    "cancelled": 0,
+                }
+            ]
+        if (
+            "FROM deltallm_batch_job" in query
+            and "WHERE batch_id = $1" in query
+            and "LEFT JOIN" not in query
+        ):
             row = self.batches.get(str(params[0]))
             if not row:
                 return []
-            return [{
-                "batch_id": row["batch_id"],
-                "status": row["status"],
-                "created_by_team_id": row["created_by_team_id"],
-                "created_by_organization_id": row["created_by_organization_id"],
-            }]
+            return [
+                {
+                    "batch_id": row["batch_id"],
+                    "status": row["status"],
+                    "created_by_team_id": row["created_by_team_id"],
+                    "created_by_organization_id": row["created_by_organization_id"],
+                }
+            ]
         if "FROM deltallm_batch_job j" in query and "LEFT JOIN deltallm_teamtable t" in query:
             if "WHERE j.batch_id = $1" in query:
                 row = self.batches.get(str(params[0]))
@@ -164,10 +190,12 @@ class FakeAuthorizationDB:
             batch = self.batches.get(str(params[0]))
             if not batch:
                 return []
-            return [{
-                "total_provider_cost": batch["total_provider_cost"],
-                "total_billed_cost": batch["total_billed_cost"],
-            }]
+            return [
+                {
+                    "total_provider_cost": batch["total_provider_cost"],
+                    "total_billed_cost": batch["total_billed_cost"],
+                }
+            ]
         if "SELECT COUNT(*) AS total FROM deltallm_batch_item" in query:
             return [{"total": len(self.batch_items)}]
         if "FROM deltallm_batch_item" in query:
@@ -182,9 +210,7 @@ class FakeAuthorizationDB:
                 for row in rows:
                     error_body = row.pop("error_body", None)
                     row["_has_error_body"] = error_body is not None
-                    row["_error_retry_category"] = (error_body or {}).get(
-                        "retry_category"
-                    )
+                    row["_error_retry_category"] = (error_body or {}).get("retry_category")
                 return rows
             if "request_body IS NOT NULL AS has_request_body" in query:
                 if "line_number > $2" in query:
@@ -209,9 +235,9 @@ class FakeAuthorizationDB:
                         "provider_cost": item["provider_cost"],
                         "billed_cost": item["billed_cost"],
                         "last_error": item["last_error"],
-                        "_error_retry_category": (
-                            item.get("error_body") or {}
-                        ).get("retry_category"),
+                        "_error_retry_category": (item.get("error_body") or {}).get(
+                            "retry_category"
+                        ),
                         "has_request_body": item.get("request_body") is not None,
                         "has_response_body": item.get("response_body") is not None,
                         "has_error_body": item.get("error_body") is not None,
@@ -221,6 +247,24 @@ class FakeAuthorizationDB:
                 ]
             return list(self.batch_items)
         return []
+
+
+def test_organization_capabilities_require_an_explicit_active_lifecycle() -> None:
+    scope = AuthScope(is_platform_admin=True, org_ids=["org-1"])
+
+    active = build_organization_capabilities(
+        scope,
+        {"organization_id": "org-1", "lifecycle_state": "active"},
+    )
+    missing = build_organization_capabilities(scope, {"organization_id": "org-1"})
+
+    assert active["manage_assets"] is True
+    assert active["manage_service_policy"] is True
+    assert missing["edit"] is False
+    assert missing["add_team"] is False
+    assert missing["manage_members"] is False
+    assert missing["manage_assets"] is False
+    assert missing["manage_service_policy"] is False
 
 
 @pytest.mark.asyncio
@@ -341,7 +385,9 @@ async def test_batch_feature_status_returns_embeddings_batch_flag(client, test_a
     setattr(test_app.state.settings, "master_key", "mk-test")
     setattr(test_app.state.app_config.general_settings, "embeddings_batch_enabled", enabled)
 
-    response = await client.get("/ui/api/batches/feature-status", headers={"Authorization": "Bearer mk-test"})
+    response = await client.get(
+        "/ui/api/batches/feature-status", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     assert response.json() == {"embeddings_batch_enabled": enabled}
@@ -367,13 +413,51 @@ async def test_batch_feature_status_requires_batch_page_permission(client, test_
 
     test_app.state.platform_identity_service = StubIdentityService()
 
-    response = await client.get("/ui/api/batches/feature-status", cookies={"deltallm_session": "session-token"})
+    response = await client.get(
+        "/ui/api/batches/feature-status", cookies={"deltallm_session": "session-token"}
+    )
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Insufficient permissions"
 
 
-def test_build_batch_create_session_capabilities_disables_admin_actions_when_runtime_unavailable() -> None:
+@pytest.mark.parametrize(
+    "state",
+    ["deletion_pending", "purging", "deletion_failed", "future_state", None],
+)
+def test_build_team_capabilities_fails_closed_for_inactive_or_unknown_org(
+    state: str | None,
+) -> None:
+    scope = AuthScope(
+        is_platform_admin=True,
+        team_ids=["team-1"],
+        team_permissions_by_id={"team-1": {Permission.TEAM_UPDATE, Permission.KEY_CREATE_SELF}},
+    )
+
+    capabilities = build_team_capabilities(
+        scope,
+        {
+            "team_id": "team-1",
+            "organization_id": "org-1",
+            "organization_lifecycle_state": state,
+            "self_service_keys_enabled": True,
+        },
+    )
+
+    assert capabilities == {
+        "view": True,
+        "edit": False,
+        "delete": False,
+        "manage_members": False,
+        "manage_assets": False,
+        "manage_self_service_policy": False,
+        "create_self_key": False,
+    }
+
+
+def test_build_batch_create_session_capabilities_disables_admin_actions_when_runtime_unavailable() -> (
+    None
+):
     scope = AuthScope(
         is_platform_admin=False,
         team_ids=["team-1"],
@@ -456,27 +540,89 @@ async def test_get_organization_returns_capabilities(client, test_app, monkeypat
         lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
             is_platform_admin=False,
             org_ids=["org-1"],
-            org_permissions_by_id={"org-1": {Permission.ORG_READ, Permission.ORG_UPDATE, Permission.TEAM_UPDATE}},
+            org_permissions_by_id={
+                "org-1": {Permission.ORG_READ, Permission.ORG_UPDATE, Permission.TEAM_UPDATE}
+            },
         ),
     )
 
-    response = await client.get("/ui/api/organizations/org-1", headers={"Authorization": "Bearer mk-test"})
+    response = await client.get(
+        "/ui/api/organizations/org-1", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["organization_id"] == "org-1"
+    assert payload["lifecycle_state"] == "active"
+    assert payload["deletion_requested_at"] is None
+    assert payload["deletion_not_before_at"] is None
     assert payload["capabilities"] == {
         "view": True,
         "edit": True,
         "add_team": True,
         "manage_members": True,
         "manage_assets": False,
+        "manage_service_policy": False,
         "view_usage": False,
     }
 
 
 @pytest.mark.asyncio
-async def test_list_batches_keeps_developer_read_access_and_hides_cancel(client, test_app, monkeypatch):
+async def test_get_inactive_organization_disables_mutation_capabilities(
+    client, test_app, monkeypatch
+):
+    fake_db = FakeAuthorizationDB()
+    deletion_requested_at = datetime.now(tz=UTC)
+    deletion_not_before_at = deletion_requested_at + timedelta(days=1)
+    fake_db.organizations["org-1"].update(
+        {
+            "lifecycle_state": "deletion_pending",
+            "deletion_requested_at": deletion_requested_at,
+            "deletion_not_before_at": deletion_not_before_at,
+        }
+    )
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.organizations.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=True,
+            org_ids=["org-1"],
+            org_permissions_by_id={
+                "org-1": {
+                    Permission.ORG_READ,
+                    Permission.ORG_UPDATE,
+                    Permission.TEAM_UPDATE,
+                }
+            },
+        ),
+    )
+
+    response = await client.get(
+        "/ui/api/organizations/org-1", headers={"Authorization": "Bearer mk-test"}
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["lifecycle_state"] == "deletion_pending"
+    assert payload["deletion_requested_at"] == deletion_requested_at.isoformat()
+    assert payload["deletion_not_before_at"] == deletion_not_before_at.isoformat()
+    assert payload["capabilities"] == {
+        "view": True,
+        "edit": False,
+        "add_team": False,
+        "manage_members": False,
+        "manage_assets": False,
+        "manage_service_policy": False,
+        "view_usage": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_batches_keeps_developer_read_access_and_hides_cancel(
+    client, test_app, monkeypatch
+):
     fake_db = FakeAuthorizationDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     setattr(test_app.state.settings, "master_key", "mk-test")
@@ -487,7 +633,9 @@ async def test_list_batches_keeps_developer_read_access_and_hides_cancel(client,
             is_platform_admin=False,
             org_ids=[],
             team_ids=["team-1"],
-            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ, Permission.KEY_CREATE_SELF}},
+            team_permissions_by_id={
+                "team-1": {Permission.TEAM_READ, Permission.KEY_READ, Permission.KEY_CREATE_SELF}
+            },
         ),
     )
 
@@ -507,7 +655,9 @@ async def test_list_batches_keeps_developer_read_access_and_hides_cancel(client,
 
 
 @pytest.mark.asyncio
-async def test_list_batches_exposes_repair_capabilities_for_updating_scope(client, test_app, monkeypatch):
+async def test_list_batches_exposes_repair_capabilities_for_updating_scope(
+    client, test_app, monkeypatch
+):
     fake_db = FakeAuthorizationDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     setattr(test_app.state.settings, "master_key", "mk-test")
@@ -518,7 +668,9 @@ async def test_list_batches_exposes_repair_capabilities_for_updating_scope(clien
             is_platform_admin=False,
             org_ids=[],
             team_ids=["team-1"],
-            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ, Permission.KEY_UPDATE}},
+            team_permissions_by_id={
+                "team-1": {Permission.TEAM_READ, Permission.KEY_READ, Permission.KEY_UPDATE}
+            },
         ),
     )
 
@@ -578,7 +730,9 @@ async def test_get_batch_detail_returns_skinny_paginated_items(client, test_app,
     assert "metadata" not in payload
     assert "total_billed_cost" not in payload
     assert "total_provider_cost" not in payload
-    assert not any("COUNT(*) AS total FROM deltallm_batch_item" in query for query, _ in fake_db.queries)
+    assert not any(
+        "COUNT(*) AS total FROM deltallm_batch_item" in query for query, _ in fake_db.queries
+    )
     assert not any("SUM(provider_cost)" in query for query, _ in fake_db.queries)
 
 
@@ -748,11 +902,13 @@ async def test_batch_ui_endpoints_sanitize_historical_provider_errors(
         ("in_progress", "batch-in-progress"),
     ],
 )
-async def test_list_batches_status_filter_uses_enum_query(client, test_app, monkeypatch, status_filter, expected_batch_id):
+async def test_list_batches_status_filter_uses_enum_query(
+    client, test_app, monkeypatch, status_filter, expected_batch_id
+):
     class FilteredBatchDB(FakeAuthorizationDB):
         async def query_raw(self, query: str, *params):
-            if 'COUNT(*) AS total FROM deltallm_batch_job j' in query:
-                if 'j.status = $' in query:
+            if "COUNT(*) AS total FROM deltallm_batch_job j" in query:
+                if "j.status = $" in query:
                     assert '::"DeltaLLM_BatchJobStatus"' in query
                     assert "j.status::text =" not in query
                     return [{"total": 1 if status_filter in params else 0}]
@@ -761,16 +917,26 @@ async def test_list_batches_status_filter_uses_enum_query(client, test_app, monk
                 if "WHERE j.batch_id = $1" in query:
                     row = self.batches.get(str(params[0]))
                     return [row] if row else []
-                if 'j.status = $' in query:
+                if "j.status = $" in query:
                     assert '::"DeltaLLM_BatchJobStatus"' in query
                     assert "j.status::text =" not in query
-                    return [{
-                        **self.batches["batch-1"],
-                        "batch_id": expected_batch_id,
-                        "status": status_filter,
-                        "in_progress_items": 0 if status_filter == "queued" else self.batches["batch-1"]["in_progress_items"],
-                        "completed_items": 0 if status_filter == "queued" else self.batches["batch-1"]["completed_items"],
-                    }] if status_filter in params else []
+                    return (
+                        [
+                            {
+                                **self.batches["batch-1"],
+                                "batch_id": expected_batch_id,
+                                "status": status_filter,
+                                "in_progress_items": 0
+                                if status_filter == "queued"
+                                else self.batches["batch-1"]["in_progress_items"],
+                                "completed_items": 0
+                                if status_filter == "queued"
+                                else self.batches["batch-1"]["completed_items"],
+                            }
+                        ]
+                        if status_filter in params
+                        else []
+                    )
                 return [self.batches["batch-1"]]
             return await super().query_raw(query, *params)
 
@@ -788,7 +954,9 @@ async def test_list_batches_status_filter_uses_enum_query(client, test_app, monk
         ),
     )
 
-    response = await client.get(f"/ui/api/batches?status={status_filter}", headers={"Authorization": "Bearer mk-test"})
+    response = await client.get(
+        f"/ui/api/batches?status={status_filter}", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -798,7 +966,9 @@ async def test_list_batches_status_filter_uses_enum_query(client, test_app, monk
 
 
 @pytest.mark.asyncio
-async def test_list_batches_includes_org_owned_batches_when_scope_has_team_and_org_memberships(client, test_app, monkeypatch):
+async def test_list_batches_includes_org_owned_batches_when_scope_has_team_and_org_memberships(
+    client, test_app, monkeypatch
+):
     class MixedScopeBatchDB(FakeAuthorizationDB):
         def __init__(self) -> None:
             super().__init__()
@@ -880,14 +1050,18 @@ async def test_batch_summary_counts_finalizing_as_in_progress(client, test_app, 
         ),
     )
 
-    response = await client.get("/ui/api/batches/summary", headers={"Authorization": "Bearer mk-test"})
+    response = await client.get(
+        "/ui/api/batches/summary", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     assert response.json()["in_progress"] == 1
 
 
 @pytest.mark.asyncio
-async def test_batch_summary_includes_org_owned_batches_when_scope_has_team_and_org_memberships(client, test_app, monkeypatch):
+async def test_batch_summary_includes_org_owned_batches_when_scope_has_team_and_org_memberships(
+    client, test_app, monkeypatch
+):
     class MixedScopeBatchDB(FakeAuthorizationDB):
         def __init__(self) -> None:
             super().__init__()
@@ -905,20 +1079,29 @@ async def test_batch_summary_includes_org_owned_batches_when_scope_has_team_and_
             }
 
         async def query_raw(self, query: str, *params):
-            if "COUNT(*) FILTER (WHERE status IN ('in_progress', 'finalizing')) AS in_progress" in query:
+            if (
+                "COUNT(*) FILTER (WHERE status IN ('in_progress', 'finalizing')) AS in_progress"
+                in query
+            ):
                 completed = sum(1 for row in self.batches.values() if row["status"] == "completed")
                 failed = sum(1 for row in self.batches.values() if row["status"] == "failed")
                 cancelled = sum(1 for row in self.batches.values() if row["status"] == "cancelled")
                 queued = sum(1 for row in self.batches.values() if row["status"] == "queued")
-                in_progress = sum(1 for row in self.batches.values() if row["status"] in {"in_progress", "finalizing"})
-                return [{
-                    "total": len(self.batches),
-                    "queued": queued,
-                    "in_progress": in_progress,
-                    "completed": completed,
-                    "failed": failed,
-                    "cancelled": cancelled,
-                }]
+                in_progress = sum(
+                    1
+                    for row in self.batches.values()
+                    if row["status"] in {"in_progress", "finalizing"}
+                )
+                return [
+                    {
+                        "total": len(self.batches),
+                        "queued": queued,
+                        "in_progress": in_progress,
+                        "completed": completed,
+                        "failed": failed,
+                        "cancelled": cancelled,
+                    }
+                ]
             return await super().query_raw(query, *params)
 
     fake_db = MixedScopeBatchDB()
@@ -936,7 +1119,9 @@ async def test_batch_summary_includes_org_owned_batches_when_scope_has_team_and_
         ),
     )
 
-    response = await client.get("/ui/api/batches/summary", headers={"Authorization": "Bearer mk-test"})
+    response = await client.get(
+        "/ui/api/batches/summary", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     assert response.json() == {
@@ -950,7 +1135,9 @@ async def test_batch_summary_includes_org_owned_batches_when_scope_has_team_and_
 
 
 @pytest.mark.asyncio
-async def test_list_batch_create_sessions_exposes_session_capabilities_for_updating_scope(client, test_app, monkeypatch):
+async def test_list_batch_create_sessions_exposes_session_capabilities_for_updating_scope(
+    client, test_app, monkeypatch
+):
     class SessionDB(FakeAuthorizationDB):
         def __init__(self) -> None:
             super().__init__()
@@ -984,7 +1171,10 @@ async def test_list_batch_create_sessions_exposes_session_capabilities_for_updat
         async def query_raw(self, query: str, *params):
             if "COUNT(*) AS total" in query and "FROM deltallm_batch_create_session s" in query:
                 return [{"total": len(self.sessions)}]
-            if "FROM deltallm_batch_create_session s" in query and "LEFT JOIN deltallm_teamtable t" in query:
+            if (
+                "FROM deltallm_batch_create_session s" in query
+                and "LEFT JOIN deltallm_teamtable t" in query
+            ):
                 if "WHERE s.session_id = $1" in query:
                     return [self.sessions[0]]
                 return list(self.sessions)
@@ -1001,11 +1191,15 @@ async def test_list_batch_create_sessions_exposes_session_capabilities_for_updat
             is_platform_admin=False,
             org_ids=[],
             team_ids=["team-1"],
-            team_permissions_by_id={"team-1": {Permission.TEAM_READ, Permission.KEY_READ, Permission.KEY_UPDATE}},
+            team_permissions_by_id={
+                "team-1": {Permission.TEAM_READ, Permission.KEY_READ, Permission.KEY_UPDATE}
+            },
         ),
     )
 
-    response = await client.get("/ui/api/batch-create-sessions", headers={"Authorization": "Bearer mk-test"})
+    response = await client.get(
+        "/ui/api/batch-create-sessions", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     payload = response.json()

--- a/tests/test_ui_key_notifications.py
+++ b/tests/test_ui_key_notifications.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from typing import Any
 
 import pytest
@@ -26,6 +27,7 @@ class _FakeKeyNotificationDB:
             }
         }
         self.accounts = {"acct-owner"}
+        self.organization_states = {"org-1": "active"}
         self.keys: dict[str, dict[str, Any]] = {
             "key-1": {
                 "token": "key-1",
@@ -37,18 +39,35 @@ class _FakeKeyNotificationDB:
             }
         }
 
+    @asynccontextmanager
+    async def tx(self):
+        yield self
+
     async def query_raw(self, query: str, *params):  # noqa: ANN201
         normalized = " ".join(query.lower().split())
         token = str(params[0]) if params else ""
 
+        if "from deltallm_organizationtable" in normalized and "for share" in normalized:
+            state = self.organization_states.get(token)
+            return (
+                [{"organization_id": token, "lifecycle_state": state}] if state is not None else []
+            )
+
         if normalized.startswith("select account_id from deltallm_platformaccount"):
             return [{"account_id": token}] if token in self.accounts else []
 
-        if "from deltallm_teamtable" in normalized and "where team_id = $1" in normalized and "team_alias" in normalized:
+        if (
+            "from deltallm_teamtable" in normalized
+            and "where team_id = $1" in normalized
+            and "team_alias" in normalized
+        ):
             row = self.teams.get(token)
             return [dict(row)] if row is not None else []
 
-        if "from deltallm_verificationtoken vt" in normalized and "left join deltallm_usertable" in normalized:
+        if (
+            "from deltallm_verificationtoken vt" in normalized
+            and "left join deltallm_usertable" in normalized
+        ):
             row = self.keys.get(token)
             if row is None:
                 return []
@@ -66,7 +85,15 @@ class _FakeKeyNotificationDB:
             return [{"token": row["token"]}] if row else []
 
         if (
-            "select vt.token, vt.key_name, vt.team_id, t.team_alias, t.organization_id," in normalized
+            normalized.startswith("select token, key_name, user_id, team_id")
+            and "from deltallm_verificationtoken" in normalized
+        ):
+            row = self.keys.get(token)
+            return [dict(row)] if row is not None else []
+
+        if (
+            "select vt.token, vt.key_name, vt.team_id, t.team_alias, t.organization_id,"
+            in normalized
             and "from deltallm_verificationtoken vt" in normalized
         ):
             row = self.keys.get(token)
@@ -117,7 +144,9 @@ class _FakeKeyNotificationDB:
                 "owner_service_account_id": owner_service_account_id,
             }
             return 1
-        if normalized.startswith("update deltallm_verificationtoken set token = $1, updated_at = now() where token = $2"):
+        if normalized.startswith(
+            "update deltallm_verificationtoken set token = $1, updated_at = now() where token = $2"
+        ):
             new_hash = str(params[0])
             old_hash = str(params[1])
             row = self.keys.pop(old_hash, None)
@@ -162,12 +191,16 @@ async def test_regenerate_delete_and_revoke_survive_notification_failure(client,
     test_app.state.key_notification_service = notifier
     setattr(test_app.state.settings, "master_key", "mk-test")
 
-    regenerate = await client.post("/ui/api/keys/key-1/regenerate", headers={"Authorization": "Bearer mk-test"})
+    regenerate = await client.post(
+        "/ui/api/keys/key-1/regenerate", headers={"Authorization": "Bearer mk-test"}
+    )
     assert regenerate.status_code == 200
     new_hash = regenerate.json()["token"]
     assert notifier.calls[0]["event_kind"] == "api_key_regenerated"
 
-    revoke = await client.post(f"/ui/api/keys/{new_hash}/revoke", headers={"Authorization": "Bearer mk-test"})
+    revoke = await client.post(
+        f"/ui/api/keys/{new_hash}/revoke", headers={"Authorization": "Bearer mk-test"}
+    )
     assert revoke.status_code == 200
     assert revoke.json() == {"revoked": True}
     assert notifier.calls[1]["event_kind"] == "api_key_revoked"
@@ -184,3 +217,67 @@ async def test_regenerate_delete_and_revoke_survive_notification_failure(client,
     assert delete.status_code == 200
     assert delete.json() == {"deleted": True}
     assert notifier.calls[2]["event_kind"] == "api_key_deleted"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["post", "delete"])
+async def test_key_deletion_rejects_inactive_organization(
+    client,
+    test_app,
+    method: str,
+) -> None:
+    db = _FakeKeyNotificationDB()
+    db.organization_states["org-1"] = "deletion_pending"
+    test_app.state.prisma_manager = type("Prisma", (), {"client": db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    path = "/ui/api/keys/key-1/revoke" if method == "post" else "/ui/api/keys/key-1"
+
+    response = await client.request(
+        method,
+        path,
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "organization_inactive"
+    assert "key-1" in db.keys
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["create", "update", "regenerate"])
+async def test_other_key_mutations_reject_inactive_organization(
+    client,
+    test_app,
+    operation: str,
+) -> None:
+    db = _FakeKeyNotificationDB()
+    db.organization_states["org-1"] = "deletion_pending"
+    test_app.state.prisma_manager = type("Prisma", (), {"client": db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    if operation == "create":
+        response = await client.post(
+            "/ui/api/keys",
+            headers={"Authorization": "Bearer mk-test"},
+            json={
+                "key_name": "Blocked Key",
+                "team_id": "team-1",
+                "owner_account_id": "acct-owner",
+            },
+        )
+    elif operation == "update":
+        response = await client.put(
+            "/ui/api/keys/key-1",
+            headers={"Authorization": "Bearer mk-test"},
+            json={"key_name": "Blocked Rename"},
+        )
+    else:
+        response = await client.post(
+            "/ui/api/keys/key-1/regenerate",
+            headers={"Authorization": "Bearer mk-test"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "organization_inactive"
+    assert set(db.keys) == {"key-1"}
+    assert db.keys["key-1"]["key_name"] == "Existing Key"

--- a/tests/test_ui_member_candidates.py
+++ b/tests/test_ui_member_candidates.py
@@ -48,7 +48,9 @@ class FakeMemberCandidateDB:
         return 1
 
     async def query_raw(self, query: str, *params):
-        if "FROM deltallm_teamtable" in query and "WHERE team_id = $1" in query:
+        if "FROM deltallm_teamtable" in query and (
+            "WHERE team_id = $1" in query or "WHERE t.team_id = $1" in query
+        ):
             if params[0] == "team-1":
                 return [
                     {

--- a/tests/test_ui_organizations_assets.py
+++ b/tests/test_ui_organizations_assets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from dataclasses import replace
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -18,6 +19,10 @@ from src.services.asset_ownership import owner_scope_from_metadata
 class _FakeAdminDB:
     def __init__(self) -> None:
         self.organizations: dict[str, dict[str, Any]] = {}
+
+    @asynccontextmanager
+    async def tx(self):
+        yield self
 
     async def execute_raw(self, query: str, *params):
         if "INSERT INTO deltallm_organizationtable" in query:
@@ -52,8 +57,12 @@ class _FakeAdminDB:
                         "organization_name": organization_name,
                         "max_budget": max_budget,
                         "soft_budget": soft_budget,
-                        "budget_duration": budget_duration if reset_fields_provided else row.get("budget_duration"),
-                        "budget_reset_at": budget_reset_at if reset_fields_provided else row.get("budget_reset_at"),
+                        "budget_duration": budget_duration
+                        if reset_fields_provided
+                        else row.get("budget_duration"),
+                        "budget_reset_at": budget_reset_at
+                        if reset_fields_provided
+                        else row.get("budget_reset_at"),
                         "rpm_limit": rpm_limit,
                         "tpm_limit": tpm_limit,
                         "rph_limit": rph_limit,
@@ -85,6 +94,9 @@ class _FakeAdminDB:
                 "model_tpm_limit": model_tpm_limit,
                 "audit_content_storage_enabled": bool(audit_content_storage_enabled),
                 "metadata": metadata or {},
+                "lifecycle_state": "active",
+                "deletion_requested_at": None,
+                "deletion_not_before_at": None,
                 "created_at": datetime.now(tz=UTC),
                 "updated_at": datetime.now(tz=UTC),
             }
@@ -171,9 +183,7 @@ class _TransactionalAdminDB(_FakeAdminDB):
                     "weight": record.weight,
                     "tier_key": record.tier_key,
                     "tier_name": record.tier_name,
-                    "effective_tier_version_id": (
-                        record.tier_version_id or "tier-version-active"
-                    ),
+                    "effective_tier_version_id": (record.tier_version_id or "tier-version-active"),
                     "tier_version_number": record.tier_version_number or 1,
                 }
                 for record in self.tier_assignments.values()
@@ -331,7 +341,9 @@ class _FakeRouteGroupRepository:
         items = list(self.groups.values())[offset : offset + limit]
         return items, len(self.groups)
 
-    async def list_bindings(self, *, group_key=None, scope_type=None, scope_id=None, limit=500, offset=0):  # noqa: ANN001, ANN201
+    async def list_bindings(
+        self, *, group_key=None, scope_type=None, scope_id=None, limit=500, offset=0
+    ):  # noqa: ANN001, ANN201
         items = [binding for bindings in self.bindings.values() for binding in bindings]
         if group_key:
             items = [binding for binding in items if binding.group_key == group_key]
@@ -379,7 +391,9 @@ class _FakeCallableTargetBindingRepository:
         self.bindings: list[CallableTargetBindingRecord] = []
         self._counter = 0
 
-    async def list_bindings(self, *, callable_key=None, scope_type=None, scope_id=None, limit=500, offset=0):  # noqa: ANN001, ANN201
+    async def list_bindings(
+        self, *, callable_key=None, scope_type=None, scope_id=None, limit=500, offset=0
+    ):  # noqa: ANN001, ANN201
         items = list(self.bindings)
         if callable_key:
             items = [item for item in items if item.callable_key == callable_key]
@@ -392,7 +406,11 @@ class _FakeCallableTargetBindingRepository:
 
     async def upsert_binding(self, *, callable_key, scope_type, scope_id, enabled, metadata):  # noqa: ANN001, ANN201
         for index, item in enumerate(self.bindings):
-            if item.callable_key == callable_key and item.scope_type == scope_type and item.scope_id == scope_id:
+            if (
+                item.callable_key == callable_key
+                and item.scope_type == scope_type
+                and item.scope_id == scope_id
+            ):
                 updated = replace(item, enabled=enabled, metadata=metadata)
                 self.bindings[index] = updated
                 return updated
@@ -556,9 +574,10 @@ async def test_create_tier_managed_organization_mirrors_tier_access_in_shadow_mo
     assert payload["service_policy"]["source"] == "tier"
     assert payload["service_policy"]["runtime_source"] == "legacy"
     assert payload["service_policy"]["tier_authoritative"] is False
-    assert {
-        item["callable_key"] for item in payload["callable_target_bindings"]
-    } == {"gpt-4o-mini", "llama-fast"}
+    assert {item["callable_key"] for item in payload["callable_target_bindings"]} == {
+        "gpt-4o-mini",
+        "llama-fast",
+    }
     assert all(
         item["metadata"]["source"] == "tier_shadow_mirror"
         for item in payload["callable_target_bindings"]
@@ -841,7 +860,10 @@ async def test_create_organization_applies_route_group_bootstrap_bindings(client
     assert response.status_code == 200
     payload = response.json()
     assert len(payload["route_group_bindings"]) == 2
-    assert {item["group_key"] for item in payload["route_group_bindings"]} == {"support-route", "sales-route"}
+    assert {item["group_key"] for item in payload["route_group_bindings"]} == {
+        "support-route",
+        "sales-route",
+    }
     assert all(item["scope_type"] == "organization" for item in payload["route_group_bindings"])
     assert all(item["scope_id"] == "org-asset" for item in payload["route_group_bindings"])
     assert {item["callable_key"] for item in payload["callable_target_bindings"]} == {
@@ -856,12 +878,16 @@ async def test_create_organization_applies_route_group_bootstrap_bindings(client
     assert len(detail.json()["route_group_bindings"]) == 2
     assert len(detail.json()["callable_target_bindings"]) == 3
 
-    visibility = await client.get("/ui/api/organizations/org-asset/asset-visibility", headers=headers)
+    visibility = await client.get(
+        "/ui/api/organizations/org-asset/asset-visibility", headers=headers
+    )
     assert visibility.status_code == 200
     visibility_payload = visibility.json()
     assert visibility_payload["route_groups"]["total"] == 2
     assert visibility_payload["callable_targets"]["total"] == 3
-    assert {item["visibility_source"] for item in visibility_payload["route_groups"]["items"]} == {"granted"}
+    assert {item["visibility_source"] for item in visibility_payload["route_groups"]["items"]} == {
+        "granted"
+    }
 
 
 @pytest.mark.asyncio
@@ -922,7 +948,9 @@ async def test_create_organization_persists_monthly_budget_reset(client, test_ap
     assert payload["budget_duration"] == "1mo"
     assert payload["budget_reset_at"] == "2099-05-01T00:00:00Z"
     assert fake_db.organizations["org-reset"]["budget_reset_at"] == datetime(2099, 5, 1)
-    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 1
+    assert (
+        fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 1
+    )
 
     detail = await client.get("/ui/api/organizations/org-reset", headers=headers)
     assert detail.status_code == 200
@@ -1046,7 +1074,9 @@ async def test_create_organization_normalizes_budget_reset_to_utc(client, test_a
     assert response.status_code == 200
     assert response.json()["budget_reset_at"] == "2099-04-30T22:30:00Z"
     assert fake_db.organizations["org-reset"]["budget_reset_at"] == datetime(2099, 4, 30, 22, 30)
-    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 30
+    assert (
+        fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 30
+    )
 
 
 @pytest.mark.asyncio
@@ -1180,7 +1210,9 @@ async def test_update_organization_persists_and_clears_monthly_budget_reset(clie
     update_payload = update.json()
     assert update_payload["budget_duration"] == "1mo"
     assert update_payload["budget_reset_at"] == "2099-06-01T00:00:00Z"
-    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 1
+    assert (
+        fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 1
+    )
 
     cleared = await client.put(
         "/ui/api/organizations/org-reset",
@@ -1196,7 +1228,9 @@ async def test_update_organization_persists_and_clears_monthly_budget_reset(clie
 
 
 @pytest.mark.asyncio
-async def test_update_organization_preserves_monthly_anchor_when_reset_fields_are_omitted(client, test_app):
+async def test_update_organization_preserves_monthly_anchor_when_reset_fields_are_omitted(
+    client, test_app
+):
     fake_db = _FakeAdminDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     test_app.state.route_group_repository = _FakeRouteGroupRepository()
@@ -1223,7 +1257,9 @@ async def test_update_organization_preserves_monthly_anchor_when_reset_fields_ar
 
     assert response.status_code == 200
     assert response.json()["budget_reset_at"] == "2099-01-30T00:00:00Z"
-    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 30
+    assert (
+        fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 30
+    )
 
 
 @pytest.mark.asyncio
@@ -1261,7 +1297,9 @@ async def test_update_organization_preserves_budget_reset_when_fields_are_omitte
 
 
 @pytest.mark.asyncio
-async def test_update_organization_preserves_custom_month_reset_when_fields_are_omitted(client, test_app):
+async def test_update_organization_preserves_custom_month_reset_when_fields_are_omitted(
+    client, test_app
+):
     fake_db = _FakeAdminDB()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     test_app.state.route_group_repository = _FakeRouteGroupRepository()
@@ -1292,7 +1330,9 @@ async def test_update_organization_preserves_custom_month_reset_when_fields_are_
     assert payload["organization_name"] == "Renamed Org Reset"
     assert payload["budget_duration"] == "3mo"
     assert payload["budget_reset_at"].startswith("2099-05-31T00:00:00")
-    assert fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 31
+    assert (
+        fake_db.organizations["org-reset"]["metadata"]["_budget_reset"]["monthly_anchor_day"] == 31
+    )
 
 
 @pytest.mark.asyncio
@@ -1359,13 +1399,25 @@ async def test_create_organization_rejects_invalid_budget_reset_fields(client, t
     )
 
     assert invalid_duration.status_code == 400
-    assert invalid_duration.json()["detail"] == "budget_duration must be a positive integer up to 10000 followed by h, d, or mo"
+    assert (
+        invalid_duration.json()["detail"]
+        == "budget_duration must be a positive integer up to 10000 followed by h, d, or mo"
+    )
     assert out_of_range_duration.status_code == 400
-    assert out_of_range_duration.json()["detail"] == "budget_duration must be a positive integer up to 10000 followed by h, d, or mo"
+    assert (
+        out_of_range_duration.json()["detail"]
+        == "budget_duration must be a positive integer up to 10000 followed by h, d, or mo"
+    )
     assert missing_reset_at.status_code == 400
-    assert missing_reset_at.json()["detail"] == "budget_reset_at is required when budget_duration is set"
+    assert (
+        missing_reset_at.json()["detail"]
+        == "budget_reset_at is required when budget_duration is set"
+    )
     assert missing_duration.status_code == 400
-    assert missing_duration.json()["detail"] == "budget_duration is required when budget_reset_at is set"
+    assert (
+        missing_duration.json()["detail"]
+        == "budget_duration is required when budget_reset_at is set"
+    )
 
 
 @pytest.mark.asyncio
@@ -1379,7 +1431,9 @@ async def test_organization_asset_visibility_includes_owned_route_groups(client,
         mode="chat",
         routing_strategy="weighted",
         enabled=True,
-        metadata={"_asset_governance": {"owner_scope_type": "organization", "owner_scope_id": "org-asset"}},
+        metadata={
+            "_asset_governance": {"owner_scope_type": "organization", "owner_scope_id": "org-asset"}
+        },
     )
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     test_app.state.route_group_repository = route_groups
@@ -1394,7 +1448,9 @@ async def test_organization_asset_visibility_includes_owned_route_groups(client,
         json={"organization_id": "org-asset"},
     )
 
-    visibility = await client.get("/ui/api/organizations/org-asset/asset-visibility", headers=headers)
+    visibility = await client.get(
+        "/ui/api/organizations/org-asset/asset-visibility", headers=headers
+    )
 
     assert visibility.status_code == 200
     route_groups_payload = visibility.json()["route_groups"]["items"]
@@ -1434,7 +1490,9 @@ async def test_create_organization_rejects_unknown_callable_target_binding(clien
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     test_app.state.route_group_repository = route_groups
     test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
-    test_app.state.callable_target_catalog = {"gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model")}
+    test_app.state.callable_target_catalog = {
+        "gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model")
+    }
     setattr(test_app.state.settings, "master_key", "mk-test")
     headers = {"Authorization": "Bearer mk-test"}
 
@@ -1453,13 +1511,17 @@ async def test_create_organization_rejects_unknown_callable_target_binding(clien
 
 
 @pytest.mark.asyncio
-async def test_update_organization_rejects_invalid_bindings_without_persisting_changes(client, test_app):
+async def test_update_organization_rejects_invalid_bindings_without_persisting_changes(
+    client, test_app
+):
     fake_db = _FakeAdminDB()
     route_groups = _FakeRouteGroupRepository()
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     test_app.state.route_group_repository = route_groups
     test_app.state.callable_target_binding_repository = _FakeCallableTargetBindingRepository()
-    test_app.state.callable_target_catalog = {"gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model")}
+    test_app.state.callable_target_catalog = {
+        "gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model")
+    }
     setattr(test_app.state.settings, "master_key", "mk-test")
     headers = {"Authorization": "Bearer mk-test"}
 

--- a/tests/test_ui_rate_limits.py
+++ b/tests/test_ui_rate_limits.py
@@ -6,10 +6,25 @@ from typing import Any
 import pytest
 
 
+class _FakeTransaction:
+    def __init__(self, db: "FakeAdminDB") -> None:
+        self.db = db
+
+    async def __aenter__(self) -> "FakeAdminDB":
+        return self.db
+
+    async def __aexit__(self, exc_type, exc, traceback) -> bool:  # noqa: ANN001
+        del exc_type, exc, traceback
+        return False
+
+
 class FakeAdminDB:
     def __init__(self) -> None:
         self.organizations: dict[str, dict[str, Any]] = {}
         self.teams: dict[str, dict[str, Any]] = {}
+
+    def tx(self) -> _FakeTransaction:
+        return _FakeTransaction(self)
 
     async def execute_raw(self, query: str, *params):
         if "INSERT INTO deltallm_organizationtable" in query:
@@ -45,8 +60,13 @@ class FakeAdminDB:
                 "tpd_limit": tpd_limit,
                 "model_rpm_limit": model_rpm_limit,
                 "model_tpm_limit": model_tpm_limit,
-                "audit_content_storage_enabled": bool(audit_content_storage_enabled) if audit_content_storage_enabled is not None else False,
+                "audit_content_storage_enabled": bool(audit_content_storage_enabled)
+                if audit_content_storage_enabled is not None
+                else False,
                 "metadata": metadata or {},
+                "lifecycle_state": "active",
+                "deletion_requested_at": None,
+                "deletion_not_before_at": None,
                 "created_at": datetime.now(tz=UTC),
                 "updated_at": datetime.now(tz=UTC),
             }
@@ -115,6 +135,7 @@ class FakeAdminDB:
                 "team_id": team_id,
                 "team_alias": team_alias,
                 "organization_id": organization_id,
+                "organization_lifecycle_state": "active",
                 "max_budget": max_budget,
                 "spend": 0.0,
                 "rpm_limit": rpm_limit,
@@ -216,7 +237,14 @@ async def test_ui_create_endpoints_accept_rate_limits(client, test_app):
     assert org.status_code == 200
     assert team.status_code == 200
     assert org.json()["rpm_limit"] == 40
+    assert org.json()["lifecycle_state"] == "active"
+    assert org.json()["capabilities"]["edit"] is True
     assert team.json()["tpm_limit"] == 3000
+
+    listed = await client.get("/ui/api/organizations", headers=headers)
+    assert listed.status_code == 200
+    assert listed.json()["data"][0]["lifecycle_state"] == "active"
+    assert listed.json()["data"][0]["capabilities"]["add_team"] is True
 
 
 @pytest.mark.asyncio
@@ -305,3 +333,78 @@ async def test_ui_update_endpoints_persist_rate_limits(client, test_app):
     assert team.status_code == 200
     assert org.json()["rpm_limit"] == 99
     assert team.json()["tpm_limit"] == 8888
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        ("post", "/ui/api/organizations", {"organization_id": "org-1", "rpm_limit": 99}),
+        ("post", "/ui/api/teams", {"team_id": "team-blocked", "organization_id": "org-1"}),
+        ("put", "/ui/api/organizations/org-1", {"rpm_limit": 99}),
+        ("put", "/ui/api/teams/team-1", {"rpm_limit": 99}),
+    ],
+)
+async def test_inactive_organization_rejects_admin_mutations(
+    client,
+    test_app,
+    method: str,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    fake_db = FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={"organization_id": "org-1"},
+    )
+    await client.post(
+        "/ui/api/teams",
+        headers=headers,
+        json={"team_id": "team-1", "organization_id": "org-1"},
+    )
+    fake_db.organizations["org-1"]["lifecycle_state"] = "deletion_pending"
+
+    response = await client.request(method, path, headers=headers, json=payload)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "code": "organization_inactive",
+        "message": "Organization administrative changes are disabled",
+        "lifecycle_state": "deletion_pending",
+    }
+
+
+@pytest.mark.asyncio
+async def test_inactive_organization_rejects_service_account_creation(
+    client,
+    test_app,
+) -> None:
+    fake_db = FakeAdminDB()
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    headers = {"Authorization": "Bearer mk-test"}
+    await client.post(
+        "/ui/api/organizations",
+        headers=headers,
+        json={"organization_id": "org-1"},
+    )
+    await client.post(
+        "/ui/api/teams",
+        headers=headers,
+        json={"team_id": "team-1", "organization_id": "org-1"},
+    )
+    fake_db.organizations["org-1"]["lifecycle_state"] = "deletion_pending"
+
+    response = await client.post(
+        "/ui/api/service-accounts",
+        headers=headers,
+        json={"team_id": "team-1", "name": "automation"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "organization_inactive"

--- a/tests/test_ui_rbac_principals.py
+++ b/tests/test_ui_rbac_principals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -59,6 +60,7 @@ class FakeDB:
             "org-1": {
                 "organization_id": "org-1",
                 "organization_name": "Sandbox Org",
+                "lifecycle_state": "active",
                 "metadata": {
                     "source": "self_registration",
                     "self_registration_default": "organization",
@@ -104,7 +106,29 @@ class FakeDB:
             }
         }
 
+    @asynccontextmanager
+    async def tx(self):
+        yield self
+
     async def query_raw(self, query: str, *params):
+        if "FROM deltallm_organizationtable" in query and "FOR SHARE" in query:
+            row = self.organizations.get(str(params[0]))
+            return [row] if row else []
+        if "SELECT DISTINCT organization_id" in query and "account_organizations" in query:
+            account_id = str(params[0])
+            organization_ids = {
+                str(row["organization_id"])
+                for row in self.org_memberships.values()
+                if row["account_id"] == account_id
+            }
+            organization_ids.update(
+                str(self.teams[row["team_id"]]["organization_id"])
+                for row in self.team_memberships.values()
+                if row["account_id"] == account_id
+                and row["team_id"] in self.teams
+                and self.teams[row["team_id"]].get("organization_id")
+            )
+            return [{"organization_id": value} for value in sorted(organization_ids)]
         if "SELECT COUNT(*) AS total FROM deltallm_platformaccount" in query:
             return [{"total": len(self.accounts)}]
         if "FROM deltallm_platformaccount" in query and "WHERE account_id = $1" in query:
@@ -119,7 +143,10 @@ class FakeDB:
         if "FROM deltallm_teamtable WHERE team_id = $1" in query:
             row = self.teams.get(str(params[0]))
             return [row] if row else []
-        if "FROM deltallm_organizationmembership" in query and "WHERE account_id = $1 AND organization_id = $2" in query:
+        if (
+            "FROM deltallm_organizationmembership" in query
+            and "WHERE account_id = $1 AND organization_id = $2" in query
+        ):
             account_id = str(params[0])
             organization_id = str(params[1])
             for row in self.org_memberships.values():
@@ -142,7 +169,9 @@ class FakeDB:
         if "FROM deltallm_organizationmembership" in query:
             rows = []
             for membership in self.org_memberships.values():
-                organization = self.organizations.get(str(membership.get("organization_id") or ""), {})
+                organization = self.organizations.get(
+                    str(membership.get("organization_id") or ""), {}
+                )
                 rows.append(
                     {
                         **membership,
@@ -151,6 +180,12 @@ class FakeDB:
                     }
                 )
             return rows
+        if "FROM deltallm_teammembership tm" in query and "WHERE tm.membership_id = $1" in query:
+            membership = self.team_memberships.get(str(params[0]))
+            if membership is None:
+                return []
+            team = self.teams.get(str(membership.get("team_id") or ""), {})
+            return [{**membership, "organization_id": team.get("organization_id")}]
         if "FROM deltallm_teammembership" in query:
             rows = []
             for membership in self.team_memberships.values():
@@ -161,7 +196,9 @@ class FakeDB:
                         "team_alias": team.get("team_alias"),
                         "organization_id": team.get("organization_id"),
                         "self_service_keys_enabled": team.get("self_service_keys_enabled"),
-                        "self_service_max_keys_per_user": team.get("self_service_max_keys_per_user"),
+                        "self_service_max_keys_per_user": team.get(
+                            "self_service_max_keys_per_user"
+                        ),
                         "self_service_budget_ceiling": team.get("self_service_budget_ceiling"),
                         "self_service_require_expiry": team.get("self_service_require_expiry"),
                         "self_service_max_expiry_days": team.get("self_service_max_expiry_days"),
@@ -228,21 +265,29 @@ class FakeDB:
             organization_id = str(params[1])
             if organization_id != "org-1":
                 return 0
-            to_delete = [k for k, v in self.team_memberships.items() if v["account_id"] == account_id and v["team_id"] == "team-1"]
+            to_delete = [
+                k
+                for k, v in self.team_memberships.items()
+                if v["account_id"] == account_id and v["team_id"] == "team-1"
+            ]
             for k in to_delete:
                 del self.team_memberships[k]
             return len(to_delete)
 
         if "DELETE FROM deltallm_teammembership WHERE account_id = $1" in query:
             account_id = str(params[0])
-            to_delete = [k for k, v in self.team_memberships.items() if v["account_id"] == account_id]
+            to_delete = [
+                k for k, v in self.team_memberships.items() if v["account_id"] == account_id
+            ]
             for k in to_delete:
                 del self.team_memberships[k]
             return len(to_delete)
 
         if "DELETE FROM deltallm_organizationmembership WHERE account_id = $1" in query:
             account_id = str(params[0])
-            to_delete = [k for k, v in self.org_memberships.items() if v["account_id"] == account_id]
+            to_delete = [
+                k for k, v in self.org_memberships.items() if v["account_id"] == account_id
+            ]
             for k in to_delete:
                 del self.org_memberships[k]
             return len(to_delete)
@@ -409,7 +454,9 @@ async def test_delete_org_membership_removes_org_and_team_memberships_in_org(cli
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     setattr(test_app.state.settings, "master_key", "mk-test")
 
-    response = await client.delete("/ui/api/rbac/organization-memberships/om-1", headers={"Authorization": "Bearer mk-test"})
+    response = await client.delete(
+        "/ui/api/rbac/organization-memberships/om-1", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     assert response.json()["deleted"] is True
@@ -424,11 +471,41 @@ async def test_delete_team_membership_removes_membership(client, test_app):
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     setattr(test_app.state.settings, "master_key", "mk-test")
 
-    response = await client.delete("/ui/api/rbac/team-memberships/tm-1", headers={"Authorization": "Bearer mk-test"})
+    response = await client.delete(
+        "/ui/api/rbac/team-memberships/tm-1", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     assert response.json()["deleted"] is True
     assert "tm-1" not in fake_db.team_memberships
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/ui/api/rbac/organization-memberships/om-1",
+        "/ui/api/rbac/team-memberships/tm-1",
+        "/ui/api/rbac/accounts/acct-1",
+    ],
+)
+async def test_rbac_deletes_reject_inactive_organization(client, test_app, path):
+    fake_db = FakeDB()
+    fake_db.organizations["org-1"]["lifecycle_state"] = "deletion_pending"
+    test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+    response = await client.delete(path, headers={"Authorization": "Bearer mk-test"})
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "code": "organization_inactive",
+        "message": "Organization administrative changes are disabled",
+        "lifecycle_state": "deletion_pending",
+    }
+    assert "acct-1" in fake_db.accounts
+    assert "om-1" in fake_db.org_memberships
+    assert "tm-1" in fake_db.team_memberships
 
 
 @pytest.mark.asyncio
@@ -437,7 +514,9 @@ async def test_delete_account_removes_memberships_sessions_identities(client, te
     test_app.state.prisma_manager = type("Prisma", (), {"client": fake_db})()
     setattr(test_app.state.settings, "master_key", "mk-test")
 
-    response = await client.delete("/ui/api/rbac/accounts/acct-1", headers={"Authorization": "Bearer mk-test"})
+    response = await client.delete(
+        "/ui/api/rbac/accounts/acct-1", headers={"Authorization": "Bearer mk-test"}
+    )
 
     assert response.status_code == 200
     assert response.json()["deleted"] is True

--- a/tests/test_ui_scope_asset_visibility.py
+++ b/tests/test_ui_scope_asset_visibility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from dataclasses import replace
 from datetime import UTC, datetime
 
@@ -26,6 +27,7 @@ class _FakeScopeDB:
                 "tpm_limit": None,
                 "audit_content_storage_enabled": False,
                 "metadata": {},
+                "lifecycle_state": "active",
                 "created_at": now,
                 "updated_at": now,
             }
@@ -62,20 +64,49 @@ class _FakeScopeDB:
             }
         }
 
+    @asynccontextmanager
+    async def tx(self):
+        yield self
+
     async def query_raw(self, query: str, *params):  # noqa: ANN201
         if "FROM deltallm_organizationtable" in query and "WHERE organization_id = $1" in query:
             organization = self.organizations.get(str(params[0]))
             return [organization] if organization else []
-        if "FROM deltallm_teamtable" in query and "WHERE team_id = $1" in query:
+        if "FROM deltallm_teamtable" in query and (
+            "WHERE team_id = $1" in query or "WHERE t.team_id = $1" in query
+        ):
             team = self.teams.get(str(params[0]))
             return [team] if team else []
         if "FROM deltallm_usertable u" in query and "WHERE u.user_id = $1" in query:
+            user = self.users.get(str(params[0]))
+            return [user] if user else []
+        if "FROM deltallm_usertable" in query and "WHERE user_id = $1" in query:
             user = self.users.get(str(params[0]))
             return [user] if user else []
         if "FROM deltallm_verificationtoken vt" in query and "WHERE vt.token = $1" in query:
             key = self.keys.get(str(params[0]))
             return [key] if key else []
         return []
+
+    async def execute_raw(self, query: str, *params):  # noqa: ANN201
+        if "UPDATE deltallm_usertable SET" in query:
+            user = self.users.get(str(params[0]))
+            if user is None:
+                return 0
+            user.update(
+                {
+                    "rpm_limit": params[1],
+                    "tpm_limit": params[2],
+                    "max_parallel_requests": params[3],
+                    "rph_limit": params[4],
+                    "rpd_limit": params[5],
+                    "tpd_limit": params[6],
+                    "max_budget": params[7],
+                    "blocked": params[8],
+                }
+            )
+            return 1
+        return 0
 
 
 class _FakeRouteGroupRepository:
@@ -107,7 +138,9 @@ class _FakeRouteGroupRepository:
         items = list(self.groups.values())[offset : offset + limit]
         return items, len(self.groups)
 
-    async def list_bindings(self, *, group_key=None, scope_type=None, scope_id=None, limit=500, offset=0):  # noqa: ANN001, ANN201
+    async def list_bindings(
+        self, *, group_key=None, scope_type=None, scope_id=None, limit=500, offset=0
+    ):  # noqa: ANN001, ANN201
         items = [binding for bindings in self.bindings.values() for binding in bindings]
         if group_key:
             items = [binding for binding in items if binding.group_key == group_key]
@@ -144,7 +177,9 @@ class _FakeCallableTargetBindingRepository:
         self.bindings: list[CallableTargetBindingRecord] = []
         self._counter = 0
 
-    async def list_bindings(self, *, callable_key=None, scope_type=None, scope_id=None, limit=500, offset=0):  # noqa: ANN001, ANN201
+    async def list_bindings(
+        self, *, callable_key=None, scope_type=None, scope_id=None, limit=500, offset=0
+    ):  # noqa: ANN001, ANN201
         items = list(self.bindings)
         if callable_key:
             items = [item for item in items if item.callable_key == callable_key]
@@ -156,7 +191,11 @@ class _FakeCallableTargetBindingRepository:
 
     async def upsert_binding(self, *, callable_key, scope_type, scope_id, enabled, metadata):  # noqa: ANN001, ANN201
         for index, item in enumerate(self.bindings):
-            if item.callable_key == callable_key and item.scope_type == scope_type and item.scope_id == scope_id:
+            if (
+                item.callable_key == callable_key
+                and item.scope_type == scope_type
+                and item.scope_id == scope_id
+            ):
                 updated = replace(item, enabled=enabled, metadata=metadata)
                 self.bindings[index] = updated
                 return updated
@@ -178,7 +217,9 @@ class _FakeCallableTargetAccessGroupBindingRepository:
         self.bindings: list[CallableTargetAccessGroupBindingRecord] = []
         self._counter = 0
 
-    async def list_bindings(self, *, group_key=None, scope_type=None, scope_id=None, limit=500, offset=0):  # noqa: ANN001, ANN201
+    async def list_bindings(
+        self, *, group_key=None, scope_type=None, scope_id=None, limit=500, offset=0
+    ):  # noqa: ANN001, ANN201
         items = list(self.bindings)
         if group_key:
             items = [item for item in items if item.group_key == group_key]
@@ -190,7 +231,11 @@ class _FakeCallableTargetAccessGroupBindingRepository:
 
     async def upsert_binding(self, *, group_key, scope_type, scope_id, enabled, metadata):  # noqa: ANN001, ANN201
         for index, item in enumerate(self.bindings):
-            if item.group_key == group_key and item.scope_type == scope_type and item.scope_id == scope_id:
+            if (
+                item.group_key == group_key
+                and item.scope_type == scope_type
+                and item.scope_id == scope_id
+            ):
                 updated = replace(item, enabled=enabled, metadata=metadata)
                 self.bindings[index] = updated
                 return updated
@@ -239,7 +284,9 @@ class _FakeCallableTargetScopePolicyRepository:
 
 
 @pytest.mark.asyncio
-async def test_team_asset_visibility_includes_org_inherited_and_team_direct_sources(client, test_app):
+async def test_team_asset_visibility_includes_org_inherited_and_team_direct_sources(
+    client, test_app
+):
     setattr(test_app.state.settings, "master_key", "mk-test")
     test_app.state.prisma_manager = type("Prisma", (), {"client": _FakeScopeDB()})()
     route_groups = _FakeRouteGroupRepository()
@@ -277,9 +324,23 @@ async def test_team_asset_visibility_includes_org_inherited_and_team_direct_sour
         enabled=True,
         metadata=None,
     )
-    await route_groups.upsert_binding("support-owned", scope_type="team", scope_id="team-1", enabled=True, metadata={"source": "team"})
-    await route_groups.upsert_binding("org-shared", scope_type="organization", scope_id="org-1", enabled=True, metadata={"source": "org"})
-    await route_groups.upsert_binding("team-only", scope_type="team", scope_id="team-1", enabled=True, metadata={"source": "team"})
+    await route_groups.upsert_binding(
+        "support-owned",
+        scope_type="team",
+        scope_id="team-1",
+        enabled=True,
+        metadata={"source": "team"},
+    )
+    await route_groups.upsert_binding(
+        "org-shared",
+        scope_type="organization",
+        scope_id="org-1",
+        enabled=True,
+        metadata={"source": "org"},
+    )
+    await route_groups.upsert_binding(
+        "team-only", scope_type="team", scope_id="team-1", enabled=True, metadata={"source": "team"}
+    )
     await callable_targets.upsert_binding(
         callable_key="support-owned",
         scope_type="team",
@@ -322,7 +383,9 @@ async def test_team_asset_visibility_includes_org_inherited_and_team_direct_sour
         enabled=True,
         metadata={"source": "team"},
     )
-    await policies.upsert_policy(scope_type="team", scope_id="team-1", mode="restrict", metadata={"rollout": "pilot"})
+    await policies.upsert_policy(
+        scope_type="team", scope_id="team-1", mode="restrict", metadata={"rollout": "pilot"}
+    )
 
     response = await client.get(
         "/ui/api/teams/team-1/asset-visibility",
@@ -338,7 +401,9 @@ async def test_team_asset_visibility_includes_org_inherited_and_team_direct_sour
 
     route_groups_payload = {item["group_key"]: item for item in payload["route_groups"]["items"]}
     assert route_groups_payload["support-owned"]["visibility_source"] == "inherited_and_granted"
-    assert {source["scope_type"] for source in route_groups_payload["support-owned"]["sources"]} == {"organization", "team"}
+    assert {
+        source["scope_type"] for source in route_groups_payload["support-owned"]["sources"]
+    } == {"organization", "team"}
     assert route_groups_payload["support-owned"]["effective_visible"] is True
     assert route_groups_payload["org-shared"]["visibility_source"] == "inherited"
     assert route_groups_payload["org-shared"]["effective_visible"] is False
@@ -347,7 +412,10 @@ async def test_team_asset_visibility_includes_org_inherited_and_team_direct_sour
 
     callable_payload = {item["callable_key"]: item for item in payload["callable_targets"]["items"]}
     assert callable_payload["gpt-4o-mini"]["visibility_source"] == "inherited_and_granted"
-    assert {source["scope_type"] for source in callable_payload["gpt-4o-mini"]["sources"]} == {"organization", "team"}
+    assert {source["scope_type"] for source in callable_payload["gpt-4o-mini"]["sources"]} == {
+        "organization",
+        "team",
+    }
     assert callable_payload["gpt-4o-mini"]["effective_visible"] is True
     assert callable_payload["team-assistant"]["visibility_source"] == "granted"
     assert callable_payload["team-assistant"]["effective_visible"] is False
@@ -366,8 +434,12 @@ async def test_parent_asset_visibility_returns_paged_selectable_access_groups(cl
     test_app.state.callable_target_access_group_repository = access_groups
     test_app.state.callable_target_scope_policy_repository = policies
     test_app.state.callable_target_catalog = {
-        "gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model", access_groups=frozenset({"beta"})),
-        "support-chat": CallableTarget(key="support-chat", target_type="route_group", access_groups=frozenset({"support"})),
+        "gpt-4o-mini": CallableTarget(
+            key="gpt-4o-mini", target_type="model", access_groups=frozenset({"beta"})
+        ),
+        "support-chat": CallableTarget(
+            key="support-chat", target_type="route_group", access_groups=frozenset({"support"})
+        ),
     }
     await access_groups.upsert_binding(
         group_key="beta",
@@ -432,9 +504,27 @@ async def test_key_asset_visibility_includes_org_team_and_key_sources(client, te
         enabled=True,
         metadata=None,
     )
-    await route_groups.upsert_binding("support-owned", scope_type="team", scope_id="team-1", enabled=True, metadata={"source": "team"})
-    await route_groups.upsert_binding("support-owned", scope_type="api_key", scope_id="key-hash-1", enabled=True, metadata={"source": "key"})
-    await route_groups.upsert_binding("key-only", scope_type="api_key", scope_id="key-hash-1", enabled=True, metadata={"source": "key"})
+    await route_groups.upsert_binding(
+        "support-owned",
+        scope_type="team",
+        scope_id="team-1",
+        enabled=True,
+        metadata={"source": "team"},
+    )
+    await route_groups.upsert_binding(
+        "support-owned",
+        scope_type="api_key",
+        scope_id="key-hash-1",
+        enabled=True,
+        metadata={"source": "key"},
+    )
+    await route_groups.upsert_binding(
+        "key-only",
+        scope_type="api_key",
+        scope_id="key-hash-1",
+        enabled=True,
+        metadata={"source": "key"},
+    )
     await callable_targets.upsert_binding(
         callable_key="support-owned",
         scope_type="team",
@@ -484,8 +574,12 @@ async def test_key_asset_visibility_includes_org_team_and_key_sources(client, te
         enabled=True,
         metadata={"source": "key"},
     )
-    await policies.upsert_policy(scope_type="team", scope_id="team-1", mode="restrict", metadata=None)
-    await policies.upsert_policy(scope_type="api_key", scope_id="key-hash-1", mode="restrict", metadata=None)
+    await policies.upsert_policy(
+        scope_type="team", scope_id="team-1", mode="restrict", metadata=None
+    )
+    await policies.upsert_policy(
+        scope_type="api_key", scope_id="key-hash-1", mode="restrict", metadata=None
+    )
 
     response = await client.get(
         "/ui/api/keys/key-hash-1/asset-visibility",
@@ -503,14 +597,20 @@ async def test_key_asset_visibility_includes_org_team_and_key_sources(client, te
 
     route_groups_payload = {item["group_key"]: item for item in payload["route_groups"]["items"]}
     assert route_groups_payload["support-owned"]["visibility_source"] == "inherited_and_granted"
-    assert {source["scope_type"] for source in route_groups_payload["support-owned"]["sources"]} == {"organization", "team", "api_key"}
+    assert {
+        source["scope_type"] for source in route_groups_payload["support-owned"]["sources"]
+    } == {"organization", "team", "api_key"}
     assert route_groups_payload["support-owned"]["effective_visible"] is True
     assert route_groups_payload["key-only"]["visibility_source"] == "granted"
     assert route_groups_payload["key-only"]["effective_visible"] is False
 
     callable_payload = {item["callable_key"]: item for item in payload["callable_targets"]["items"]}
     assert callable_payload["gpt-4o-mini"]["visibility_source"] == "inherited_and_granted"
-    assert {source["scope_type"] for source in callable_payload["gpt-4o-mini"]["sources"]} == {"organization", "team", "api_key"}
+    assert {source["scope_type"] for source in callable_payload["gpt-4o-mini"]["sources"]} == {
+        "organization",
+        "team",
+        "api_key",
+    }
     assert callable_payload["gpt-4o-mini"]["effective_visible"] is True
     assert callable_payload["key-assistant"]["visibility_source"] == "granted"
     assert callable_payload["key-assistant"]["effective_visible"] is False
@@ -577,7 +677,9 @@ async def test_key_asset_visibility_applies_user_scope_narrowing(client, test_ap
 
 
 @pytest.mark.asyncio
-async def test_user_asset_visibility_treats_disabled_access_group_binding_as_authoritative(client, test_app):
+async def test_user_asset_visibility_treats_disabled_access_group_binding_as_authoritative(
+    client, test_app
+):
     setattr(test_app.state.settings, "master_key", "mk-test")
     test_app.state.prisma_manager = type("Prisma", (), {"client": _FakeScopeDB()})()
     callable_targets = _FakeCallableTargetBindingRepository()
@@ -585,9 +687,13 @@ async def test_user_asset_visibility_treats_disabled_access_group_binding_as_aut
     test_app.state.route_group_repository = _FakeRouteGroupRepository()
     test_app.state.callable_target_binding_repository = callable_targets
     test_app.state.callable_target_access_group_repository = access_groups
-    test_app.state.callable_target_scope_policy_repository = _FakeCallableTargetScopePolicyRepository()
+    test_app.state.callable_target_scope_policy_repository = (
+        _FakeCallableTargetScopePolicyRepository()
+    )
     test_app.state.callable_target_catalog = {
-        "gpt-4o-mini": CallableTarget(key="gpt-4o-mini", target_type="model", access_groups=frozenset({"beta"})),
+        "gpt-4o-mini": CallableTarget(
+            key="gpt-4o-mini", target_type="model", access_groups=frozenset({"beta"})
+        ),
     }
     await callable_targets.upsert_binding(
         callable_key="gpt-4o-mini",
@@ -623,7 +729,9 @@ async def test_user_asset_visibility_treats_disabled_access_group_binding_as_aut
 
 
 @pytest.mark.asyncio
-async def test_org_asset_visibility_paginates_large_route_group_and_callable_target_sets(client, test_app):
+async def test_org_asset_visibility_paginates_large_route_group_and_callable_target_sets(
+    client, test_app
+):
     setattr(test_app.state.settings, "master_key", "mk-test")
     test_app.state.prisma_manager = type("Prisma", (), {"client": _FakeScopeDB()})()
     route_groups = _FakeRouteGroupRepository()
@@ -696,7 +804,9 @@ async def test_user_asset_access_routes_support_explicit_user_scope(client, test
         metadata={"source": "team"},
     )
 
-    access = await client.get("/ui/api/users/user-1/asset-access", headers={"Authorization": "Bearer mk-test"})
+    access = await client.get(
+        "/ui/api/users/user-1/asset-access", headers={"Authorization": "Bearer mk-test"}
+    )
     assert access.status_code == 200
     access_payload = access.json()
     assert access_payload["scope_type"] == "user"
@@ -714,12 +824,48 @@ async def test_user_asset_access_routes_support_explicit_user_scope(client, test
     assert update_payload["mode"] == "restrict"
     assert update_payload["selected_callable_keys"] == ["gpt-4o-mini"]
 
-    visibility = await client.get("/ui/api/users/user-1/asset-visibility", headers={"Authorization": "Bearer mk-test"})
+    visibility = await client.get(
+        "/ui/api/users/user-1/asset-visibility", headers={"Authorization": "Bearer mk-test"}
+    )
     assert visibility.status_code == 200
     visibility_payload = visibility.json()
     assert visibility_payload["user_id"] == "user-1"
     assert visibility_payload["scope_policies"]["user"] == "restrict"
-    callable_items = {item["callable_key"]: item for item in visibility_payload["callable_targets"]["items"]}
+    callable_items = {
+        item["callable_key"]: item for item in visibility_payload["callable_targets"]["items"]
+    }
     assert visibility_payload["callable_targets"]["total"] == 2
     assert callable_items["gpt-4o-mini"]["effective_visible"] is True
     assert callable_items["team-assistant"]["effective_visible"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/ui/api/users/user-1", {"rpm_limit": 10}),
+        (
+            "/ui/api/users/user-1/asset-access",
+            {"mode": "restrict", "selected_callable_keys": []},
+        ),
+    ],
+)
+async def test_user_mutations_reject_inactive_organization(
+    client,
+    test_app,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    setattr(test_app.state.settings, "master_key", "mk-test")
+    db = _FakeScopeDB()
+    db.organizations["org-1"]["lifecycle_state"] = "deletion_pending"
+    test_app.state.prisma_manager = type("Prisma", (), {"client": db})()
+
+    response = await client.put(
+        path,
+        headers={"Authorization": "Bearer mk-test"},
+        json=payload,
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "organization_inactive"

--- a/tests/test_ui_self_service_keys.py
+++ b/tests/test_ui_self_service_keys.py
@@ -37,6 +37,18 @@ class _FakeKeyDB:
     ) -> None:
         self.keys = dict(keys)
         self.teams = dict(teams or {})
+        self.organization_states = {
+            str(team.get("organization_id")): "active"
+            for team in self.teams.values()
+            if team.get("organization_id")
+        }
+        self.organization_states.update(
+            {
+                str(key.get("organization_id")): "active"
+                for key in self.keys.values()
+                if key.get("organization_id")
+            }
+        )
         self.users = dict(users or {})
         self.account_ids = set(account_ids or set())
         self.advisory_locks: list[int] = []
@@ -57,18 +69,29 @@ class _FakeKeyDB:
         return params[index]
 
     def _in_values(self, params: tuple[Any, ...], placeholders: str) -> set[str]:
-        return {str(self._param_value(params, placeholder) or "") for placeholder in re.findall(r"\$\d+", placeholders)}
+        return {
+            str(self._param_value(params, placeholder) or "")
+            for placeholder in re.findall(r"\$\d+", placeholders)
+        }
 
-    def _list_key_rows(self, normalized_query: str, params: tuple[Any, ...]) -> list[tuple[str, dict[str, Any]]]:
+    def _list_key_rows(
+        self, normalized_query: str, params: tuple[Any, ...]
+    ) -> list[tuple[str, dict[str, Any]]]:
         owner_scoped_orgs: list[tuple[str, set[str]]] = []
         owner_scoped_teams: list[tuple[str, set[str]]] = []
 
-        owner_org_pattern = r"\(t\.organization_id in \(([^)]*)\) and vt\.owner_account_id = \$(\d+)\)"
+        owner_org_pattern = (
+            r"\(t\.organization_id in \(([^)]*)\) and vt\.owner_account_id = \$(\d+)\)"
+        )
         owner_team_pattern = r"\(vt\.team_id in \(([^)]*)\) and vt\.owner_account_id = \$(\d+)\)"
         for placeholders, owner_index in re.findall(owner_org_pattern, normalized_query):
-            owner_scoped_orgs.append((str(params[int(owner_index) - 1] or ""), self._in_values(params, placeholders)))
+            owner_scoped_orgs.append(
+                (str(params[int(owner_index) - 1] or ""), self._in_values(params, placeholders))
+            )
         for placeholders, owner_index in re.findall(owner_team_pattern, normalized_query):
-            owner_scoped_teams.append((str(params[int(owner_index) - 1] or ""), self._in_values(params, placeholders)))
+            owner_scoped_teams.append(
+                (str(params[int(owner_index) - 1] or ""), self._in_values(params, placeholders))
+            )
 
         full_scope_query = re.sub(owner_org_pattern, "", normalized_query)
         full_scope_query = re.sub(owner_team_pattern, "", full_scope_query)
@@ -80,15 +103,23 @@ class _FakeKeyDB:
             full_teams.update(self._in_values(params, placeholders))
 
         global_owner_match = re.search(r"where vt\.owner_account_id = \$(\d+)", normalized_query)
-        global_owner_id = str(params[int(global_owner_match.group(1)) - 1] or "") if global_owner_match else None
+        global_owner_id = (
+            str(params[int(global_owner_match.group(1)) - 1] or "") if global_owner_match else None
+        )
         exact_team_match = re.search(r"(?:where| and) vt\.team_id = \$(\d+)", normalized_query)
-        exact_team_id = str(params[int(exact_team_match.group(1)) - 1] or "") if exact_team_match else None
-        search_match = re.search(r"\(vt\.key_name ilike \$(\d+) or vt\.token ilike \$\d+\)", normalized_query)
+        exact_team_id = (
+            str(params[int(exact_team_match.group(1)) - 1] or "") if exact_team_match else None
+        )
+        search_match = re.search(
+            r"\(vt\.key_name ilike \$(\d+) or vt\.token ilike \$\d+\)", normalized_query
+        )
         search_term = None
         if search_match:
             search_term = str(params[int(search_match.group(1)) - 1] or "").strip("%").lower()
 
-        has_scope_predicate = bool(full_orgs or full_teams or owner_scoped_orgs or owner_scoped_teams)
+        has_scope_predicate = bool(
+            full_orgs or full_teams or owner_scoped_orgs or owner_scoped_teams
+        )
 
         def _row_org(row: dict[str, Any]) -> str:
             team = self.teams.get(str(row.get("team_id") or ""), {})
@@ -112,11 +143,18 @@ class _FakeKeyDB:
 
         rows: list[tuple[str, dict[str, Any]]] = []
         for token_hash, row in self.keys.items():
-            if global_owner_id is not None and str(row.get("owner_account_id") or "") != global_owner_id:
+            if (
+                global_owner_id is not None
+                and str(row.get("owner_account_id") or "") != global_owner_id
+            ):
                 continue
             if exact_team_id is not None and str(row.get("team_id") or "") != exact_team_id:
                 continue
-            if search_term and search_term not in str(row.get("key_name") or "").lower() and search_term not in token_hash.lower():
+            if (
+                search_term
+                and search_term not in str(row.get("key_name") or "").lower()
+                and search_term not in token_hash.lower()
+            ):
                 continue
             if _scope_matches(row):
                 rows.append((token_hash, row))
@@ -126,7 +164,18 @@ class _FakeKeyDB:
         normalized = " ".join(query.lower().split())
         token_hash = str(params[0]) if params else ""
 
-        if "from deltallm_verificationtoken vt" in normalized and "left join deltallm_platformaccount" in normalized:
+        if "from deltallm_organizationtable" in normalized and "for share" in normalized:
+            lifecycle_state = self.organization_states.get(token_hash)
+            return (
+                [{"organization_id": token_hash, "lifecycle_state": lifecycle_state}]
+                if lifecycle_state is not None
+                else []
+            )
+
+        if (
+            "from deltallm_verificationtoken vt" in normalized
+            and "left join deltallm_platformaccount" in normalized
+        ):
             rows = self._list_key_rows(normalized, params)
             if normalized.startswith("select count(*) as total"):
                 return [{"total": len(rows)}]
@@ -160,7 +209,10 @@ class _FakeKeyDB:
                 )
             return response_rows
 
-        if "from deltallm_verificationtoken vt" in normalized and "left join deltallm_usertable" in normalized:
+        if (
+            "from deltallm_verificationtoken vt" in normalized
+            and "left join deltallm_usertable" in normalized
+        ):
             row = self.keys.get(token_hash)
             if row is None:
                 return []
@@ -181,7 +233,8 @@ class _FakeKeyDB:
             return [{"owner_account_id": row.get("owner_account_id")}]
 
         if (
-            "select vt.token, vt.key_name, vt.team_id, t.team_alias, t.organization_id," in normalized
+            "select vt.token, vt.key_name, vt.team_id, t.team_alias, t.organization_id,"
+            in normalized
             and "from deltallm_verificationtoken vt" in normalized
         ):
             row = self.keys.get(token_hash)
@@ -215,12 +268,16 @@ class _FakeKeyDB:
             row = self.teams.get(team_id)
             return [dict(row)] if row is not None else []
 
-        if normalized.startswith("select rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit from deltallm_teamtable"):
+        if normalized.startswith(
+            "select rpm_limit, tpm_limit, rph_limit, rpd_limit, tpd_limit from deltallm_teamtable"
+        ):
             team_id = token_hash
             row = self.teams.get(team_id)
             return [dict(row)] if row is not None else []
 
-        if normalized.startswith("select user_id from deltallm_usertable where user_id = $1 and team_id = $2"):
+        if normalized.startswith(
+            "select user_id from deltallm_usertable where user_id = $1 and team_id = $2"
+        ):
             self._record_event("resolve_runtime_user")
             account_id = str(params[0])
             team_id = str(params[1])
@@ -229,7 +286,9 @@ class _FakeKeyDB:
                 return [{"user_id": row.get("user_id", account_id)}]
             return []
 
-        if normalized.startswith("select user_id from deltallm_usertable where lower(user_email) = lower($1)"):
+        if normalized.startswith(
+            "select user_id from deltallm_usertable where lower(user_email) = lower($1)"
+        ):
             self._record_event("resolve_runtime_user")
             email = str(params[0] or "").strip().lower()
             team_id = str(params[1])
@@ -240,7 +299,9 @@ class _FakeKeyDB:
                     return [{"user_id": candidate_user_id}]
             return []
 
-        if normalized.startswith("select count(*) as cnt from deltallm_verificationtoken where team_id = $1 and owner_account_id = $2"):
+        if normalized.startswith(
+            "select count(*) as cnt from deltallm_verificationtoken where team_id = $1 and owner_account_id = $2"
+        ):
             self._record_event("count_active_keys")
             team_id = str(params[0])
             owner_account_id = str(params[1])
@@ -306,7 +367,9 @@ class _FakeKeyDB:
                 "expires": expires,
             }
             return 1
-        if normalized.startswith("update deltallm_verificationtoken set token = $1, updated_at = now() where token = $2"):
+        if normalized.startswith(
+            "update deltallm_verificationtoken set token = $1, updated_at = now() where token = $2"
+        ):
             new_hash = str(params[0])
             old_hash = str(params[1])
             row = self.keys.pop(old_hash, None)
@@ -323,9 +386,13 @@ class _FakeKeyDBWithoutTransactions(_FakeKeyDB):
 
 
 def _set_auth_context(monkeypatch: pytest.MonkeyPatch, context: PlatformAuthContext | None) -> None:
-    monkeypatch.setattr("src.middleware.platform_auth.get_platform_auth_context", lambda request: context)
+    monkeypatch.setattr(
+        "src.middleware.platform_auth.get_platform_auth_context", lambda request: context
+    )
     monkeypatch.setattr("src.middleware.admin.get_platform_auth_context", lambda request: context)
-    monkeypatch.setattr("src.api.admin.endpoints.keys.get_platform_auth_context", lambda request: context)
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.keys.get_platform_auth_context", lambda request: context
+    )
 
 
 def _is_active_key(row: dict[str, Any]) -> bool:
@@ -425,12 +492,16 @@ def _install_key_asset_read_stubs(monkeypatch: pytest.MonkeyPatch) -> list[dict[
         calls.append(call)
         return call
 
-    monkeypatch.setattr("src.api.admin.endpoints.keys.build_asset_visibility_preview", fake_visibility)
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.keys.build_asset_visibility_preview", fake_visibility
+    )
     monkeypatch.setattr("src.api.admin.endpoints.keys.build_scope_asset_access", fake_access)
     return calls
 
 
-def test_get_auth_scope_tracks_effective_permissions_beyond_endpoint_permissions(monkeypatch: pytest.MonkeyPatch):
+def test_get_auth_scope_tracks_effective_permissions_beyond_endpoint_permissions(
+    monkeypatch: pytest.MonkeyPatch,
+):
     context = _make_context(
         account_id="acct-admin",
         org_memberships=[{"organization_id": "org-1", "role": OrganizationRole.ADMIN}],
@@ -471,7 +542,9 @@ def test_get_auth_scope_keeps_permissions_separated_by_team(monkeypatch: pytest.
 
 
 @pytest.mark.asyncio
-async def test_org_admin_can_revoke_non_owned_key_within_org_scope(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_org_admin_can_revoke_non_owned_key_within_org_scope(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {
@@ -497,7 +570,9 @@ async def test_org_admin_can_revoke_non_owned_key_within_org_scope(client, test_
 
 
 @pytest.mark.asyncio
-async def test_self_service_user_cannot_revoke_owned_key_outside_team_scope(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_user_cannot_revoke_owned_key_outside_team_scope(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {
@@ -523,7 +598,9 @@ async def test_self_service_user_cannot_revoke_owned_key_outside_team_scope(clie
 
 
 @pytest.mark.asyncio
-async def test_self_service_user_can_revoke_owned_key_within_team_scope(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_user_can_revoke_owned_key_within_team_scope(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {
@@ -549,7 +626,9 @@ async def test_self_service_user_can_revoke_owned_key_within_team_scope(client, 
 
 
 @pytest.mark.asyncio
-async def test_mixed_role_user_cannot_revoke_non_owned_key_in_self_service_team(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_mixed_role_user_cannot_revoke_non_owned_key_in_self_service_team(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {
@@ -578,7 +657,9 @@ async def test_mixed_role_user_cannot_revoke_non_owned_key_in_self_service_team(
 
 
 @pytest.mark.asyncio
-async def test_mixed_role_user_can_revoke_non_owned_key_in_admin_team(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_mixed_role_user_can_revoke_non_owned_key_in_admin_team(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {
@@ -642,9 +723,21 @@ async def test_mixed_role_user_lists_all_admin_team_keys_and_only_owned_develope
             },
         },
         teams={
-            "team-admin": {"team_id": "team-admin", "team_alias": "Admin Team", "organization_id": "org-admin"},
-            "team-dev": {"team_id": "team-dev", "team_alias": "Developer Team", "organization_id": "org-dev"},
-            "team-outside": {"team_id": "team-outside", "team_alias": "Outside Team", "organization_id": "org-outside"},
+            "team-admin": {
+                "team_id": "team-admin",
+                "team_alias": "Admin Team",
+                "organization_id": "org-admin",
+            },
+            "team-dev": {
+                "team_id": "team-dev",
+                "team_alias": "Developer Team",
+                "organization_id": "org-dev",
+            },
+            "team-outside": {
+                "team_id": "team-outside",
+                "team_alias": "Outside Team",
+                "organization_id": "org-outside",
+            },
         },
     )
     _set_auth_context(
@@ -665,7 +758,9 @@ async def test_mixed_role_user_lists_all_admin_team_keys_and_only_owned_develope
 
 
 @pytest.mark.asyncio
-async def test_mixed_role_my_keys_lists_only_owned_keys_in_authorized_scopes(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_mixed_role_my_keys_lists_only_owned_keys_in_authorized_scopes(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {
@@ -691,9 +786,21 @@ async def test_mixed_role_my_keys_lists_only_owned_keys_in_authorized_scopes(cli
             },
         },
         teams={
-            "team-admin": {"team_id": "team-admin", "team_alias": "Admin Team", "organization_id": "org-admin"},
-            "team-dev": {"team_id": "team-dev", "team_alias": "Developer Team", "organization_id": "org-dev"},
-            "team-outside": {"team_id": "team-outside", "team_alias": "Outside Team", "organization_id": "org-outside"},
+            "team-admin": {
+                "team_id": "team-admin",
+                "team_alias": "Admin Team",
+                "organization_id": "org-admin",
+            },
+            "team-dev": {
+                "team_id": "team-dev",
+                "team_alias": "Developer Team",
+                "organization_id": "org-dev",
+            },
+            "team-outside": {
+                "team_id": "team-outside",
+                "team_alias": "Outside Team",
+                "organization_id": "org-outside",
+            },
         },
     )
     _set_auth_context(
@@ -714,7 +821,9 @@ async def test_mixed_role_my_keys_lists_only_owned_keys_in_authorized_scopes(cli
 
 
 @pytest.mark.asyncio
-async def test_self_service_developer_lists_only_owned_team_keys(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_developer_lists_only_owned_team_keys(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {
@@ -735,8 +844,16 @@ async def test_self_service_developer_lists_only_owned_team_keys(client, test_ap
             },
         },
         teams={
-            "team-dev": {"team_id": "team-dev", "team_alias": "Developer Team", "organization_id": "org-dev"},
-            "team-outside": {"team_id": "team-outside", "team_alias": "Outside Team", "organization_id": "org-outside"},
+            "team-dev": {
+                "team_id": "team-dev",
+                "team_alias": "Developer Team",
+                "organization_id": "org-dev",
+            },
+            "team-outside": {
+                "team_id": "team-outside",
+                "team_alias": "Outside Team",
+                "organization_id": "org-outside",
+            },
         },
     )
     _set_auth_context(
@@ -755,7 +872,9 @@ async def test_self_service_developer_lists_only_owned_team_keys(client, test_ap
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("org_role", [OrganizationRole.BILLING, OrganizationRole.AUDITOR])
-async def test_read_only_org_role_lists_scoped_keys(client, test_app, monkeypatch: pytest.MonkeyPatch, org_role: str):
+async def test_read_only_org_role_lists_scoped_keys(
+    client, test_app, monkeypatch: pytest.MonkeyPatch, org_role: str
+):
     _install_key_db(
         test_app,
         {
@@ -778,7 +897,11 @@ async def test_read_only_org_role_lists_scoped_keys(client, test_app, monkeypatc
         teams={
             "team-1": {"team_id": "team-1", "team_alias": "Team One", "organization_id": "org-1"},
             "team-2": {"team_id": "team-2", "team_alias": "Team Two", "organization_id": "org-1"},
-            "team-outside": {"team_id": "team-outside", "team_alias": "Outside Team", "organization_id": "org-2"},
+            "team-outside": {
+                "team_id": "team-outside",
+                "team_alias": "Outside Team",
+                "organization_id": "org-2",
+            },
         },
     )
     _set_auth_context(
@@ -969,7 +1092,9 @@ async def test_mixed_role_user_key_asset_read_is_full_in_admin_team_and_owner_on
 
 
 @pytest.mark.asyncio
-async def test_mixed_role_user_can_create_self_service_key_in_developer_team(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_mixed_role_user_can_create_self_service_key_in_developer_team(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {},
@@ -1027,7 +1152,9 @@ async def test_mixed_role_user_can_create_self_service_key_in_developer_team(cli
 
 
 @pytest.mark.asyncio
-async def test_self_registered_user_self_service_key_binds_runtime_user(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_registered_user_self_service_key_binds_runtime_user(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     expires = (datetime.now(tz=UTC) + timedelta(days=7)).isoformat()
     db = _install_key_db(
         test_app,
@@ -1077,7 +1204,9 @@ async def test_self_registered_user_self_service_key_binds_runtime_user(client, 
 
 
 @pytest.mark.asyncio
-async def test_self_service_key_creation_resolves_runtime_user_by_email(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_key_creation_resolves_runtime_user_by_email(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     expires = (datetime.now(tz=UTC) + timedelta(days=7)).isoformat()
     db = _install_key_db(
         test_app,
@@ -1116,7 +1245,9 @@ async def test_self_service_key_creation_resolves_runtime_user_by_email(client, 
 
 
 @pytest.mark.asyncio
-async def test_self_service_key_creation_stores_normalized_utc_expiry(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_key_creation_stores_normalized_utc_expiry(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     utc_expiry = datetime.now(tz=UTC).replace(microsecond=0) + timedelta(days=7)
     offset_expiry = utc_expiry.astimezone(timezone(timedelta(hours=3)))
     expected_expiry = offset_expiry.astimezone(UTC).isoformat()
@@ -1124,7 +1255,13 @@ async def test_self_service_key_creation_stores_normalized_utc_expiry(client, te
         test_app,
         {},
         teams={"team-sandbox": _self_service_team()},
-        users={"acct-dev": {"user_id": "acct-dev", "user_email": "acct-dev@example.com", "team_id": "team-sandbox"}},
+        users={
+            "acct-dev": {
+                "user_id": "acct-dev",
+                "user_email": "acct-dev@example.com",
+                "team_id": "team-sandbox",
+            }
+        },
     )
     _set_auth_context(
         monkeypatch,
@@ -1151,7 +1288,9 @@ async def test_self_service_key_creation_stores_normalized_utc_expiry(client, te
 
 
 @pytest.mark.asyncio
-async def test_self_service_key_creation_requires_runtime_user(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_key_creation_requires_runtime_user(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {},
@@ -1176,16 +1315,27 @@ async def test_self_service_key_creation_requires_runtime_user(client, test_app,
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "Self-service key creation requires a runtime user in this team"
+    assert (
+        response.json()["detail"]
+        == "Self-service key creation requires a runtime user in this team"
+    )
 
 
 @pytest.mark.asyncio
-async def test_self_service_key_creation_requires_transaction_support(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_key_creation_requires_transaction_support(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {},
         teams={"team-sandbox": _self_service_team()},
-        users={"acct-dev": {"user_id": "acct-dev", "user_email": "acct-dev@example.com", "team_id": "team-sandbox"}},
+        users={
+            "acct-dev": {
+                "user_id": "acct-dev",
+                "user_email": "acct-dev@example.com",
+                "team_id": "team-sandbox",
+            }
+        },
         db_cls=_FakeKeyDBWithoutTransactions,
     )
     _set_auth_context(
@@ -1207,11 +1357,16 @@ async def test_self_service_key_creation_requires_transaction_support(client, te
     )
 
     assert response.status_code == 503
-    assert response.json()["detail"] == "Database transactions are required for self-service key creation"
+    assert (
+        response.json()["detail"]
+        == "Database transactions are required for self-service key creation"
+    )
 
 
 @pytest.mark.asyncio
-async def test_self_service_key_creation_enforces_max_active_keys(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_key_creation_enforces_max_active_keys(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {
@@ -1248,7 +1403,9 @@ async def test_self_service_key_creation_enforces_max_active_keys(client, test_a
 
 
 @pytest.mark.asyncio
-async def test_self_service_key_creation_enforces_budget_ceiling(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_key_creation_enforces_budget_ceiling(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {},
@@ -1278,7 +1435,9 @@ async def test_self_service_key_creation_enforces_budget_ceiling(client, test_ap
 
 
 @pytest.mark.asyncio
-async def test_self_service_key_creation_requires_budget_when_ceiling_configured(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_key_creation_requires_budget_when_ceiling_configured(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {},
@@ -1307,7 +1466,9 @@ async def test_self_service_key_creation_requires_budget_when_ceiling_configured
 
 
 @pytest.mark.asyncio
-async def test_self_service_key_creation_rejects_negative_budget_without_ceiling(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_key_creation_rejects_negative_budget_without_ceiling(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {},
@@ -1388,7 +1549,9 @@ async def test_self_service_key_creation_enforces_expiry_policy(
 
 
 @pytest.mark.asyncio
-async def test_self_service_key_creation_rejects_limits_above_team_limits(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_key_creation_rejects_limits_above_team_limits(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {},
@@ -1419,7 +1582,9 @@ async def test_self_service_key_creation_rejects_limits_above_team_limits(client
 
 
 @pytest.mark.asyncio
-async def test_self_service_user_cannot_update_key_asset_access(client, test_app, monkeypatch: pytest.MonkeyPatch):
+async def test_self_service_user_cannot_update_key_asset_access(
+    client, test_app, monkeypatch: pytest.MonkeyPatch
+):
     _install_key_db(
         test_app,
         {

--- a/tests/test_ui_tier_assignments_api.py
+++ b/tests/test_ui_tier_assignments_api.py
@@ -76,6 +76,7 @@ class _RecordingGovernanceInvalidationService:
 class _FakeTierAssignmentRepository:
     def __init__(self) -> None:
         self.organizations = {"org-1"}
+        self.organization_lifecycle_states = {"org-1": "active"}
         self.assignments: dict[str, OrganizationTierAssignmentRecord] = {}
         self.upsert_error: str | None = None
         self.upsert_exception: Exception | None = None
@@ -262,6 +263,19 @@ class _FakeTierAssignmentRepository:
         return True
 
     async def query_raw(self, sql: str, *params: object) -> list[dict[str, object]]:
+        if "FROM deltallm_organizationtable" in sql:
+            organization_id = str(params[0])
+            lifecycle_state = self.organization_lifecycle_states.get(organization_id)
+            return (
+                [
+                    {
+                        "organization_id": organization_id,
+                        "lifecycle_state": lifecycle_state,
+                    }
+                ]
+                if lifecycle_state is not None
+                else []
+            )
         if "INSERT INTO deltallm_cacheinvalidationoutbox" not in sql:
             return []
         if self.cache_enqueue_fail:
@@ -307,6 +321,7 @@ class _FakeTierAssignmentTxContext:
         self.root.tx_started += 1
         tx = _FakeTierAssignmentRepository()
         tx.organizations = set(self.root.organizations)
+        tx.organization_lifecycle_states = dict(self.root.organization_lifecycle_states)
         tx.assignments = dict(self.root.assignments)
         tx.upsert_error = self.root.upsert_error
         tx.upsert_exception = self.root.upsert_exception
@@ -730,9 +745,7 @@ async def test_org_tier_assignment_disabled_tier_conflict_returns_409(client, te
     )
 
     assert response.status_code == 409
-    assert response.json()["detail"] == (
-        "enabled tier assignments require an enabled tier"
-    )
+    assert response.json()["detail"] == ("enabled tier assignments require an enabled tier")
     assert key_service.org_invalidation_attempts == []
     assert test_app.state.cache_invalidation_outbox_repository.enqueues == []
     assert audit.sync_calls == []
@@ -744,9 +757,7 @@ async def test_org_tier_assignment_disabled_tier_database_race_returns_409(
     test_app,
 ) -> None:
     repository = _FakeTierAssignmentRepository()
-    repository.upsert_exception = RuntimeError(
-        "enabled tier assignments require an enabled tier"
-    )
+    repository.upsert_exception = RuntimeError("enabled tier assignments require an enabled tier")
     audit, key_service = _install_assignment_services(test_app, repository)
 
     response = await client.post(
@@ -756,9 +767,7 @@ async def test_org_tier_assignment_disabled_tier_database_race_returns_409(
     )
 
     assert response.status_code == 409
-    assert response.json()["detail"] == (
-        "enabled tier assignments require an enabled tier"
-    )
+    assert response.json()["detail"] == ("enabled tier assignments require an enabled tier")
     assert key_service.org_invalidation_attempts == []
     assert test_app.state.cache_invalidation_outbox_repository.enqueues == []
     assert audit.sync_calls == []

--- a/ui/scripts/run-unit-tests.mjs
+++ b/ui/scripts/run-unit-tests.mjs
@@ -24,6 +24,7 @@ const testSources = [
   'tests/batchDetailResource.test.ts',
   'tests/organizationPolicy.test.ts',
   'tests/organizationDeletion.test.ts',
+  'tests/organizationLifecycle.test.ts',
   'tests/tierHelpers.test.ts',
   'tests/dashboardAnalytics.test.ts',
   'tests/format.test.ts',

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,16 +14,12 @@ import Models from './pages/Models';
 import Tiers from './pages/Tiers';
 import TierDetail from './pages/TierDetail';
 import ApiKeys from './pages/ApiKeys';
-import Organizations from './pages/Organizations';
 import Teams from './pages/Teams';
 import UsersPage from './pages/UsersPage';
 import Usage from './pages/Usage';
 import Guardrails from './pages/Guardrails';
 import BatchJobs from './pages/BatchJobs';
 import BatchJobDetail from './pages/BatchJobDetail';
-import OrganizationDetail from './pages/OrganizationDetail';
-import OrganizationCreate from './pages/OrganizationCreate';
-import TeamCreate from './pages/TeamCreate';
 import TeamDetail from './pages/TeamDetail';
 import ModelDetail from './pages/ModelDetail';
 import ModelEdit from './pages/ModelEdit';
@@ -45,6 +41,10 @@ import { defaultRouteForUiAccess, resolveUiAccess } from './lib/authorization';
 import { loginPathFor, returnToFromSearch } from './lib/authRedirect';
 
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
+const Organizations = lazy(() => import('./pages/Organizations'));
+const OrganizationDetail = lazy(() => import('./pages/OrganizationDetail'));
+const OrganizationCreate = lazy(() => import('./pages/OrganizationCreate'));
+const TeamCreate = lazy(() => import('./pages/TeamCreate'));
 
 class RouteChunkBoundary extends Component<
   { children: ReactNode },
@@ -65,7 +65,7 @@ class RouteChunkBoundary extends Component<
       return (
         <div className="flex min-h-64 items-center justify-center px-4">
           <div className="max-w-md rounded-xl border border-amber-200 bg-white p-6 text-center shadow-sm">
-            <h1 className="text-lg font-semibold text-gray-900">Unable to load settings</h1>
+            <h1 className="text-lg font-semibold text-gray-900">Unable to load this page</h1>
             <p className="mt-2 text-sm text-gray-600">
               Reload the application to retry loading this section.
             </p>
@@ -82,9 +82,19 @@ class RouteChunkBoundary extends Component<
 
 function RouteLoading() {
   return (
-    <div className="flex min-h-64 items-center justify-center" role="status" aria-label="Loading settings">
+    <div className="flex min-h-64 items-center justify-center" role="status" aria-label="Loading page">
       <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-brand-primary" />
     </div>
+  );
+}
+
+function ChunkedRoute({ children }: { children: ReactNode }) {
+  return (
+    <RouteChunkBoundary>
+      <Suspense fallback={<RouteLoading />}>
+        {children}
+      </Suspense>
+    </RouteChunkBoundary>
   );
 }
 
@@ -197,11 +207,11 @@ function AppRoutes() {
         <Route path="/mcp-servers/:serverId" element={uiAccess.mcp_servers ? <MCPServerDetail /> : <Navigate to="/" replace />} />
         <Route path="/mcp-approvals" element={uiAccess.mcp_approvals ? <MCPApprovalQueue /> : <Navigate to="/" replace />} />
         <Route path="/keys" element={uiAccess.keys ? <ApiKeys /> : <Navigate to="/" replace />} />
-        <Route path="/organizations" element={uiAccess.organizations ? <Organizations /> : <Navigate to="/" replace />} />
-        <Route path="/organizations/new" element={uiAccess.organization_create ? <OrganizationCreate /> : <Navigate to="/organizations" replace />} />
-        <Route path="/organizations/:orgId" element={uiAccess.organizations ? <OrganizationDetail /> : <Navigate to="/" replace />} />
+        <Route path="/organizations" element={uiAccess.organizations ? <ChunkedRoute><Organizations /></ChunkedRoute> : <Navigate to="/" replace />} />
+        <Route path="/organizations/new" element={uiAccess.organization_create ? <ChunkedRoute><OrganizationCreate /></ChunkedRoute> : <Navigate to="/organizations" replace />} />
+        <Route path="/organizations/:orgId" element={uiAccess.organizations ? <ChunkedRoute><OrganizationDetail /></ChunkedRoute> : <Navigate to="/" replace />} />
         <Route path="/teams" element={uiAccess.teams ? <Teams /> : <Navigate to="/" replace />} />
-        <Route path="/teams/new" element={uiAccess.team_create ? <TeamCreate /> : <Navigate to="/teams" replace />} />
+        <Route path="/teams/new" element={uiAccess.team_create ? <ChunkedRoute><TeamCreate /></ChunkedRoute> : <Navigate to="/teams" replace />} />
         <Route path="/teams/:teamId" element={uiAccess.teams ? <TeamDetail /> : <Navigate to="/" replace />} />
         <Route path="/users" element={uiAccess.people_access ? <UsersPage /> : <Navigate to="/" replace />} />
         <Route path="/audit" element={uiAccess.audit ? <AuditLogs /> : <Navigate to="/" replace />} />
@@ -213,11 +223,7 @@ function AppRoutes() {
         <Route
           path="/settings"
           element={uiAccess.settings ? (
-            <RouteChunkBoundary>
-              <Suspense fallback={<RouteLoading />}>
-                <SettingsPage />
-              </Suspense>
-            </RouteChunkBoundary>
+            <ChunkedRoute><SettingsPage /></ChunkedRoute>
           ) : <Navigate to="/" replace />}
         />
         <Route path="/access-control" element={<Navigate to={uiAccess.people_access ? "/users" : defaultRoute} replace />} />

--- a/ui/src/components/admin/OrganizationDeletionPanel.tsx
+++ b/ui/src/components/admin/OrganizationDeletionPanel.tsx
@@ -9,11 +9,16 @@ import {
   type OrganizationDeletionJob,
   type OrganizationDeletionPlan,
 } from '../../lib/organizationDeletion';
+import {
+  organizationLifecycleTransitionForDeletionJob,
+  type OrganizationLifecycleTransition,
+} from '../../lib/organizationLifecycle';
 
 
 type Props = {
   organizationId: string;
   organizationName: string;
+  onLifecycleChange?: (transition: OrganizationLifecycleTransition) => Promise<void>;
 };
 
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'restored']);
@@ -107,6 +112,7 @@ function ProgressSummary({ job }: { job: OrganizationDeletionJob }) {
 export default function OrganizationDeletionPanel({
   organizationId,
   organizationName,
+  onLifecycleChange,
 }: Props) {
   const navigate = useNavigate();
   const { pushToast } = useToast();
@@ -121,6 +127,15 @@ export default function OrganizationDeletionPanel({
   const [confirmationName, setConfirmationName] = useState('');
   const [acknowledged, setAcknowledged] = useState(false);
   const [idempotencyKey, setIdempotencyKey] = useState('');
+
+  const reconcileLifecycle = useCallback(async (nextJob: OrganizationDeletionJob) => {
+    if (!onLifecycleChange) return;
+    try {
+      await onLifecycleChange(organizationLifecycleTransitionForDeletionJob(nextJob));
+    } catch {
+      // The lifecycle transition remains successful; the parent renders refresh recovery.
+    }
+  }, [onLifecycleChange]);
 
   const loadPlan = useCallback(async (signal: AbortSignal) => {
     const nextPlan = await organizationDeletion.plan(organizationId, signal);
@@ -172,6 +187,9 @@ export default function OrganizationDeletionPanel({
           controller.signal,
         );
         setJob(nextJob);
+        if (nextJob.phase !== job.phase || nextJob.status !== job.status) {
+          await reconcileLifecycle(nextJob);
+        }
         if (nextJob.status === 'completed') {
           pushToast({ tone: 'success', title: 'Organization deleted', message: `${organizationName} was permanently deleted.` });
           navigate('/organizations', { replace: true });
@@ -200,7 +218,7 @@ export default function OrganizationDeletionPanel({
       if (timeoutId !== undefined) window.clearTimeout(timeoutId);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [job, navigate, organizationId, organizationName, pushToast]);
+  }, [job, navigate, organizationId, organizationName, pushToast, reconcileLifecycle]);
 
   useEffect(() => () => operationController.current?.abort(), []);
 
@@ -238,6 +256,7 @@ export default function OrganizationDeletionPanel({
       setJob(nextJob);
       setDeleteOpen(false);
       pushToast({ tone: 'info', title: 'Deletion scheduled', message: `Access is revoked now. Permanent deletion is scheduled after ${plan.recovery_window_hours} hours.` });
+      void reconcileLifecycle(nextJob);
     } catch (nextError: unknown) {
       if (!controller.signal.aborted) setError(errorMessage(nextError, 'Unable to schedule deletion.'));
     } finally {
@@ -258,6 +277,7 @@ export default function OrganizationDeletionPanel({
         : await organizationDeletion.retry(organizationId, job.deletion_job_id, controller.signal);
       setJob(nextJob);
       setRestoreOpen(false);
+      void reconcileLifecycle(nextJob);
       if (action === 'restore') {
         await loadPlan(controller.signal);
         pushToast({ tone: 'success', title: 'Organization restored', message: 'Access is active again. Cancelled work is not restarted.' });

--- a/ui/src/components/admin/OrganizationLifecycleStatus.tsx
+++ b/ui/src/components/admin/OrganizationLifecycleStatus.tsx
@@ -1,0 +1,66 @@
+import { AlertTriangle, CheckCircle2, Clock3, Loader2 } from 'lucide-react';
+
+import {
+  formatOrganizationDeletionDeadline,
+  organizationLifecyclePresentation,
+  type OrganizationLifecycleState,
+} from '../../lib/organizationLifecycle';
+
+type LifecycleProps = {
+  state: OrganizationLifecycleState;
+};
+
+type NoticeProps = LifecycleProps & {
+  deletionNotBeforeAt?: string | null;
+};
+
+function LifecycleIcon({ state, className }: LifecycleProps & { className: string }) {
+  if (state === 'active') return <CheckCircle2 className={className} />;
+  if (state === 'deletion_pending') return <Clock3 className={className} />;
+  if (state === 'purging') return <Loader2 className={`${className} animate-spin`} />;
+  return <AlertTriangle className={className} />;
+}
+
+export function OrganizationLifecycleBadge({ state }: LifecycleProps) {
+  const presentation = organizationLifecyclePresentation(state);
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold ring-1 ring-inset ${presentation.badgeClassName}`}
+    >
+      <LifecycleIcon state={state} className="h-3.5 w-3.5" />
+      {presentation.label}
+    </span>
+  );
+}
+
+export function OrganizationLifecycleNotice({ state, deletionNotBeforeAt }: NoticeProps) {
+  if (state === 'active') return null;
+
+  const presentation = organizationLifecyclePresentation(state);
+  const deadline = formatOrganizationDeletionDeadline(deletionNotBeforeAt);
+  let message: string;
+  if (state === 'deletion_pending') {
+    message = deadline
+      ? `Runtime access and administrative changes are disabled now. Permanent deletion will not start before ${deadline}. A platform administrator can restore the organization during the recovery window.`
+      : 'Runtime access and administrative changes are disabled now. A platform administrator can restore the organization while cleanup remains reversible.';
+  } else if (state === 'purging') {
+    message = 'Runtime access and administrative changes are disabled. Irreversible cleanup has started, so the organization can no longer be restored.';
+  } else if (state === 'deletion_failed') {
+    message = 'Runtime access and administrative changes remain disabled. A platform administrator must retry cleanup from the Danger zone.';
+  } else {
+    message = 'Administrative changes are disabled until the organization lifecycle status can be verified. Refresh this page before trying again.';
+  }
+
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-xl border px-4 py-3 ${presentation.noticeClassName || ''}`}
+      role="status"
+    >
+      <LifecycleIcon state={state} className="mt-0.5 h-4 w-4 shrink-0" />
+      <div>
+        <p className="text-sm font-semibold">{presentation.noticeTitle}</p>
+        <p className="mt-1 text-xs leading-relaxed opacity-90">{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/admin/OrganizationTeamSelector.tsx
+++ b/ui/src/components/admin/OrganizationTeamSelector.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Building2 } from 'lucide-react';
+
+import {
+  organizationRecordsApi,
+  type OrganizationRecord,
+} from '../../lib/api/organizations';
+import { useApi } from '../../lib/hooks';
+import { organizationLifecyclePresentation } from '../../lib/organizationLifecycle';
+
+interface Props {
+  value: string;
+  disabled?: boolean;
+  enabled?: boolean;
+  onChange: (organizationId: string) => void;
+  onSelectedOrganizationChange: (organization: OrganizationRecord | null) => void;
+}
+
+function errorMessage(error: unknown): string | null {
+  if (error instanceof Error && error.message) return error.message;
+  return error ? 'Unable to load organizations.' : null;
+}
+
+export default function OrganizationTeamSelector({
+  value,
+  disabled = false,
+  enabled = true,
+  onChange,
+  onSelectedOrganizationChange,
+}: Props) {
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setSearch(searchInput.trim()), 250);
+    return () => window.clearTimeout(timeoutId);
+  }, [searchInput]);
+
+  const { data: page, error: pageError, loading } = useApi(
+    (signal) => enabled
+      ? organizationRecordsApi.list({ search: search || undefined, limit: 50, offset: 0 }, signal)
+      : Promise.resolve({
+        data: [],
+        pagination: { total: 0, limit: 50, offset: 0, has_more: false },
+      }),
+    [enabled, search],
+  );
+  const pageOrganizations = useMemo(() => page?.data ?? [], [page?.data]);
+  const selectedFromPage = pageOrganizations.find(
+    (organization) => organization.organization_id === value,
+  ) ?? null;
+  const { data: fetchedSelected, error: selectedError } = useApi(
+    (signal) => enabled && value && !selectedFromPage
+      ? organizationRecordsApi.get(value, signal)
+      : Promise.resolve(null),
+    [enabled, value, selectedFromPage?.organization_id],
+  );
+  const currentFetchedSelected = fetchedSelected?.organization_id === value
+    ? fetchedSelected
+    : null;
+  const selectedOrganization = selectedFromPage ?? currentFetchedSelected;
+  const organizations = useMemo(() => {
+    if (!selectedOrganization) return pageOrganizations;
+    return [
+      selectedOrganization,
+      ...pageOrganizations.filter(
+        (organization) => organization.organization_id !== selectedOrganization.organization_id,
+      ),
+    ];
+  }, [pageOrganizations, selectedOrganization]);
+
+  useEffect(() => {
+    onSelectedOrganizationChange(selectedOrganization ?? null);
+  }, [onSelectedOrganizationChange, selectedOrganization]);
+
+  const loadError = errorMessage(pageError) ?? errorMessage(selectedError);
+  return (
+    <div className="space-y-2">
+      <label htmlFor="team-organization-search" className="sr-only">
+        Search organizations
+      </label>
+      <input
+        id="team-organization-search"
+        type="search"
+        value={searchInput}
+        onChange={(event) => setSearchInput(event.target.value)}
+        placeholder="Search organizations…"
+        disabled={disabled || !enabled}
+        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary disabled:opacity-50"
+      />
+      <div className="relative">
+        <Building2 className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+        <select
+          aria-label="Organization"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          disabled={disabled || !enabled}
+          className="w-full appearance-none rounded-lg border border-gray-300 bg-white py-2 pl-8 pr-4 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-primary disabled:opacity-50"
+        >
+          <option value="">Select an organization…</option>
+          {organizations.map((organization) => {
+            const lifecycle = organizationLifecyclePresentation(organization.lifecycle_state);
+            const canAddTeam = organization.capabilities.add_team;
+            return (
+              <option
+                key={organization.organization_id}
+                value={organization.organization_id}
+                disabled={!canAddTeam}
+              >
+                {organization.organization_name || organization.organization_id}
+                {canAddTeam ? '' : ` — ${lifecycle.label}`}
+              </option>
+            );
+          })}
+        </select>
+      </div>
+      {loading ? <p className="text-xs text-gray-500">Loading organizations…</p> : null}
+      {page?.pagination.has_more ? (
+        <p className="text-xs text-gray-500">Refine the search to find additional organizations.</p>
+      ) : null}
+      {loadError ? <p className="text-xs text-red-700">{loadError}</p> : null}
+    </div>
+  );
+}

--- a/ui/src/components/tiers/OrganizationTierPanel.tsx
+++ b/ui/src/components/tiers/OrganizationTierPanel.tsx
@@ -26,6 +26,7 @@ import TierSimulationPanel from './TierSimulationPanel';
 type OrganizationTierPanelProps = {
   organizationId: string;
   canManage: boolean;
+  readOnlyReason?: string;
 };
 
 const EMPTY_FORM: AssignmentForm = {
@@ -43,7 +44,11 @@ function createEmptyForm(): AssignmentForm {
   return { ...EMPTY_FORM };
 }
 
-export default function OrganizationTierPanel({ organizationId, canManage }: OrganizationTierPanelProps) {
+export default function OrganizationTierPanel({
+  organizationId,
+  canManage,
+  readOnlyReason,
+}: OrganizationTierPanelProps) {
   const { pushToast } = useToast();
   const [formOpen, setFormOpen] = useState(false);
   const [form, setForm] = useState<AssignmentForm>(() => createEmptyForm());
@@ -70,8 +75,8 @@ export default function OrganizationTierPanel({ organizationId, canManage }: Org
   }, [organizationId]);
 
   const { data: assignmentsResponse, loading: assignmentsLoading, error: assignmentsError, refetch: refetchAssignments } = useApi(
-    () => canManage ? organizations.tierAssignments(organizationId) : Promise.resolve({ data: [] }),
-    [organizationId, canManage],
+    (signal) => organizations.tierAssignments(organizationId, undefined, signal),
+    [organizationId],
   );
   const { data: tierPage } = useApi(
     () => canManage ? tiers.listAll({ enabled: true }) : Promise.resolve([]),
@@ -82,8 +87,8 @@ export default function OrganizationTierPanel({ organizationId, canManage }: Org
     [canManage, form.tier_id],
   );
   const { data: preview, loading: previewLoading, error: previewError, refetch: refetchPreview } = useApi(
-    () => canManage ? organizations.tierPolicyPreview(organizationId) : Promise.resolve(null),
-    [organizationId, canManage],
+    (signal) => organizations.tierPolicyPreview(organizationId, signal),
+    [organizationId],
   );
 
   const assignments = useMemo(
@@ -284,7 +289,7 @@ export default function OrganizationTierPanel({ organizationId, canManage }: Org
         <div>
           <h3 className="text-sm font-semibold text-gray-900">Service policy is read-only</h3>
           <p className="mt-1 text-xs leading-relaxed text-gray-600">
-            Tier assignments are managed by a platform administrator. Organization roles cannot assign, change, or remove tiers.
+            {readOnlyReason || 'Tier assignments are managed by a platform administrator. Organization roles cannot assign, change, or remove tiers.'}
           </p>
         </div>
       </section>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,7 +1,21 @@
 import { apiFetch, withQuery } from './api/transport';
+import {
+  organizationRecordsApi,
+  type OrganizationTierAssignment,
+  type OrganizationTierAssignmentPayload,
+} from './api/organizations';
 
 export { ApiError, structuredApiErrorDetail } from './api/transport';
 export type { StructuredApiErrorDetail } from './api/transport';
+export type {
+  OrganizationCapabilities,
+  OrganizationCreatePayload,
+  OrganizationPrimaryTierSummary,
+  OrganizationRecord,
+  OrganizationServicePolicy,
+  OrganizationTierAssignment,
+  OrganizationTierAssignmentPayload,
+} from './api/organizations';
 
 export function reportingRequestInit(signal: AbortSignal, forceRefresh = false): RequestInit {
   return forceRefresh
@@ -1172,110 +1186,12 @@ export interface TierActivationPreview {
   can_activate: boolean;
 }
 
-export interface OrganizationTierAssignment {
-  assignment_id: string;
-  organization_id: string;
-  tier_id: string;
-  tier_key?: string | null;
-  tier_name?: string | null;
-  tier_version_id?: string | null;
-  tier_version_number?: number | null;
-  tier_version_status?: string | null;
-  assignment_type: 'primary' | 'addon' | 'override' | string;
-  enabled: boolean;
-  weight: number;
-  starts_at?: string | null;
-  ends_at?: string | null;
-  metadata?: Record<string, unknown> | null;
-  created_at?: string | null;
-  updated_at?: string | null;
-}
-
-export interface OrganizationTierAssignmentPayload {
-  tier_id: string;
-  tier_version_id?: string | null;
-  assignment_type: string;
-  enabled?: boolean;
-  weight?: number;
-  starts_at?: string | null;
-  ends_at?: string | null;
-  metadata?: Record<string, unknown> | null;
-}
-
-export interface OrganizationPrimaryTierSummary {
-  assignment_id?: string | null;
-  tier_id?: string | null;
-  tier_key?: string | null;
-  tier_name?: string | null;
-  tier_version_id?: string | null;
-  tier_version_number?: number | null;
-  follows_active_version: boolean;
-}
-
-export interface OrganizationServicePolicy {
-  source: 'tier' | 'legacy';
-  runtime_source: 'tier' | 'legacy';
-  tier_authoritative: boolean;
-  tier_policy_mode: 'disabled' | 'shadow' | 'enforce' | string;
-  primary_tier: OrganizationPrimaryTierSummary | null;
-  active_assignment_count: number;
-  overlay_count: number;
-  hard_caps_configured: boolean;
-  organization_hard_caps: Partial<Record<'rpm_limit' | 'tpm_limit' | 'rph_limit' | 'rpd_limit' | 'tpd_limit', number>>;
-  legacy_model_limits_configured: boolean;
-}
-
-export interface OrganizationRecord {
-  organization_id: string;
-  organization_name?: string | null;
-  max_budget?: number | null;
-  soft_budget?: number | null;
-  spend?: number | null;
-  budget_duration?: string | null;
-  budget_reset_at?: string | null;
-  rpm_limit?: number | null;
-  tpm_limit?: number | null;
-  rph_limit?: number | null;
-  rpd_limit?: number | null;
-  tpd_limit?: number | null;
-  model_rpm_limit?: Record<string, number> | null;
-  model_tpm_limit?: Record<string, number> | null;
-  audit_content_storage_enabled?: boolean | null;
-  service_policy: OrganizationServicePolicy;
-  primary_tier_assignment?: OrganizationTierAssignment;
-  capabilities?: Record<string, boolean>;
-  team_count?: number;
-  member_count?: number;
-  user_count?: number;
-  created_at?: string | null;
-  updated_at?: string | null;
-  [key: string]: unknown;
-}
-
-export interface OrganizationCreatePayload {
-  organization_name: string;
-  legacy_policy_exception?: boolean;
-  primary_tier?: {
-    tier_id: string;
-    tier_version_id?: string | null;
-  };
-  max_budget?: number;
-  soft_budget?: number;
-  budget_duration?: string;
-  budget_reset_at?: string;
-  rpm_limit?: number;
-  tpm_limit?: number;
-  rph_limit?: number;
-  rpd_limit?: number;
-  tpd_limit?: number;
-  audit_content_storage_enabled?: boolean;
-  callable_target_bindings?: Array<{ callable_key: string }>;
-}
-
 export interface TeamRecord {
   team_id: string;
   team_alias?: string | null;
   organization_id?: string | null;
+  organization_name?: string | null;
+  organization_lifecycle_state?: string | null;
   max_budget?: number | null;
   spend?: number | null;
   rpm_limit?: number | null;
@@ -1779,37 +1695,64 @@ export const tiers = {
 };
 
 export const organizations = {
-  list: (params?: { search?: string; limit?: number; offset?: number }) =>
-    apiFetch<Paginated<OrganizationRecord>>(withQuery('/ui/api/organizations', params)),
-  get: (orgId: string) => apiFetch<OrganizationRecord>(`/ui/api/organizations/${encodeURIComponent(orgId)}`),
-  create: (payload: OrganizationCreatePayload) =>
-    apiFetch<OrganizationRecord>('/ui/api/organizations', { method: 'POST', json: payload }),
-  update: (orgId: string, payload: object) =>
-    apiFetch<OrganizationRecord>(`/ui/api/organizations/${encodeURIComponent(orgId)}`, { method: 'PUT', json: payload }),
-  members: (orgId: string) => apiFetch<Record<string, unknown>[]>(`/ui/api/organizations/${encodeURIComponent(orgId)}/members`),
-  memberCandidates: (orgId: string, params?: { search?: string; limit?: number }) =>
-    apiFetch<Record<string, unknown>[]>(withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/member-candidates`, params)),
+  ...organizationRecordsApi,
+  members: (orgId: string, signal?: AbortSignal) => apiFetch<Record<string, unknown>[]>(
+    `/ui/api/organizations/${encodeURIComponent(orgId)}/members`,
+    { signal },
+  ),
+  memberCandidates: (
+    orgId: string,
+    params?: { search?: string; limit?: number },
+    signal?: AbortSignal,
+  ) => apiFetch<Record<string, unknown>[]>(
+    withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/member-candidates`, params),
+    { signal },
+  ),
   addMember: (orgId: string, payload: object) =>
     apiFetch<Record<string, unknown>>(`/ui/api/organizations/${encodeURIComponent(orgId)}/members`, { method: 'POST', json: payload }),
   removeMember: (orgId: string, membershipId: string) =>
     apiFetch<{ deleted: boolean }>(`/ui/api/organizations/${encodeURIComponent(orgId)}/members/${encodeURIComponent(membershipId)}`, { method: 'DELETE' }),
-  teams: (orgId: string) => apiFetch<TeamRecord[]>(`/ui/api/organizations/${encodeURIComponent(orgId)}/teams`),
-  assetVisibility: (orgId: string, params?: AssetVisibilityParams) =>
-    apiFetch<AssetVisibilityResponse>(withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/asset-visibility`, params)),
-  assetAccess: (orgId: string, params?: ScopedAssetAccessParams) =>
-    apiFetch<ScopedAssetAccess>(withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/asset-access`, params)),
+  teams: (orgId: string, signal?: AbortSignal) => apiFetch<TeamRecord[]>(
+    `/ui/api/organizations/${encodeURIComponent(orgId)}/teams`,
+    { signal },
+  ),
+  assetVisibility: (
+    orgId: string,
+    params?: AssetVisibilityParams,
+    signal?: AbortSignal,
+  ) => apiFetch<AssetVisibilityResponse>(
+    withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/asset-visibility`, params),
+    { signal },
+  ),
+  assetAccess: (
+    orgId: string,
+    params?: ScopedAssetAccessParams,
+    signal?: AbortSignal,
+  ) => apiFetch<ScopedAssetAccess>(
+    withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/asset-access`, params),
+    { signal },
+  ),
   updateAssetAccess: (orgId: string, payload: { mode?: string; selected_callable_keys: string[]; selected_access_group_keys?: string[]; select_all_selectable?: boolean }) =>
     apiFetch<ScopedAssetAccess>(`/ui/api/organizations/${encodeURIComponent(orgId)}/asset-access`, { method: 'PUT', json: payload }),
-  tierAssignments: (orgId: string, params?: { enabled?: boolean | string }) =>
-    apiFetch<{ data: OrganizationTierAssignment[] }>(withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/tier-assignments`, params)),
+  tierAssignments: (
+    orgId: string,
+    params?: { enabled?: boolean | string },
+    signal?: AbortSignal,
+  ) => apiFetch<{ data: OrganizationTierAssignment[] }>(
+    withQuery(`/ui/api/organizations/${encodeURIComponent(orgId)}/tier-assignments`, params),
+    { signal },
+  ),
   createTierAssignment: (orgId: string, payload: OrganizationTierAssignmentPayload) =>
     apiFetch<OrganizationTierAssignment>(`/ui/api/organizations/${encodeURIComponent(orgId)}/tier-assignments`, { method: 'POST', json: payload }),
   updateTierAssignment: (orgId: string, assignmentId: string, payload: Partial<OrganizationTierAssignmentPayload>) =>
     apiFetch<OrganizationTierAssignment>(`/ui/api/organizations/${encodeURIComponent(orgId)}/tier-assignments/${encodeURIComponent(assignmentId)}`, { method: 'PATCH', json: payload }),
   deleteTierAssignment: (orgId: string, assignmentId: string) =>
     apiFetch<{ deleted: boolean; assignment_id: string; organization_id: string }>(`/ui/api/organizations/${encodeURIComponent(orgId)}/tier-assignments/${encodeURIComponent(assignmentId)}`, { method: 'DELETE' }),
-  tierPolicyPreview: (orgId: string) =>
-    apiFetch<OrganizationTierPolicyPreview>(`/ui/api/organizations/${encodeURIComponent(orgId)}/tier-policy-preview`),
+  tierPolicyPreview: (orgId: string, signal?: AbortSignal) =>
+    apiFetch<OrganizationTierPolicyPreview>(
+      `/ui/api/organizations/${encodeURIComponent(orgId)}/tier-policy-preview`,
+      { signal },
+    ),
   simulateTierPolicy: (orgId: string, payload: TierPolicySimulationPayload) =>
     apiFetch<TierPolicySimulation>(`/ui/api/organizations/${encodeURIComponent(orgId)}/tier-policy/simulate`, { method: 'POST', json: payload }),
 };
@@ -1823,9 +1766,14 @@ export interface SelfServicePolicy {
 }
 
 export const teams = {
-  list: (params?: { search?: string; organization_id?: string; limit?: number; offset?: number }) =>
-    apiFetch<Paginated<TeamRecord>>(withQuery('/ui/api/teams', params)),
-  get: (teamId: string) => apiFetch<TeamRecord>(`/ui/api/teams/${encodeURIComponent(teamId)}`),
+  list: (
+    params?: { search?: string; organization_id?: string; limit?: number; offset?: number },
+    signal?: AbortSignal,
+  ) => apiFetch<Paginated<TeamRecord>>(withQuery('/ui/api/teams', params), { signal }),
+  get: (teamId: string, signal?: AbortSignal) => apiFetch<TeamRecord>(
+    `/ui/api/teams/${encodeURIComponent(teamId)}`,
+    { signal },
+  ),
   getSelfServicePolicy: async (teamId: string): Promise<SelfServicePolicy> => {
     const t = await apiFetch<TeamRecord>(`/ui/api/teams/${encodeURIComponent(teamId)}`);
     return {

--- a/ui/src/lib/api/organizations.ts
+++ b/ui/src/lib/api/organizations.ts
@@ -1,0 +1,218 @@
+import { apiFetch, withQuery } from './transport';
+import {
+  normalizeOrganizationLifecycleState,
+  type OrganizationLifecycleState,
+} from '../organizationLifecycle';
+
+export interface OrganizationTierAssignment {
+  assignment_id: string;
+  organization_id: string;
+  tier_id: string;
+  tier_key?: string | null;
+  tier_name?: string | null;
+  tier_version_id?: string | null;
+  tier_version_number?: number | null;
+  tier_version_status?: string | null;
+  assignment_type: 'primary' | 'addon' | 'override' | string;
+  enabled: boolean;
+  weight: number;
+  starts_at?: string | null;
+  ends_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface OrganizationTierAssignmentPayload {
+  tier_id: string;
+  tier_version_id?: string | null;
+  assignment_type: string;
+  enabled?: boolean;
+  weight?: number;
+  starts_at?: string | null;
+  ends_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface OrganizationPrimaryTierSummary {
+  assignment_id?: string | null;
+  tier_id?: string | null;
+  tier_key?: string | null;
+  tier_name?: string | null;
+  tier_version_id?: string | null;
+  tier_version_number?: number | null;
+  follows_active_version: boolean;
+}
+
+export interface OrganizationServicePolicy {
+  source: 'tier' | 'legacy';
+  runtime_source: 'tier' | 'legacy';
+  tier_authoritative: boolean;
+  tier_policy_mode: 'disabled' | 'shadow' | 'enforce' | string;
+  primary_tier: OrganizationPrimaryTierSummary | null;
+  active_assignment_count: number;
+  overlay_count: number;
+  hard_caps_configured: boolean;
+  organization_hard_caps: Partial<Record<
+    'rpm_limit' | 'tpm_limit' | 'rph_limit' | 'rpd_limit' | 'tpd_limit',
+    number
+  >>;
+  legacy_model_limits_configured: boolean;
+}
+
+export interface OrganizationCapabilities {
+  view: boolean;
+  edit: boolean;
+  add_team: boolean;
+  manage_members: boolean;
+  manage_assets: boolean;
+  manage_service_policy: boolean;
+  view_usage: boolean;
+}
+
+export interface OrganizationRecord {
+  organization_id: string;
+  organization_name?: string | null;
+  lifecycle_state: OrganizationLifecycleState;
+  deletion_requested_at?: string | null;
+  deletion_not_before_at?: string | null;
+  max_budget?: number | null;
+  soft_budget?: number | null;
+  spend?: number | null;
+  budget_duration?: string | null;
+  budget_reset_at?: string | null;
+  rpm_limit?: number | null;
+  tpm_limit?: number | null;
+  rph_limit?: number | null;
+  rpd_limit?: number | null;
+  tpd_limit?: number | null;
+  model_rpm_limit?: Record<string, number> | null;
+  model_tpm_limit?: Record<string, number> | null;
+  audit_content_storage_enabled?: boolean | null;
+  service_policy: OrganizationServicePolicy;
+  primary_tier_assignment?: OrganizationTierAssignment;
+  capabilities: OrganizationCapabilities;
+  team_count?: number;
+  member_count?: number;
+  user_count?: number;
+  created_at?: string | null;
+  updated_at?: string | null;
+  [key: string]: unknown;
+}
+
+export interface OrganizationCreatePayload {
+  organization_name: string;
+  legacy_policy_exception?: boolean;
+  primary_tier?: {
+    tier_id: string;
+    tier_version_id?: string | null;
+  };
+  max_budget?: number;
+  soft_budget?: number;
+  budget_duration?: string;
+  budget_reset_at?: string;
+  rpm_limit?: number;
+  tpm_limit?: number;
+  rph_limit?: number;
+  rpd_limit?: number;
+  tpd_limit?: number;
+  audit_content_storage_enabled?: boolean;
+  callable_target_bindings?: Array<{ callable_key: string }>;
+}
+
+export interface OrganizationPage {
+  data: OrganizationRecord[];
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+    has_more: boolean;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function capability(value: Record<string, unknown> | null, key: string): boolean {
+  return value?.[key] === true;
+}
+
+export function normalizeOrganizationCapabilities(
+  value: unknown,
+  lifecycleState: OrganizationLifecycleState,
+): OrganizationCapabilities {
+  const raw = isRecord(value) ? value : null;
+  const active = lifecycleState === 'active';
+  return {
+    view: raw?.view !== false,
+    edit: active && capability(raw, 'edit'),
+    add_team: active && capability(raw, 'add_team'),
+    manage_members: active && capability(raw, 'manage_members'),
+    manage_assets: active && capability(raw, 'manage_assets'),
+    manage_service_policy: active && capability(raw, 'manage_service_policy'),
+    view_usage: lifecycleState !== 'unavailable' && capability(raw, 'view_usage'),
+  };
+}
+
+export function normalizeOrganizationRecord(value: unknown): OrganizationRecord {
+  if (!isRecord(value)) throw new Error('Invalid organization response');
+  const organizationId = typeof value.organization_id === 'string'
+    ? value.organization_id.trim()
+    : '';
+  if (!organizationId) throw new Error('Invalid organization response');
+
+  const lifecycleState = normalizeOrganizationLifecycleState(value.lifecycle_state);
+  return {
+    ...value,
+    organization_id: organizationId,
+    lifecycle_state: lifecycleState,
+    capabilities: normalizeOrganizationCapabilities(value.capabilities, lifecycleState),
+  } as OrganizationRecord;
+}
+
+function normalizeOrganizationPage(value: unknown): OrganizationPage {
+  if (!isRecord(value) || !Array.isArray(value.data) || !isRecord(value.pagination)) {
+    throw new Error('Invalid organization list response');
+  }
+  const pagination = value.pagination;
+  return {
+    data: value.data.map(normalizeOrganizationRecord),
+    pagination: {
+      total: Number(pagination.total || 0),
+      limit: Number(pagination.limit || 0),
+      offset: Number(pagination.offset || 0),
+      has_more: pagination.has_more === true,
+    },
+  };
+}
+
+export const organizationRecordsApi = {
+  list: async (
+    params?: { search?: string; limit?: number; offset?: number },
+    signal?: AbortSignal,
+  ): Promise<OrganizationPage> => normalizeOrganizationPage(
+    await apiFetch<unknown>(withQuery('/ui/api/organizations', params), { signal }),
+  ),
+  get: async (organizationId: string, signal?: AbortSignal): Promise<OrganizationRecord> => (
+    normalizeOrganizationRecord(
+      await apiFetch<unknown>(
+        `/ui/api/organizations/${encodeURIComponent(organizationId)}`,
+        { signal },
+      ),
+    )
+  ),
+  create: async (payload: OrganizationCreatePayload): Promise<OrganizationRecord> => (
+    normalizeOrganizationRecord(
+      await apiFetch<unknown>('/ui/api/organizations', { method: 'POST', json: payload }),
+    )
+  ),
+  update: async (organizationId: string, payload: object): Promise<OrganizationRecord> => (
+    normalizeOrganizationRecord(
+      await apiFetch<unknown>(
+        `/ui/api/organizations/${encodeURIComponent(organizationId)}`,
+        { method: 'PUT', json: payload },
+      ),
+    )
+  ),
+};

--- a/ui/src/lib/organizationDeletion.ts
+++ b/ui/src/lib/organizationDeletion.ts
@@ -1,4 +1,7 @@
 import { apiFetch } from './api/transport';
+import type { KnownOrganizationLifecycleState } from './organizationLifecycle';
+
+export type { OrganizationLifecycleState } from './organizationLifecycle';
 
 export type OrganizationDeletionCounts = {
   teams: number;
@@ -28,12 +31,6 @@ export type OrganizationDeletionCounts = {
   retained_batch_files: number;
 };
 
-export type OrganizationLifecycleState =
-  | 'active'
-  | 'deletion_pending'
-  | 'purging'
-  | 'deletion_failed';
-
 export type OrganizationDeletionPhase =
   | 'cancel_pending'
   | 'cancel_batches'
@@ -50,7 +47,7 @@ export type OrganizationDeletionPhase =
 export type OrganizationDeletionPlan = {
   organization_id: string;
   organization_name: string | null;
-  lifecycle_state: OrganizationLifecycleState;
+  lifecycle_state: KnownOrganizationLifecycleState;
   lifecycle_version: number;
   deletion_job_id: string | null;
   deletion_requested_at: string | null;

--- a/ui/src/lib/organizationLifecycle.ts
+++ b/ui/src/lib/organizationLifecycle.ts
@@ -1,0 +1,102 @@
+export const ORGANIZATION_LIFECYCLE_STATES = [
+  'active',
+  'deletion_pending',
+  'purging',
+  'deletion_failed',
+] as const;
+
+export type KnownOrganizationLifecycleState = typeof ORGANIZATION_LIFECYCLE_STATES[number];
+export type OrganizationLifecycleState = KnownOrganizationLifecycleState | 'unavailable';
+
+export interface OrganizationLifecycleTransition {
+  lifecycleState: KnownOrganizationLifecycleState;
+  deletionNotBeforeAt?: string | null;
+}
+
+export type OrganizationLifecyclePresentation = {
+  label: string;
+  badgeClassName: string;
+  noticeTitle: string | null;
+  noticeClassName: string | null;
+};
+
+const PRESENTATION: Record<OrganizationLifecycleState, OrganizationLifecyclePresentation> = {
+  active: {
+    label: 'Active',
+    badgeClassName: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    noticeTitle: null,
+    noticeClassName: null,
+  },
+  deletion_pending: {
+    label: 'Deletion pending',
+    badgeClassName: 'bg-amber-50 text-amber-800 ring-amber-200',
+    noticeTitle: 'Deletion scheduled — access is disabled',
+    noticeClassName: 'border-amber-200 bg-amber-50 text-amber-950',
+  },
+  purging: {
+    label: 'Purging',
+    badgeClassName: 'bg-red-50 text-red-700 ring-red-200',
+    noticeTitle: 'Permanent deletion is in progress',
+    noticeClassName: 'border-red-200 bg-red-50 text-red-950',
+  },
+  deletion_failed: {
+    label: 'Deletion failed',
+    badgeClassName: 'bg-red-50 text-red-700 ring-red-200',
+    noticeTitle: 'Deletion needs attention — access remains disabled',
+    noticeClassName: 'border-red-200 bg-red-50 text-red-950',
+  },
+  unavailable: {
+    label: 'Status unavailable',
+    badgeClassName: 'bg-slate-100 text-slate-700 ring-slate-300',
+    noticeTitle: 'Organization status could not be verified',
+    noticeClassName: 'border-slate-300 bg-slate-50 text-slate-900',
+  },
+};
+
+const IRREVERSIBLE_DELETION_PHASES = new Set([
+  'resolve_owned_assets',
+  'purge_sensitive_history',
+  'remove_scoped_access',
+  'revoke_credentials',
+  'remove_tenant_state',
+  'finalize',
+  'completed',
+]);
+
+export function organizationLifecycleTransitionForDeletionJob(job: {
+  status: string;
+  phase: string;
+  not_before_at: string | null;
+}): OrganizationLifecycleTransition {
+  if (job.status === 'restored') return { lifecycleState: 'active' };
+  if (job.status === 'failed') return { lifecycleState: 'deletion_failed' };
+  if (IRREVERSIBLE_DELETION_PHASES.has(job.phase)) return { lifecycleState: 'purging' };
+  return {
+    lifecycleState: 'deletion_pending',
+    deletionNotBeforeAt: job.not_before_at,
+  };
+}
+
+export function normalizeOrganizationLifecycleState(value: unknown): OrganizationLifecycleState {
+  return typeof value === 'string'
+    && (ORGANIZATION_LIFECYCLE_STATES as readonly string[]).includes(value)
+    ? value as KnownOrganizationLifecycleState
+    : 'unavailable';
+}
+
+export function organizationLifecyclePresentation(
+  state: OrganizationLifecycleState,
+): OrganizationLifecyclePresentation {
+  return PRESENTATION[state];
+}
+
+export function isOrganizationActive(state: OrganizationLifecycleState): boolean {
+  return state === 'active';
+}
+
+export function formatOrganizationDeletionDeadline(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const deadline = new Date(value);
+  if (Number.isNaN(deadline.getTime())) return null;
+  return deadline.toLocaleString();
+}

--- a/ui/src/lib/useOrganizationResource.ts
+++ b/ui/src/lib/useOrganizationResource.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  normalizeOrganizationCapabilities,
+  organizationRecordsApi,
+  type OrganizationRecord,
+} from './api/organizations';
+import type { OrganizationLifecycleTransition } from './organizationLifecycle';
+
+export type { OrganizationLifecycleTransition } from './organizationLifecycle';
+
+export function reconcileOrganizationLifecycleTransition(
+  organization: OrganizationRecord,
+  transition: OrganizationLifecycleTransition,
+): OrganizationRecord {
+  return {
+    ...organization,
+    lifecycle_state: transition.lifecycleState,
+    deletion_requested_at: transition.lifecycleState === 'active'
+      ? null
+      : organization.deletion_requested_at,
+    deletion_not_before_at: transition.lifecycleState === 'active'
+      ? null
+      : transition.deletionNotBeforeAt ?? organization.deletion_not_before_at,
+    capabilities: normalizeOrganizationCapabilities(
+      transition.lifecycleState === 'active' ? null : organization.capabilities,
+      transition.lifecycleState,
+    ),
+  };
+}
+
+export function useOrganizationResource(organizationId: string | undefined) {
+  const [data, setData] = useState<OrganizationRecord | null>(null);
+  const [initialError, setInitialError] = useState<unknown>(null);
+  const [refreshError, setRefreshError] = useState<unknown>(null);
+  const [initialLoading, setInitialLoading] = useState(Boolean(organizationId));
+  const [refreshing, setRefreshing] = useState(false);
+  const dataRef = useRef<OrganizationRecord | null>(null);
+  const requestIdRef = useRef(0);
+  const controllerRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      controllerRef.current?.abort();
+    };
+  }, []);
+
+  const load = useCallback(async (): Promise<OrganizationRecord> => {
+    if (!organizationId) throw new Error('Organization id is required');
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    const requestId = ++requestIdRef.current;
+    const isInitial = dataRef.current === null;
+    if (isInitial) {
+      setInitialLoading(true);
+      setInitialError(null);
+    } else {
+      setRefreshing(true);
+      setRefreshError(null);
+    }
+
+    try {
+      const next = await organizationRecordsApi.get(organizationId, controller.signal);
+      if (requestId !== requestIdRef.current || !mountedRef.current) return next;
+      dataRef.current = next;
+      setData(next);
+      setInitialError(null);
+      setRefreshError(null);
+      return next;
+    } catch (error: unknown) {
+      if (controller.signal.aborted || requestId !== requestIdRef.current) throw error;
+      if (mountedRef.current) {
+        if (dataRef.current === null) setInitialError(error);
+        else setRefreshError(error);
+      }
+      throw error;
+    } finally {
+      if (requestId === requestIdRef.current && mountedRef.current) {
+        setInitialLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, [organizationId]);
+
+  useEffect(() => {
+    dataRef.current = null;
+    setData(null);
+    setRefreshError(null);
+    if (!organizationId) {
+      setInitialLoading(false);
+      setInitialError(new Error('Organization id is required'));
+      return undefined;
+    }
+    void load().catch(() => undefined);
+    return () => controllerRef.current?.abort();
+  }, [load, organizationId]);
+
+  const applyLifecycleTransition = useCallback((transition: OrganizationLifecycleTransition) => {
+    setData((current) => {
+      if (current === null) return current;
+      const next = reconcileOrganizationLifecycleTransition(current, transition);
+      dataRef.current = next;
+      return next;
+    });
+  }, []);
+
+  return {
+    data,
+    initialError,
+    initialLoading,
+    refreshing,
+    refreshError,
+    refresh: load,
+    applyLifecycleTransition,
+  };
+}

--- a/ui/src/pages/OrganizationDetail.tsx
+++ b/ui/src/pages/OrganizationDetail.tsx
@@ -1,6 +1,10 @@
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
 import { useApi } from '../lib/hooks';
+import {
+  useOrganizationResource,
+  type OrganizationLifecycleTransition,
+} from '../lib/useOrganizationResource';
 import {
   callableTargets,
   organizations,
@@ -30,6 +34,10 @@ import {
   EntityDetailShell,
   TextTabs,
 } from '../components/admin/shells';
+import {
+  OrganizationLifecycleBadge,
+  OrganizationLifecycleNotice,
+} from '../components/admin/OrganizationLifecycleStatus';
 import {
   ArrowLeft, Building2, Users, DollarSign, Gauge, TrendingUp, Pencil, Plus,
   UserPlus, Trash2, ChevronRight, Shield, CheckCircle2, AlertTriangle,
@@ -158,28 +166,47 @@ export default function OrganizationDetail() {
   }, [isPlatformAdmin, location.hash]);
 
   /* ── data ── */
-  const { data: org, loading: orgLoading, refetch: refetchOrg } = useApi(
-    () => organizations.get(orgId!), [orgId],
-  );
+  const {
+    data: org,
+    initialError: orgInitialError,
+    initialLoading: orgLoading,
+    refreshing: orgRefreshing,
+    refreshError: orgRefreshError,
+    refresh: refetchOrg,
+    applyLifecycleTransition,
+  } = useOrganizationResource(orgId);
+  const handleLifecycleChange = useCallback(async (
+    transition: OrganizationLifecycleTransition,
+  ) => {
+    applyLifecycleTransition(transition);
+    await refetchOrg();
+  }, [applyLifecycleTransition, refetchOrg]);
+  const reconcileOrganizationAfterMutation = useCallback(async () => {
+    try {
+      await refetchOrg();
+    } catch {
+      // The mutation remains successful; the resource hook exposes refresh recovery.
+    }
+  }, [refetchOrg]);
   const servicePolicy = org?.service_policy;
   const hasTier = servicePolicy?.source === 'tier';
   const isTierAuthoritative = Boolean(servicePolicy?.tier_authoritative);
   const { data: orgTeams, loading: teamsLoading } = useApi(
-    () => organizations.teams(orgId!), [orgId],
+    (signal) => organizations.teams(orgId!, signal), [orgId],
   );
   const { data: orgMembers, loading: membersLoading, refetch: refetchMembers } = useApi(
-    () => organizations.members(orgId!), [orgId],
+    (signal) => organizations.members(orgId!, signal), [orgId],
   );
   const { data: orgAssetAccess, error: orgAssetAccessError, loading: orgAssetAccessLoading, refetch: refetchOrgAssetAccess } = useApi(
-    () => (isPlatformAdmin && !isTierAuthoritative
-      ? organizations.assetAccess(orgId!, { include_targets: false })
+    (signal) => (isPlatformAdmin && !isTierAuthoritative
+      ? organizations.assetAccess(orgId!, { include_targets: false }, signal)
       : Promise.resolve(null)),
     [orgId, isPlatformAdmin, isTierAuthoritative],
   );
   /* full targets: only loaded when assets tab is active */
   const { data: orgAssetTargetsFull, loading: orgAssetTargetsFullLoading } = useApi(
-    () => (tab === 'assets' && isPlatformAdmin && !isTierAuthoritative
-      ? organizations.assetAccess(orgId!, { include_targets: true })
+    (signal) => (tab === 'assets' && isPlatformAdmin && !isTierAuthoritative
+      ? organizations.assetAccess(orgId!, { include_targets: true }, signal)
       : Promise.resolve(null)),
     [orgId, isPlatformAdmin, isTierAuthoritative, tab],
   );
@@ -364,7 +391,7 @@ export default function OrganizationDetail() {
       }
       await organizations.update(orgId!, payload);
       setIsEditingSettings(false);
-      refetchOrg();
+      await reconcileOrganizationAfterMutation();
     } catch (err: unknown) {
       setOrgError(getErrorMessage(err, 'Failed to update organization'));
     } finally {
@@ -385,7 +412,7 @@ export default function OrganizationDetail() {
         model_rpm_limit: null,
         model_tpm_limit: null,
       });
-      refetchOrg();
+      await reconcileOrganizationAfterMutation();
     } catch (err: unknown) {
       setPageError(getErrorMessage(err, 'Failed to clear legacy per-model limits.'));
     } finally {
@@ -412,7 +439,7 @@ export default function OrganizationDetail() {
       });
       refetchOrgAssetAccess();
       setIsEditingAssets(false);
-      refetchOrg();
+      await reconcileOrganizationAfterMutation();
     } catch (err: unknown) {
       setOrgError(getErrorMessage(err, 'Failed to update asset access'));
     } finally {
@@ -434,7 +461,9 @@ export default function OrganizationDetail() {
   const [memberError, setMemberError] = useState<string | null>(null);
 
   const { data: memberCandidates, loading: memberCandidatesLoading } = useApi(
-    () => showAddMember ? organizations.memberCandidates(orgId!, { search: memberSearch, limit: 50 }) : Promise.resolve([]),
+    (signal) => showAddMember
+      ? organizations.memberCandidates(orgId!, { search: memberSearch, limit: 50 }, signal)
+      : Promise.resolve([]),
     [orgId, showAddMember, memberSearch],
   );
 
@@ -480,11 +509,12 @@ export default function OrganizationDetail() {
   const teamList = (orgTeams || []) as OrganizationTeamRow[];
   const memberList = (orgMembers || []) as OrganizationMemberRow[];
   const memberCandidateList = (memberCandidates || []) as MemberCandidateOption[];
-  const orgCapabilities = org?.capabilities || {};
-  const canEditOrganization = Boolean(orgCapabilities.edit);
-  const canAddTeam = Boolean(orgCapabilities.add_team);
-  const canManageMembers = Boolean(orgCapabilities.manage_members);
-  const canManageAssets = Boolean(orgCapabilities.manage_assets) && !isTierAuthoritative;
+  const organizationIsActive = org?.lifecycle_state === 'active';
+  const canEditOrganization = Boolean(org?.capabilities?.edit);
+  const canAddTeam = Boolean(org?.capabilities?.add_team);
+  const canManageMembers = Boolean(org?.capabilities?.manage_members);
+  const canManageAssets = Boolean(org?.capabilities?.manage_assets) && !isTierAuthoritative;
+  const canManageServicePolicy = Boolean(org?.capabilities?.manage_service_policy);
   const spend = org?.spend || 0;
   const budget = org?.max_budget ?? null;
   const spendPct = budget ? Math.min(100, Math.round((spend / budget) * 100)) : null;
@@ -514,6 +544,14 @@ export default function OrganizationDetail() {
       )
     : null;
 
+  useEffect(() => {
+    if (!org || organizationIsActive) return;
+    setIsEditingSettings(false);
+    setIsEditingAssets(false);
+    setShowAddMember(false);
+    if (tab === 'assets') setTab('overview');
+  }, [org, organizationIsActive, tab]);
+
   /* teams over 80% of budget = "warning" for alert card */
   const warningTeam = teamList.find(isBudgetWarningTeam);
 
@@ -529,7 +567,20 @@ export default function OrganizationDetail() {
   if (!org) {
     return (
       <div className="p-6">
-        <p className="text-gray-500">Organization not found.</p>
+        <p className="text-gray-500">
+          {orgInitialError
+            ? getErrorMessage(orgInitialError, 'Unable to load organization.')
+            : 'Organization not found.'}
+        </p>
+        {orgInitialError ? (
+          <button
+            type="button"
+            className="mt-3 text-sm font-medium text-brand-primary-ink"
+            onClick={() => void refetchOrg().catch(() => undefined)}
+          >
+            Try again
+          </button>
+        ) : null}
         <Link to="/organizations" className="text-brand-primary-ink text-sm mt-2 inline-block">Back to Organizations</Link>
       </div>
     );
@@ -550,9 +601,7 @@ export default function OrganizationDetail() {
       )}
       title={orgName}
       badges={(
-        <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600">
-          <CheckCircle2 className="h-3.5 w-3.5" /> Active
-        </span>
+        <OrganizationLifecycleBadge state={org.lifecycle_state} />
       )}
       meta={(
         <div className="flex items-center gap-3">
@@ -649,8 +698,32 @@ export default function OrganizationDetail() {
           ]}
         />
       )}
-      notice={pageError ? (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">{pageError}</div>
+      notice={!organizationIsActive || pageError || orgRefreshError ? (
+        <div className="space-y-3">
+          <OrganizationLifecycleNotice
+            state={org.lifecycle_state}
+            deletionNotBeforeAt={org.deletion_not_before_at}
+          />
+          {pageError ? (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">{pageError}</div>
+          ) : null}
+          {orgRefreshError ? (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+              <p>
+                The last action succeeded, but the latest organization state could not be loaded.
+                Existing data is being kept until refresh succeeds.
+              </p>
+              <button
+                type="button"
+                className="mt-2 font-semibold text-brand-primary-ink disabled:opacity-50"
+                disabled={orgRefreshing}
+                onClick={() => void refetchOrg().catch(() => undefined)}
+              >
+                {orgRefreshing ? 'Refreshing…' : 'Retry refresh'}
+              </button>
+            </div>
+          ) : null}
+        </div>
       ) : undefined}
     >
       {tab === 'overview' && (
@@ -700,7 +773,7 @@ export default function OrganizationDetail() {
                             <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-3 text-xs leading-relaxed text-red-800">
                               <p className="font-semibold">Legacy per-model RPM/TPM caps still apply</p>
                               <p className="mt-1">Move equivalent limits into the tier, then clear the legacy maps so the tier is the only per-model policy source.</p>
-                              {isPlatformAdmin && (
+                              {canManageServicePolicy && (
                                 <button
                                   type="button"
                                   onClick={handleClearLegacyModelLimits}
@@ -729,7 +802,9 @@ export default function OrganizationDetail() {
                       onClick={() => setTab('tiers')}
                       className="shrink-0 rounded-lg border border-blue-200 bg-white px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-50"
                     >
-                      {hasTier ? 'Manage policy' : 'Assign tier'}
+                      {canManageServicePolicy
+                        ? hasTier ? 'Manage policy' : 'Assign tier'
+                        : 'View policy'}
                     </button>
                   ) : (
                     <span className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-gray-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-600">
@@ -1174,6 +1249,7 @@ export default function OrganizationDetail() {
                   <OrganizationDeletionPanel
                     organizationId={orgId}
                     organizationName={orgName}
+                    onLifecycleChange={handleLifecycleChange}
                   />
                 </Suspense>
               )}
@@ -1399,7 +1475,13 @@ export default function OrganizationDetail() {
 
         {/* ── ASSETS ── */}
         {tab === 'tiers' && isPlatformAdmin && (
-          <OrganizationTierPanel organizationId={orgId!} canManage={isPlatformAdmin} />
+          <OrganizationTierPanel
+            organizationId={orgId!}
+            canManage={canManageServicePolicy}
+            readOnlyReason={organizationIsActive
+              ? undefined
+              : 'Tier assignments cannot be changed while organization access is disabled.'}
+          />
         )}
 
         {tab === 'assets' && canManageAssets && (

--- a/ui/src/pages/Organizations.tsx
+++ b/ui/src/pages/Organizations.tsx
@@ -6,6 +6,8 @@ import { resolveUiAccess } from '../lib/authorization';
 import {
   callableTargets,
   organizations,
+  type CallableTargetListItem,
+  type OrganizationRecord,
   type OrganizationServicePolicy,
 } from '../lib/api';
 import {
@@ -21,6 +23,7 @@ import {
 } from '../lib/format';
 import Modal from '../components/Modal';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
+import { OrganizationLifecycleBadge } from '../components/admin/OrganizationLifecycleStatus';
 import { ContentCard, IndexShell } from '../components/admin/shells';
 import {
   Plus, Building2, Users, DollarSign,
@@ -30,8 +33,23 @@ import {
 
 /* ─────────────── sub-components ─────────────── */
 
-function BudgetRing({ spend, budget }: { spend: number; budget: number | null }) {
-  if (!budget) return <span className="text-xs text-gray-400 font-medium">Unlimited</span>;
+const BUDGET_STATUS: Record<string, { dot: string; label: string }> = {
+  healthy: { dot: 'bg-emerald-500', label: 'Budget healthy' },
+  warning: { dot: 'bg-amber-500', label: 'Budget near limit' },
+  over: { dot: 'bg-red-500', label: 'Budget over limit' },
+  idle: { dot: 'bg-gray-300', label: 'No spend' },
+};
+
+function BudgetRing({
+  spend,
+  budget,
+  status,
+}: {
+  spend: number;
+  budget: number | null;
+  status: string;
+}) {
+  if (!budget) return <span className="text-xs text-gray-500 font-medium">Budget unlimited</span>;
   const pct = Math.min(100, (spend / budget) * 100);
   const r = 18;
   const circ = 2 * Math.PI * r;
@@ -54,19 +72,13 @@ function BudgetRing({ spend, budget }: { spend: number; budget: number | null })
           ${spend.toLocaleString(undefined, { maximumFractionDigits: 0 })}
         </p>
         <p className="text-[10px] text-gray-400">of ${budget.toLocaleString()}</p>
+        <p className="mt-0.5 inline-flex items-center gap-1 text-[10px] text-gray-500">
+          <span className={`h-1.5 w-1.5 rounded-full ${BUDGET_STATUS[status]?.dot ?? 'bg-gray-300'}`} />
+          {BUDGET_STATUS[status]?.label ?? 'Budget status unavailable'}
+        </p>
       </div>
     </div>
   );
-}
-
-function StatusDot({ status }: { status: string }) {
-  const map: Record<string, string> = {
-    healthy: 'bg-emerald-500',
-    warning: 'bg-amber-500',
-    over: 'bg-red-500',
-    idle: 'bg-gray-300',
-  };
-  return <span className={`inline-block w-2 h-2 rounded-full shrink-0 ${map[status] ?? 'bg-gray-300'}`} />;
 }
 
 function ServicePolicySummary({ policy }: { policy?: OrganizationServicePolicy | null }) {
@@ -116,7 +128,7 @@ function ServicePolicySummary({ policy }: { policy?: OrganizationServicePolicy |
   );
 }
 
-function getStatus(row: any): string {
+function getStatus(row: Pick<OrganizationRecord, 'spend' | 'max_budget'>): string {
   const spend = row.spend || 0;
   const budget = row.max_budget ?? null;
   if (budget !== null && spend > budget) return 'over';
@@ -150,10 +162,10 @@ export default function Organizations() {
   }, [searchInput]);
 
   const { data: result, loading, refetch } = useApi(
-    () => organizations.list({ search, limit: pageSize, offset: pageOffset }),
+    (signal) => organizations.list({ search, limit: pageSize, offset: pageOffset }, signal),
     [search, pageOffset],
   );
-  const rawItems: any[] = result?.data || [];
+  const rawItems: OrganizationRecord[] = result?.data || [];
   const pagination = result?.pagination;
 
   /* client-side status filter (only filters the current page) */
@@ -191,7 +203,7 @@ export default function Organizations() {
   }, [assetSearchInput]);
 
   /* ── modal state ── */
-  const [editItem, setEditItem] = useState<any>(null);
+  const [editItem, setEditItem] = useState<OrganizationRecord | null>(null);
   const [form, setForm] = useState({
     organization_name: '',
     max_budget: '',
@@ -355,14 +367,14 @@ export default function Organizations() {
       setEditItem(null);
       resetForm();
       refetch();
-    } catch (err: any) {
-      setError(err?.message || 'Failed to save organization');
+    } catch (err: unknown) {
+      setError(err instanceof Error && err.message ? err.message : 'Failed to save organization');
     } finally {
       setSaving(false);
     }
   };
 
-  const openEdit = (row: any) => {
+  const openEdit = (row: OrganizationRecord) => {
     setPageError(null);
     setForm({
       organization_name: row.organization_name || '',
@@ -391,7 +403,7 @@ export default function Organizations() {
   };
 
   const assetTargets = buildCatalogAssetTargets(
-    (callableTargetPage?.data || []) as any[],
+    (callableTargetPage?.data || []) as CallableTargetListItem[],
     form.selected_callable_keys,
     currentEditAssetAccess?.selected_callable_keys || [],
   );
@@ -532,7 +544,7 @@ export default function Organizations() {
                   </td>
                 </tr>
               ) : (
-                items.map((row: any, i: number) => {
+                items.map((row, i) => {
                   const status = getStatus(row);
                   const name = row.organization_name || row.organization_id;
                   return (
@@ -552,7 +564,7 @@ export default function Organizations() {
                           <div>
                             <div className="flex items-center gap-2">
                               <span className="font-semibold text-gray-900 text-sm">{name}</span>
-                              <StatusDot status={status} />
+                              <OrganizationLifecycleBadge state={row.lifecycle_state} />
                             </div>
                             <code className="text-[10px] text-gray-400 font-mono">{row.organization_id}</code>
                           </div>
@@ -561,7 +573,11 @@ export default function Organizations() {
 
                       {/* Budget ring */}
                       <td className="px-4 py-3.5">
-                        <BudgetRing spend={row.spend || 0} budget={row.max_budget ?? null} />
+                        <BudgetRing
+                          spend={row.spend || 0}
+                          budget={row.max_budget ?? null}
+                          status={status}
+                        />
                       </td>
 
                       {/* Service policy */}

--- a/ui/src/pages/TeamCreate.tsx
+++ b/ui/src/pages/TeamCreate.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { useApi } from '../lib/hooks';
-import { teams, organizations } from '../lib/api';
+import {
+  teams,
+  organizations,
+  type OrganizationRecord,
+  type TeamRecord,
+} from '../lib/api';
 import {
   assetAccessLoadErrorMessage,
   buildParentScopedAssetTargets,
@@ -10,12 +15,14 @@ import {
 } from '../lib/assetAccess';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
 import TeamSelfServicePolicySection from '../components/admin/TeamSelfServicePolicySection';
+import OrganizationTeamSelector from '../components/admin/OrganizationTeamSelector';
+import { OrganizationLifecycleBadge } from '../components/admin/OrganizationLifecycleStatus';
 import ToggleSwitch from '../components/ToggleSwitch';
 import { useAuth } from '../lib/auth';
 import { resolveUiAccess } from '../lib/authorization';
 import {
   Users, X, DollarSign, Gauge, TrendingUp, Info,
-  ChevronRight, Check, AlertCircle, Building2,
+  ChevronRight, Check, AlertCircle,
   Shield, Lock, Unlock, AlertOctagon, Clock, CalendarDays,
 } from 'lucide-react';
 
@@ -51,7 +58,7 @@ function InheritBadge({ value, unit }: { value: number | null | undefined; unit:
 
 /* ─────────────── faded background list ─────────────── */
 
-function BgList({ items }: { items: any[] }) {
+function BgList({ items }: { items: TeamRecord[] }) {
   return (
     <div className="flex-1 bg-gray-50 overflow-hidden pointer-events-none select-none">
       <div className="bg-white border-b border-gray-200 px-6 py-4">
@@ -80,7 +87,7 @@ function BgList({ items }: { items: any[] }) {
               </tr>
             </thead>
             <tbody>
-              {(items.length > 0 ? items : Array.from({ length: 5 })).map((t: any, i: number) => {
+              {(items.length > 0 ? items : Array.from({ length: 5 }, () => null)).map((t, i) => {
                 const name = t?.team_alias || t?.team_id || '—';
                 const orgName = t?.organization_name || t?.organization_id || '—';
                 const pct = t?.max_budget ? Math.min(100, ((t.spend || 0) / t.max_budget) * 100) : null;
@@ -127,24 +134,16 @@ export default function TeamCreate() {
 
   /* background teams list */
   const { data: teamsResult } = useApi(
-    () => uiAccess.team_create
-      ? teams.list({ limit: 8, offset: 0 })
+    (signal) => uiAccess.team_create
+      ? teams.list({ limit: 8, offset: 0 }, signal)
       : Promise.resolve({ data: [], pagination: { total: 0, limit: 8, offset: 0, has_more: false } }),
     [uiAccess.team_create],
   );
-  const bgItems: any[] = teamsResult?.data || [];
-
-  /* org list for selector */
-  const { data: orgResult } = useApi(
-    () => uiAccess.team_create
-      ? organizations.list({ limit: 500 })
-      : Promise.resolve({ data: [], pagination: { total: 0, limit: 500, offset: 0, has_more: false } }),
-    [uiAccess.team_create],
-  );
-  const orgList: any[] = orgResult?.data || [];
+  const bgItems: TeamRecord[] = teamsResult?.data || [];
 
   /* form state */
   const [selectedOrgId, setSelectedOrgId] = useState(preselectedOrgId);
+  const [selectedOrg, setSelectedOrg] = useState<OrganizationRecord | null>(null);
   const [teamName, setTeamName] = useState('');
   const [nameError, setNameError] = useState(false);
   const [budgetEnabled, setBudgetEnabled] = useState(false);
@@ -174,7 +173,6 @@ export default function TeamCreate() {
   const [blocked, setBlocked] = useState(false);
 
   /* selected org details */
-  const selectedOrg = orgList.find((o) => o.organization_id === selectedOrgId) || null;
   const remainingBudget = selectedOrg?.max_budget != null
     ? Math.max(0, selectedOrg.max_budget - (selectedOrg.spend || 0))
     : null;
@@ -200,13 +198,13 @@ export default function TeamCreate() {
 
   /* org asset visibility for restrict mode */
   const { data: orgAssetVisibility, error: orgAssetVisibilityError, loading: orgAssetVisibilityLoading } = useApi(
-    () => (assetMode === 'restrict' && selectedOrgId
+    (signal) => (assetMode === 'restrict' && selectedOrgId
       ? organizations.assetVisibility(selectedOrgId, {
           include_access_groups: true,
           access_group_search: assetSearch || undefined,
           access_group_limit: accessGroupPageSize,
           access_group_offset: accessGroupPageOffset,
-        })
+        }, signal)
       : Promise.resolve(null)),
     [assetMode, selectedOrgId, assetSearch, accessGroupPageOffset],
   );
@@ -236,7 +234,9 @@ export default function TeamCreate() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const isReady = teamName.trim().length > 0 && selectedOrgId.length > 0;
+  const isReady = teamName.trim().length > 0
+    && selectedOrgId.length > 0
+    && selectedOrg?.capabilities.add_team === true;
 
   const resetSelfServicePolicy = () => {
     setSelfServiceMaxKeysPerUser('');
@@ -248,6 +248,10 @@ export default function TeamCreate() {
   const handleCreate = async () => {
     if (!teamName.trim()) { setNameError(true); return; }
     if (!selectedOrgId) { setError('Please select an organization.'); return; }
+    if (!selectedOrg || !selectedOrg.capabilities.add_team) {
+      setError('Teams cannot be added while the selected organization is not active.');
+      return;
+    }
     if (assetAccessLoading) {
       setError('Wait for asset access options to finish loading before creating the team.');
       return;
@@ -259,7 +263,7 @@ export default function TeamCreate() {
     setError(null);
     setSaving(true);
     try {
-      const payload: any = {
+      const payload: Record<string, unknown> = {
         team_alias: teamName.trim(),
         organization_id: selectedOrgId,
         max_budget: budgetEnabled && budgetValue ? Number(budgetValue) : undefined,
@@ -296,16 +300,18 @@ export default function TeamCreate() {
             selected_callable_keys: selectedKeys,
             selected_access_group_keys: selectedAccessGroupKeys,
           });
-        } catch (err: any) {
-          pageWarning = err?.message || 'Team created, but restricted asset access could not be applied.';
+        } catch (err: unknown) {
+          pageWarning = err instanceof Error && err.message
+            ? err.message
+            : 'Team created, but restricted asset access could not be applied.';
         }
       }
 
       navigate(`/teams/${created.team_id}`, {
         state: pageWarning ? { pageWarning } : undefined,
       });
-    } catch (err: any) {
-      setError(err?.message || 'Failed to create team');
+    } catch (err: unknown) {
+      setError(err instanceof Error && err.message ? err.message : 'Failed to create team');
     } finally {
       setSaving(false);
     }
@@ -369,25 +375,17 @@ export default function TeamCreate() {
               {/* Org selector */}
               <div>
                 <FieldLabel label="Organization" required />
-                <div className="relative">
-                  <Building2 className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" />
-                  <select
-                    value={selectedOrgId}
-                    onChange={(e) => handleOrgChange(e.target.value)}
-                    disabled={saving}
-                    className="w-full pl-8 pr-4 py-2 text-sm border border-gray-300 rounded-lg bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-primary appearance-none disabled:opacity-50"
-                  >
-                    <option value="">Select an organization…</option>
-                    {orgList.map((o: any) => (
-                      <option key={o.organization_id} value={o.organization_id}>
-                        {o.organization_name || o.organization_id}
-                      </option>
-                    ))}
-                  </select>
-                </div>
+                <OrganizationTeamSelector
+                  value={selectedOrgId}
+                  disabled={saving}
+                  enabled={uiAccess.team_create}
+                  onChange={handleOrgChange}
+                  onSelectedOrganizationChange={setSelectedOrg}
+                />
                 {selectedOrg && (
                   <div className="mt-2 flex flex-wrap items-center gap-2 px-3 py-2 rounded-lg bg-indigo-50 border border-indigo-200 text-xs text-indigo-700">
                     <span className="font-semibold">{selectedOrg.organization_name || selectedOrg.organization_id}</span>
+                    <OrganizationLifecycleBadge state={selectedOrg.lifecycle_state} />
                     <span className="text-indigo-300">·</span>
                     <span>
                       Budget:{' '}
@@ -427,6 +425,11 @@ export default function TeamCreate() {
                     )}
                   </div>
                 )}
+                {selectedOrg && !selectedOrg.capabilities.add_team ? (
+                  <p className="mt-2 rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900">
+                    Teams cannot be added because this organization is not active.
+                  </p>
+                ) : null}
               </div>
 
               {/* Team name */}

--- a/ui/tests/organizationLifecycle.test.ts
+++ b/ui/tests/organizationLifecycle.test.ts
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement, useEffect } from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { JSDOM } from 'jsdom';
+
+import {
+  OrganizationLifecycleBadge,
+  OrganizationLifecycleNotice,
+} from '../src/components/admin/OrganizationLifecycleStatus';
+import {
+  formatOrganizationDeletionDeadline,
+  isOrganizationActive,
+  normalizeOrganizationLifecycleState,
+  organizationLifecycleTransitionForDeletionJob,
+  organizationLifecyclePresentation,
+} from '../src/lib/organizationLifecycle';
+import {
+  normalizeOrganizationRecord,
+  organizationRecordsApi,
+} from '../src/lib/api/organizations';
+import type { OrganizationDeletionJob } from '../src/lib/organizationDeletion';
+import {
+  reconcileOrganizationLifecycleTransition,
+  useOrganizationResource,
+} from '../src/lib/useOrganizationResource';
+
+test('organization lifecycle presentation distinguishes disabled states from active', () => {
+  assert.equal(organizationLifecyclePresentation('active').label, 'Active');
+  assert.equal(organizationLifecyclePresentation('deletion_pending').label, 'Deletion pending');
+  assert.equal(organizationLifecyclePresentation('purging').label, 'Purging');
+  assert.equal(organizationLifecyclePresentation('deletion_failed').label, 'Deletion failed');
+  assert.equal(isOrganizationActive('active'), true);
+  assert.equal(isOrganizationActive('deletion_pending'), false);
+  assert.equal(isOrganizationActive('purging'), false);
+  assert.equal(isOrganizationActive('deletion_failed'), false);
+  assert.equal(isOrganizationActive('unavailable'), false);
+});
+
+test('organization lifecycle normalization fails closed for old and future API responses', () => {
+  assert.equal(normalizeOrganizationLifecycleState(undefined), 'unavailable');
+  assert.equal(normalizeOrganizationLifecycleState('future_state'), 'unavailable');
+  assert.equal(organizationLifecyclePresentation('unavailable').label, 'Status unavailable');
+
+  const organization = normalizeOrganizationRecord({
+    organization_id: 'org-1',
+    organization_name: 'Legacy API organization',
+    capabilities: {
+      view: true,
+      edit: true,
+      add_team: true,
+      manage_members: true,
+      manage_assets: true,
+      manage_service_policy: true,
+      view_usage: true,
+    },
+    service_policy: {},
+  });
+
+  assert.equal(organization.lifecycle_state, 'unavailable');
+  assert.deepEqual(organization.capabilities, {
+    view: true,
+    edit: false,
+    add_team: false,
+    manage_members: false,
+    manage_assets: false,
+    manage_service_policy: false,
+    view_usage: false,
+  });
+});
+
+test('organization deletion deadline formatting rejects missing and invalid values', () => {
+  assert.equal(formatOrganizationDeletionDeadline(null), null);
+  assert.equal(formatOrganizationDeletionDeadline('not-a-date'), null);
+  assert.ok(formatOrganizationDeletionDeadline('2026-09-03T09:16:35.000Z'));
+});
+
+test('organization lifecycle UI explains immediate disablement and recovery', () => {
+  const badge = renderToStaticMarkup(OrganizationLifecycleBadge({ state: 'deletion_pending' }));
+  const notice = renderToStaticMarkup(OrganizationLifecycleNotice({
+    state: 'deletion_pending',
+    deletionNotBeforeAt: '2026-09-03T09:16:35.000Z',
+  }));
+
+  assert.match(badge, /Deletion pending/);
+  assert.match(notice, /access is disabled/);
+  assert.match(notice, /administrative changes are disabled now/);
+  assert.match(notice, /platform administrator can restore/);
+});
+
+test('organization lifecycle UI renders unavailable state without crashing', () => {
+  const badge = renderToStaticMarkup(OrganizationLifecycleBadge({ state: 'unavailable' }));
+  const notice = renderToStaticMarkup(OrganizationLifecycleNotice({ state: 'unavailable' }));
+
+  assert.match(badge, /Status unavailable/);
+  assert.match(notice, /could not be verified/);
+  assert.match(notice, /Administrative changes are disabled/);
+});
+
+test('organization lifecycle transition disables mutations before refresh and restores fail closed', () => {
+  const active = normalizeOrganizationRecord({
+    organization_id: 'org-1',
+    lifecycle_state: 'active',
+    service_policy: {},
+    capabilities: {
+      view: true,
+      edit: true,
+      add_team: true,
+      manage_members: true,
+      manage_assets: true,
+      manage_service_policy: true,
+      view_usage: true,
+    },
+  });
+  const pending = reconcileOrganizationLifecycleTransition(active, {
+    lifecycleState: 'deletion_pending',
+    deletionNotBeforeAt: '2026-09-03T09:16:35.000Z',
+  });
+  assert.equal(pending.lifecycle_state, 'deletion_pending');
+  assert.equal(pending.capabilities.edit, false);
+  assert.equal(pending.capabilities.add_team, false);
+
+  const restored = reconcileOrganizationLifecycleTransition(pending, {
+    lifecycleState: 'active',
+  });
+  assert.equal(restored.lifecycle_state, 'active');
+  assert.equal(restored.deletion_not_before_at, null);
+  assert.equal(restored.capabilities.edit, false);
+  assert.equal(restored.capabilities.add_team, false);
+});
+
+test('organization refresh is awaitable and preserves last-good data on failure', async () => {
+  const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousActEnvironment = (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT;
+  Object.defineProperties(globalThis, {
+    window: { configurable: true, value: dom.window },
+    document: { configurable: true, value: dom.window.document },
+    IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+  });
+
+  const originalGet = organizationRecordsApi.get;
+  const pending: Array<{
+    signal?: AbortSignal;
+    resolve: (value: ReturnType<typeof normalizeOrganizationRecord>) => void;
+    reject: (reason: Error) => void;
+  }> = [];
+  organizationRecordsApi.get = (_organizationId, signal) => new Promise((resolve, reject) => {
+    pending.push({ signal, resolve, reject });
+  });
+
+  let resource: ReturnType<typeof useOrganizationResource> | null = null;
+  function Probe() {
+    const current = useOrganizationResource('org-1');
+    useEffect(() => {
+      resource = current;
+    }, [current]);
+    return createElement('div', null, current.data?.lifecycle_state ?? 'loading');
+  }
+
+  const rootNode = document.getElementById('root');
+  assert.ok(rootNode);
+  const root = createRoot(rootNode);
+  const active = normalizeOrganizationRecord({
+    organization_id: 'org-1',
+    lifecycle_state: 'active',
+    capabilities: { view: true, edit: true },
+    service_policy: {},
+  });
+
+  try {
+    await act(async () => root.render(createElement(Probe)));
+    assert.equal(pending.length, 1);
+    await act(async () => {
+      pending[0].resolve(active);
+      await Promise.resolve();
+    });
+    assert.equal(resource?.data?.lifecycle_state, 'active');
+
+    const refreshError = new Error('refresh unavailable');
+    let refreshPromise: Promise<ReturnType<typeof normalizeOrganizationRecord>> | undefined;
+    await act(async () => {
+      refreshPromise = resource?.refresh();
+      await Promise.resolve();
+    });
+    assert.equal(pending.length, 2);
+    await act(async () => {
+      pending[1].reject(refreshError);
+      await assert.rejects(refreshPromise, /refresh unavailable/);
+    });
+    assert.equal(resource?.data, active);
+    assert.equal(resource?.refreshError, refreshError);
+    assert.equal(resource?.refreshing, false);
+
+    await act(async () => root.unmount());
+    assert.equal(pending[1].signal?.aborted, true);
+  } finally {
+    organizationRecordsApi.get = originalGet;
+    dom.window.close();
+    Object.defineProperties(globalThis, {
+      window: { configurable: true, value: previousWindow },
+      document: { configurable: true, value: previousDocument },
+      IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: previousActEnvironment },
+    });
+  }
+});
+
+test('deletion job progress maps to the parent lifecycle state', () => {
+  const job = (overrides: Partial<OrganizationDeletionJob>): OrganizationDeletionJob => ({
+    deletion_job_id: 'job-1',
+    organization_id: 'org-1',
+    status: 'waiting',
+    phase: 'wait_for_batches',
+    progress: {},
+    not_before_at: '2026-09-03T09:16:35.000Z',
+    attempt_count: 0,
+    max_attempts: 20,
+    last_error_code: null,
+    last_error_detail: null,
+    created_at: null,
+    updated_at: null,
+    completed_at: null,
+    restored_at: null,
+    restore_allowed: true,
+    ...overrides,
+  });
+
+  assert.equal(organizationLifecycleTransitionForDeletionJob(job({})).lifecycleState, 'deletion_pending');
+  assert.equal(organizationLifecycleTransitionForDeletionJob(job({ phase: 'remove_scoped_access' })).lifecycleState, 'purging');
+  assert.equal(organizationLifecycleTransitionForDeletionJob(job({ status: 'failed' })).lifecycleState, 'deletion_failed');
+  assert.equal(organizationLifecycleTransitionForDeletionJob(job({ status: 'restored' })).lifecycleState, 'active');
+});


### PR DESCRIPTION
## Summary

- expose organization lifecycle state and fail-closed capabilities through typed backend and frontend contracts
- clearly show that deletion-pending organizations have runtime access and administrative changes disabled immediately
- enforce the authoritative PostgreSQL lifecycle check in the same transaction as organization-scoped human and admin mutations
- preserve read, recovery, and deletion-worker behavior while keeping inactive organization controls read-only
- add awaitable organization refresh reconciliation, searchable team organization selection, and lazy-loaded organization routes

## Verification

- `uv run ruff check <touched Python paths>`: passed
- `uv run ruff format --check <touched Python paths>`: passed
- focused lifecycle, authorization, mutation, and API suites: 202 passed
- organization deletion and worker regression suites: 25 passed
- organization response contract and authorization suites: 105 passed
- `npm --prefix ui run test:unit`: 176 passed
- touched-file ESLint: passed with zero findings
- `npm --prefix ui run build`: passed; initial bundle is 405.70 KB gzip versus the approximately 409 KB audited baseline, and organization lazy chunks are at most 17.97 KB gzip
- `git diff --check`: passed

The repository-wide UI lint command still reports the existing baseline debt; touched files are clean and this change does not add findings.

## Operational notes

- no Helm or `values.yaml` change is required for this remediation
- PostgreSQL remains the source of truth and unknown lifecycle states deny mutation rather than defaulting to active
- the cleanup worker continues to use its lifecycle-aware repository path and is covered by regression tests
