### PR TITLE
Accept contentless assistant tool-call messages

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,6 +1,75 @@
 {
   "components": {
     "schemas": {
+      "AssistantChatMessage": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "role": {
+            "const": "assistant",
+            "title": "Role",
+            "type": "string"
+          },
+          "tool_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Call Id"
+          },
+          "tool_calls": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Calls"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "title": "AssistantChatMessage",
+        "type": "object"
+      },
       "AudioSpeechRequest": {
         "properties": {
           "input": {
@@ -220,7 +289,29 @@
           },
           "messages": {
             "items": {
-              "$ref": "#/components/schemas/ChatMessage"
+              "discriminator": {
+                "mapping": {
+                  "assistant": "#/components/schemas/AssistantChatMessage",
+                  "system": "#/components/schemas/SystemChatMessage",
+                  "tool": "#/components/schemas/ToolChatMessage",
+                  "user": "#/components/schemas/UserChatMessage"
+                },
+                "propertyName": "role"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SystemChatMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/UserChatMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantChatMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolChatMessage"
+                }
+              ]
             },
             "title": "Messages",
             "type": "array"
@@ -406,78 +497,6 @@
           "messages"
         ],
         "title": "ChatCompletionRequest",
-        "type": "object"
-      },
-      "ChatMessage": {
-        "properties": {
-          "content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              }
-            ],
-            "title": "Content"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "role": {
-            "enum": [
-              "system",
-              "user",
-              "assistant",
-              "tool"
-            ],
-            "title": "Role",
-            "type": "string"
-          },
-          "tool_call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tool Call Id"
-          },
-          "tool_calls": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tool Calls"
-          }
-        },
-        "required": [
-          "role",
-          "content"
-        ],
-        "title": "ChatMessage",
         "type": "object"
       },
       "CompletionsRequest": {
@@ -3710,6 +3729,73 @@
         "title": "SchedulerModeUpdateRequest",
         "type": "object"
       },
