### PR TITLE
Fix GLM reasoning stream failover and health handling

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -430,10 +430,10 @@ when a dynamic update attempts to change them.
 | `cache_backend` | `memory` | Cache backend: `memory`, `redis`, or `s3` |
 | `cache_ttl` | `3600` | Cache entry time-to-live in seconds |
 | `cache_max_size` | `10000` | Maximum entries for memory cache |
-| `stream_cache_max_bytes` | `262144` | Max buffered streaming response bytes before streaming cache is disabled for that stream |
+| `stream_cache_max_bytes` | `262144` | Max total bytes across retained SSE data frames before streaming cache is disabled for that stream |
 | `prompt_singleflight_max_keys` | `256` | Maximum distinct prompt-resolution cache misses admitted per process; callers for an existing key share its task |
 | `prompt_singleflight_timeout_seconds` | `2` | Deadline for an owned prompt-resolution cache-miss task before it fails with a controlled service-unavailable response |
-| `stream_cache_max_fragments` | `2048` | Max buffered streaming content fragments before streaming cache is disabled for that stream |
+| `stream_cache_max_fragments` | `2048` | Max retained SSE data frames before streaming cache is disabled for that stream |
 | `failover_event_history_size` | `1000` | Max in-memory failover events retained per instance for `/health/fallback-events` |
 
 ## Health Check Settings

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -189,12 +189,31 @@ the bounded provider-specific context/content markers.
 
 No fallback starts after a streaming response frame has been sent. Provider role and metadata
 events are held in a bounded pre-commit buffer until output or a valid terminal event establishes a
-real response. This lets OpenAI-compatible, Azure OpenAI, Anthropic, and Bedrock classified terminal
-events select a specialized fallback when they arrive before output. Empty, terminal-only, and
-truncated pre-output streams are malformed successes and may use the general fallback chain. After
-partial output has committed a response, a classified stop terminates that stream with the compatible
-`content_filter` or `length` finish reason instead of starting another provider attempt. Any other
-malformed committed stream is aborted, marked unhealthy, and never cached as a complete response.
+real response. For OpenAI-compatible streams, non-empty `reasoning`, `reasoning_content`, and
+`reasoning_details` deltas are output, just like content, refusals, and tool calls. The first such
+delta commits the response, releases buffered metadata in its original order, and prevents replay on
+another deployment. This lets OpenAI-compatible, Azure OpenAI, Anthropic, and Bedrock classified
+terminal events select a specialized fallback when they arrive before output. Empty, terminal-only,
+and truncated pre-output streams are malformed successes and may use the general fallback chain.
+After partial output has committed a response, a classified stop terminates that stream with the
+compatible `content_filter` or `length` finish reason instead of starting another provider attempt.
+Any other malformed committed stream is aborted, marked unhealthy, and never cached as a complete
+response. Exceeding the bounded pre-commit buffer with otherwise well-formed, unrecognized metadata
+is treated as a gateway compatibility failure: it returns the same sanitized provider-response error
+but does not cool down the deployment. A clean `[DONE]` marker after only unrecognized, non-empty
+delta fields follows the same health-neutral path. Before any response frame is sent, the router
+skips a same-deployment retry and tries the next eligible deployment once. If every eligible
+deployment returns only unrecognized output fields and reaches either boundary, the request fails
+with the sanitized provider-response error and none of those deployments is marked unhealthy. A
+buffer filled only with known metadata, such as repeated role-only deltas, is instead a malformed
+provider stream and affects health.
+
+For OpenAI-compatible streaming requests, DeltaLLM asks OpenAI-family and vLLM deployments for a
+final usage chunk even when the client did not request one; that internal chunk is hidden from the
+client. If the provider omits usage, fallback estimation deduplicates textual `reasoning`,
+`reasoning_content`, and `reasoning_details` aliases within each delta, then sums the deltas. Opaque
+reasoning details use a conservative payload-size estimate and are marked incomplete in usage
+metadata.
 
 Each replica serializes durable config loads, subscriber application, publication, and rollback.
 Runtime reloads publish all three immutable maps as one generation, and publication is fenced by

--- a/docs/features/caching.md
+++ b/docs/features/caching.md
@@ -70,8 +70,17 @@ DeltaLLM builds cache keys from:
 - relevant request parameters
 - an optional custom cache key
 - the authenticated request scope
+- the cache schema version and response mode (`json` or `stream`)
 
-This means two different API keys do not share cache entries by default.
+This means two different API keys do not share cache entries by default, and a streaming response
+cannot be returned to a non-streaming request (or the reverse). Cache schema v2 intentionally treats
+older streaming entries as misses because they did not preserve the complete event stream.
+
+For chat streams, DeltaLLM stores each validated SSE data frame rather than rebuilding a response
+from content text. Cache hits therefore preserve reasoning fields, refusals, tool calls, provider
+extensions, finish reasons, and frame order. A provider usage frame is replayed only when the client
+requested `stream_options.include_usage`; `[DONE]` is emitted exactly once. Incomplete, cancelled,
+malformed, or over-limit streams are not cached.
 
 ## Verify Cache Hits
 
@@ -119,6 +128,8 @@ The cache middleware also reads:
 - Cache accounting still updates request, usage, and spend metrics on cache hits
 - Budget enforcement and auth still happen before a cached response is returned
 - If caching is disabled globally, request-level cache metadata has no effect
+- `stream_cache_max_bytes` and `stream_cache_max_fragments` bound all retained SSE data frames, not
+  only content fragments
 
 ## Related Pages
 

--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -76,6 +76,7 @@ Core metrics include:
 | `deltallm_router_health_transitions_total` | Counter | Actual cooldown, manual-cooldown, and recovery transitions |
 | `deltallm_router_health_update_failures_total` | Counter | Post-outcome router health updates that could not be persisted |
 | `deltallm_provider_error_body_discards_total` | Counter | Encoded or oversized provider error bodies excluded from classification |
+| `deltallm_provider_stream_validation_failures_total` | Counter | Rejected OpenAI-compatible streams by a fixed validation reason |
 | `deltallm_prompt_resolutions_total` | Counter | Prompt registry resolution results |
 | `deltallm_prompt_resolution_latency_seconds` | Histogram | Prompt resolution latency |
 | `deltallm_prompt_singleflight_inflight` | Gauge | Distinct process-owned prompt cold-load tasks currently running |
@@ -119,6 +120,14 @@ Blocked required audits need operator replay after the dependency is repaired;
 unknown delivery outcomes require provider reconciliation and explicit resolution.
 Sustained prompt singleflight overload or timeout outcomes indicate that the
 configured distinct-key bound or the prompt dependency latency needs attention.
+
+Provider stream validation reasons are bounded. In particular,
+`precommit_unknown_output_limit` indicates a health-neutral compatibility failure that may move to
+the next deployment, and `precommit_unknown_output_terminal` records the same decision when a clean
+`[DONE]` marker follows only unknown output fields. `precommit_no_output_limit` indicates a
+health-affecting stream that repeated known metadata without producing output. Other reasons identify
+invalid SSE/JSON/schema, oversized frames, incomplete streams, unknown error envelopes, or
+termination before output.
 
 Both static hard caps and advanced fair-share strategies emit `deltallm_tier_capacity_requests_total` and saturation. Capacity request metrics intentionally omit organization IDs to keep Prometheus cardinality bounded; use the admin capacity dashboard for per-organization top-consumer and limit-hit details. Active-organization, fair-share-decision, and fair-share-latency series apply only to `weighted_fair` and `reserved_burst`. See the [Organization Tiers Rollout](../deployment/organization-tiers-rollout.md) runbook for queries and release checks.
 

--- a/docs/features/routing.md
+++ b/docs/features/routing.md
@@ -498,6 +498,14 @@ committed stream is marked unhealthy and never cached as a complete response. Op
 streams close without `[DONE]`; Anthropic Messages streams emit one sanitized `event: error` frame.
 Neither path starts another provider attempt after commit.
 
+Before commit, a bounded run of non-empty, unknown delta fields is treated as a forward-compatibility
+failure rather than evidence that the deployment is unhealthy. The router skips a same-deployment
+retry and tries the next eligible deployment once. This applies when the pre-commit buffer reaches
+its bound or a clean `[DONE]` marker follows only those unknown fields. Repeated known metadata with
+no output, such as role-only deltas, remains a malformed provider stream and follows the
+health-affecting general fallback path. Non-empty `reasoning`, `reasoning_content`, and
+`reasoning_details` are recognized output and commit immediately.
+
 All three maps are immutable members of one routing-runtime generation. Each replica serializes the
 durable config load, subscriber application, generation publication, and rollback. Publication is
 fenced by the complete generation identity, so a slower reload cannot overwrite a newer grant or

--- a/src/cache/backends/base.py
+++ b/src/cache/backends/base.py
@@ -16,6 +16,8 @@ class CacheEntry:
     deployment_id: str | None = None
     provider: str | None = None
     deployment_model: str | None = None
+    stream_lines: list[str] | None = None
+    stream_usage_line: str | None = None
 
 
 class CacheBackend(ABC):

--- a/src/cache/backends/memory.py
+++ b/src/cache/backends/memory.py
@@ -39,6 +39,10 @@ class InMemoryBackend(CacheBackend):
                     deployment_id=entry.deployment_id,
                     provider=entry.provider,
                     deployment_model=entry.deployment_model,
+                    stream_lines=(
+                        list(entry.stream_lines) if entry.stream_lines is not None else None
+                    ),
+                    stream_usage_line=entry.stream_usage_line,
                 )
 
             if key in self._cache:

--- a/src/cache/backends/redis.py
+++ b/src/cache/backends/redis.py
@@ -44,6 +44,8 @@ class RedisBackend(CacheBackend):
             deployment_id=payload.get("deployment_id"),
             provider=payload.get("provider"),
             deployment_model=payload.get("deployment_model"),
+            stream_lines=_stream_lines(payload.get("stream_lines")),
+            stream_usage_line=_stream_usage_line(payload.get("stream_usage_line")),
         )
 
     async def set(self, key: str, entry: CacheEntry, ttl: int | None = None) -> None:
@@ -65,3 +67,15 @@ class RedisBackend(CacheBackend):
                 await self.redis.delete(*keys)
             if cursor == 0:
                 break
