### PR TITLE
Show organization member counts in list

### DIFF
--- a/docs/admin-ui/organizations.md
+++ b/docs/admin-ui/organizations.md
@@ -13,7 +13,7 @@ deletion are platform-admin actions; scoped edits require `org.update` for that 
 - Organization identity and display name
 - Top-level budgets and rate limits (RPM, TPM, RPH, RPD, TPD)
 - Audit content storage behavior
-- Team count and ownership context
+- Direct organization-member and team counts
 - The tenant boundary that callable-target and access-group grants inherit from
 
 ## Typical workflow

--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -407,6 +407,11 @@ group's configured strategy.
 | `DELETE` | `/ui/api/organizations/{organization_id}/members/{membership_id}` | Remove a member |
 | `GET` | `/ui/api/organizations/{organization_id}/teams` | List teams in the organization |
 
+Each item returned by `GET /ui/api/organizations` includes non-null `member_count` and
+`team_count` aggregates. `member_count` counts direct rows in
+`deltallm_organizationmembership`; the aggregate is limited to organizations visible to the
+authenticated principal.
+
 ### RBAC
 
 | Method | Endpoint | Purpose |

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2075,11 +2075,287 @@
         "title": "OrganizationLifecycleState",
         "type": "string"
       },
+      "OrganizationListItemResponse": {
+        "additionalProperties": true,
+        "description": "Organization fields whose aggregates are authoritative on list responses.",
+        "properties": {
+          "audit_content_storage_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audit Content Storage Enabled"
+          },
+          "budget_duration": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Duration"
+          },
+          "budget_reset_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Reset At"
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/OrganizationCapabilitiesResponse"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "deletion_not_before_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deletion Not Before At"
+          },
+          "deletion_requested_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deletion Requested At"
+          },
+          "lifecycle_state": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OrganizationLifecycleState"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Budget"
+          },
+          "member_count": {
+            "minimum": 0.0,
+            "title": "Member Count",
+            "type": "integer"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "model_rpm_limit": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Rpm Limit"
+          },
+          "model_tpm_limit": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Tpm Limit"
+          },
+          "organization_id": {
+            "minLength": 1,
+            "title": "Organization Id",
+            "type": "string"
+          },
+          "organization_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization Name"
+          },
+          "rpd_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rpd Limit"
+          },
+          "rph_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rph Limit"
+          },
+          "rpm_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rpm Limit"
+          },
+          "service_policy": {
+            "additionalProperties": true,
+            "title": "Service Policy",
+            "type": "object"
+          },
+          "soft_budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Soft Budget"
+          },
+          "spend": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spend"
+          },
+          "team_count": {
+            "minimum": 0.0,
+            "title": "Team Count",
+            "type": "integer"
+          },
+          "tpd_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tpd Limit"
+          },
+          "tpm_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tpm Limit"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "user_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Count"
+          }
+        },
+        "required": [
+          "organization_id",
+          "lifecycle_state",
+          "service_policy",
+          "team_count",
+          "member_count"
+        ],
+        "title": "OrganizationListItemResponse",
+        "type": "object"
+      },
       "OrganizationListResponse": {
         "properties": {
           "data": {
             "items": {
-              "$ref": "#/components/schemas/OrganizationResponse"
+              "$ref": "#/components/schemas/OrganizationListItemResponse"
             },
             "title": "Data",
             "type": "array"

--- a/src/api/admin/endpoints/organization_schemas.py
+++ b/src/api/admin/endpoints/organization_schemas.py
@@ -52,6 +52,13 @@ class OrganizationResponse(BaseModel):
     updated_at: str | None = None
 
 
+class OrganizationListItemResponse(OrganizationResponse):
+    """Organization fields whose aggregates are authoritative on list responses."""
+
+    team_count: int = Field(ge=0)
+    member_count: int = Field(ge=0)
+
+
 class OrganizationPaginationResponse(BaseModel):
     total: int = Field(ge=0)
     limit: int = Field(ge=1)
@@ -60,12 +67,13 @@ class OrganizationPaginationResponse(BaseModel):
 
 
 class OrganizationListResponse(BaseModel):
-    data: list[OrganizationResponse]
+    data: list[OrganizationListItemResponse]
     pagination: OrganizationPaginationResponse
 
 
 __all__ = [
     "OrganizationCapabilitiesResponse",
+    "OrganizationListItemResponse",
     "OrganizationListResponse",
     "OrganizationPaginationResponse",
     "OrganizationResponse",

--- a/src/api/admin/endpoints/organizations.py
+++ b/src/api/admin/endpoints/organizations.py
@@ -1053,7 +1053,8 @@ async def list_organizations(
                    o.audit_content_storage_enabled, o.metadata,
                    o.lifecycle_state, o.deletion_requested_at, o.deletion_not_before_at,
                    o.created_at, o.updated_at,
-                   (SELECT COUNT(*) FROM deltallm_teamtable t WHERE t.organization_id = o.organization_id) AS team_count"""
+                   (SELECT COUNT(*)::int FROM deltallm_teamtable t WHERE t.organization_id = o.organization_id) AS team_count,
+                   (SELECT COUNT(*)::int FROM deltallm_organizationmembership om WHERE om.organization_id = o.organization_id) AS member_count"""
 
     count_rows = await db.query_raw(
         f"SELECT COUNT(*) AS total FROM deltallm_organizationtable o {where_sql}",

--- a/tests/test_ui_organization_member_count.py
+++ b/tests/test_ui_organization_member_count.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from src.api.admin.endpoints.common import AuthScope
+from src.auth.roles import Permission
+
+
+class _OrganizationListDB:
+    def __init__(self) -> None:
+        now = datetime.now(tz=UTC)
+        self.organizations = {
+            "org-visible": {
+                "organization_id": "org-visible",
+                "organization_name": "Visible",
+                "lifecycle_state": "active",
+                "created_at": now,
+                "updated_at": now,
+            },
+            "org-hidden": {
+                "organization_id": "org-hidden",
+                "organization_name": "Hidden",
+                "lifecycle_state": "active",
+                "created_at": now,
+                "updated_at": now,
+            },
+        }
+        self.organization_members = {
+            "org-visible": {"account-1", "account-2"},
+            "org-hidden": set(),
+        }
+        self.organization_teams = {
+            "org-visible": {"team-1"},
+            "org-hidden": set(),
+        }
+        self.queries: list[tuple[str, tuple[Any, ...]]] = []
+
+    def _visible_organization_ids(
+        self, normalized_query: str, params: tuple[Any, ...]
+    ) -> list[str]:
+        if "o.organization_id in ($1)" in normalized_query:
+            return [str(params[0])]
+        return list(self.organizations)
+
+    async def query_raw(self, query: str, *params: Any) -> list[dict[str, Any]]:
+        self.queries.append((query, params))
+        normalized = " ".join(query.lower().split())
+        if "from deltallm_organizationtierassignment a" in normalized:
+            return []
+
+        organization_ids = self._visible_organization_ids(normalized, params)
+        if "count(*) as total" in normalized:
+            return [{"total": len(organization_ids)}]
+        if "from deltallm_organizationtable o" not in normalized:
+            return []
+
+        assert "from deltallm_organizationmembership om" in normalized
+        assert "om.organization_id = o.organization_id" in normalized
+        return [
+            {
+                **self.organizations[organization_id],
+                "team_count": len(self.organization_teams[organization_id]),
+                "member_count": len(self.organization_members[organization_id]),
+            }
+            for organization_id in organization_ids
+        ]
+
+
+def _install_db(test_app: Any, db: _OrganizationListDB) -> None:
+    test_app.state.prisma_manager = type("Prisma", (), {"client": db})()
+    setattr(test_app.state.settings, "master_key", "mk-test")
+
+
+@pytest.mark.asyncio
+async def test_list_organizations_returns_authoritative_member_counts(client, test_app) -> None:
+    db = _OrganizationListDB()
+    _install_db(test_app, db)
+
+    response = await client.get(
+        "/ui/api/organizations",
+        headers={"Authorization": "Bearer mk-test"},
+    )
+
+    assert response.status_code == 200
+    organizations = {item["organization_id"]: item for item in response.json()["data"]}
+    assert organizations["org-visible"]["member_count"] == 2
+    assert organizations["org-hidden"]["member_count"] == 0
+    assert organizations["org-visible"]["team_count"] == 1
+    assert organizations["org-hidden"]["team_count"] == 0
+
+    list_queries = [
+        query
+        for query, _params in db.queries
+        if "FROM deltallm_organizationtable o" in query and "ORDER BY" in query
+    ]
+    assert len(list_queries) == 1
+    assert sum("FROM deltallm_organizationmembership" in query for query, _ in db.queries) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_organization_member_counts_remain_tenant_scoped(
+    client,
+    test_app,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _OrganizationListDB()
+    _install_db(test_app, db)
+    monkeypatch.setattr(
+        "src.api.admin.endpoints.organizations.get_auth_scope",
+        lambda request, authorization=None, x_master_key=None, required_permission=None: AuthScope(
+            is_platform_admin=False,
+            org_ids=["org-visible"],
+            org_permissions_by_id={"org-visible": {Permission.ORG_READ}},
+        ),
+    )
+
+    response = await client.get("/ui/api/organizations")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["pagination"]["total"] == 1
+    assert [(item["organization_id"], item["member_count"]) for item in payload["data"]] == [
+        ("org-visible", 2)
+    ]
+    list_query = next(
+        query
+        for query, _params in db.queries
+        if "FROM deltallm_organizationtable o" in query and "ORDER BY" in query
+    )
+    assert "o.organization_id IN ($1)" in list_query

--- a/tests/test_ui_organizations_assets.py
+++ b/tests/test_ui_organizations_assets.py
@@ -149,7 +149,10 @@ class _FakeAdminDB:
         if "count(*) as total" in normalized and "from deltallm_organizationtable" in normalized:
             return [{"total": len(self.organizations)}]
         if "from deltallm_organizationtable o" in normalized:
-            return list(self.organizations.values())
+            return [
+                {**organization, "team_count": 0, "member_count": 0}
+                for organization in self.organizations.values()
+            ]
         if "FROM deltallm_organizationtable" in query:
             organization_id = str(params[0])
             row = self.organizations.get(organization_id)

--- a/tests/test_ui_rate_limits.py
+++ b/tests/test_ui_rate_limits.py
@@ -201,11 +201,24 @@ class FakeAdminDB:
         return 1
 
     async def query_raw(self, query: str, *params):
+        normalized = " ".join(query.lower().split())
+        if "count(*) as total" in normalized and "from deltallm_organizationtable" in normalized:
+            return [{"total": len(self.organizations)}]
         if "FROM deltallm_organizationtable" in query:
             if "WHERE organization_id = $1" in query:
                 row = self.organizations.get(str(params[0]))
                 return [row] if row else []
-            return list(self.organizations.values())
+            return [
+                {
+                    **row,
+                    "team_count": sum(
+                        team.get("organization_id") == organization_id
+                        for team in self.teams.values()
+                    ),
+                    "member_count": 0,
+                }
+                for organization_id, row in self.organizations.items()
+            ]
 
         if "FROM deltallm_teamtable" in query:
             if "WHERE team_id = $1" in query:

--- a/ui/scripts/run-unit-tests.mjs
+++ b/ui/scripts/run-unit-tests.mjs
@@ -25,6 +25,7 @@ const testSources = [
   'tests/organizationPolicy.test.ts',
   'tests/organizationDeletion.test.ts',
   'tests/organizationLifecycle.test.ts',
+  'tests/organizationCounts.test.ts',
   'tests/tierHelpers.test.ts',
   'tests/dashboardAnalytics.test.ts',
   'tests/format.test.ts',

--- a/ui/src/components/admin/OrganizationMembershipSummary.tsx
+++ b/ui/src/components/admin/OrganizationMembershipSummary.tsx
@@ -1,0 +1,45 @@
+import { Building2, Users } from 'lucide-react';
+
+import {
+  formatOrganizationCount,
+  normalizeOrganizationCount,
+} from '../../lib/organizationCounts';
+
+interface OrganizationMembershipSummaryProps {
+  memberCount: number | null | undefined;
+  teamCount: number | null | undefined;
+}
+
+function countAriaLabel(count: number | null, singular: string, plural: string): string {
+  if (count === null) return `${singular} count unavailable`;
+  return `${count} ${count === 1 ? singular.toLowerCase() : plural.toLowerCase()}`;
+}
+
+export function OrganizationMembershipSummary({
+  memberCount,
+  teamCount,
+}: OrganizationMembershipSummaryProps) {
+  const normalizedMemberCount = normalizeOrganizationCount(memberCount);
+  const normalizedTeamCount = normalizeOrganizationCount(teamCount);
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex items-center gap-1 text-gray-700">
+        <Users className="w-3.5 h-3.5 text-gray-400" aria-hidden="true" />
+        <span
+          className="text-sm font-medium"
+          aria-label={countAriaLabel(normalizedMemberCount, 'Member', 'Members')}
+        >
+          {formatOrganizationCount(normalizedMemberCount)}
+        </span>
+      </div>
+      <span className="text-gray-300" aria-hidden="true">·</span>
+      <div className="flex items-center gap-1 text-gray-500 text-xs">
+        <Building2 className="w-3.5 h-3.5 text-gray-400" aria-hidden="true" />
+        <span aria-label={countAriaLabel(normalizedTeamCount, 'Team', 'Teams')}>
+          {formatOrganizationCount(normalizedTeamCount)} teams
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -10,6 +10,7 @@ export type { StructuredApiErrorDetail } from './api/transport';
 export type {
   OrganizationCapabilities,
   OrganizationCreatePayload,
+  OrganizationListItem,
   OrganizationPrimaryTierSummary,
   OrganizationRecord,
   OrganizationServicePolicy,

--- a/ui/src/lib/api/organizations.ts
+++ b/ui/src/lib/api/organizations.ts
@@ -3,6 +3,10 @@ import {
   normalizeOrganizationLifecycleState,
   type OrganizationLifecycleState,
 } from '../organizationLifecycle';
+import {
+  normalizeOrganizationCount,
+  type OrganizationCount,
+} from '../organizationCounts';
 
 export interface OrganizationTierAssignment {
   assignment_id: string;
@@ -92,12 +96,17 @@ export interface OrganizationRecord {
   service_policy: OrganizationServicePolicy;
   primary_tier_assignment?: OrganizationTierAssignment;
   capabilities: OrganizationCapabilities;
-  team_count?: number;
-  member_count?: number;
-  user_count?: number;
+  team_count?: number | null;
+  member_count?: number | null;
+  user_count?: number | null;
   created_at?: string | null;
   updated_at?: string | null;
   [key: string]: unknown;
+}
+
+export interface OrganizationListItem extends OrganizationRecord {
+  team_count: OrganizationCount;
+  member_count: OrganizationCount;
 }
 
 export interface OrganizationCreatePayload {
@@ -121,7 +130,7 @@ export interface OrganizationCreatePayload {
 }
 
 export interface OrganizationPage {
-  data: OrganizationRecord[];
+  data: OrganizationListItem[];
   pagination: {
     total: number;
     limit: number;
@@ -171,13 +180,22 @@ export function normalizeOrganizationRecord(value: unknown): OrganizationRecord 
   } as OrganizationRecord;
 }
 
-function normalizeOrganizationPage(value: unknown): OrganizationPage {
+export function normalizeOrganizationListItem(value: unknown): OrganizationListItem {
+  if (!isRecord(value)) throw new Error('Invalid organization response');
+  return {
+    ...normalizeOrganizationRecord(value),
+    team_count: normalizeOrganizationCount(value.team_count),
+    member_count: normalizeOrganizationCount(value.member_count),
+  };
+}
+
+export function normalizeOrganizationPage(value: unknown): OrganizationPage {
   if (!isRecord(value) || !Array.isArray(value.data) || !isRecord(value.pagination)) {
     throw new Error('Invalid organization list response');
   }
   const pagination = value.pagination;
   return {
-    data: value.data.map(normalizeOrganizationRecord),
+    data: value.data.map(normalizeOrganizationListItem),
     pagination: {
       total: Number(pagination.total || 0),
       limit: Number(pagination.limit || 0),

--- a/ui/src/lib/organizationCounts.ts
+++ b/ui/src/lib/organizationCounts.ts
@@ -1,0 +1,11 @@
+export type OrganizationCount = number | null;
+
+export function normalizeOrganizationCount(value: unknown): OrganizationCount {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+export function formatOrganizationCount(value: OrganizationCount): string {
+  return value === null ? '—' : String(value);
+}

--- a/ui/src/pages/Organizations.tsx
+++ b/ui/src/pages/Organizations.tsx
@@ -7,6 +7,7 @@ import {
   callableTargets,
   organizations,
   type CallableTargetListItem,
+  type OrganizationListItem,
   type OrganizationRecord,
   type OrganizationServicePolicy,
 } from '../lib/api';
@@ -24,6 +25,7 @@ import {
 import Modal from '../components/Modal';
 import AssetAccessEditor from '../components/access/AssetAccessEditor';
 import { OrganizationLifecycleBadge } from '../components/admin/OrganizationLifecycleStatus';
+import { OrganizationMembershipSummary } from '../components/admin/OrganizationMembershipSummary';
 import { ContentCard, IndexShell } from '../components/admin/shells';
 import {
   Plus, Building2, Users, DollarSign,
@@ -165,7 +167,7 @@ export default function Organizations() {
     (signal) => organizations.list({ search, limit: pageSize, offset: pageOffset }, signal),
     [search, pageOffset],
   );
-  const rawItems: OrganizationRecord[] = result?.data || [];
+  const rawItems: OrganizationListItem[] = result?.data || [];
   const pagination = result?.pagination;
 
   /* client-side status filter (only filters the current page) */
@@ -587,17 +589,10 @@ export default function Organizations() {
 
                       {/* Members + teams */}
                       <td className="px-4 py-3.5">
-                        <div className="flex items-center gap-3">
-                          <div className="flex items-center gap-1 text-gray-700">
-                            <Users className="w-3.5 h-3.5 text-gray-400" />
-                            <span className="text-sm font-medium">{row.member_count ?? row.user_count ?? 0}</span>
-                          </div>
-                          <span className="text-gray-300">·</span>
-                          <div className="flex items-center gap-1 text-gray-500 text-xs">
-                            <Building2 className="w-3.5 h-3.5 text-gray-400" />
-                            {row.team_count ?? 0} teams
-                          </div>
-                        </div>
+                        <OrganizationMembershipSummary
+                          memberCount={row.member_count}
+                          teamCount={row.team_count}
+                        />
                       </td>
 
                       {/* Actions */}

--- a/ui/tests/organizationCounts.test.ts
+++ b/ui/tests/organizationCounts.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { OrganizationMembershipSummary } from '../src/components/admin/OrganizationMembershipSummary';
+import { normalizeOrganizationPage } from '../src/lib/api/organizations';
+import {
+  formatOrganizationCount,
+  normalizeOrganizationCount,
+} from '../src/lib/organizationCounts';
+
+function organizationPage(memberCount: unknown, teamCount: unknown) {
+  return {
+    data: [
+      {
+        organization_id: 'org-1',
+        lifecycle_state: 'active',
+        service_policy: {},
+        capabilities: {},
+        member_count: memberCount,
+        team_count: teamCount,
+      },
+    ],
+    pagination: { total: 1, limit: 20, offset: 0, has_more: false },
+  };
+}
+
+test('organization list normalization preserves authoritative counts', () => {
+  const populated = normalizeOrganizationPage(organizationPage(3, 2)).data[0];
+  assert.equal(populated.member_count, 3);
+  assert.equal(populated.team_count, 2);
+
+  const empty = normalizeOrganizationPage(organizationPage(0, 0)).data[0];
+  assert.equal(empty.member_count, 0);
+  assert.equal(empty.team_count, 0);
+});
+
+test('organization counts fail closed to unavailable instead of zero', () => {
+  for (const invalid of [undefined, null, -1, 1.5, '2', Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.equal(normalizeOrganizationCount(invalid), null);
+  }
+  assert.equal(formatOrganizationCount(null), '—');
+
+  const unavailable = normalizeOrganizationPage(organizationPage(undefined, -1)).data[0];
+  assert.equal(unavailable.member_count, null);
+  assert.equal(unavailable.team_count, null);
+});
+
+test('organization membership summary renders counts and unavailable state explicitly', () => {
+  const populated = renderToStaticMarkup(
+    createElement(OrganizationMembershipSummary, { memberCount: 3, teamCount: 1 }),
+  );
+  assert.match(populated, /aria-label="3 members"/);
+  assert.match(populated, /aria-label="1 team"/);
+
+  const empty = renderToStaticMarkup(
+    createElement(OrganizationMembershipSummary, { memberCount: 0, teamCount: 0 }),
+  );
+  assert.match(empty, /aria-label="0 members"/);
+  assert.match(empty, /aria-label="0 teams"/);
+
+  const unavailable = renderToStaticMarkup(
+    createElement(OrganizationMembershipSummary, { memberCount: undefined, teamCount: null }),
+  );
+  assert.match(unavailable, /aria-label="Member count unavailable"/);
+  assert.match(unavailable, /aria-label="Team count unavailable"/);
+  assert.match(unavailable, /—/);
+});


### PR DESCRIPTION
## Summary

Fix the Organizations list so its Members column reports authoritative direct organization-membership counts instead of always displaying zero.

- add `member_count` to the bounded organization list query, alongside `team_count`, without an extra database round trip
- expose non-null list aggregates through the FastAPI/OpenAPI contract
- normalize and render unavailable counts as `—` rather than silently coercing them to zero
- add tenant-scope, adapter, rendering, and regression coverage
- update the admin API and UI documentation

Closes #299

## Validation

- `uv run pytest -q tests/test_ui_organization_member_count.py tests/test_ui_rate_limits.py tests/test_ui_organizations_assets.py` — 38 passed
- `uv run pytest -q tests/test_ui_organization_member_count.py tests/test_ui_rate_limits.py tests/test_ui_organizations_assets.py tests/test_ui_authorization.py` — 69 passed
- `uv run ruff check <touched Python paths>` — passed
- `uv run ruff format --check <touched Python paths>` — passed
- `npm --prefix ui run test:unit` — 179 passed
- touched-file ESLint — passed with zero findings
- `npm --prefix ui run build` — passed; initial bundle 405.79 kB gzip versus the documented ~409 kB audit baseline
- `uv run pytest -q tests/docs/test_generated_references.py` — 5 passed
- `uv run python scripts/docs/export_openapi.py --check` — current, 215 paths / 280 operations
- `git diff --check` — passed
- `npm --prefix ui run lint` — existing repository baseline remains: 118 errors and 4 warnings, all outside touched files

A live PostgreSQL integration run was not available locally because `DATABASE_URL` is not configured. The repository pull-request workflow supplies PostgreSQL and Redis and runs the full test suite.

## Product and documentation impact

- [x] Public API, errors, streaming, authentication, or tenant scope reviewed
- [x] Settings, environment variables, defaults, secrets, and restart/reload behavior reviewed
- [x] Schema, migrations, mixed-version sequencing, and rollback safety reviewed
- [x] Provider capabilities, model metadata, pricing, and credentials reviewed
- [x] Admin UI workflow, permissions, states, and screenshots reviewed
- [x] Deployment, probes, metrics, alerts, security, backup, and runbooks reviewed
- [x] Public docs/nav/links and release/deprecation notes updated, or no-doc-impact reason below
- [x] Generated OpenAPI/config/provider artifacts regenerated and checked when their source changed

Documentation was updated in `docs/api/admin.md` and `docs/admin-ui/organizations.md`; the generated OpenAPI artifact was regenerated.

## Rollout and rollback

No schema migration or feature gate is required. The response change is additive, and the frontend remains mixed-version safe by rendering absent or malformed aggregate fields as unavailable. Roll back by reverting this commit; no persisted state requires cleanup.