+      "SystemChatMessage": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Content"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "role": {
+            "const": "system",
+            "title": "Role",
+            "type": "string"
+          },
+          "tool_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Call Id"
+          },
+          "tool_calls": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Calls"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "title": "SystemChatMessage",
+        "type": "object"
+      },
       "TierActivationRequest": {
         "additionalProperties": false,
         "properties": {
@@ -4601,6 +4687,73 @@
         "title": "TierVersionCreateRequest",
         "type": "object"
       },
+      "ToolChatMessage": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Content"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "role": {
+            "const": "tool",
+            "title": "Role",
+            "type": "string"
+          },
+          "tool_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Call Id"
+          },
+          "tool_calls": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Calls"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "title": "ToolChatMessage",
+        "type": "object"
+      },
       "ToolChoice": {
         "properties": {
           "function": {
@@ -4897,6 +5050,73 @@
           }
         },
         "title": "UIBrandingUpdatePayload",
+        "type": "object"
+      },
+      "UserChatMessage": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Content"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "role": {
+            "const": "user",
+            "title": "Role",
+            "type": "string"
+          },
+          "tool_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Call Id"
+          },
+          "tool_calls": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Calls"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "title": "UserChatMessage",
         "type": "object"
       },
       "ValidationError": {

--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -61,6 +61,33 @@ This is the main endpoint most applications should start with.
 
 Chat requests also support DeltaLLM-managed MCP tools through `tools: [{ "type": "mcp", ... }]` on non-streaming requests. See [MCP Gateway & Tooling](mcp.md).
 
+OpenAI-compatible client-managed tool histories may omit assistant `content`, or set it to
+`null`, when that assistant message contains non-empty `tool_calls`. Follow the assistant turn
+with the matching tool result:
+
+```json
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {"role": "user", "content": "Search the documentation."},
+    {
+      "role": "assistant",
+      "tool_calls": [
+        {
+          "id": "call_1",
+          "type": "function",
+          "function": {"name": "search", "arguments": "{\"query\":\"DeltaLLM\"}"}
+        }
+      ]
+    },
+    {"role": "tool", "tool_call_id": "call_1", "content": "Search result"}
+  ]
+}
+```
+
+System, user, and tool messages still require non-null `content`. Use
+`POST /v1/chat/completions`, not the legacy `POST /v1/completions`, for tool-calling requests.
+
 Provider error bodies are bounded and never returned verbatim. Encoded error bodies are kept opaque
 and classified from trusted status and `Retry-After` metadata instead of being decompressed; bounded
 identity bodies may also contribute provider-specific classifications. Before response commit,

--- a/src/chat/stream_usage.py
+++ b/src/chat/stream_usage.py
@@ -99,6 +99,8 @@ def _is_provider_token_usage(usage: dict[str, Any]) -> bool:
 
 
 def _content_chars(content: Any) -> int:
+    if content is None:
+        return 0
     if isinstance(content, str):
         return len(content)
     return len(json.dumps(content, sort_keys=True, separators=(",", ":"), default=str))

--- a/src/mcp/orchestrator.py
+++ b/src/mcp/orchestrator.py
@@ -17,10 +17,11 @@ from src.models.errors import (
     ServiceUnavailableError,
 )
 from src.models.requests import (
+    AssistantChatMessage,
     ChatCompletionRequest,
-    ChatMessage,
     FunctionToolDefinition,
     MCPToolDefinition,
+    ToolChatMessage,
 )
 from src.models.responses import UserAPIKeyAuth
 from src.services.audit_service import (
@@ -331,7 +332,7 @@ class MCPChatOrchestrator:
                     operation_id=tool_operation_id,
                 )
                 next_messages.append(
-                    ChatMessage(
+                    ToolChatMessage(
                         role="tool",
                         content=self._tool_message_content(guarded_result),
                         tool_call_id=str(tool_call.get("id") or tool_name),
@@ -357,7 +358,9 @@ class MCPChatOrchestrator:
         return [item for item in tool_calls if isinstance(item, dict)]
 
     @staticmethod
-    def _assistant_message_from_response(response_payload: dict[str, Any]) -> ChatMessage:
+    def _assistant_message_from_response(
+        response_payload: dict[str, Any],
+    ) -> AssistantChatMessage:
         choice = (
             ((response_payload.get("choices") or [{}])[0])
             if isinstance(response_payload.get("choices"), list)
@@ -366,7 +369,7 @@ class MCPChatOrchestrator:
         message = choice.get("message") if isinstance(choice, dict) else {}
         if not isinstance(message, dict):
             message = {}
-        return ChatMessage(
+        return AssistantChatMessage(
             role="assistant",
             content=message.get("content")
             if isinstance(message.get("content"), list)

--- a/src/models/request_serialization.py
+++ b/src/models/request_serialization.py
@@ -4,7 +4,28 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from src.models.requests import AssistantChatMessage, ChatCompletionRequest
+
 
 def dump_request_for_preflight(payload: BaseModel) -> dict[str, Any]:
     """Serialize request data without losing explicit nulls or adding defaults."""
     return payload.model_dump(mode="python", exclude_unset=True)
+
+
+def dump_openai_chat_request(payload: ChatCompletionRequest) -> dict[str, Any]:
+    """Serialize chat data while preserving explicit-null assistant content."""
+    data = payload.model_dump(mode="python", exclude_none=True)
+    messages = data["messages"]
+    if not isinstance(messages, list) or len(messages) != len(payload.messages):
+        raise RuntimeError("serialized chat messages do not match the canonical request")
+
+    for source, serialized in zip(payload.messages, messages, strict=True):
+        if not isinstance(serialized, dict):
+            raise RuntimeError("serialized chat message is not an object")
+        if (
+            isinstance(source, AssistantChatMessage)
+            and source.content is None
+            and "content" in source.model_fields_set
+        ):
+            serialized["content"] = None
+    return data

--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -1,16 +1,49 @@
 from __future__ import annotations
 
-from typing import Any, Literal, Self, TypeAlias
+from typing import Annotated, Any, Literal, Self, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-class ChatMessage(BaseModel):
-    role: Literal["system", "user", "assistant", "tool"]
-    content: str | list[dict[str, Any]]
+ChatMessageContent: TypeAlias = str | list[dict[str, Any]]
+
+
+class ChatMessageBase(BaseModel):
     name: str | None = None
     tool_calls: list[dict[str, Any]] | None = None
     tool_call_id: str | None = None
+
+
+class SystemChatMessage(ChatMessageBase):
+    role: Literal["system"]
+    content: ChatMessageContent
+
+
+class UserChatMessage(ChatMessageBase):
+    role: Literal["user"]
+    content: ChatMessageContent
+
+
+class AssistantChatMessage(ChatMessageBase):
+    role: Literal["assistant"]
+    content: ChatMessageContent | None = None
+
+    @model_validator(mode="after")
+    def validate_content_or_tool_calls(self) -> Self:
+        if self.content is None and not self.tool_calls:
+            raise ValueError("assistant message requires content or non-empty tool_calls")
+        return self
+
+
+class ToolChatMessage(ChatMessageBase):
+    role: Literal["tool"]
+    content: ChatMessageContent
+
+
+ChatRequestMessage: TypeAlias = Annotated[
+    SystemChatMessage | UserChatMessage | AssistantChatMessage | ToolChatMessage,
+    Field(discriminator="role"),
+]
 
 
 class FunctionToolDefinition(BaseModel):
@@ -40,7 +73,7 @@ class ResponseFormat(BaseModel):
 
 class ChatCompletionRequest(BaseModel):
     model: str
-    messages: list[ChatMessage]
+    messages: list[ChatRequestMessage]
     temperature: float | None = Field(default=1.0, ge=0, le=2)
     max_tokens: int | None = Field(default=None, ge=1)
     top_p: float | None = Field(default=1.0, ge=0, le=1)

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from .requests import ChatMessage
+from .requests import AssistantChatMessage
 
 
 class Usage(BaseModel):
@@ -15,7 +15,7 @@ class Usage(BaseModel):
 
 class Choice(BaseModel):
     index: int
-    message: ChatMessage
+    message: AssistantChatMessage
     finish_reason: Literal["stop", "length", "tool_calls", "content_filter"] | None = None
     logprobs: dict[str, Any] | None = None
 

--- a/src/providers/azure.py
+++ b/src/providers/azure.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncIterator
 import httpx
 
 from src.models.errors import FailureClassification, ProxyError
+from src.models.request_serialization import dump_openai_chat_request
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 from src.providers.base import (
@@ -54,7 +55,7 @@ class AzureOpenAIAdapter(ProviderAdapter):
     async def translate_request(
         self, canonical_request: ChatCompletionRequest, provider_config: dict[str, Any]
     ) -> dict[str, Any]:
-        payload = canonical_request.model_dump(exclude_none=True)
+        payload = dump_openai_chat_request(canonical_request)
         if payload.get("tool_choice") is not None and not payload.get("tools"):
             payload.pop("tool_choice", None)
         provider = resolve_provider(provider_config)

--- a/src/providers/gemini.py
+++ b/src/providers/gemini.py
@@ -136,6 +136,15 @@ class GeminiAdapter(ProviderAdapter):
         canonical_request: ChatCompletionRequest,
         provider_config: dict[str, Any],
     ) -> dict[str, Any]:
+        if canonical_request.tools or any(
+            message.role == "tool" or bool(message.tool_calls)
+            for message in canonical_request.messages
+        ):
+            raise InvalidRequestError(
+                message="Provider 'gemini' does not support tool calling",
+                param="tools",
+            )
+
         system_parts: list[dict[str, str]] = []
         contents: list[dict[str, Any]] = []
         for message in canonical_request.messages:
@@ -147,7 +156,7 @@ class GeminiAdapter(ProviderAdapter):
                     for part in content
                 )
             else:
-                text = str(content)
+                text = str(content or "")
             if role == "system":
                 if text:
                     system_parts.append({"text": text})

--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncIterator
 import httpx
 
 from src.models.errors import FailureClassification, ProxyError
+from src.models.request_serialization import dump_openai_chat_request
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
 from src.providers.base import (
@@ -69,7 +70,7 @@ class OpenAIAdapter(ProviderAdapter):
         canonical_request: ChatCompletionRequest,
         provider_config: dict[str, Any],
     ) -> dict[str, Any]:
-        payload = canonical_request.model_dump(exclude_none=True)
+        payload = dump_openai_chat_request(canonical_request)
         if payload.get("tool_choice") is not None and not payload.get("tools"):
             payload.pop("tool_choice", None)
         provider = resolve_provider(provider_config)

--- a/tests/docs/test_generated_references.py
+++ b/tests/docs/test_generated_references.py
@@ -49,6 +49,42 @@ def test_committed_openapi_operation_ids_are_unique() -> None:
     assert "get_ui_branding_asset" in operation_ids
 
 
+def test_committed_openapi_chat_messages_are_role_aware() -> None:
+    schema = json.loads((PROJECT_ROOT / "docs" / "api" / "openapi.json").read_text())
+    schemas = schema["components"]["schemas"]
+    message_items = schemas["ChatCompletionRequest"]["properties"]["messages"]["items"]
+
+    assert message_items["discriminator"] == {
+        "propertyName": "role",
+        "mapping": {
+            "assistant": "#/components/schemas/AssistantChatMessage",
+            "system": "#/components/schemas/SystemChatMessage",
+            "tool": "#/components/schemas/ToolChatMessage",
+            "user": "#/components/schemas/UserChatMessage",
+        },
+    }
+    assert {item["$ref"] for item in message_items["oneOf"]} == {
+        "#/components/schemas/AssistantChatMessage",
+        "#/components/schemas/SystemChatMessage",
+        "#/components/schemas/ToolChatMessage",
+        "#/components/schemas/UserChatMessage",
+    }
+
+    assistant = schemas["AssistantChatMessage"]
+    assert "content" not in assistant["required"]
+    assert {variant.get("type") for variant in assistant["properties"]["content"]["anyOf"]} >= {
+        "string",
+        "array",
+        "null",
+    }
+    for name in ("SystemChatMessage", "ToolChatMessage", "UserChatMessage"):
+        assert "content" in schemas[name]["required"]
+        assert all(
+            variant.get("type") != "null"
+            for variant in schemas[name]["properties"]["content"]["anyOf"]
+        )
+
+
 def test_generated_artifact_check_detects_drift(tmp_path: Path) -> None:
     artifact = tmp_path / "artifact.md"
     artifact.write_text("old\n", encoding="utf-8")

--- a/tests/test_batch_service.py
+++ b/tests/test_batch_service.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 import logging
 
 import pytest
 from fastapi import HTTPException
 
-from src.batch.models import BatchFileRecord, BatchJobRecord, BatchJobStatus, OPENAI_BATCH_COMPLETION_WINDOW
+from src.batch.models import (
+    BatchFileRecord,
+    BatchJobRecord,
+    BatchJobStatus,
+    OPENAI_BATCH_COMPLETION_WINDOW,
+)
 from src.batch.service import OPENAI_BATCH_STATUS_VALUES, BatchService
 from src.metrics.batch import deltallm_batch_artifact_failures_metric
 from src.db.callable_targets import CallableTargetBindingRecord
@@ -32,7 +38,9 @@ class _DummyStorage:
         self.reads.append(storage_key)
         return b"{}"
 
-    async def iter_lines(self, storage_key: str, chunk_size: int = 65_536, max_line_bytes: int | None = None):  # noqa: ARG002
+    async def iter_lines(
+        self, storage_key: str, chunk_size: int = 65_536, max_line_bytes: int | None = None
+    ):  # noqa: ARG002
         del max_line_bytes
         self.reads.append(storage_key)
         for line in self.lines_by_key.get(storage_key, []):
@@ -177,7 +185,9 @@ class _FakeCallableTargetBindingRepository:
     def __init__(self, bindings: list[CallableTargetBindingRecord]) -> None:
         self.bindings = list(bindings)
 
-    async def list_bindings(self, *, callable_key=None, scope_type=None, scope_id=None, limit=200, offset=0):  # noqa: ANN001, ANN201
+    async def list_bindings(
+        self, *, callable_key=None, scope_type=None, scope_id=None, limit=200, offset=0
+    ):  # noqa: ANN001, ANN201
         items = list(self.bindings)
         if callable_key:
             items = [item for item in items if item.callable_key == callable_key]
@@ -286,6 +296,56 @@ async def test_parse_input_jsonl_accepts_chat_completion_lines() -> None:
     assert items[0].request_body["model"] == "gpt-4o-mini"
     assert items[0].request_body["messages"] == [{"role": "user", "content": "hello"}]
     assert items[0].request_body["stream"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "include_assistant_content",
+    [pytest.param(False, id="omitted"), pytest.param(True, id="null")],
+)
+async def test_parse_input_jsonl_preserves_assistant_tool_call_content_presence(
+    include_assistant_content: bool,
+) -> None:
+    service = _service(callable_target_scope_policy_mode="shadow")
+    auth = UserAPIKeyAuth(api_key="sk-test", models=["gpt-4o-mini"])
+    assistant: dict[str, object] = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ],
+    }
+    if include_assistant_content:
+        assistant["content"] = None
+    line = {
+        "custom_id": "chat-tool-1",
+        "method": "POST",
+        "url": "/v1/chat/completions",
+        "body": {
+            "model": "gpt-4o-mini",
+            "messages": [
+                {"role": "user", "content": "search"},
+                assistant,
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ],
+        },
+    }
+
+    items, model = service._parse_input_jsonl(
+        (json.dumps(line) + "\n").encode(),
+        endpoint="/v1/chat/completions",
+        auth=auth,
+    )
+
+    assert model == "gpt-4o-mini"
+    stored_assistant = items[0].request_body["messages"][1]
+    assert ("content" in stored_assistant) is include_assistant_content
+    if include_assistant_content:
+        assert stored_assistant["content"] is None
+    assert stored_assistant["tool_calls"] == assistant["tool_calls"]
 
 
 @pytest.mark.asyncio
@@ -563,7 +623,9 @@ async def test_get_file_content_allows_same_organization_without_team_match() ->
 
 
 @pytest.mark.asyncio
-async def test_get_file_content_denies_same_organization_for_team_owned_file_with_different_team() -> None:
+async def test_get_file_content_denies_same_organization_for_team_owned_file_with_different_team() -> (
+    None
+):
     now = datetime.now(tz=UTC)
 
     class _Repo:
@@ -653,7 +715,9 @@ async def test_get_file_content_increments_artifact_read_failure_metric() -> Non
 
 
 @pytest.mark.asyncio
-async def test_batch_service_refresh_runtime_metrics_logs_debug_on_failure(caplog: pytest.LogCaptureFixture) -> None:
+async def test_batch_service_refresh_runtime_metrics_logs_debug_on_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     class _Repo:
         async def summarize_runtime_statuses(self, *, now):  # noqa: ANN001
             del now
@@ -898,7 +962,9 @@ async def test_list_batches_prefers_team_scope_over_org_scope_for_runtime_visibi
 
 
 @pytest.mark.asyncio
-async def test_get_batch_denies_same_organization_for_team_owned_batch_with_different_team() -> None:
+async def test_get_batch_denies_same_organization_for_team_owned_batch_with_different_team() -> (
+    None
+):
     now = datetime.now(tz=UTC)
 
     class _Repo:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -327,6 +327,75 @@ async def test_chat_completion_success(client, test_app):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "include_assistant_content",
+    [pytest.param(False, id="omitted"), pytest.param(True, id="null")],
+)
+async def test_chat_completion_preserves_assistant_tool_call_content_presence(
+    client,
+    test_app,
+    include_assistant_content: bool,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def post(url, headers, json, timeout):  # noqa: ANN001, ANN201
+        del url, headers, timeout
+        captured.update(json)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-tool-history",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "model": json["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "done"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 1, "total_tokens": 5},
+            },
+        )
+
+    test_app.state.http_client.post = post
+    assistant: dict[str, object] = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ],
+    }
+    if include_assistant_content:
+        assistant["content"] = None
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [
+                {"role": "user", "content": "search"},
+                assistant,
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ],
+            "stream": False,
+        },
+    )
+
+    assert response.status_code == 200
+    forwarded_assistant = captured["messages"][1]
+    assert ("content" in forwarded_assistant) is include_assistant_content
+    if include_assistant_content:
+        assert forwarded_assistant["content"] is None
+    assert forwarded_assistant["tool_calls"] == assistant["tool_calls"]
+
+
+@pytest.mark.asyncio
 async def test_chat_authorizes_the_model_after_pre_call_transformation(client, test_app):
     rewriter = RewritingPreCallCallback(model="forbidden-model")
     manager = CallbackManager()