+
+
+def _stream_lines(value: object) -> list[str] | None:
+    if not isinstance(value, list) or not value:
+        return None
+    if not all(isinstance(line, str) for line in value):
+        return None
+    return list(value)
+
+
+def _stream_usage_line(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/src/cache/middleware.py
+++ b/src/cache/middleware.py
@@ -46,6 +46,7 @@ from .metrics import CacheMetricsProtocol, NoopCacheMetrics
 from .pricing import has_cache_hit_only_pricing, provider_cache_miss_usage
 
 logger = logging.getLogger(__name__)
+_CACHE_SCHEMA_VERSION = "v2"
 
 
 class CacheControl(str, Enum):
@@ -169,7 +170,11 @@ class CacheMiddleware(BaseHTTPMiddleware):
                 return response
 
             cache_key = key_builder.build_key_from_payload(request_data, cache_options.custom_key)
-            cache_key = f"endpoint:{endpoint}:{cache_key}"
+            response_mode = "stream" if bool(request_data.get("stream")) else "json"
+            cache_key = (
+                f"schema:{_CACHE_SCHEMA_VERSION}:mode:{response_mode}:"
+                f"endpoint:{endpoint}:{cache_key}"
+            )
             cache_key = self._scoped_cache_key(cache_key, request)
             request.state.cache_context = CacheContext(
                 cache_key=cache_key, options=cache_options, model=model
@@ -183,7 +188,7 @@ class CacheMiddleware(BaseHTTPMiddleware):
                     return response
                 if cache_options.control != CacheControl.NO_CACHE:
                     cached = await backend.get(cache_key)
-                    if cached is not None:
+                    if cached is not None and streaming_handler.can_replay(cached):
                         metrics.hit(endpoint=endpoint, model=model)
                         request.state.cache_context.hit = True
                         request.state.cache_hit = True
@@ -192,7 +197,7 @@ class CacheMiddleware(BaseHTTPMiddleware):
                         )
                         return StreamingResponse(
                             streaming_handler.reconstruct_sse_stream(
-                                cached.response,
+                                cached,
                                 include_usage=_stream_usage_requested(request_data),
                             ),
                             media_type="text/event-stream",

--- a/src/cache/streaming.py
+++ b/src/cache/streaming.py
@@ -33,7 +33,11 @@ class _StreamAccumulator:
     model: str | None = None
     finish_reason: str = "stop"
     content_parts: list[str] = field(default_factory=list)
-    usage: dict[str, Any] = field(default_factory=lambda: {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0})
+    stream_lines: list[str] = field(default_factory=list)
+    stream_usage_line: str | None = None
+    usage: dict[str, Any] = field(
+        default_factory=lambda: {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    )
     buffered_bytes: int = 0
     fragment_count: int = 0
     disabled_reason: str | None = None
@@ -44,12 +48,22 @@ class _StreamAccumulator:
             return
         self.disabled_reason = reason
         self.content_parts.clear()
+        self.stream_lines.clear()
+        self.stream_usage_line = None
         self.buffered_bytes = 0
         self.fragment_count = 0
 
-    def add_chunk(self, chunk: dict[str, Any]) -> str | None:
+    def add_chunk(self, chunk: dict[str, Any], line: str) -> str | None:
         if self.disabled_reason is not None:
             return self.disabled_reason
+
+        next_fragment_count = self.fragment_count + 1
+        if next_fragment_count > self.max_fragments:
+            return "fragment_limit_exceeded"
+
+        next_buffered_bytes = self.buffered_bytes + len(line.encode("utf-8"))
+        if next_buffered_bytes > self.max_buffer_bytes:
+            return "buffer_limit_exceeded"
 
         self.saw_chunk = True
         if self.response_id is None:
@@ -74,6 +88,12 @@ class _StreamAccumulator:
 
         choices = chunk.get("choices") or []
         if not choices:
+            if isinstance(usage, dict):
+                self.stream_usage_line = line
+            else:
+                self.stream_lines.append(line)
+            self.fragment_count = next_fragment_count
+            self.buffered_bytes = next_buffered_bytes
             return None
 
         choice = choices[0] or {}
@@ -82,27 +102,17 @@ class _StreamAccumulator:
             self.finish_reason = str(finish_reason)
 
         delta = choice.get("delta") or {}
-        if "content" not in delta:
-            return None
-
-        content = str(delta.get("content") or "")
-        if not content:
-            return None
-
-        next_fragment_count = self.fragment_count + 1
-        if next_fragment_count > self.max_fragments:
-            return "fragment_limit_exceeded"
-
-        next_buffered_bytes = self.buffered_bytes + len(content.encode("utf-8"))
-        if next_buffered_bytes > self.max_buffer_bytes:
-            return "buffer_limit_exceeded"
-
-        self.content_parts.append(content)
+        content = delta.get("content")
+        if isinstance(content, str) and content:
+            self.content_parts.append(content)
+        self.stream_lines.append(line)
         self.fragment_count = next_fragment_count
         self.buffered_bytes = next_buffered_bytes
         return None
 
-    def build_response(self, *, fallback_model: str, usage: Mapping[str, Any] | None = None) -> dict[str, Any] | None:
+    def build_response(
+        self, *, fallback_model: str, usage: Mapping[str, Any] | None = None
+    ) -> dict[str, Any] | None:
         if not self.saw_chunk or self.disabled_reason is not None:
             return None
         resolved_usage = _normalized_usage(usage if usage is not None else self.usage)
@@ -150,20 +160,41 @@ class StreamingCacheHandler:
     def write_failures_total(self) -> int:
         return self._write_failures_total
 
-    def reconstruct_sse_stream(self, response: dict[str, Any], *, include_usage: bool = False):
+    def can_replay(self, entry: CacheEntry) -> bool:
+        lines = entry.stream_lines
+        usage_line = entry.stream_usage_line
+        valid_usage_line = usage_line is None or (
+            usage_line.startswith("data:") and usage_line.strip() != "data: [DONE]"
+        )
+        return (
+            valid_usage_line
+            and bool(lines)
+            and all(
+                isinstance(line, str)
+                and line.startswith("data:")
+                and line.strip() != "data: [DONE]"
+                for line in lines
+            )
+        )
+
+    def reconstruct_sse_stream(self, entry: CacheEntry, *, include_usage: bool = False):
         async def generator():
-            for chunk in self._response_to_chunks(response):
-                yield f"data: {json.dumps(chunk, separators=(',', ':'))}\n\n"
+            for line in entry.stream_lines or []:
+                yield f"{line}\n\n"
             if include_usage:
-                usage_chunk = {
-                    "id": response.get("id"),
-                    "object": "chat.completion.chunk",
-                    "created": response.get("created"),
-                    "model": response.get("model"),
-                    "choices": [],
-                    "usage": _normalized_usage(response.get("usage") or {}),
-                }
-                yield f"data: {json.dumps(usage_chunk, separators=(',', ':'))}\n\n"
+                if entry.stream_usage_line is not None:
+                    yield f"{entry.stream_usage_line}\n\n"
+                else:
+                    response = entry.response
+                    usage_chunk = {
+                        "id": response.get("id"),
+                        "object": "chat.completion.chunk",
+                        "created": response.get("created"),
+                        "model": response.get("model"),
+                        "choices": [],
+                        "usage": _normalized_usage(response.get("usage") or {}),
+                    }
+                    yield f"data: {json.dumps(usage_chunk, separators=(',', ':'))}\n\n"
             yield "data: [DONE]\n\n"
 
         return generator()
@@ -196,7 +227,7 @@ class StreamingCacheHandler:
             self._disable_stream(state, reason="invalid_payload")
             return
 
-        reason = state.add_chunk(chunk)
+        reason = state.add_chunk(chunk, line)
         if reason is not None:
             self._disable_stream(state, reason=reason)
 
@@ -226,6 +257,8 @@ class StreamingCacheHandler:
             deployment_id=ctx.deployment_id,
             provider=ctx.provider,
             deployment_model=ctx.deployment_model,
+            stream_lines=list(state.stream_lines),
+            stream_usage_line=state.stream_usage_line,
         )
         try:
             await self.backend.set(ctx.cache_key, entry, ctx.ttl)
@@ -241,40 +274,6 @@ class StreamingCacheHandler:
         state.disable(reason)
         if was_enabled:
             self._disabled_streams_total += 1
-
-    def _response_to_chunks(self, response: dict[str, Any]) -> list[dict[str, Any]]:
-        choices = response.get("choices") or []
-        if not choices:
-            return []
-
-        content = ((choices[0] or {}).get("message") or {}).get("content") or ""
-        words = str(content).split(" ") if content else [""]
-        base_id = response.get("id") or f"chatcmpl-{uuid.uuid4().hex}"
-        created = int(response.get("created") or time.time())
-        model = str(response.get("model") or "unknown")
-        finish_reason = choices[0].get("finish_reason") or "stop"
-
-        chunks: list[dict[str, Any]] = []
-        for idx, word in enumerate(words):
-            tail = " " if idx < len(words) - 1 else ""
-            chunks.append(
-                {
-                    "id": base_id,
-                    "object": "chat.completion.chunk",
-                    "created": created,
-                    "model": model,
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {"content": f"{word}{tail}"},
-                            "finish_reason": None,
-                        }
-                    ],
-                }
-            )
-
-        chunks[-1]["choices"][0]["finish_reason"] = finish_reason
-        return chunks
 
 
 def _normalized_usage(usage: Mapping[str, Any]) -> dict[str, int]:

--- a/src/chat/__init__.py
+++ b/src/chat/__init__.py
@@ -2,8 +2,8 @@ from src.chat.audit import audit_action_for_path, emit_text_audit_event
 from src.chat.executor import OpenedStream, execute_chat, open_stream_with_first_chunk
 from src.chat.preflight import run_text_preflight
 from src.chat.telemetry import (
-    emit_nonstream_failure,
     emit_nonstream_success,
+    emit_precommit_failure,
     emit_stream_failure,
     emit_stream_success,
 )