@@ -1386,6 +1455,48 @@ async def test_chat_completion_streaming_success(client, test_app):
     deployment_id = str(response.headers["x-deltallm-route-deployment"])
     usage = await test_app.state.router_state_backend.get_usage(deployment_id)
     assert usage == {"rpm": 1, "tpm": 3}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "include_assistant_content",
+    [pytest.param(False, id="omitted"), pytest.param(True, id="null")],
+)
+async def test_chat_completion_streaming_accepts_contentless_assistant_tool_call_history(
+    client,
+    test_app,
+    include_assistant_content: bool,
+) -> None:
+    assistant: dict[str, object] = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ],
+    }
+    if include_assistant_content:
+        assistant["content"] = None
+
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [
+                {"role": "user", "content": "search"},
+                assistant,
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert "data: [DONE]" in response.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_chat_request_models.py
+++ b/tests/test_chat_request_models.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.request_serialization import (
+    dump_openai_chat_request,
+    dump_request_for_preflight,
+)
+from src.models.requests import AssistantChatMessage, ChatCompletionRequest
+
+
+def _tool_call() -> dict[str, object]:
+    return {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "search", "arguments": "{}"},
+    }
+
+
+@pytest.mark.parametrize(
+    "include_content",
+    [pytest.param(False, id="omitted"), pytest.param(True, id="null")],
+)
+def test_assistant_tool_call_content_may_be_omitted_or_null(include_content: bool) -> None:
+    assistant: dict[str, object] = {"role": "assistant", "tool_calls": [_tool_call()]}
+    if include_content:
+        assistant["content"] = None
+
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "gpt-4o-mini",
+            "messages": [
+                {"role": "user", "content": "search"},
+                assistant,
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ],
+        }
+    )
+
+    parsed = request.messages[1]
+    assert isinstance(parsed, AssistantChatMessage)
+    assert parsed.content is None
+    assert ("content" in parsed.model_fields_set) is include_content
+
+
+@pytest.mark.parametrize(
+    "assistant",
+    [
+        {"role": "assistant"},
+        {"role": "assistant", "content": None},
+        {"role": "assistant", "tool_calls": []},
+        {"role": "assistant", "content": None, "tool_calls": []},
+    ],
+)
+def test_assistant_requires_content_or_non_empty_tool_calls(
+    assistant: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="content or non-empty tool_calls"):
+        ChatCompletionRequest.model_validate({"model": "gpt-4o-mini", "messages": [assistant]})
+
+
+@pytest.mark.parametrize("role", ["system", "user", "tool"])
+@pytest.mark.parametrize("content", [pytest.param("omitted"), pytest.param(None)])
+def test_non_assistant_content_remains_required(role: str, content: object) -> None:
+    message: dict[str, object] = {"role": role}
+    if role == "tool":
+        message["tool_call_id"] = "call_1"
+    if content != "omitted":
+        message["content"] = content
+
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest.model_validate({"model": "gpt-4o-mini", "messages": [message]})
+
+
+@pytest.mark.parametrize(
+    "include_content",
+    [pytest.param(False, id="omitted"), pytest.param(True, id="null")],
+)
+def test_chat_serializers_preserve_assistant_content_presence(include_content: bool) -> None:
+    assistant: dict[str, object] = {"role": "assistant", "tool_calls": [_tool_call()]}
+    if include_content:
+        assistant["content"] = None
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "gpt-4o-mini",
+            "messages": [
+                {"role": "user", "content": "search"},
+                assistant,
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ],
+        }
+    )
+
+    preflight = dump_request_for_preflight(request)
+    upstream = dump_openai_chat_request(request)
+    assert ("content" in preflight["messages"][1]) is include_content
+    assert ("content" in upstream["messages"][1]) is include_content
+    if include_content:
+        assert preflight["messages"][1]["content"] is None
+        assert upstream["messages"][1]["content"] is None

--- a/tests/test_provider_compat.py
+++ b/tests/test_provider_compat.py
@@ -35,6 +35,27 @@ from src.providers.openai import OpenAIAdapter
 from src.providers.registry import ProviderErrorMapperRegistry
 from src.upstream_http import build_upstream_http_client
 
+_OMITTED = object()
+
+
+def _assistant_tool_call_message(content: object = _OMITTED) -> dict[str, object]:
+    message: dict[str, object] = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "toolu_1",
+                "type": "function",
+                "function": {
+                    "name": "docs.search",
+                    "arguments": json.dumps({"query": "delta"}),
+                },
+            }
+        ],
+    }
+    if content is not _OMITTED:
+        message["content"] = content
+    return message
+
 
 async def _line_stream(lines: list[str]):
     for line in lines:
@@ -134,6 +155,46 @@ async def test_openai_adapter_keeps_tool_choice_with_tools() -> None:
         )
         payload = await adapter.translate_request(req, {"model": "openai/gpt-4o-mini"})
         assert payload.get("tool_choice") == "auto"
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+@pytest.mark.parametrize(
+    ("assistant_content", "expected_present"),
+    [pytest.param(_OMITTED, False, id="omitted"), pytest.param(None, True, id="null")],
+)
+async def test_openai_compatible_adapter_preserves_assistant_content_presence(
+    adapter_type,
+    assistant_content: object,
+    expected_present: bool,
+) -> None:
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        req = ChatCompletionRequest.model_validate(
+            {
+                "model": "gpt-4o-mini",
+                "messages": [
+                    {"role": "user", "content": "search docs"},
+                    _assistant_tool_call_message(assistant_content),
+                    {"role": "tool", "tool_call_id": "toolu_1", "content": "result"},
+                ],
+            }
+        )
+        payload = await adapter.translate_request(
+            req,
+            {
+                "provider": adapter.provider_name,
+                "model": f"{adapter.provider_name}/gpt-4o-mini",
+            },
+        )
+
+        assistant = payload["messages"][1]
+        assert ("content" in assistant) is expected_present
+        if expected_present:
+            assert assistant["content"] is None
+        assert assistant["tool_calls"] == _assistant_tool_call_message()["tool_calls"]
     finally:
         await adapter.http_client.aclose()
 