@@ -11,8 +11,8 @@ from src.chat.telemetry import (
 __all__ = [
     "OpenedStream",
     "audit_action_for_path",
-    "emit_nonstream_failure",
     "emit_nonstream_success",
+    "emit_precommit_failure",
     "emit_stream_failure",
     "emit_stream_success",
     "emit_text_audit_event",

--- a/src/chat/executor.py
+++ b/src/chat/executor.py
@@ -14,7 +14,7 @@ from src.models.requests import ChatCompletionRequest
 from src.metrics import observe_request_phase
 from src.providers.base import ProviderAdapter, read_streaming_provider_error_details
 from src.providers.registry import resolve_chat_upstream
-from src.providers.resolution import is_openai_family_provider, resolve_provider
+from src.providers.resolution import provider_supports_stream_usage_request, resolve_provider
 from src.providers.signing import apply_request_signing
 from src.router.router import Deployment
 from src.router.usage import record_router_usage
@@ -298,7 +298,7 @@ def _request_stream_usage_when_supported(
 ) -> bool:
     if not upstream_payload.get("stream"):
         return False
-    if not is_openai_family_provider(resolve_provider(params)):
+    if not provider_supports_stream_usage_request(resolve_provider(params)):
         return False
     stream_options = upstream_payload.get("stream_options")
     if stream_options is None:

--- a/src/chat/stream_usage.py
+++ b/src/chat/stream_usage.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from src.models.requests import ChatCompletionRequest
+from src.providers.openai_stream_contract import OpenAIStreamDeltaField
 
 StreamUsageSource = Literal["provider", "estimated"]
 _TOKEN_USAGE_KEYS = ("prompt_tokens", "completion_tokens", "total_tokens")
@@ -19,6 +20,7 @@ class StreamLineInfo:
 class StreamUsage:
     usage: dict[str, Any]
     source: StreamUsageSource
+    estimate_incomplete: bool = False
 
     @property
     def estimated(self) -> bool:
@@ -28,13 +30,23 @@ class StreamUsage:
         return {
             "usage_source": self.source,
             "usage_estimated": self.estimated,
+            "usage_estimate_incomplete": self.estimate_incomplete,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class _CompletionDeltaUsage:
+    ordinary_chars: int = 0
+    reasoning_chars: int = 0
+    reasoning_estimate_incomplete: bool = False
 
 
 class StreamUsageTracker:
     def __init__(self) -> None:
         self._provider_usage: dict[str, Any] | None = None
         self._completion_chars = 0
+        self._reasoning_chars = 0
+        self._reasoning_estimate_incomplete = False
 
     def add_line(self, line: str) -> StreamLineInfo:
         if not line.startswith("data:"):
@@ -53,7 +65,12 @@ class StreamUsageTracker:
         if isinstance(usage, dict) and _is_provider_token_usage(usage):
             self._provider_usage = dict(usage)
 
-        self._completion_chars += _completion_delta_chars(chunk)
+        delta_usage = _completion_delta_usage(chunk)
+        self._completion_chars += delta_usage.ordinary_chars
+        self._reasoning_chars += delta_usage.reasoning_chars
+        self._reasoning_estimate_incomplete = (
+            self._reasoning_estimate_incomplete or delta_usage.reasoning_estimate_incomplete
+        )
         return StreamLineInfo(is_usage_only_chunk=_is_usage_only_chunk(chunk))
 
     def resolve(self, payload: ChatCompletionRequest) -> StreamUsage:
@@ -61,7 +78,10 @@ class StreamUsageTracker:
             return StreamUsage(usage=_normalized_usage(self._provider_usage), source="provider")
 
         prompt_tokens = estimate_chat_prompt_tokens(payload)
-        completion_tokens = _estimate_tokens_from_chars(self._completion_chars, minimum=0)
+        completion_tokens = _estimate_tokens_from_chars(
+            self._completion_chars + self._reasoning_chars,
+            minimum=0,
+        )
         return StreamUsage(
             usage={
                 "prompt_tokens": prompt_tokens,
@@ -69,6 +89,7 @@ class StreamUsageTracker:
                 "total_tokens": prompt_tokens + completion_tokens,
             },
             source="estimated",
+            estimate_incomplete=self._reasoning_estimate_incomplete,
         )
 
 
@@ -106,23 +127,33 @@ def _content_chars(content: Any) -> int:
     return len(json.dumps(content, sort_keys=True, separators=(",", ":"), default=str))
 
 
-def _completion_delta_chars(chunk: dict[str, Any]) -> int:
+def _completion_delta_usage(chunk: dict[str, Any]) -> _CompletionDeltaUsage:
     choices = chunk.get("choices")
     if not isinstance(choices, list):
-        return 0
+        return _CompletionDeltaUsage()
 
-    total = 0
+    ordinary_chars = 0
+    reasoning_chars = 0
+    reasoning_estimate_incomplete = False
     for choice in choices:
         if not isinstance(choice, dict):
             continue
         delta = choice.get("delta")
-        if isinstance(delta, dict):
-            total += _delta_chars(delta)
+        if not isinstance(delta, dict):
+            delta = choice.get("message")
+        if not isinstance(delta, dict):
             continue
-        message = choice.get("message")
-        if isinstance(message, dict):
-            total += _delta_chars(message)
-    return total
+        delta_usage = _delta_usage(delta)
+        ordinary_chars += delta_usage.ordinary_chars
+        reasoning_chars += delta_usage.reasoning_chars
+        reasoning_estimate_incomplete = (
+            reasoning_estimate_incomplete or delta_usage.reasoning_estimate_incomplete
+        )
+    return _CompletionDeltaUsage(
+        ordinary_chars=ordinary_chars,
+        reasoning_chars=reasoning_chars,
+        reasoning_estimate_incomplete=reasoning_estimate_incomplete,
+    )
 
 
 def _is_usage_only_chunk(chunk: dict[str, Any]) -> bool:
@@ -131,19 +162,79 @@ def _is_usage_only_chunk(chunk: dict[str, Any]) -> bool:
     return isinstance(usage, dict) and isinstance(choices, list) and not choices
 
 
-def _delta_chars(delta: dict[str, Any]) -> int:
-    total = 0
-    content = delta.get("content")
+def _delta_usage(delta: dict[str, Any]) -> _CompletionDeltaUsage:
+    ordinary_chars = 0
+    content = delta.get(OpenAIStreamDeltaField.CONTENT.value)
     if isinstance(content, str):
-        total += len(content)
+        ordinary_chars += len(content)
     elif content is not None:
-        total += _content_chars(content)
+        ordinary_chars += _content_chars(content)
 
-    for key in ("refusal", "function_call", "tool_calls"):
+    for key in (
+        OpenAIStreamDeltaField.REFUSAL.value,
+        OpenAIStreamDeltaField.FUNCTION_CALL.value,
+        OpenAIStreamDeltaField.TOOL_CALLS.value,
+    ):
         value = delta.get(key)
         if value is not None:
-            total += _content_chars(value)
-    return total
+            ordinary_chars += _content_chars(value)
+
+    reasoning_chars, reasoning_incomplete = _reasoning_text_chars(
+        delta.get(OpenAIStreamDeltaField.REASONING.value)
+    )
+    reasoning_content_chars, reasoning_content_incomplete = _reasoning_text_chars(
+        delta.get(OpenAIStreamDeltaField.REASONING_CONTENT.value)
+    )
+    reasoning_details_chars, reasoning_details_incomplete = _reasoning_details_text_chars(
+        delta.get(OpenAIStreamDeltaField.REASONING_DETAILS.value)
+    )
+    return _CompletionDeltaUsage(
+        ordinary_chars=ordinary_chars,
+        reasoning_chars=max(
+            reasoning_chars,
+            reasoning_content_chars,
+            reasoning_details_chars,
+        ),
+        reasoning_estimate_incomplete=(
+            reasoning_incomplete or reasoning_content_incomplete or reasoning_details_incomplete
+        ),
+    )
+
+
+def _reasoning_text_chars(value: Any) -> tuple[int, bool]:
+    if value in (None, "", [], {}):
+        return 0, False
+    if isinstance(value, str):
+        return len(value), False
+    return _content_chars(value), True
+
+
+def _reasoning_details_text_chars(value: Any) -> tuple[int, bool]:
+    if value in (None, "", [], {}):
+        return 0, False
+    if isinstance(value, str):
+        return len(value), False
+
+    items = value if isinstance(value, list) else [value]
+    total = 0
+    incomplete = False
+    for item in items:
+        if isinstance(item, str):
+            total += len(item)
+            continue
+        if not isinstance(item, dict):
+            total += _content_chars(item)
+            incomplete = True
+            continue
+        item_chars = sum(
+            len(text) for key in ("text", "summary") if isinstance((text := item.get(key)), str)
+        )
+        if item_chars == 0:
+            opaque_value = item.get("data")
+            item_chars = _content_chars(opaque_value if opaque_value is not None else item)
+            incomplete = True
+        total += item_chars
+    return total, incomplete
 
 
 def _estimate_tokens_from_chars(char_count: int, *, minimum: int) -> int:

--- a/src/chat/telemetry.py
+++ b/src/chat/telemetry.py
@@ -525,7 +525,7 @@ async def emit_nonstream_success(
     )
 
 
-async def emit_nonstream_failure(
+async def emit_precommit_failure(
     *,
     request: Request,
     auth: Any,
@@ -544,6 +544,7 @@ async def emit_nonstream_failure(
     api_base: str,
     exc: Exception,
     status_code: int,
+    stream: bool,
 ) -> None:
     failure_fields = _resolve_failure_fields(
         request,
@@ -569,7 +570,7 @@ async def emit_nonstream_failure(
                 request,
                 {
                     "route": request.url.path,
-                    "stream": False,
+                    "stream": stream,
                     "cache_hit": cache_hit,
                     "cache_key": cache_key,
                     "api_base": failure_fields["api_base"],
@@ -648,7 +649,7 @@ async def emit_nonstream_failure(
             request,
             {
                 "route": request.url.path,
-                "stream": False,
+                "stream": stream,
                 "cache_hit": cache_hit,
                 "cache_key": cache_key,
                 "api_base": failure_fields["api_base"],

--- a/src/metrics/__init__.py
+++ b/src/metrics/__init__.py
@@ -124,6 +124,7 @@ from src.metrics.prompt import (
     set_prompt_singleflight_inflight,
 )
 from src.metrics.counters import (
+    ProviderStreamValidationFailureReason,
     increment_cache_hit,
     increment_cache_miss,
     increment_callable_target_policy_fallback,
@@ -131,6 +132,7 @@ from src.metrics.counters import (
     increment_config_reload,
     increment_prompt_cache_lookup,
     increment_prompt_resolution,
+    increment_provider_stream_validation_failure,
     increment_request,
     increment_request_failure,
     increment_router_health_transition,
@@ -158,6 +160,7 @@ from src.metrics.prometheus import get_prometheus_registry, infer_provider
 from src.metrics.request_phases import observe_request_phase
 
 __all__ = [
+    "ProviderStreamValidationFailureReason",
     "get_prometheus_registry",
     "infer_provider",
     "collect_batch_scheduler_status_metrics",
@@ -293,6 +296,7 @@ __all__ = [
     "increment_config_reload",
     "increment_prompt_cache_lookup",
     "increment_prompt_resolution",
+    "increment_provider_stream_validation_failure",
     "observe_request_latency",
     "observe_api_latency",
     "observe_prompt_resolution_latency",

--- a/src/metrics/counters.py
+++ b/src/metrics/counters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any
 
 from prometheus_client import Counter, Gauge
@@ -11,6 +12,21 @@ from src.metrics.prometheus import (
     hash_api_key,
     sanitize_label,
 )
+
+
+class ProviderStreamValidationFailureReason(StrEnum):
+    FRAME_TOO_LARGE = "frame_too_large"
+    INCOMPLETE_STREAM = "incomplete_stream"
+    INVALID_CHOICES = "invalid_choices"
+    INVALID_JSON = "invalid_json"
+    INVALID_PAYLOAD = "invalid_payload"
+    INVALID_SSE = "invalid_sse"
+    PRECOMMIT_NO_OUTPUT_LIMIT = "precommit_no_output_limit"
+    PRECOMMIT_UNKNOWN_OUTPUT_LIMIT = "precommit_unknown_output_limit"
+    PRECOMMIT_UNKNOWN_OUTPUT_TERMINAL = "precommit_unknown_output_terminal"
+    TERMINAL_BEFORE_OUTPUT = "terminal_before_output"
+    UNKNOWN_ERROR_ENVELOPE = "unknown_error_envelope"
+
 
 deltallm_requests_metric = Counter(
     "deltallm_requests_total",
@@ -137,6 +153,13 @@ deltallm_provider_error_body_discards_metric = Counter(
     registry=get_prometheus_registry(),
 )
 
+deltallm_provider_stream_validation_failures_metric = Counter(
+    "deltallm_provider_stream_validation_failures_total",
+    "OpenAI-compatible provider streams rejected by bounded validation reason",
+    ["reason"],
+    registry=get_prometheus_registry(),
+)
+
 deltallm_tier_capacity_fair_share_decisions_metric = Counter(
     "deltallm_tier_capacity_fair_share_decisions_total",
     "Tier capacity fair-share decisions",
@@ -176,6 +199,15 @@ def increment_provider_error_body_discard(*, reason: str) -> None:
     if reason not in {"encoded", "oversized"}:
         raise ValueError("unsupported provider error body discard reason")
     deltallm_provider_error_body_discards_metric.labels(reason=reason).inc()
+
+
+def increment_provider_stream_validation_failure(
+    *,
+    reason: ProviderStreamValidationFailureReason,
+) -> None:
+    if not isinstance(reason, ProviderStreamValidationFailureReason):
+        raise ValueError("unsupported provider stream validation failure reason")
+    deltallm_provider_stream_validation_failures_metric.labels(reason=reason.value).inc()
 
 
 def increment_usage(

--- a/src/models/errors.py
+++ b/src/models/errors.py
@@ -19,6 +19,14 @@ class FailureClassification(StrEnum):
     GENERIC = "generic"
 
 
+class RoutingFailureAction(StrEnum):
+    """Explicit request-local routing action, independent of deployment health."""
+
+    FAIL_FAST = "fail_fast"
+    RETRY_OR_NEXT = "retry_or_next"
+    NEXT_DEPLOYMENT = "next_deployment"
+
+
 def parse_retry_after_header(value: str | None) -> int | None:
     if value is None:
         return None
@@ -57,12 +65,14 @@ class ProxyError(Exception):
         *,
         affects_deployment_health: bool | None = None,
         failure_classification: FailureClassification | None = None,
+        routing_failure_action: RoutingFailureAction | None = None,
     ):
         self.message = message or self.message
         self.param = param
         self.code = code
         self.affects_deployment_health = affects_deployment_health
         self.failure_classification = failure_classification
+        self.routing_failure_action = routing_failure_action
         super().__init__(self.message)
 
 

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -16,6 +16,7 @@ from src.models.errors import (
     NO_HEALTHY_DEPLOYMENTS_CODE,
     ProxyError,
     RateLimitError,
+    RoutingFailureAction,
     ServiceUnavailableError,
     TimeoutError,
     parse_retry_after_header,
@@ -207,13 +208,18 @@ def reject_openai_compatible_failure_response(payload: object) -> None:
             )
 
 
-def invalid_provider_response_error() -> ServiceUnavailableError:
-    """Return the one sanitized error for malformed nominal-success payloads."""
+def invalid_provider_response_error(
+    *,
+    affects_deployment_health: bool = True,
+    routing_failure_action: RoutingFailureAction | None = None,
+) -> ServiceUnavailableError:
+    """Return the one sanitized error for nominal-success validation failures."""
 
     return ServiceUnavailableError(
         message=INVALID_PROVIDER_RESPONSE_MESSAGE,
-        affects_deployment_health=True,
+        affects_deployment_health=affects_deployment_health,
         failure_classification=FailureClassification.GENERIC,
+        routing_failure_action=routing_failure_action,
     )
 
 

--- a/src/providers/openai_compatible.py
+++ b/src/providers/openai_compatible.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator, Callable, Mapping
 
-from src.models.errors import FailureClassification, InvalidRequestError, ProxyError
+from src.metrics.counters import (
+    ProviderStreamValidationFailureReason,
+    increment_provider_stream_validation_failure,
+)
+from src.models.errors import (
+    FailureClassification,
+    InvalidRequestError,
+    ProxyError,
+    RoutingFailureAction,
+)
 from src.providers.base import (
     ProviderErrorDetails,
     invalid_provider_response_error,
@@ -12,6 +21,7 @@ from src.providers.base import (
     provider_error_details_from_payload,
     validate_provider_success_payload,
 )
+from src.providers.openai_stream_contract import inspect_openai_stream_choices
 
 _MAX_PRECOMMIT_STREAM_FRAMES = 32
 _MAX_PRECOMMIT_STREAM_CHARS = 262_144
@@ -90,39 +100,57 @@ async def translate_openai_compatible_stream(
 
     pending: list[str] = []
     pending_chars = 0
+    pending_unknown_output_candidate = False
     emitted_output = False
     saw_terminal = False
 
     async for line in provider_stream:
         if not line or line.startswith(":") or line.startswith("event:"):
             continue
-        if len(line) > _MAX_STREAM_FRAME_CHARS or not line.startswith("data:"):
-            raise invalid_provider_response_error()
+        if len(line) > _MAX_STREAM_FRAME_CHARS:
+            raise _invalid_stream_response_error(
+                ProviderStreamValidationFailureReason.FRAME_TOO_LARGE
+            )
+        if not line.startswith("data:"):
+            raise _invalid_stream_response_error(ProviderStreamValidationFailureReason.INVALID_SSE)
 
         raw_payload = line[len("data:") :].strip()
         if not raw_payload:
             continue
         if raw_payload == "[DONE]":
             if not emitted_output:
-                raise invalid_provider_response_error()
+                reason = (
+                    ProviderStreamValidationFailureReason.PRECOMMIT_UNKNOWN_OUTPUT_TERMINAL
+                    if pending_unknown_output_candidate
+                    else ProviderStreamValidationFailureReason.TERMINAL_BEFORE_OUTPUT
+                )
+                raise _invalid_stream_response_error(reason)
             yield line
             return
 
         try:
             payload = json.loads(raw_payload)
         except (RecursionError, TypeError, ValueError) as exc:
-            raise invalid_provider_response_error() from exc
+            raise _invalid_stream_response_error(
+                ProviderStreamValidationFailureReason.INVALID_JSON
+            ) from exc
         if not isinstance(payload, Mapping):
-            raise invalid_provider_response_error()
+            raise _invalid_stream_response_error(
+                ProviderStreamValidationFailureReason.INVALID_PAYLOAD
+            )
 
         if "error" in payload:
             raise _map_openai_compatible_stream_error(payload, classify_failure)
 
         choices = payload.get("choices")
         if not isinstance(choices, list):
-            raise invalid_provider_response_error()
+            raise _invalid_stream_response_error(
+                ProviderStreamValidationFailureReason.INVALID_CHOICES
+            )
         if not _valid_stream_choices(choices):
-            raise invalid_provider_response_error()
+            raise _invalid_stream_response_error(
+                ProviderStreamValidationFailureReason.INVALID_CHOICES
+            )
 
         classified_stop = _content_filter_stop(choices)
         if classified_stop and not emitted_output:
@@ -132,10 +160,19 @@ async def translate_openai_compatible_stream(
                 failure_classification=FailureClassification.CONTENT_POLICY,
             )
 
-        has_output = _choices_have_output(choices)
+        inspection = inspect_openai_stream_choices(choices)
+        has_output = inspection.has_output
         has_terminal = _choices_have_terminal(choices)
         if not emitted_output and not has_output and not has_terminal:
-            pending_chars = _buffer_precommit_frame(pending, pending_chars, line)
+            pending_unknown_output_candidate = (
+                pending_unknown_output_candidate or inspection.has_unknown_output_candidate
+            )
+            pending_chars = _buffer_precommit_frame(
+                pending,
+                pending_chars,
+                line,
+                has_unknown_output_candidate=pending_unknown_output_candidate,
+            )
             continue
 
         if not emitted_output:
@@ -147,7 +184,9 @@ async def translate_openai_compatible_stream(
         saw_terminal = saw_terminal or has_terminal
 
     if not emitted_output or not saw_terminal:
-        raise invalid_provider_response_error()
+        raise _invalid_stream_response_error(
+            ProviderStreamValidationFailureReason.INCOMPLETE_STREAM
+        )
 
 
 def _valid_stream_choices(choices: list[object]) -> bool:
@@ -168,20 +207,6 @@ def _valid_stream_choices(choices: list[object]) -> bool:
     return True
 
 
-def _choices_have_output(choices: list[object]) -> bool:
-    for value in choices:
-        if not isinstance(value, Mapping):
-            continue
-        delta = value.get("delta")
-        if not isinstance(delta, Mapping):
-            continue
-        for key in ("content", "refusal", "function_call", "tool_calls"):
-            output = delta.get(key)
-            if output not in (None, "", [], {}):
-                return True
-    return False
-
-
 def _choices_have_terminal(choices: list[object]) -> bool:
     return any(
         isinstance(value, Mapping)
@@ -200,12 +225,39 @@ def _content_filter_stop(choices: list[object]) -> bool:
     )
 
 
-def _buffer_precommit_frame(pending: list[str], pending_chars: int, line: str) -> int:
+def _buffer_precommit_frame(
+    pending: list[str],
+    pending_chars: int,
+    line: str,
+    *,
+    has_unknown_output_candidate: bool,
+) -> int:
     next_chars = pending_chars + len(line)
     if len(pending) >= _MAX_PRECOMMIT_STREAM_FRAMES or next_chars > _MAX_PRECOMMIT_STREAM_CHARS:
-        raise invalid_provider_response_error()
+        reason = (
+            ProviderStreamValidationFailureReason.PRECOMMIT_UNKNOWN_OUTPUT_LIMIT
+            if has_unknown_output_candidate
+            else ProviderStreamValidationFailureReason.PRECOMMIT_NO_OUTPUT_LIMIT
+        )
+        raise _invalid_stream_response_error(reason)
     pending.append(line)
     return next_chars
+
+
+def _invalid_stream_response_error(
+    reason: ProviderStreamValidationFailureReason,
+) -> ProxyError:
+    increment_provider_stream_validation_failure(reason=reason)
+    compatibility_failure = reason in {
+        ProviderStreamValidationFailureReason.PRECOMMIT_UNKNOWN_OUTPUT_LIMIT,
+        ProviderStreamValidationFailureReason.PRECOMMIT_UNKNOWN_OUTPUT_TERMINAL,
+    }
+    return invalid_provider_response_error(
+        affects_deployment_health=not compatibility_failure,
+        routing_failure_action=(
+            RoutingFailureAction.NEXT_DEPLOYMENT if compatibility_failure else None
+        ),
+    )
 
 
 def _map_openai_compatible_stream_error(
@@ -225,4 +277,6 @@ def _map_openai_compatible_stream_error(
         return map_standard_provider_status_error(400)
     if details.identifiers & _SERVER_ERROR_IDENTIFIERS:
         return map_standard_provider_status_error(500)
-    return invalid_provider_response_error()
+    return _invalid_stream_response_error(
+        ProviderStreamValidationFailureReason.UNKNOWN_ERROR_ENVELOPE
+    )

--- a/src/providers/openai_stream_contract.py
+++ b/src/providers/openai_stream_contract.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class OpenAIStreamDeltaField(StrEnum):
+    """Known OpenAI-compatible delta fields with routing significance."""
+
+    CONTENT = "content"
+    FUNCTION_CALL = "function_call"
+    REASONING = "reasoning"
+    REASONING_CONTENT = "reasoning_content"
+    REASONING_DETAILS = "reasoning_details"
+    REFUSAL = "refusal"
+    ROLE = "role"
+    TOOL_CALLS = "tool_calls"
+
+
+OPENAI_STREAM_OUTPUT_DELTA_FIELDS = frozenset(
+    {
+        OpenAIStreamDeltaField.CONTENT.value,
+        OpenAIStreamDeltaField.FUNCTION_CALL.value,
+        OpenAIStreamDeltaField.REASONING.value,
+        OpenAIStreamDeltaField.REASONING_CONTENT.value,
+        OpenAIStreamDeltaField.REASONING_DETAILS.value,
+        OpenAIStreamDeltaField.REFUSAL.value,
+        OpenAIStreamDeltaField.TOOL_CALLS.value,
+    }
+)
+OPENAI_STREAM_KNOWN_DELTA_FIELDS = OPENAI_STREAM_OUTPUT_DELTA_FIELDS | {
+    OpenAIStreamDeltaField.ROLE.value
+}
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAIStreamChoiceInspection:
+    has_output: bool = False
+    has_unknown_output_candidate: bool = False
+
+
+def inspect_openai_stream_choices(
+    choices: list[object],
+) -> OpenAIStreamChoiceInspection:
+    """Classify bounded delta fields without retaining provider-owned values."""
+
+    has_output = False
+    has_unknown_output_candidate = False
+    for value in choices:
+        if not isinstance(value, Mapping):
+            continue
+        delta = value.get("delta")
+        if not isinstance(delta, Mapping):
+            continue
+        for key, output in delta.items():
+            if output in (None, "", [], {}):
+                continue
+            if key in OPENAI_STREAM_OUTPUT_DELTA_FIELDS:
+                has_output = True
+            elif key not in OPENAI_STREAM_KNOWN_DELTA_FIELDS:
+                has_unknown_output_candidate = True
+
+    return OpenAIStreamChoiceInspection(
+        has_output=has_output,
+        has_unknown_output_candidate=has_unknown_output_candidate,
+    )

--- a/src/providers/resolution.py
+++ b/src/providers/resolution.py
@@ -28,6 +28,9 @@ OPENAI_FAMILY_PROVIDERS = {
     "azure_openai",
 }
 
+# Providers where requesting the final OpenAI stream usage chunk is supported.
+STREAM_USAGE_REQUEST_PROVIDERS = OPENAI_FAMILY_PROVIDERS | {"vllm"}
+
 PROVIDER_MODEL_PREFIXES_TO_STRIP: dict[str, tuple[str, ...]] = {
     "openai": ("openai/",),
     "anthropic": ("anthropic/",),
@@ -167,6 +170,10 @@ def resolve_upstream_model(
 
 def is_openai_family_provider(provider: str) -> bool:
     return (provider or "").strip().lower() in OPENAI_FAMILY_PROVIDERS
+
+
+def provider_supports_stream_usage_request(provider: str) -> bool:
+    return (provider or "").strip().lower() in STREAM_USAGE_REQUEST_PROVIDERS
 
 
 def normalize_openai_chat_payload(

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -22,6 +22,7 @@ from src.models.errors import (
     NO_HEALTHY_DEPLOYMENTS_CODE,
     ProxyError,
     RateLimitError,
+    RoutingFailureAction,
     ServiceUnavailableError,
     TimeoutError,
     parse_retry_after_header,
@@ -39,6 +40,7 @@ from src.router.execution import (
     attach_failover_attempt_context,
     attach_failover_original_error,
 )
+from src.router.failure_policy import routing_failure_action
 from src.router.health_policy import affects_deployment_health
 from src.router.router import Deployment
 from src.router.state import DeploymentStateBackend
@@ -570,7 +572,8 @@ class FailoverManager:
                                     return result, served
                                 return result
 
-                    if not affects_deployment_health(last_error):
+                    failure_action = routing_failure_action(last_error)
+                    if failure_action is RoutingFailureAction.FAIL_FAST:
                         attach_failover_attempt_context(
                             last_error,
                             model_group=model_group,
@@ -579,6 +582,9 @@ class FailoverManager:
                         if last_error is exc:
                             raise last_error
                         raise last_error from exc
+
+                    if failure_action is RoutingFailureAction.NEXT_DEPLOYMENT:
+                        break
 
                     if (
                         not entered_cooldown
@@ -774,12 +780,15 @@ class FailoverManager:
                         attempted_deployment_ids=attempt_history,
                     )
                     raise normalized_error from exc
-                if not affects_deployment_health(
-                    normalized_error
-                ) and failure_classification not in {
-                    ErrorClassification.CONTEXT_WINDOW,
-                    ErrorClassification.CONTENT_POLICY,
-                }:
+                failure_action = routing_failure_action(normalized_error)
+                if (
+                    failure_action is RoutingFailureAction.FAIL_FAST
+                    and failure_classification
+                    not in {
+                        ErrorClassification.CONTEXT_WINDOW,
+                        ErrorClassification.CONTENT_POLICY,
+                    }
+                ):
                     if normalized_error is exc:
                         attach_failover_attempt_context(
                             normalized_error,

--- a/src/router/failure_policy.py
+++ b/src/router/failure_policy.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from src.models.errors import RoutingFailureAction
+from src.router.health_policy import affects_deployment_health
+
+
+def routing_failure_action(exc: Exception) -> RoutingFailureAction:
+    """Resolve retry/failover behavior without conflating it with health state."""
+
+    explicit = getattr(exc, "routing_failure_action", None)
+    if isinstance(explicit, RoutingFailureAction):
+        return explicit
+    if affects_deployment_health(exc):
+        return RoutingFailureAction.RETRY_OR_NEXT
+    return RoutingFailureAction.FAIL_FAST

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -14,8 +14,8 @@ from src.cache.pricing import cache_pricing_snapshot_from_deployment
 from src.cache.streaming import StreamWriteContext
 from src.chat import (
     audit_action_for_path,
-    emit_nonstream_failure,
     emit_nonstream_success,
+    emit_precommit_failure,
     emit_stream_failure,
     emit_stream_success,
     execute_chat,
@@ -506,7 +506,7 @@ async def handle_chat_like_request(
     except httpx.HTTPError as exc:
         provider_registry = request.app.state.provider_error_mapper_registry
         mapped_error = provider_registry.map_error(api_provider, exc)
-        await emit_nonstream_failure(
+        await emit_precommit_failure(
             request=request,
             auth=auth,
             payload=payload,
@@ -524,11 +524,12 @@ async def handle_chat_like_request(
             api_base=api_base,
             exc=mapped_error,
             status_code=mapped_error.status_code,
+            stream=bool(payload.stream),
         )
         raise mapped_error from exc
     except Exception as exc:
         status_code = int(getattr(exc, "status_code", 500) or 500)
-        await emit_nonstream_failure(
+        await emit_precommit_failure(
             request=request,
             auth=auth,
             payload=payload,
@@ -546,5 +547,6 @@ async def handle_chat_like_request(
             api_base=api_base,
             exc=exc,
             status_code=status_code,
+            stream=bool(payload.stream),
         )
         raise

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -392,6 +392,7 @@ async def test_streaming_cache_hit(client, test_app):
     assert r1.headers["x-deltallm-cache-hit"] == "false"
     assert r2.headers["x-deltallm-cache-hit"] == "true"
     assert "data: [DONE]" in r2.text
+    assert r2.text == r1.text
     assert test_app.state.http_client.stream_calls == 1
 
 
@@ -415,10 +416,106 @@ async def test_streaming_cache_miss_populates_cache_entry(client, test_app):
     assert len(backend._cache) == 1
     stored = next(iter(backend._cache.values()))
     assert stored.response.get("object") == "chat.completion"
+    assert stored.stream_lines
 
 
 @pytest.mark.asyncio
-async def test_streaming_cache_hit_bills_from_estimated_usage_without_provider_cost(
+async def test_streaming_cache_replays_reasoning_tools_and_usage_exactly(client, test_app):
+    _enable_stream_cache(test_app)
+    calls = {"count": 0}
+    lines = [
+        'data: {"id":"chatcmpl-reasoning-cache","object":"chat.completion.chunk",'
+        '"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+        'data: {"id":"chatcmpl-reasoning-cache","object":"chat.completion.chunk",'
+        '"choices":[{"index":0,"delta":{"reasoning_content":"think"},'
+        '"finish_reason":null}]}',
+        'data: {"id":"chatcmpl-reasoning-cache","object":"chat.completion.chunk",'
+        '"choices":[{"index":0,"delta":{"reasoning_details":'
+        '[{"type":"reasoning.text","text":"step"}],"tool_calls":[{"index":0,'
+        '"id":"call_1","type":"function","function":{"name":"search",'
+        '"arguments":"{}"}}]},"finish_reason":null}]}',
+        'data: {"id":"chatcmpl-reasoning-cache","object":"chat.completion.chunk",'
+        '"choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":"stop"}]}',
+        'data: {"id":"chatcmpl-reasoning-cache","object":"chat.completion.chunk",'
+        '"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}',
+        "data: [DONE]",
+    ]
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict[str, Any], timeout: int):  # noqa: ANN001
+        del method, url, headers, json, timeout
+        calls["count"] += 1
+        return _StreamContext(lines=lines)
+
+    test_app.state.http_client.stream = stream
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "reason about this"}],
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+
+    warm = await client.post("/v1/chat/completions", headers=headers, json=body)
+    hit = await client.post("/v1/chat/completions", headers=headers, json=body)
+
+    assert warm.status_code == 200
+    assert hit.status_code == 200
+    assert hit.headers["x-deltallm-cache-hit"] == "true"
+    assert hit.text == warm.text
+    assert calls["count"] == 1
+    stored = next(iter(test_app.state.cache_backend._cache.values()))
+    assert stored.stream_lines == lines[:-2]
+    assert stored.stream_usage_line == lines[-2]
+
+
+@pytest.mark.asyncio
+async def test_streaming_cache_legacy_entry_is_treated_as_miss(client, test_app):
+    _enable_stream_cache(test_app)
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "legacy entry"}],
+        "stream": True,
+    }
+
+    warm = await client.post("/v1/chat/completions", headers=headers, json=body)
+    assert warm.status_code == 200
+    stored = next(iter(test_app.state.cache_backend._cache.values()))
+    stored.stream_lines = None
+
+    miss = await client.post("/v1/chat/completions", headers=headers, json=body)
+
+    assert miss.status_code == 200
+    assert miss.headers["x-deltallm-cache-hit"] == "false"
+    assert test_app.state.http_client.stream_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_keys_are_versioned_and_separated_by_response_mode(client, test_app):
+    _enable_cache(test_app)
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    base = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "same input"}],
+    }
+
+    json_response = await client.post(
+        "/v1/chat/completions", headers=headers, json={**base, "stream": False}
+    )
+    stream_response = await client.post(
+        "/v1/chat/completions", headers=headers, json={**base, "stream": True}
+    )
+
+    assert json_response.status_code == 200
+    assert stream_response.status_code == 200
+    keys = list(test_app.state.cache_backend._cache)
+    assert len(keys) == 2
+    assert any("schema:v2:mode:json:" in key for key in keys)
+    assert any("schema:v2:mode:stream:" in key for key in keys)
+
+
+@pytest.mark.asyncio
+async def test_streaming_reasoning_cache_hit_bills_estimated_usage_without_provider_cost(
     client, test_app
 ):
     _enable_stream_cache(test_app)
@@ -436,7 +533,7 @@ async def test_streaming_cache_hit_bills_from_estimated_usage_without_provider_c
         return _StreamContext(
             lines=[
                 'data: {"id":"chatcmpl-est-cache","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
-                'data: {"id":"chatcmpl-est-cache","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"done"},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-est-cache","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}',
                 "data: [DONE]",
             ]
         )
@@ -454,8 +551,8 @@ async def test_streaming_cache_hit_bills_from_estimated_usage_without_provider_c
     stored = next(iter(test_app.state.cache_backend._cache.values()))
     assert stored.response["usage"] == {
         "prompt_tokens": 3,
-        "completion_tokens": 1,
-        "total_tokens": 4,
+        "completion_tokens": 2,
+        "total_tokens": 5,
     }
 
     hit = await client.post("/v1/chat/completions", headers=headers, json=body)
@@ -466,13 +563,13 @@ async def test_streaming_cache_hit_bills_from_estimated_usage_without_provider_c
     assert recorder.events[-1]["cache_hit"] is True
     assert recorder.events[-1]["usage"] == {
         "prompt_tokens": 3,
-        "completion_tokens": 1,
-        "total_tokens": 4,
+        "completion_tokens": 2,
+        "total_tokens": 5,
         "prompt_tokens_cached": 3,
     }
-    assert recorder.events[-1]["cost"] == 5.0
+    assert recorder.events[-1]["cost"] == 7.0
     assert recorder.events[-1]["metadata"]["provider_cost"] == 0.0
-    assert recorder.events[-1]["metadata"]["provider_cost_avoided"] == 5.0
+    assert recorder.events[-1]["metadata"]["provider_cost_avoided"] == 7.0
     assert recorder.events[-1]["metadata"]["cache_cost_basis"] == "avoided_provider_cost"
 
 

--- a/tests/test_cache_redis_integration.py
+++ b/tests/test_cache_redis_integration.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from uuid import uuid4
+
+import pytest
+from redis.asyncio import Redis
+
+from src.cache.backends.base import CacheEntry
+from src.cache.backends.redis import RedisBackend
+from src.cache.streaming import StreamingCacheHandler
+
+
+@pytest.mark.skipif(
+    not os.getenv("DELTALLM_TEST_REDIS_URL"),
+    reason="DELTALLM_TEST_REDIS_URL is required for the Redis integration test",
+)
+async def test_stream_cache_fields_round_trip_across_redis_clients_with_ttl() -> None:
+    local_redis = Redis.from_url(
+        os.environ["DELTALLM_TEST_REDIS_URL"],
+        decode_responses=True,
+    )
+    remote_redis = Redis.from_url(
+        os.environ["DELTALLM_TEST_REDIS_URL"],
+        decode_responses=True,
+    )
+    key = f"stream-cache-integration-{uuid4().hex}"
+    local_backend = RedisBackend(local_redis)
+    remote_backend = RedisBackend(remote_redis)
+    lines = [
+        'data: {"id":"chatcmpl-redis","choices":[{"index":0,'
+        '"delta":{"reasoning_content":"think"},"finish_reason":null}]}',
+        'data: {"id":"chatcmpl-redis","choices":[{"index":0,'
+        '"delta":{"content":"answer"},"finish_reason":"stop"}]}',
+    ]
+    usage_line = (
+        'data: {"id":"chatcmpl-redis","choices":[],"usage":'
+        '{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}'
+    )
+    entry = CacheEntry(
+        response={
+            "id": "chatcmpl-redis",
+            "model": "group",
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        },
+        model="group",
+        cached_at=time.time(),
+        ttl=60,
+        stream_lines=lines,
+        stream_usage_line=usage_line,
+    )
+
+    try:
+        await local_backend.set(key, entry, 60)
+
+        loaded = await remote_backend.get(key)
+
+        assert loaded is not None
+        assert loaded.stream_lines == lines
+        assert loaded.stream_usage_line == usage_line
+        ttl_ms = await remote_redis.pttl(f"cache:{key}")
+        assert 0 < ttl_ms <= 60_000
+        handler = StreamingCacheHandler(remote_backend)
+        replayed = [
+            line async for line in handler.reconstruct_sse_stream(loaded, include_usage=True)
+        ]
+        assert replayed == [
+            *(f"{line}\n\n" for line in lines),
+            f"{usage_line}\n\n",
+            "data: [DONE]\n\n",
+        ]
+    finally:
+        await local_backend.delete(key)
+        await local_redis.aclose()
+        await remote_redis.aclose()
+
+
+@pytest.mark.skipif(
+    not os.getenv("DELTALLM_TEST_REDIS_URL"),
+    reason="DELTALLM_TEST_REDIS_URL is required for the Redis integration test",
+)
+async def test_legacy_redis_stream_cache_entry_is_not_replayable() -> None:
+    redis = Redis.from_url(
+        os.environ["DELTALLM_TEST_REDIS_URL"],
+        decode_responses=True,
+    )
+    backend = RedisBackend(redis)
+    key = f"legacy-stream-cache-integration-{uuid4().hex}"
+    payload = {
+        "response": {"id": "legacy", "usage": {}},
+        "model": "group",
+        "cached_at": time.time(),
+        "ttl": 60,
+    }
+
+    try:
+        await redis.setex(f"cache:{key}", 60, json.dumps(payload))
+        loaded = await backend.get(key)
+
+        assert loaded is not None
+        assert StreamingCacheHandler(backend).can_replay(loaded) is False
+    finally:
+        await backend.delete(key)
+        await redis.aclose()

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2035,6 +2035,48 @@ async def test_chat_stream_billing_uses_provider_usage_when_present(client, test
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_requests_usage_from_vllm(client, test_app):
+    deployment = test_app.state.router.deployment_registry["gpt-4o-mini"][0]
+    deployment.deltallm_params.update(
+        {
+            "provider": "vllm",
+            "model": "zai-org/GLM-5.3-Flash",
+            "api_base": "https://vllm.example/v1",
+        }
+    )
+    captured_payloads: list[dict[str, Any]] = []
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict[str, Any], timeout: int):  # noqa: ANN001
+        del method, url, headers, timeout
+        captured_payloads.append(dict(json))
+        return _StreamContext(
+            status_code=200,
+            lines=[
+                'data: {"id":"chatcmpl-vllm-usage","choices":[{"index":0,'
+                '"delta":{"content":"ok"},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-vllm-usage","choices":[],"usage":'
+                '{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}',
+                "data: [DONE]",
+            ],
+        )
+
+    test_app.state.http_client.stream = stream
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured_payloads[-1]["stream_options"] == {"include_usage": True}
+    assert '"choices":[]' not in response.text
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_default_usage_collection_does_not_expose_usage_chunk(client, test_app):
     recorder = _SpendRecorder()
     test_app.state.spend_tracking_service = recorder
@@ -2127,9 +2169,7 @@ async def test_chat_stream_forwards_usage_chunk_when_client_requested_usage(clie
 
 
 @pytest.mark.asyncio
-async def test_chat_stream_billing_estimates_missing_usage_and_applies_tier_pricing(
-    client, test_app
-):
+async def test_chat_stream_billing_estimates_reasoning_and_applies_tier_pricing(client, test_app):
     recorder = _SpendRecorder()
     test_app.state.spend_tracking_service = recorder
     test_app.state.tier_policy_service = _TierPricingService(
@@ -2144,7 +2184,7 @@ async def test_chat_stream_billing_estimates_missing_usage_and_applies_tier_pric
             status_code=200,
             lines=[
                 'data: {"id":"chatcmpl-est","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
-                'data: {"id":"chatcmpl-est","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"done"},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-est","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}',
                 "data: [DONE]",
             ],
         )
@@ -2162,19 +2202,20 @@ async def test_chat_stream_billing_estimates_missing_usage_and_applies_tier_pric
     assert response.status_code == 200
     deployment_id = str(response.headers["x-deltallm-route-deployment"])
     usage = await test_app.state.router_state_backend.get_usage(deployment_id)
-    assert usage == {"rpm": 1, "tpm": 4}
+    assert usage == {"rpm": 1, "tpm": 5}
     await asyncio.sleep(0.05)
     assert recorder.events[-1]["usage"] == {
         "prompt_tokens": 3,
-        "completion_tokens": 1,
-        "total_tokens": 4,
+        "completion_tokens": 2,
+        "total_tokens": 5,
     }
-    assert recorder.events[-1]["cost"] == 22.0
-    assert recorder.events[-1]["metadata"]["provider_cost"] == 5.0
+    assert recorder.events[-1]["cost"] == 32.0
+    assert recorder.events[-1]["metadata"]["provider_cost"] == 7.0
     assert recorder.events[-1]["metadata"]["pricing_source"] == "tier"
     assert recorder.events[-1]["metadata"]["customer_tier_key"] == "enterprise"
     assert recorder.events[-1]["metadata"]["usage_source"] == "estimated"
     assert recorder.events[-1]["metadata"]["usage_estimated"] is True
+    assert recorder.events[-1]["metadata"]["usage_estimate_incomplete"] is False
 
 
 @pytest.mark.asyncio
@@ -2292,6 +2333,243 @@ async def test_stream_retries_before_first_token_with_failover(client, test_app)
     assert calls["count"] == 2
     assert response.headers["x-deltallm-route-deployment"] == "gpt-4o-mini-fallback"
     assert response.headers["x-deltallm-route-fallback-used"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_stream_reasoning_commits_without_cooling_or_trying_fallback(client, test_app):
+    primary, fallback = _configure_chat_fallback(test_app)
+    test_app.state.cooldown_manager.allowed_fails = 0
+    attempted_auths: list[str | None] = []
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
+        del method, url, json, timeout
+        attempted_auths.append(headers.get("Authorization"))
+        return _StreamContext(
+            status_code=200,
+            lines=[
+                'data: {"id":"chatcmpl-reasoning","choices":[{"index":0,'
+                '"delta":{"role":"assistant"},"finish_reason":null}]}',
+                *[
+                    "data: "
+                    + jsonlib.dumps(
+                        {
+                            "id": "chatcmpl-reasoning",
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"reasoning_content": f"step-{index}"},
+                                    "finish_reason": None,
+                                }
+                            ],
+                        },
+                        separators=(",", ":"),
+                    )
+                    for index in range(33)
+                ],
+                'data: {"id":"chatcmpl-reasoning","choices":[{"index":0,'
+                '"delta":{"content":"answer"},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-reasoning","choices":[{"index":0,'
+                '"delta":{},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ],
+        )
+
+    test_app.state.http_client.stream = stream
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert '"reasoning_content":"step-32"' in response.text
+    assert '"content":"answer"' in response.text
+    assert "data: [DONE]" in response.text
+    assert attempted_auths == ["Bearer provider-key"]
+    assert response.headers["x-deltallm-route-deployment"] == primary.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "false"
+    for deployment in (primary, fallback):
+        health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+        assert int(health.get("consecutive_failures", 0) or 0) == 0
+        assert health.get("last_error") is None
+
+
+@pytest.mark.asyncio
+async def test_stream_does_not_fail_over_after_reasoning_output(client, test_app):
+    primary, fallback = _configure_chat_fallback(test_app)
+    test_app.state.cooldown_manager.allowed_fails = 0
+    attempted_auths: list[str | None] = []
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
+        del method, url, json, timeout
+        attempted_auths.append(headers.get("Authorization"))
+        return _StreamContext(
+            status_code=200,
+            lines=[
+                'data: {"id":"chatcmpl-reasoning-partial","choices":[{"index":0,'
+                '"delta":{"reasoning_content":"partial thought"},"finish_reason":null}]}'
+            ],
+            line_error=httpx.ReadError("stream broke after reasoning output"),
+        )
+
+    test_app.state.http_client.stream = stream
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "partial thought" in response.text
+    assert "data: [DONE]" not in response.text
+    assert attempted_auths == ["Bearer provider-key"]
+    primary_health = await test_app.state.router_state_backend.get_health(primary.deployment_id)
+    fallback_health = await test_app.state.router_state_backend.get_health(fallback.deployment_id)
+    assert primary_health.get("last_error") == "Provider unavailable"
+    assert fallback_health.get("last_error") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("unknown_frame_count", "include_terminal"),
+    [(33, False), (2, True)],
+)
+async def test_stream_precommit_unknown_output_fails_over_without_cooldown(
+    client,
+    test_app,
+    unknown_frame_count: int,
+    include_terminal: bool,
+):
+    primary, fallback = _configure_chat_fallback(test_app)
+    test_app.state.cooldown_manager.allowed_fails = 0
+    spend = _SpendRecorder()
+    audit = _RecordingAuditService()
+    test_app.state.spend_tracking_service = spend
+    test_app.state.audit_service = audit
+    attempted_auths: list[str | None] = []
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
+        del method, url, json, timeout
+        authorization = headers.get("Authorization")
+        attempted_auths.append(authorization)
+        if authorization == "Bearer provider-key-fallback":
+            return _StreamContext(
+                status_code=200,
+                lines=[
+                    'data: {"id":"chatcmpl-fallback","object":"chat.completion.chunk",'
+                    '"choices":[{"index":0,"delta":{"content":"fallback ok"},'
+                    '"finish_reason":null}]}',
+                    'data: {"id":"chatcmpl-fallback","object":"chat.completion.chunk",'
+                    '"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+                    "data: [DONE]",
+                ],
+            )
+        lines = [
+            "data: "
+            + jsonlib.dumps(
+                {
+                    "id": "chatcmpl-future-output",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"future_reasoning_field": f"step-{index}"},
+                            "finish_reason": None,
+                        }
+                    ],
+                },
+                separators=(",", ":"),
+            )
+            for index in range(unknown_frame_count)
+        ]
+        if include_terminal:
+            lines.append("data: [DONE]")
+        return _StreamContext(status_code=200, lines=lines)
+
+    test_app.state.http_client.stream = stream
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert '"content":"fallback ok"' in response.text
+    assert attempted_auths == ["Bearer provider-key", "Bearer provider-key-fallback"]
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    assert response.headers["x-deltallm-route-fallback-used"] == "true"
+    for deployment in (primary, fallback):
+        health = await test_app.state.router_state_backend.get_health(deployment.deployment_id)
+        assert int(health.get("consecutive_failures", 0) or 0) == 0
+        assert health.get("last_error") is None
+
+    await asyncio.wait_for(spend.wait_for_events(1), timeout=0.5)
+    assert spend.events[-1]["metadata"]["stream"] is True
+    chat_audits = [
+        event
+        for event, _, _ in audit.records
+        if getattr(event, "action", None) == "CHAT_COMPLETION_REQUEST"
+    ]
+    assert chat_audits[-1].metadata["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_stream_precommit_role_only_limit_cools_primary_and_fails_over(client, test_app):
+    primary, fallback = _configure_chat_fallback(test_app)
+    test_app.state.cooldown_manager.allowed_fails = 0
+    attempted_auths: list[str | None] = []
+
+    def stream(method: str, url: str, headers: dict[str, str], json: dict, timeout: int):  # noqa: ANN001
+        del method, url, json, timeout
+        authorization = headers.get("Authorization")
+        attempted_auths.append(authorization)
+        if authorization == "Bearer provider-key-fallback":
+            return _StreamContext(
+                status_code=200,
+                lines=[
+                    'data: {"id":"chatcmpl-fallback","choices":[{"index":0,'
+                    '"delta":{"content":"ok"},"finish_reason":null}]}',
+                    'data: {"id":"chatcmpl-fallback","choices":[{"index":0,'
+                    '"delta":{},"finish_reason":"stop"}]}',
+                    "data: [DONE]",
+                ],
+            )
+        return _StreamContext(
+            status_code=200,
+            lines=[
+                'data: {"id":"chatcmpl-role-only","choices":[{"index":0,'
+                '"delta":{"role":"assistant"},"finish_reason":null}]}'
+                for _ in range(33)
+            ],
+        )
+
+    test_app.state.http_client.stream = stream
+    response = await client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {test_app.state._test_key}"},
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert attempted_auths == ["Bearer provider-key", "Bearer provider-key-fallback"]
+    assert response.headers["x-deltallm-route-deployment"] == fallback.deployment_id
+    primary_health = await test_app.state.router_state_backend.get_health(primary.deployment_id)
+    assert primary_health["last_error"] == "Provider returned an invalid response"
 
 
 @pytest.mark.asyncio

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -16,6 +16,7 @@ from src.models.errors import (
     InvalidRequestError,
     NO_HEALTHY_DEPLOYMENTS_CODE,
     RateLimitError,
+    RoutingFailureAction,
     ServiceUnavailableError,
     TimeoutError,
     parse_retry_after_header,
@@ -1706,6 +1707,68 @@ async def test_failover_local_execution_error_does_not_affect_deployment_health_
 
 
 @pytest.mark.asyncio
+async def test_health_neutral_next_deployment_action_skips_retry_and_preserves_health():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback = _deployment("dep-b")
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=3, retry_after=0, timeout=1.0),
+        candidate_planner=_planner(state, {"group-a": [primary, fallback]}),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            raise invalid_provider_response_error(
+                affects_deployment_health=False,
+                routing_failure_action=RoutingFailureAction.NEXT_DEPLOYMENT,
+            )
+        return "ok"
+
+    result = await manager.execute_with_failover(primary, "group-a", run)
+
+    assert result == "ok"
+    assert attempts == [primary.deployment_id, fallback.deployment_id]
+    for deployment in (primary, fallback):
+        health = await state.get_health(deployment.deployment_id)
+        assert int(health.get("consecutive_failures", 0) or 0) == 0
+        assert health.get("last_error") is None
+
+
+@pytest.mark.asyncio
+async def test_health_neutral_next_deployment_action_exhausts_each_candidate_once():
+    state = RedisStateBackend(redis=None)
+    deployments = [_deployment(f"dep-{suffix}") for suffix in ("a", "b", "c")]
+    manager = FailoverManager(
+        config=FallbackConfig(num_retries=3, retry_after=0, timeout=1.0),
+        candidate_planner=_planner(state, {"group-a": deployments}),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        raise invalid_provider_response_error(
+            affects_deployment_health=False,
+            routing_failure_action=RoutingFailureAction.NEXT_DEPLOYMENT,
+        )
+
+    with pytest.raises(ServiceUnavailableError) as exc_info:
+        await manager.execute_with_failover(deployments[0], "group-a", run)
+
+    assert exc_info.value.routing_failure_action is RoutingFailureAction.NEXT_DEPLOYMENT
+    assert attempts == [deployment.deployment_id for deployment in deployments]
+    for deployment in deployments:
+        health = await state.get_health(deployment.deployment_id)
+        assert int(health.get("consecutive_failures", 0) or 0) == 0
+        assert health.get("last_error") is None
+
+
+@pytest.mark.asyncio
 async def test_failover_classified_fallback_local_error_does_not_cool_down_or_try_next_fallback():
     state = RedisStateBackend(redis=None)
     primary = _deployment("dep-a")
@@ -1746,6 +1809,55 @@ async def test_failover_classified_fallback_local_error_does_not_cool_down_or_tr
     assert not await state.is_cooled_down(primary.deployment_id)
     assert not await state.is_cooled_down(fallback_a.deployment_id)
     assert not await state.is_cooled_down(fallback_b.deployment_id)
+
+
+@pytest.mark.asyncio
+async def test_classified_fallback_honors_health_neutral_next_deployment_action():
+    state = RedisStateBackend(redis=None)
+    primary = _deployment("dep-a")
+    fallback_a = _deployment("dep-b")
+    fallback_b = _deployment("dep-c")
+    manager = FailoverManager(
+        config=FallbackConfig(
+            num_retries=0,
+            timeout=1.0,
+            context_window_fallbacks={"group-a": ["ctx-fallbacks"]},
+        ),
+        candidate_planner=_planner(
+            state,
+            {"group-a": [primary], "ctx-fallbacks": [fallback_a, fallback_b]},
+        ),
+        state_backend=state,
+        cooldown_manager=CooldownManager(state, allowed_fails=0),
+    )
+    attempts: list[str] = []
+
+    async def run(deployment: Deployment) -> str:
+        attempts.append(deployment.deployment_id)
+        if deployment is primary:
+            raise InvalidRequestError(
+                message="Provider rejected request",
+                failure_classification=FailureClassification.CONTEXT_WINDOW,
+            )
+        if deployment is fallback_a:
+            raise invalid_provider_response_error(
+                affects_deployment_health=False,
+                routing_failure_action=RoutingFailureAction.NEXT_DEPLOYMENT,
+            )
+        return "ok"
+
+    result = await manager.execute_with_failover(primary, "group-a", run)
+
+    assert result == "ok"
+    assert attempts == [
+        primary.deployment_id,
+        fallback_a.deployment_id,
+        fallback_b.deployment_id,
+    ]
+    for deployment in (primary, fallback_a, fallback_b):
+        health = await state.get_health(deployment.deployment_id)
+        assert int(health.get("consecutive_failures", 0) or 0) == 0
+        assert health.get("last_error") is None
 
 
 @pytest.mark.asyncio
@@ -2162,14 +2274,17 @@ async def test_cooldown_manager_ignores_invalid_request_errors():
 async def test_failover_treats_pool_timeout_as_gateway_capacity_error():
     state = RedisStateBackend(redis=None)
     primary = _deployment("dep-a")
+    fallback = _deployment("dep-b")
     manager = FailoverManager(
         config=FallbackConfig(num_retries=0, timeout=1.0),
-        candidate_planner=_planner(state, {"group-a": [primary]}),
+        candidate_planner=_planner(state, {"group-a": [primary, fallback]}),
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
+    attempts: list[str] = []
 
-    async def run(deployment: Deployment):  # noqa: ARG001, ANN202
+    async def run(deployment: Deployment):  # noqa: ANN202
+        attempts.append(deployment.deployment_id)
         raise httpx.PoolTimeout("connection pool exhausted")
 
     with pytest.raises(GatewayCapacityError) as exc_info:
@@ -2177,6 +2292,7 @@ async def test_failover_treats_pool_timeout_as_gateway_capacity_error():
 
     assert exc_info.value.code == "upstream_pool_timeout"
     assert exc_info.value.affects_deployment_health is False
+    assert attempts == [primary.deployment_id]
     health = await state.get_health(primary.deployment_id)
     assert health.get("healthy", "true") != "false"
     assert int(health.get("consecutive_failures", 0) or 0) == 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
 from src.db.callable_targets import CallableTargetBindingRecord
 from src.db.callable_target_policies import CallableTargetScopePolicyRecord
 from src.db.prompt_registry import PromptResolvedRecord
 from src.cache import CacheKeyBuilder, InMemoryBackend, PrometheusCacheMetrics
+from src.metrics import (
+    ProviderStreamValidationFailureReason,
+    increment_provider_stream_validation_failure,
+)
 from src.services.callable_target_grants import CallableTargetGrantService
 from src.services.prompt_registry import PromptRegistryService
 
@@ -144,6 +150,23 @@ async def test_metrics_endpoint_exposes_router_health_transitions(client, test_a
     text = metrics.text
     assert "deltallm_router_health_transitions_total" in text
     assert 'transition="manual_cooldown"' in text
+
+
+async def test_metrics_endpoint_exposes_bounded_provider_stream_validation_failures(client):
+    increment_provider_stream_validation_failure(
+        reason=ProviderStreamValidationFailureReason.PRECOMMIT_UNKNOWN_OUTPUT_LIMIT
+    )
+
+    metrics = await client.get("/metrics")
+
+    assert metrics.status_code == 200
+    assert "deltallm_provider_stream_validation_failures_total" in metrics.text
+    assert 'reason="precommit_unknown_output_limit"' in metrics.text
+    with pytest.raises(
+        ValueError,
+        match="unsupported provider stream validation failure reason",
+    ):
+        increment_provider_stream_validation_failure(reason="provider-owned-value")
 
 
 async def test_metrics_endpoint_exposes_prompt_registry_metrics(client, test_app):

--- a/tests/test_provider_compat.py
+++ b/tests/test_provider_compat.py
@@ -13,6 +13,7 @@ from src.models.errors import (
     FailureClassification,
     InvalidRequestError,
     RateLimitError,
+    RoutingFailureAction,
     ServiceUnavailableError,
     TimeoutError,
 )
@@ -544,12 +545,205 @@ async def test_openai_compatible_stream_preserves_filter_after_output(adapter_ty
 @pytest.mark.asyncio
 @pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
 @pytest.mark.parametrize(
+    ("reasoning_field", "reasoning_value"),
+    [
+        ("reasoning", "step"),
+        ("reasoning_content", "step"),
+        ("reasoning_details", [{"type": "reasoning.text", "text": "step"}]),
+    ],
+)
+async def test_openai_compatible_stream_treats_reasoning_as_output(
+    adapter_type,
+    reasoning_field: str,
+    reasoning_value: object,
+) -> None:
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        lines = [
+            'data: {"id":"chatcmpl-reasoning","choices":[{"index":0,'
+            '"delta":{"role":"assistant"},"finish_reason":null}]}',
+            *[
+                "data: "
+                + json.dumps(
+                    {
+                        "id": "chatcmpl-reasoning",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    reasoning_field: reasoning_value,
+                                    "provider_extension": {"sequence": index},
+                                },
+                                "finish_reason": None,
+                            }
+                        ],
+                    },
+                    separators=(",", ":"),
+                )
+                for index in range(33)
+            ],
+            'data: {"id":"chatcmpl-reasoning","choices":[{"index":0,'
+            '"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function",'
+            '"function":{"name":"search","arguments":"{}"}}]},"finish_reason":null}]}',
+            'data: {"id":"chatcmpl-reasoning","choices":[{"index":0,'
+            '"delta":{"content":"answer"},"finish_reason":null}]}',
+            'data: {"id":"chatcmpl-reasoning","choices":[{"index":0,'
+            '"delta":{},"finish_reason":"stop"}]}',
+            "data: [DONE]",
+        ]
+
+        out = [line async for line in adapter.translate_stream(_line_stream(lines))]
+
+        assert out == lines
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+async def test_openai_compatible_stream_marks_unknown_output_limit_for_next_deployment(
+    adapter_type,
+    monkeypatch,
+) -> None:
+    validation_reasons: list[str] = []
+
+    def record_validation_failure(*, reason) -> None:  # noqa: ANN001
+        validation_reasons.append(reason.value)
+
+    monkeypatch.setattr(
+        "src.providers.openai_compatible.increment_provider_stream_validation_failure",
+        record_validation_failure,
+    )
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        lines = [
+            "data: "
+            + json.dumps(
+                {
+                    "id": "chatcmpl-future-output",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"future_reasoning_field": f"step-{index}"},
+                            "finish_reason": None,
+                        }
+                    ],
+                },
+                separators=(",", ":"),
+            )
+            for index in range(33)
+        ]
+
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            async for _ in adapter.translate_stream(_line_stream(lines)):
+                pass
+
+        assert str(error_info.value) == INVALID_PROVIDER_RESPONSE_MESSAGE
+        assert error_info.value.affects_deployment_health is False
+        assert error_info.value.failure_classification is FailureClassification.GENERIC
+        assert error_info.value.routing_failure_action is RoutingFailureAction.NEXT_DEPLOYMENT
+        assert validation_reasons == ["precommit_unknown_output_limit"]
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+async def test_openai_compatible_stream_marks_unknown_output_terminal_for_next_deployment(
+    adapter_type,
+    monkeypatch,
+) -> None:
+    validation_reasons: list[str] = []
+
+    def record_validation_failure(*, reason) -> None:  # noqa: ANN001
+        validation_reasons.append(reason.value)
+
+    monkeypatch.setattr(
+        "src.providers.openai_compatible.increment_provider_stream_validation_failure",
+        record_validation_failure,
+    )
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        lines = [
+            'data: {"id":"chatcmpl-future-output","choices":[{"index":0,'
+            '"delta":{"future_reasoning_field":"step"},"finish_reason":null}]}',
+            "data: [DONE]",
+        ]
+
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            async for _ in adapter.translate_stream(_line_stream(lines)):
+                pass
+
+        assert str(error_info.value) == INVALID_PROVIDER_RESPONSE_MESSAGE
+        assert error_info.value.affects_deployment_health is False
+        assert error_info.value.failure_classification is FailureClassification.GENERIC
+        assert error_info.value.routing_failure_action is RoutingFailureAction.NEXT_DEPLOYMENT
+        assert validation_reasons == ["precommit_unknown_output_terminal"]
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+async def test_openai_compatible_stream_marks_role_only_limit_as_provider_failure(
+    adapter_type,
+    monkeypatch,
+) -> None:
+    validation_reasons: list[str] = []
+
+    def record_validation_failure(*, reason) -> None:  # noqa: ANN001
+        validation_reasons.append(reason.value)
+
+    monkeypatch.setattr(
+        "src.providers.openai_compatible.increment_provider_stream_validation_failure",
+        record_validation_failure,
+    )
+    adapter = adapter_type(httpx.AsyncClient())
+    try:
+        lines = [
+            "data: "
+            + json.dumps(
+                {
+                    "id": "chatcmpl-role-only",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant"},
+                            "finish_reason": None,
+                        }
+                    ],
+                },
+                separators=(",", ":"),
+            )
+            for _ in range(33)
+        ]
+
+        with pytest.raises(ServiceUnavailableError) as error_info:
+            async for _ in adapter.translate_stream(_line_stream(lines)):
+                pass
+
+        assert error_info.value.affects_deployment_health is True
+        assert error_info.value.routing_failure_action is None
+        assert validation_reasons == ["precommit_no_output_limit"]
+    finally:
+        await adapter.http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_type", [OpenAIAdapter, AzureOpenAIAdapter])
+@pytest.mark.parametrize(
     "lines",
     [
         ["data: [DONE]"],
         [
             'data: {"id":"chatcmpl-truncated","choices":[{"index":0,'
             '"delta":{"role":"assistant"},"finish_reason":null}]}'
+        ],
+        [
+            'data: {"id":"chatcmpl-empty-reasoning","choices":[{"index":0,'
+            '"delta":{"reasoning_content":"","reasoning_details":[]},'
+            '"finish_reason":null}]}',
+            "data: [DONE]",
         ],
     ],
 )

--- a/tests/test_provider_resolution.py
+++ b/tests/test_provider_resolution.py
@@ -5,6 +5,7 @@ import pytest
 from src.config_runtime.models import ModelHotReloadManager
 from src.providers.resolution import (
     is_openai_compatible_provider,
+    provider_supports_stream_usage_request,
     provider_from_model,
     provider_supports_mode,
     resolve_provider,
@@ -65,6 +66,12 @@ def test_openai_compatible_registry_contains_common_gateways() -> None:
     assert is_openai_compatible_provider("groq") is True
     assert is_openai_compatible_provider("anthropic") is False
     assert is_openai_compatible_provider("elevenlabs") is False
+
+
+def test_stream_usage_request_capability_includes_vllm_but_not_openrouter() -> None:
+    assert provider_supports_stream_usage_request("openai") is True
+    assert provider_supports_stream_usage_request("vllm") is True
+    assert provider_supports_stream_usage_request("openrouter") is False
 
 
 def test_model_validation_rejects_unsupported_provider_mode_combo() -> None:

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -34,6 +34,110 @@ def test_stream_usage_tracker_estimates_when_provider_usage_missing() -> None:
 
     assert resolved.source == "estimated"
     assert resolved.usage == {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4}
+    assert resolved.estimate_incomplete is False
+
+
+def test_stream_usage_tracker_counts_reasoning_only_output() -> None:
+    tracker = StreamUsageTracker()
+
+    tracker.add_line(
+        'data: {"choices":[{"index":0,"delta":{"reasoning_content":"thinking"},'
+        '"finish_reason":null}]}'
+    )
+    resolved = tracker.resolve(_payload())
+
+    assert resolved.usage == {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+    assert resolved.estimate_incomplete is False
+
+
+def test_stream_usage_tracker_does_not_double_count_reasoning_aliases() -> None:
+    tracker = StreamUsageTracker()
+
+    tracker.add_line(
+        'data: {"choices":[{"index":0,"delta":{"reasoning":"abcdefgh",'
+        '"reasoning_content":"abcdefgh","reasoning_details":'
+        '[{"type":"reasoning.text","text":"abcdefgh"}]},"finish_reason":null}]}'
+    )
+    resolved = tracker.resolve(_payload())
+
+    assert resolved.usage == {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+
+def test_stream_usage_tracker_sums_reasoning_when_representation_changes_between_deltas() -> None:
+    tracker = StreamUsageTracker()
+
+    tracker.add_line(
+        'data: {"choices":[{"index":0,"delta":{"reasoning":"abcdefgh"},"finish_reason":null}]}'
+    )
+    tracker.add_line(
+        'data: {"choices":[{"index":0,"delta":{"reasoning_content":"ijklmnop"},'
+        '"finish_reason":null}]}'
+    )
+    tracker.add_line(
+        'data: {"choices":[{"index":0,"delta":{"reasoning_details":'
+        '[{"type":"reasoning.text","text":"qrstuvwx"}]},"finish_reason":null}]}'
+    )
+    resolved = tracker.resolve(_payload())
+
+    assert resolved.usage == {"prompt_tokens": 3, "completion_tokens": 6, "total_tokens": 9}
+
+
+def test_stream_usage_tracker_counts_reasoning_detail_text_and_summary() -> None:
+    tracker = StreamUsageTracker()
+
+    tracker.add_line(
+        'data: {"choices":[{"index":0,"delta":{"reasoning_details":'
+        '[{"type":"reasoning.text","text":"step","summary":"plan"}]},'
+        '"finish_reason":null}]}'
+    )
+    resolved = tracker.resolve(_payload())
+
+    assert resolved.usage == {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+    assert resolved.estimate_incomplete is False
+
+
+def test_stream_usage_tracker_conservatively_counts_encrypted_reasoning() -> None:
+    tracker = StreamUsageTracker()
+
+    tracker.add_line(
+        'data: {"choices":[{"index":0,"delta":{"reasoning_details":'
+        '[{"type":"reasoning.encrypted","data":"opaque"}]},"finish_reason":null}]}'
+    )
+    resolved = tracker.resolve(_payload())
+
+    assert resolved.usage == {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+    assert resolved.estimate_incomplete is True
+    assert resolved.metadata()["usage_estimate_incomplete"] is True
+
+
+def test_stream_usage_tracker_conservatively_counts_structured_reasoning() -> None:
+    tracker = StreamUsageTracker()
+
+    tracker.add_line(
+        'data: {"choices":[{"index":0,"delta":{"reasoning":{"data":"opaque"}},'
+        '"finish_reason":null}]}'
+    )
+    resolved = tracker.resolve(_payload())
+
+    assert resolved.usage == {"prompt_tokens": 3, "completion_tokens": 5, "total_tokens": 8}
+    assert resolved.estimate_incomplete is True
+
+
+def test_stream_usage_tracker_provider_usage_overrides_incomplete_estimate() -> None:
+    tracker = StreamUsageTracker()
+
+    tracker.add_line(
+        'data: {"choices":[{"index":0,"delta":{"reasoning_details":'
+        '[{"type":"reasoning.encrypted","data":"opaque"}]},"finish_reason":null}]}'
+    )
+    tracker.add_line(
+        'data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":7,"total_tokens":10}}'
+    )
+    resolved = tracker.resolve(_payload())
+
+    assert resolved.source == "provider"
+    assert resolved.usage == {"prompt_tokens": 3, "completion_tokens": 7, "total_tokens": 10}
+    assert resolved.estimate_incomplete is False
 
 
 def test_stream_usage_tracker_estimates_when_provider_usage_is_malformed() -> None:


### PR DESCRIPTION
## Summary

- recognize reasoning, reasoning_content, and reasoning_details deltas as committed stream output
- separate request-local routing actions from deployment health so unknown future output fields can try the next deployment without poisoning group health
- validate and classify OpenAI-compatible stream failures with bounded metrics and sanitized errors
- request provider usage from vLLM, estimate missing reasoning usage conservatively, and propagate estimate metadata
- preserve reasoning, refusal, tool-call, and provider-extension frames in versioned streaming cache entries
- correct pre-commit stream failure telemetry and document routing, caching, usage, and observability behavior

## Verification

- uv run pytest tests/test_provider_compat.py tests/test_stream_usage.py tests/test_chat.py tests/test_failover.py tests/test_metrics.py tests/test_provider_resolution.py tests/test_cache.py tests/test_cache_redis_integration.py tests/docs -q
  - 382 passed, 2 skipped because DELTALLM_TEST_REDIS_URL was not configured
- uv run ruff check on all touched Python files
- uv run ruff format --check on all touched Python files
- uv run --extra docs mkdocs build --strict
- git diff --check origin/main

## Known limitation

Streaming cache replay stores a usage-only frame separately and emits it after ordinary frames. Standard final usage chunks are preserved, but a nonstandard provider that emits usage earlier or emits multiple usage-only frames will not retain exact frame order or multiplicity on a cache hit.

Closes #300