@@ -1052,7 +1113,17 @@ async def test_anthropic_adapter_translate_request_and_response() -> None:
 
 
 @pytest.mark.asyncio
-async def test_anthropic_adapter_forwards_tools_and_tool_messages() -> None:
+@pytest.mark.parametrize(
+    "assistant_content",
+    [
+        pytest.param(_OMITTED, id="omitted"),
+        pytest.param(None, id="null"),
+        pytest.param("", id="empty-string"),
+    ],
+)
+async def test_anthropic_adapter_forwards_tools_and_tool_messages(
+    assistant_content: object,
+) -> None:
     adapter = AnthropicAdapter(httpx.AsyncClient())
     try:
         req = ChatCompletionRequest.model_validate(
@@ -1061,20 +1132,7 @@ async def test_anthropic_adapter_forwards_tools_and_tool_messages() -> None:
                 "max_tokens": 32,
                 "messages": [
                     {"role": "user", "content": "search docs for delta"},
-                    {
-                        "role": "assistant",
-                        "content": "",
-                        "tool_calls": [
-                            {
-                                "id": "toolu_1",
-                                "type": "function",
-                                "function": {
-                                    "name": "docs.search",
-                                    "arguments": json.dumps({"query": "delta"}),
-                                },
-                            }
-                        ],
-                    },
+                    _assistant_tool_call_message(assistant_content),
                     {"role": "tool", "tool_call_id": "toolu_1", "content": "delta docs result"},
                 ],
                 "tools": [
@@ -1398,6 +1456,51 @@ async def test_gemini_adapter_translate_request_and_response() -> None:
         payload = canonical.model_dump(mode="json")
         assert payload["choices"][0]["message"]["content"] == "Hello"
         assert payload["usage"]["total_tokens"] == 6
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_payload",
+    [
+        pytest.param(
+            {
+                "model": "gemini-2.5-flash",
+                "messages": [{"role": "user", "content": "search"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": "search", "parameters": {"type": "object"}},
+                    }
+                ],
+            },
+            id="tool-definition",
+        ),
+        pytest.param(
+            {
+                "model": "gemini-2.5-flash",
+                "messages": [
+                    {"role": "user", "content": "search"},
+                    _assistant_tool_call_message(),
+                    {"role": "tool", "tool_call_id": "toolu_1", "content": "result"},
+                ],
+            },
+            id="tool-history",
+        ),
+    ],
+)
+async def test_gemini_adapter_rejects_unsupported_tool_calling(
+    request_payload: dict[str, object],
+) -> None:
+    adapter = GeminiAdapter(httpx.AsyncClient())
+    try:
+        request = ChatCompletionRequest.model_validate(request_payload)
+
+        with pytest.raises(InvalidRequestError, match="does not support tool calling") as exc_info:
+            await adapter.translate_request(request, {"model": "gemini/gemini-2.5-flash"})
+
+        assert exc_info.value.param == "tools"
     finally:
         await adapter.http_client.aclose()
 
@@ -1832,7 +1935,17 @@ async def test_bedrock_adapter_translate_stream_uses_sequential_tool_call_indexe
 
 
 @pytest.mark.asyncio
-async def test_bedrock_adapter_forwards_tools_and_tool_messages() -> None:
+@pytest.mark.parametrize(
+    "assistant_content",
+    [
+        pytest.param(_OMITTED, id="omitted"),
+        pytest.param(None, id="null"),
+        pytest.param("", id="empty-string"),
+    ],
+)
+async def test_bedrock_adapter_forwards_tools_and_tool_messages(
+    assistant_content: object,
+) -> None:
     adapter = BedrockAdapter(httpx.AsyncClient())
     try:
         req = ChatCompletionRequest.model_validate(
@@ -1841,20 +1954,7 @@ async def test_bedrock_adapter_forwards_tools_and_tool_messages() -> None:
                 "max_tokens": 32,
                 "messages": [
                     {"role": "user", "content": "search docs for delta"},
-                    {
-                        "role": "assistant",
-                        "content": "",
-                        "tool_calls": [
-                            {
-                                "id": "toolu_1",
-                                "type": "function",
-                                "function": {
-                                    "name": "docs.search",
-                                    "arguments": json.dumps({"query": "delta"}),
-                                },
-                            }
-                        ],
-                    },
+                    _assistant_tool_call_message(assistant_content),
                     {"role": "tool", "tool_call_id": "toolu_1", "content": "delta docs result"},
                 ],
                 "tools": [

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -49,3 +49,32 @@ def test_stream_usage_tracker_estimates_when_provider_usage_is_malformed() -> No
 
     assert resolved.source == "estimated"
     assert resolved.usage == {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4}
+
+
+def test_stream_usage_tracker_handles_contentless_assistant_tool_call_history() -> None:
+    payload = ChatCompletionRequest.model_validate(
+        {
+            "model": "gpt-4o-mini",
+            "messages": [
+                {"role": "user", "content": "search"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "search", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ],
+            "stream": True,
+        }
+    )
+    tracker = StreamUsageTracker()
+
+    resolved = tracker.resolve(payload)
+
+    assert resolved.source == "estimated"
+    assert resolved.usage == {"prompt_tokens": 8, "completion_tokens": 0, "total_tokens": 8}


### PR DESCRIPTION
## Summary

- accept OpenAI-compatible assistant tool-call history when `content` is omitted or explicitly `null`
- preserve omitted-versus-null behavior through preflight plus OpenAI and Azure forwarding
- keep non-assistant content requirements and legacy `/v1/completions` behavior unchanged
- translate supported Anthropic and Bedrock histories without fake text, and reject unsupported Gemini tool calling instead of silently discarding it
- update batch, streaming usage, MCP typing, public docs, and generated OpenAPI coverage

Closes #297.

## Validation

- `uv run pytest tests/test_provider_compat.py tests/test_chat_request_models.py tests/test_stream_usage.py -q` — 139 passed
- `uv run pytest tests/test_chat.py tests/mcp/test_chat_execution.py -q` — 65 passed
- `uv run pytest tests/test_batch_service.py tests/test_messages_endpoint.py tests/test_text_endpoints.py -q` — 82 passed
- `uv run pytest tests/test_openai_payload_normalization.py tests/test_batch_worker.py tests/test_batch_worker_microbatch.py -q` — 165 passed
- `uv run pytest tests/docs/test_generated_references.py -q` — 5 passed
- `uv run python scripts/docs/export_openapi.py --check` — current; 215 paths and 280 operations
- `uv run ruff check <touched Python paths>` — passed
- `uv run ruff format --check <touched Python paths>` — passed
- `git diff --check` — passed

The test environment reports existing Python 3.14 Prisma/Pydantic v1 and pytest-asyncio deprecation warnings.

## Product and documentation impact

- [x] Public API, errors, streaming, authentication, or tenant scope reviewed
- [x] Settings, environment variables, defaults, secrets, and restart/reload behavior reviewed
- [x] Schema, migrations, mixed-version sequencing, and rollback safety reviewed
- [x] Provider capabilities, model metadata, pricing, and credentials reviewed
- [x] Admin UI workflow, permissions, states, and screenshots reviewed
- [x] Deployment, probes, metrics, alerts, security, backup, and runbooks reviewed
- [x] Public docs/nav/links and release/deprecation notes updated, or no-doc-impact reason below
- [x] Generated OpenAPI/config/provider artifacts regenerated and checked when their source changed

No-documentation-impact rationale:

Not applicable. The public proxy documentation and generated OpenAPI artifact are updated in this PR.

## Rollout and rollback

This is an additive request-compatibility change with no feature gate, database migration, configuration change, new dependency, or additional I/O. Deploy normally and monitor bounded 422 classifications for `messages.*.content` plus provider invalid-request classifications without logging request bodies, tool arguments, headers, or credentials.

Rollback is a normal revert of this PR. There is no persisted state or mixed-version sequencing requirement.
