### PR TITLE
ci: split tests into parallel dependency lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches: [main, master, feature/org-tiers]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ui-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ui
@@ -25,12 +33,49 @@ jobs:
       - name: Install UI dependencies
         run: npm ci
 
+      - name: Run UI unit tests
+        run: npm run test:unit
+
       - name: Build UI
         run: npm run build
 
-  test:
+  python-tests:
+    name: Python tests (${{ matrix.lane }})
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        lane: [hermetic, app]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Generate Prisma client
+        run: uv run prisma generate --schema=./prisma/schema.prisma
+
+      - name: Run ${{ matrix.lane }} tests
+        env:
+          DELTALLM_MASTER_KEY: sk-test-master-key-for-ci-only-0000
+          DELTALLM_SALT_KEY: ci-salt-key-for-testing-only-do-not-use-in-production
+        run: >-
+          uv run pytest -q -m "${{ matrix.lane }}"
+          --durations=25 --durations-min=0.5
+
+  postgres-tests:
+    name: Python tests (postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:15
@@ -48,7 +93,43 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-      
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Generate Prisma client
+        run: uv run prisma generate --schema=./prisma/schema.prisma
+
+      - name: Apply Prisma migrations
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/deltallm_test
+        run: uv run prisma migrate deploy --schema=./prisma/schema.prisma
+
+      - name: Run PostgreSQL tests
+        env:
+          CI: 'true'
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/deltallm_test
+          DELTALLM_MASTER_KEY: sk-test-master-key-for-ci-only-0000
+          DELTALLM_SALT_KEY: ci-salt-key-for-testing-only-do-not-use-in-production
+        run: >-
+          uv run pytest -q -m postgres
+          --durations=25 --durations-min=0.5
+
+  redis-tests:
+    name: Python tests (redis)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
       redis:
         image: redis:7
         credentials:
@@ -61,7 +142,52 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Generate Prisma client
+        run: uv run prisma generate --schema=./prisma/schema.prisma
+
+      - name: Run Redis tests
+        env:
+          REDIS_URL: redis://localhost:6379/0
+          DELTALLM_TEST_REDIS_URL: redis://localhost:6379/0
+        run: >-
+          uv run pytest -q -m redis -rs
+          --durations=25 --durations-min=0.5
+
+  migration-paths:
+    name: PostgreSQL migration paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:15
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: deltallm_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,7 +202,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Generate Prisma client
         run: uv run prisma generate --schema=./prisma/schema.prisma
@@ -86,35 +212,28 @@ jobs:
           MIGRATION_TEST_ADMIN_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
         run: uv run python scripts/verify_migration_paths.py
 
-      - name: Apply Prisma migrations
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/deltallm_test
-        run: uv run prisma migrate deploy --schema=./prisma/schema.prisma
-
-      - name: Run Redis integration tests
-        env:
-          DELTALLM_TEST_REDIS_URL: redis://localhost:6379/0
-        run: >-
-          uv run pytest -v -rs
-          tests/services/test_tier_fair_share_redis_integration.py
-          tests/test_router_redis_cutover_integration.py
-          tests/test_router_redis_integration.py
-
-      - name: Run tests
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/deltallm_test
-          REDIS_URL: redis://localhost:6379/0
-          DELTALLM_MASTER_KEY: sk-test-master-key-for-ci-only-0000
-          DELTALLM_SALT_KEY: ci-salt-key-for-testing-only-do-not-use-in-production
-        run: uv run pytest -v --ignore=tests/test_provider_presets_smoke.py
-
   helm:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Generate Prisma client
+        run: uv run prisma generate --schema=./prisma/schema.prisma
 
       - name: Validate chart
         run: |
@@ -158,8 +277,36 @@ jobs:
             --set runtime.redis.url="${VALID_REDIS_URL}" \
             > /dev/null
 
+      - name: Run Helm tests
+        run: >-
+          uv run pytest -q -m helm -rs
+          --durations=25 --durations-min=0.5
+
+  test:
+    name: test
+    if: ${{ always() }}
+    needs: [python-tests, postgres-tests, redis-tests, migration-paths, helm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify all Python test lanes passed
+        env:
+          APP_AND_HERMETIC: ${{ needs.python-tests.result }}
+          POSTGRES: ${{ needs.postgres-tests.result }}
+          REDIS: ${{ needs.redis-tests.result }}
+          MIGRATIONS: ${{ needs.migration-paths.result }}
+          HELM: ${{ needs.helm.result }}
+        run: |
+          for result in "$APP_AND_HERMETIC" "$POSTGRES" "$REDIS" "$MIGRATIONS" "$HELM"; do
+            if [ "$result" != success ]; then
+              echo "Required test job finished with status: $result"
+              exit 1
+            fi
+          done
+
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -172,7 +319,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Run linter
         run: uv run ruff check .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,16 +107,54 @@ See [Local Development](README.md#local-development) in the README for more deta
 - Ensure existing tests pass
 - Use `pytest` for running tests
 
+Every Python test belongs to exactly one dependency lane. Pytest assigns `app`
+automatically when a test uses the shared `test_app` fixture and assigns
+`hermetic` when no other lane applies. A test module that opens a real
+infrastructure client must declare its lane for every test in that module,
+normally with a module-level `pytestmark`.
+
+| Lane | What it exercises | Required dependency |
+| --- | --- | --- |
+| `hermetic` | Domain, service, repository-fake, and focused component behavior | None outside the Python process |
+| `app` | The complete in-process FastAPI route graph with fake adapters and stores | None outside the Python process |
+| `postgres` | SQL, constraints, transactions, locking, and Prisma behavior | Migrated PostgreSQL plus the generated Prisma client |
+| `redis` | Lua, cross-client coordination, reconnect, TTL, and outage behavior | Real Redis through `DELTALLM_TEST_REDIS_URL` |
+| `helm` | Chart schema, rendering, and deployment profiles | Helm CLI and built chart dependencies |
+
+The `integration` marker remains an aggregate selector for the `postgres`,
+`redis`, and `helm` lanes. It is not a primary lane.
+
 ```bash
 # Run all tests
 uv run pytest
 
-# Run with verbose output
-uv run pytest -v
+# Show the current test count in each lane
+uv run pytest --collect-only -qq --dependency-lane-report | tail -n 7
+
+# Run one dependency lane
+uv run pytest -q -m hermetic
+uv run pytest -q -m app
+
+# Run PostgreSQL tests after generating the client and migrating the test database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/deltallm_test \
+  uv run pytest -q -m postgres
+
+# Run Redis integration tests
+DELTALLM_TEST_REDIS_URL=redis://localhost:6379/0 \
+  REDIS_URL=redis://localhost:6379/0 \
+  uv run pytest -q -m redis
+
+# Run Helm tests after building chart dependencies
+uv run pytest -q -m helm
 
 # Run specific test file
 uv run pytest tests/test_specific.py
 ```
+
+The collection hook fails when a test declares multiple primary lanes or when
+real Prisma, Redis, or Helm usage is missing its matching explicit marker. This
+keeps lane selection exhaustive and prevents infrastructure tests from silently
+running in a fake-only job.
 
 ## Reporting Issues
 

--- a/RULES.md
+++ b/RULES.md
@@ -358,9 +358,9 @@ Run the smallest focused checks first, then the broader gate required by risk.
 | Change | Required verification |
 | --- | --- |
 | Python behavior | `uv run ruff check <touched paths>`, `uv run ruff format --check <touched paths>`, and focused `uv run pytest ...`; full relevant suite for shared code |
-| Auth, tenant scope, billing, routing, config, cache, streaming | Focused failure/denial/cancellation tests plus the full affected integration suite |
-| Redis atomicity/degradation | Unit tests and real Redis concurrency/TTL/outage/recovery coverage |
-| Database/schema | `uv run prisma generate --schema=./prisma/schema.prisma`, migration on fresh and upgrade DBs, repository/integration tests |
+| Auth, tenant scope, billing, routing, config, cache, streaming | Focused failure/denial/cancellation tests plus the full affected `app` and real-dependency suites; `-m integration` alone does not cover application-route tests |
+| Redis atomicity/degradation | Focused fake-based tests and the affected `redis` suite with real concurrency/TTL/outage/recovery coverage |
+| Database/schema | `uv run prisma generate --schema=./prisma/schema.prisma`, migration on fresh and upgrade DBs, and affected `postgres` tests in addition to repository-fake tests |
 | Hot data-plane dependency path | Before/after SQL/Redis/network call counts, timeout/overload tests, representative query plans, and constant-arrival latency/queue evidence |
 | Hard budget/quota | Multi-replica concurrent reservation, retry/idempotency, crash/reclaim, reconciliation, and fail-mode tests against real PostgreSQL/Redis as applicable |
 | Production capacity/autoscaling | Checked deployment-wide pool/connection/worker arithmetic, Helm/schema rejection tests, and scale/overload evidence using the declared saturation signal |
@@ -368,9 +368,37 @@ Run the smallest focused checks first, then the broader gate required by risk.
 | API shape used by UI | Backend contract test, frontend type/adapter test, and production UI build |
 | Helm/config | Helm lint/template for base, eval, and production values plus relevant `tests/helm` tests |
 | Container/release | Image build, non-root startup, migration-job behavior, health smoke, graceful termination |
+| Test classification, shared fixtures, or CI selection | Classifier regression tests, full collection with `--dependency-lane-report`, exhaustive and mutually exclusive lane selection, affected lane execution, and workflow/gate review |
 | Docs only | Link/path review, command/config parity check, and `git diff --check` |
 
-Additional rules:
+### Test dependency lanes
+
+Every collected Python test MUST belong to exactly one primary dependency lane. [The classifier](tests/dependency_lanes.py) owns selection, [pytest configuration](pyproject.toml) registers markers with strict-marker checking, and [CI](.github/workflows/ci.yml) owns lane execution and dependency setup. Classify by the dependency actually exercised, not by filenames, feature area, or a desired runtime budget.
+
+| Primary lane | Scope | Runtime dependency |
+| --- | --- | --- |
+| `hermetic` | Focused domain/service/component behavior and fake repositories without the shared full-app fixture | No real PostgreSQL, Redis, or Helm dependency; temporary files and local test helpers are permitted |
+| `app` | In-process FastAPI application routes and lifecycle through the shared `test_app` fixture, with fake adapters/stores | No real PostgreSQL or Redis service |
+| `postgres` | Real SQL, Prisma, constraints, transactions, and locking | Migrated test PostgreSQL via `DATABASE_URL` |
+| `redis` | Real Lua, cross-client coordination, TTL, outage, and recovery behavior | Test Redis; set both `REDIS_URL` and `DELTALLM_TEST_REDIS_URL` to that instance |
+| `helm` | Chart schema, rendering, and deployment profiles | Helm CLI and built chart dependencies |
+
+- Without an explicit primary marker, the shared `test_app` fixture (including transitive fixture use) selects `app`; otherwise the fallback is `hermetic`. Explicit markers take precedence, but MUST reflect actual dependencies. Multiple primary lanes on one test are a collection error.
+- Real PostgreSQL, Redis, and Helm tests MUST declare their matching primary marker, normally as module-level `pytestmark = pytest.mark.postgres`, `pytest.mark.redis`, or `pytest.mark.helm`. When the classifier detects infrastructure use in a module, every test in that module must carry the matching marker; split independent fake-only tests into another module when useful.
+- The infrastructure guard recognizes specific client-use patterns in test-module source and the `tests/helm` path; it is not a complete dependency analyzer. Imported helpers or new client construction patterns do not remove the explicit-marker requirement. Extend detection and classifier regression tests when introducing a new infrastructure access pattern.
+- A module using multiple real dependencies must be split where the behaviors are independent. If a behavior genuinely needs multiple services together, deliberately extend the classifier, marker registration, CI provisioning, and documentation together; do not replace necessary real-service coverage with fakes to fit a lane.
+- `integration` is an aggregate selector for `postgres`, `redis`, and `helm`, not a sixth primary lane and not a substitute for `app` coverage.
+- Use `uv run pytest -q -m <lane>` for a lane and `uv run pytest --collect-only -qq --dependency-lane-report` to inspect classification. Counts are derived from collection, not maintained filename lists or fixed totals. Keep classifier behavior covered in `tests/test_dependency_lanes.py`.
+- All lanes currently require installed Python development dependencies and a generated Prisma client for full-suite collection, even when their execution needs no database: `uv sync --frozen --extra dev`, then `uv run prisma generate --schema=./prisma/schema.prisma`. See [CONTRIBUTING.md](CONTRIBUTING.md#testing) and the workflow for service-specific setup and commands. Use isolated test services, never production databases or Redis instances.
+
+### CI coverage and runtime safeguards
+
+- CI MUST execute all five Python lanes. Each job provisions only its required services; migration-path verification remains an independent PostgreSQL job using `scripts/verify_migration_paths.py`, not a replacement for the `postgres` test lane. Preserve fresh, last-release, and shared-feature migration checks and Helm lint/template checks for base, eval, and production values.
+- Preserve the compatibility check named `test`: it runs even when dependencies fail and succeeds only when both Python matrix lanes, PostgreSQL tests, Redis tests, migration verification, and Helm succeed. Failed, skipped, or cancelled dependency jobs MUST NOT produce a successful aggregate. Keep UI unit tests/build and Ruff as separate CI gates; `test` alone does not cover them.
+- Lane or workflow changes MUST preserve exhaustive, non-overlapping Python coverage and the aggregate dependency list. Do not silently drop tests through filename allowlists, ignore lists, marker changes, optional-service skips in provisioned CI jobs, or a condition that bypasses a required gate.
+- Use the per-lane `--durations` output to investigate slow tests and repeated setup. Improve dependency isolation, setup, or parallel execution while preserving behavioral coverage; growing runtime alone is not a reason to delete tests, weaken assertions, or move required regression coverage off pull requests.
+
+### Additional verification rules
 
 - Test discovery SHOULD be automatic and new runners MUST NOT introduce a hard-coded filename list. Until the current UI runner is migrated, register every new UI test in `ui/scripts/run-unit-tests.mjs` in the same change and verify that it actually executes.
 - Distributed correctness uses real PostgreSQL/Redis integration tests in addition to fakes.
@@ -408,7 +436,7 @@ Audit date: **2026-08-16**. Code revision inspected: **`e1e7420cf9be`**. This sn
 - Static bundle/SPA serving is split between `src/ui/routes.py` and `src/main.py`; do not add a third path, and consolidate ownership when this boundary is touched.
 - UI contracts contain substantial `any`; `useApi.refetch` is synchronous/non-awaitable; routes are eagerly bundled. New code adds no `any`, no false `await refetch`, and no initial-bundle growth.
 - At the audit revision, `npm --prefix ui run test:unit` passed 62 tests, `npm --prefix ui run build` produced an initial bundle about 409 KB gzip, and `npm --prefix ui run lint` reported 295 findings. These are dated baselines, not current claims. Changed UI files MUST have zero lint errors; record full-lint and bundle deltas until checked-in automated budgets replace the manual baseline.
-- CI has strong backend/PostgreSQL/Redis/Helm coverage but currently builds the UI without running its tests/lint, and the UI runner lists test files manually. Do not add undiscovered tests; move toward automatic discovery and full UI gates.
+- Testing/CI follow-up (2026-09-07): CI now runs the five dependency lanes and migration-path verification separately, and `ui-build` runs UI unit tests before the production build. Full UI lint is still not a CI gate, and the UI runner still lists test files manually. Preserve the coverage and aggregate-check guarantees in section 18; do not add undiscovered UI tests, and move toward automatic discovery and the remaining UI lint gate. This focused update does not refresh the other audit baselines.
 - Docker/Railway dependency installation can drift from the tested `uv.lock`; container variants are duplicated. Dependency/build changes MUST reduce or at least not widen that gap.
 - Production hardening gaps include root containers, mutable default image tags, per-pod migration startup, incomplete proxy/cookie trust, unauthenticated detailed diagnostics, and high-cardinality identity metrics. Do not copy these defaults into new surfaces.
 - Some persisted credential/config fields are plaintext or insufficiently redacted. New secrets use references/encryption and write-only APIs; touching an old secret path must not expose it further.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,15 @@ guardrails-presidio = [
 ]
 
 [tool.pytest.ini_options]
+addopts = ["--strict-markers"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 markers = [
+  "hermetic: uses only in-process code, fakes, and temporary files",
+  "app: exercises the in-process FastAPI application with fake dependencies",
+  "postgres: requires a real PostgreSQL database and generated Prisma client",
+  "redis: requires a real Redis server",
+  "helm: requires the Helm CLI and chart dependencies",
   "integration: exercises a real local infrastructure dependency when available",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,9 @@ from src.services.key_service import KeyService
 from src.services.limit_counter import LimitCounter
 
 
+pytest_plugins = ("tests.dependency_lanes",)
+
+
 class NoopBudgetService:
     async def check_budgets(self, **kwargs):
         return None

--- a/tests/db/test_model_group_compatibility.py
+++ b/tests/db/test_model_group_compatibility.py
@@ -10,6 +10,9 @@ from src.services.model_deployments import build_model_registry_from_records
 from tests.db.tier_migration_helpers import connect_prisma
 
 
+pytestmark = pytest.mark.postgres
+
+
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_database_and_registry_preserve_implicit_model_group_members() -> None:

--- a/tests/db/test_organization_deletion_integration.py
+++ b/tests/db/test_organization_deletion_integration.py
@@ -27,6 +27,9 @@ from src.services.organization_deletion_worker import (
 from tests.db.tier_migration_helpers import connect_prisma
 
 
+pytestmark = pytest.mark.postgres
+
+
 async def _seed_tenant(
     db,  # noqa: ANN001
     *,

--- a/tests/db/test_organization_deletion_invariant_repairs.py
+++ b/tests/db/test_organization_deletion_invariant_repairs.py
@@ -16,6 +16,9 @@ from src.db.organization_deletion_tenant_cleanup import OrganizationDeletionTena
 from tests.db.tier_migration_helpers import connect_prisma
 
 
+pytestmark = pytest.mark.postgres
+
+
 @pytest.mark.asyncio
 async def test_batch_ownership_is_snapshotted_and_inactive_webhooks_are_suppressed() -> None:
     db = await connect_prisma()

--- a/tests/db/test_route_policy_publication_invariants.py
+++ b/tests/db/test_route_policy_publication_invariants.py
@@ -14,6 +14,9 @@ from src.services.route_group_mutations import RouteGroupMutationService
 from tests.db.tier_migration_helpers import connect_prisma, seed_organization
 
 
+pytestmark = pytest.mark.postgres
+
+
 async def _require_route_policy_schema(db) -> None:  # noqa: ANN001
     rows = await db.query_raw(
         "SELECT to_regclass('public.deltallm_routepolicy')::text AS relation_name"

--- a/tests/db/test_tier_assignment_lifecycle_invariants.py
+++ b/tests/db/test_tier_assignment_lifecycle_invariants.py
@@ -14,6 +14,9 @@ from tests.db.tier_migration_helpers import seed_tier
 from tests.db.tier_migration_helpers import seed_tier_version
 
 
+pytestmark = pytest.mark.postgres
+
+
 def _relative_timestamp(*, days: int) -> datetime:
     return (datetime.now(UTC) + timedelta(days=days)).replace(tzinfo=None)
 

--- a/tests/db/test_tier_assignment_repository_integration.py
+++ b/tests/db/test_tier_assignment_repository_integration.py
@@ -14,6 +14,9 @@ from tests.db.tier_migration_helpers import seed_tier
 from tests.db.tier_migration_helpers import seed_tier_version
 
 
+pytestmark = pytest.mark.postgres
+
+
 @pytest.mark.asyncio
 async def test_upsert_org_assignment_persists_timestamps_and_metadata_against_postgres() -> None:
     db = await connect_prisma()

--- a/tests/db/test_tier_migration_invariants.py
+++ b/tests/db/test_tier_migration_invariants.py
@@ -13,6 +13,9 @@ from tests.db.tier_migration_helpers import seed_tier as _seed_tier
 from tests.db.tier_migration_helpers import seed_tier_version as _seed_tier_version
 
 
+pytestmark = pytest.mark.postgres
+
+
 @pytest.mark.asyncio
 async def test_tier_version_creation_constraints_reject_invalid_rows() -> None:
     db = await _connect_prisma()

--- a/tests/db/test_tier_policy_assignment_invariants.py
+++ b/tests/db/test_tier_policy_assignment_invariants.py
@@ -16,6 +16,9 @@ from tests.db.tier_migration_helpers import seed_tier
 from tests.db.tier_migration_helpers import seed_tier_version
 
 
+pytestmark = pytest.mark.postgres
+
+
 @pytest.mark.asyncio
 async def test_model_policy_capacity_pool_foreign_key_rejects_missing_pool() -> None:
     db = await connect_prisma()

--- a/tests/db/test_tier_revision_provenance_migration.py
+++ b/tests/db/test_tier_revision_provenance_migration.py
@@ -17,6 +17,9 @@ from tests.db.tier_migration_helpers import require_tier_schema
 from tests.db.tier_migration_helpers import seed_tier
 
 
+pytestmark = pytest.mark.postgres
+
+
 MIGRATION = (
     Path(__file__).resolve().parents[2]
     / "prisma/migrations/20260814120000_tier_version_revision_provenance/migration.sql"
@@ -28,7 +31,7 @@ def test_revision_provenance_migration_declares_required_invariants() -> None:
 
     for fragment in (
         'ADD COLUMN "configuration_revision" INTEGER NOT NULL DEFAULT 0',
-        'ADD COLUMN "created_by_kind" TEXT NOT NULL DEFAULT \'unknown\'',
+        "ADD COLUMN \"created_by_kind\" TEXT NOT NULL DEFAULT 'unknown'",
         'CONSTRAINT "deltallm_tierversion_configuration_revision_check"',
         'CONSTRAINT "deltallm_tierversion_created_by_kind_check"',
         'CONSTRAINT "deltallm_tierversion_source_not_self_check"',
@@ -39,7 +42,7 @@ def test_revision_provenance_migration_declares_required_invariants() -> None:
         'CONSTRAINT "deltallm_tiercreationrequest_idempotency_key_check"',
         'CREATE UNIQUE INDEX "deltallm_tiercreationrequest_scope_key"',
         'CREATE UNIQUE INDEX "deltallm_tiercreationrequest_tier_id_key"',
-        'ON DELETE CASCADE',
+        "ON DELETE CASCADE",
     ):
         assert fragment in sql
 
@@ -217,7 +220,7 @@ async def test_revision_provenance_and_creation_request_constraints_against_post
                 second_tier_id,
             )
 
-        await db.execute_raw('DELETE FROM deltallm_tier WHERE tier_id = $1', tier_id)
+        await db.execute_raw("DELETE FROM deltallm_tier WHERE tier_id = $1", tier_id)
         request_rows = await db.query_raw(
             """
             SELECT COUNT(*)::int AS total

--- a/tests/db/test_tier_version_clone_repository.py
+++ b/tests/db/test_tier_version_clone_repository.py
@@ -14,6 +14,9 @@ from tests.db.tier_migration_helpers import require_tier_schema
 from tests.db.tier_migration_helpers import seed_tier
 
 
+pytestmark = pytest.mark.postgres
+
+
 @pytest.mark.asyncio
 async def test_clone_tier_version_copies_pool_and_policy_rows_against_postgres() -> None:
     db = await connect_prisma()

--- a/tests/dependency_lanes.py
+++ b/tests/dependency_lanes.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+
+DEPENDENCY_LANES = ("hermetic", "app", "postgres", "redis", "helm")
+EXTERNAL_DEPENDENCY_LANES = frozenset({"postgres", "redis", "helm"})
+_APP_FIXTURE = "test_app"
+_EXTERNAL_USAGE_PATTERNS = {
+    "postgres": (
+        re.compile(r"\b_?connect_prisma\s*\("),
+        re.compile(r"\bPrisma\s*\(\s*datasource\s*="),
+    ),
+    "redis": (
+        re.compile(r"\bRedis\s*\.\s*from_url\s*\("),
+        re.compile(r"[\"']DELTALLM_TEST_REDIS_URL[\"']"),
+    ),
+}
+
+
+class DependencyLaneError(ValueError):
+    """Raised when a test cannot be assigned to one dependency lane safely."""
+
+
+def classify_dependency_lane(
+    *,
+    marker_names: Iterable[str],
+    fixture_names: Iterable[str],
+    expected_external_lane: str | None,
+) -> str:
+    declared_lanes = set(marker_names).intersection(DEPENDENCY_LANES)
+    if len(declared_lanes) > 1:
+        rendered = ", ".join(sorted(declared_lanes))
+        raise DependencyLaneError(f"multiple dependency lanes declared: {rendered}")
+
+    declared_lane = next(iter(declared_lanes), None)
+    if expected_external_lane is not None:
+        if declared_lane is None:
+            raise DependencyLaneError(
+                f"real {expected_external_lane} usage requires an explicit "
+                f"@pytest.mark.{expected_external_lane} marker"
+            )
+        if declared_lane != expected_external_lane:
+            raise DependencyLaneError(
+                f"real {expected_external_lane} usage is marked as {declared_lane}"
+            )
+
+    if declared_lane is not None:
+        return declared_lane
+    if _APP_FIXTURE in fixture_names:
+        return "app"
+    return "hermetic"
+
+
+def detect_external_dependency(*, path: Path, source: str) -> str | None:
+    detected: set[str] = set()
+    normalized_parts = path.as_posix().split("/")
+    if "tests" in normalized_parts and "helm" in normalized_parts:
+        detected.add("helm")
+    detected.update(
+        lane
+        for lane, patterns in _EXTERNAL_USAGE_PATTERNS.items()
+        if any(pattern.search(source) for pattern in patterns)
+    )
+
+    if len(detected) > 1:
+        rendered = ", ".join(sorted(detected))
+        raise DependencyLaneError(
+            f"test module uses multiple external dependencies ({rendered}); "
+            "split the module or extend the lane model deliberately"
+        )
+    return next(iter(detected), None)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("test dependency lanes")
+    group.addoption(
+        "--dependency-lane-report",
+        action="store_true",
+        help="report collected test counts for each dependency lane",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    del config
+    expected_by_path: dict[Path, str | None] = {}
+    errors: list[str] = []
+
+    for item in items:
+        path = Path(item.path)
+        if path not in expected_by_path:
+            try:
+                expected_by_path[path] = detect_external_dependency(
+                    path=path,
+                    source=path.read_text(encoding="utf-8"),
+                )
+            except (DependencyLaneError, OSError) as exc:
+                errors.append(f"{item.nodeid}: {exc}")
+                continue
+
+        try:
+            lane = classify_dependency_lane(
+                marker_names=(marker.name for marker in item.iter_markers()),
+                fixture_names=item.fixturenames,
+                expected_external_lane=expected_by_path[path],
+            )
+        except DependencyLaneError as exc:
+            errors.append(f"{item.nodeid}: {exc}")
+            continue
+
+        if item.get_closest_marker(lane) is None:
+            item.add_marker(lane)
+        if lane in EXTERNAL_DEPENDENCY_LANES and item.get_closest_marker("integration") is None:
+            item.add_marker("integration")
+
+    if errors:
+        details = "\n".join(f"  - {error}" for error in errors)
+        raise pytest.UsageError(f"invalid test dependency classification:\n{details}")
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    if not session.config.getoption("--dependency-lane-report"):
+        return
+
+    counts = Counter(
+        lane
+        for item in session.items
+        for lane in DEPENDENCY_LANES
+        if item.get_closest_marker(lane) is not None
+    )
+    terminal_reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if terminal_reporter is None:
+        return
+
+    terminal_reporter.write_sep("=", "test dependency lanes")
+    for lane in DEPENDENCY_LANES:
+        terminal_reporter.write_line(f"{lane:>10}: {counts[lane]}")
+    terminal_reporter.write_line(f"{'total':>10}: {sum(counts.values())}")

--- a/tests/helm/test_batch_worker_split.py
+++ b/tests/helm/test_batch_worker_split.py
@@ -9,6 +9,9 @@ import pytest
 import yaml
 
 
+pytestmark = pytest.mark.helm
+
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELM_CHART_DIR = REPO_ROOT / "deploy" / "kubernetes" / "helm"
 HELM = shutil.which("helm")

--- a/tests/helm/test_organization_deletion_settings.py
+++ b/tests/helm/test_organization_deletion_settings.py
@@ -11,6 +11,9 @@ import yaml
 from src.models.organization_lifecycle import ORGANIZATION_LIFECYCLE_PROTOCOL_VERSION
 
 
+pytestmark = pytest.mark.helm
+
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELM_CHART_DIR = REPO_ROOT / "deploy" / "kubernetes" / "helm"
 HELM = shutil.which("helm")

--- a/tests/helm/test_router_state_schema_cutover.py
+++ b/tests/helm/test_router_state_schema_cutover.py
@@ -9,6 +9,9 @@ import pytest
 import yaml
 
 
+pytestmark = pytest.mark.helm
+
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELM_CHART_DIR = REPO_ROOT / "deploy" / "kubernetes" / "helm"
 HELM = shutil.which("helm")

--- a/tests/helm/test_telemetry_settings.py
+++ b/tests/helm/test_telemetry_settings.py
@@ -8,6 +8,9 @@ import pytest
 import yaml
 
 
+pytestmark = pytest.mark.helm
+
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELM_CHART_DIR = REPO_ROOT / "deploy" / "kubernetes" / "helm"
 HELM = shutil.which("helm")

--- a/tests/helm/test_tier_policy_settings.py
+++ b/tests/helm/test_tier_policy_settings.py
@@ -9,6 +9,9 @@ import pytest
 import yaml
 
 
+pytestmark = pytest.mark.helm
+
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELM_CHART_DIR = REPO_ROOT / "deploy" / "kubernetes" / "helm"
 HELM = shutil.which("helm")
@@ -45,7 +48,9 @@ def _render(*args: str) -> list[dict[str, Any]]:
         capture_output=True,
         text=True,
     )
-    return [document for document in yaml.safe_load_all(result.stdout) if isinstance(document, dict)]
+    return [
+        document for document in yaml.safe_load_all(result.stdout) if isinstance(document, dict)
+    ]
 
 
 def _config_maps(documents: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/services/test_tier_fair_share_redis_integration.py
+++ b/tests/services/test_tier_fair_share_redis_integration.py
@@ -19,6 +19,9 @@ from src.services.tier_capacity_fair_share import (
 from src.tier_rate_limit_policy import TierCapacityRateCheck
 
 
+pytestmark = pytest.mark.redis
+
+
 @pytest.mark.skipif(
     not os.getenv("DELTALLM_TEST_REDIS_URL"),
     reason="DELTALLM_TEST_REDIS_URL is required for the Redis integration test",
@@ -148,10 +151,7 @@ async def test_static_hard_cap_telemetry_lua_against_real_redis() -> None:
     heatmap_key = fair_share_limit_hit_heatmap_key()
     rank_key = fair_share_limit_hit_heatmap_rank_key()
     total_key = fair_share_limit_hit_total_key()
-    field = (
-        f"{pool_key}|{callable_key}|{organization_id}|"
-        "tier_pool_model_rpm|integration"
-    )
+    field = f"{pool_key}|{callable_key}|{organization_id}|tier_pool_model_rpm|integration"
 
     try:
         admitted = await limiter.check_rate_limits_and_tier_fair_share_atomic(

--- a/tests/test_audit_policy_redis_integration.py
+++ b/tests/test_audit_policy_redis_integration.py
@@ -11,6 +11,9 @@ from src.services.audit_policy_invalidation import AuditPolicyInvalidation
 from src.telemetry.lifecycle import WorkerState
 
 
+pytestmark = pytest.mark.redis
+
+
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/15")
 
 

--- a/tests/test_batch_db_integration.py
+++ b/tests/test_batch_db_integration.py
@@ -62,6 +62,9 @@ except Exception:  # pragma: no cover
     Prisma = None  # type: ignore[assignment]
 
 
+pytestmark = pytest.mark.postgres
+
+
 DATABASE_URL = os.getenv("DATABASE_URL")
 BATCH_JOB_STATUS_RECONCILIATION_MIGRATION_PATH = (
     Path(__file__).resolve().parents[1]

--- a/tests/test_cache_redis_integration.py
+++ b/tests/test_cache_redis_integration.py
@@ -13,6 +13,9 @@ from src.cache.backends.redis import RedisBackend
 from src.cache.streaming import StreamingCacheHandler
 
 
+pytestmark = pytest.mark.redis
+
+
 @pytest.mark.skipif(
     not os.getenv("DELTALLM_TEST_REDIS_URL"),
     reason="DELTALLM_TEST_REDIS_URL is required for the Redis integration test",

--- a/tests/test_dependency_lanes.py
+++ b/tests/test_dependency_lanes.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pytest
+
+from tests.dependency_lanes import DEPENDENCY_LANES
+from tests.dependency_lanes import DependencyLaneError
+from tests.dependency_lanes import classify_dependency_lane
+from tests.dependency_lanes import detect_external_dependency
+
+
+def test_dependency_lanes_are_stable_and_mutually_exclusive() -> None:
+    assert DEPENDENCY_LANES == ("hermetic", "app", "postgres", "redis", "helm")
+
+
+def test_explicit_external_lane_takes_precedence_over_app_fixture() -> None:
+    assert (
+        classify_dependency_lane(
+            marker_names=["postgres", "asyncio"],
+            fixture_names=["test_app"],
+            expected_external_lane="postgres",
+        )
+        == "postgres"
+    )
+
+
+def test_shared_application_fixture_selects_app_lane() -> None:
+    assert (
+        classify_dependency_lane(
+            marker_names=["asyncio"],
+            fixture_names=["client", "test_app"],
+            expected_external_lane=None,
+        )
+        == "app"
+    )
+
+
+def test_dependency_free_test_defaults_to_hermetic_lane() -> None:
+    assert (
+        classify_dependency_lane(
+            marker_names=[],
+            fixture_names=["tmp_path"],
+            expected_external_lane=None,
+        )
+        == "hermetic"
+    )
+
+
+def test_conflicting_primary_lanes_are_rejected() -> None:
+    with pytest.raises(DependencyLaneError, match="multiple dependency lanes"):
+        classify_dependency_lane(
+            marker_names=["app", "redis"],
+            fixture_names=[],
+            expected_external_lane="redis",
+        )
+
+
+def test_unmarked_external_dependency_is_rejected() -> None:
+    with pytest.raises(DependencyLaneError, match="explicit @pytest.mark.redis"):
+        classify_dependency_lane(
+            marker_names=[],
+            fixture_names=[],
+            expected_external_lane="redis",
+        )
+
+
+@pytest.mark.parametrize(
+    ("path", "source", "expected"),
+    [
+        (Path("tests/helm/test_chart.py"), "", "helm"),
+        (Path("tests/test_cache.py"), "Redis" + ".from_url(url)", "redis"),
+        (Path("tests/test_cache.py"), "Redis" + " . from_url (url)", "redis"),
+        (
+            Path("tests/test_cache.py"),
+            'os.environ["DELTALLM_TEST_' + 'REDIS_URL"]',
+            "redis",
+        ),
+        (Path("tests/test_repository.py"), "await connect_" + "prisma()", "postgres"),
+        (
+            Path("tests/test_repository.py"),
+            "await connect_" + "prisma ()",
+            "postgres",
+        ),
+        (
+            Path("tests/test_repository.py"),
+            "await _connect_" + "prisma()",
+            "postgres",
+        ),
+        (
+            Path("tests/test_repository.py"),
+            "Prisma" + "(datasource={'url': url})",
+            "postgres",
+        ),
+        (Path("tests/test_service.py"), "FakeRedis()", None),
+    ],
+)
+def test_external_dependency_detection(
+    path: Path,
+    source: str,
+    expected: str | None,
+) -> None:
+    assert detect_external_dependency(path=path, source=source) == expected

--- a/tests/test_route_group_redis_integration.py
+++ b/tests/test_route_group_redis_integration.py
@@ -13,6 +13,9 @@ from src.services.governance_invalidation import GovernanceInvalidationService
 from src.services.route_groups import RouteGroupRuntimeCache, load_route_groups
 
 
+pytestmark = pytest.mark.redis
+
+
 class _MutableRouteGroupRepository:
     def __init__(self, groups: list[dict]) -> None:
         self.groups = groups

--- a/tests/test_router_redis_cutover_integration.py
+++ b/tests/test_router_redis_cutover_integration.py
@@ -14,6 +14,9 @@ from scripts.router_redis_schema_cutover import (
 )
 
 
+pytestmark = pytest.mark.redis
+
+
 def test_resolve_redis_url_reads_and_trims_secret_file(tmp_path: Path) -> None:
     redis_url_file = tmp_path / "redis-url"
     redis_url_file.write_text("  redis://localhost:6379/0\n", encoding="utf-8")

--- a/tests/test_router_redis_integration.py
+++ b/tests/test_router_redis_integration.py
@@ -25,6 +25,9 @@ from src.router.health_state import DeploymentHealthRef, HEALTH_STATE_RETENTION_
 from src.router.router import Deployment
 
 
+pytestmark = pytest.mark.redis
+
+
 @pytest.mark.skipif(
     not os.getenv("DELTALLM_TEST_REDIS_URL"),
     reason="DELTALLM_TEST_REDIS_URL is required for the Redis integration test",

--- a/tests/test_telemetry_ingestion_db_integration.py
+++ b/tests/test_telemetry_ingestion_db_integration.py
@@ -27,6 +27,9 @@ except Exception:  # pragma: no cover
     Prisma = None  # type: ignore[assignment]
 
 
+pytestmark = pytest.mark.postgres
+
+
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 

--- a/tests/test_ui_branding_db_integration.py
+++ b/tests/test_ui_branding_db_integration.py
@@ -23,6 +23,9 @@ except Exception:  # pragma: no cover
     Prisma = None  # type: ignore[assignment]
 
 
+pytestmark = pytest.mark.postgres
+
+
 DATABASE_URL = os.getenv("DATABASE_URL")
 _PNG_BYTES = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"


### PR DESCRIPTION
## Summary

The main test job runs Python tests and migration checks sequentially, making CI feedback slow and obscuring which infrastructure each test needs. Split Python tests into parallel `hermetic`, `app`, `postgres`, `redis`, and `helm` lanes, with PostgreSQL migration verification in its own job.

- Classify every collected Python test into one lane; use the shared `test_app` fixture for app tests and explicit markers for real infrastructure. Reject conflicting markers and missing markers for the repository's recognized infrastructure-client patterns.
- Provision PostgreSQL and Redis only in their respective jobs, preserve the existing Helm lint/template checks, and retain the `test` status as an aggregate that fails if any Python lane or migration job fails, is skipped, or is cancelled.
- Run UI unit tests before the UI build, include the previously excluded mocked provider smoke tests, and select Redis tests by marker instead of a filename list.
- Document each lane and local commands in CONTRIBUTING.md, and update RULES.md with the canonical classification, verification, and CI coverage safeguards. Add slow-test reports, frozen dependency installation, job timeouts, and cancellation of superseded runs.

Rebased onto `d628f169` (main, including #306). Current collection: 2,542 hermetic + 1,011 app + 164 PostgreSQL + 16 Redis + 59 Helm = 3,792 Python tests. The newly merged organization-deletion tests are included.

## Validation

After rebasing, using Python 3.11.13:

- `uv sync --python 3.11 --frozen --extra dev`, `uv run prisma generate --schema=./prisma/schema.prisma`, and `uv lock --check`: passed.
- `.venv/bin/pytest --collect-only -qq --dependency-lane-report`: all 3,792 tests classified.
- `.venv/bin/pytest -q -m hermetic -rs` with `CI=true` and no database/Redis variables: 2,541 passed, one local-socket sandbox skip.
- `.venv/bin/pytest -q -m app -rs` with `CI=true` and no database/Redis variables: 1,011 passed in 4m28s.
- `npm --prefix ui run test:unit`: 199 passed.
- `.venv/bin/ruff check .`, Ruff format check on all 27 touched Python files, `git diff --check origin/main...HEAD`, and actionlint 1.7.12: passed.

All checks on implementation commit `b537a5a2` passed: [GitHub CI run 34121235202](https://github.com/deltawi/deltallm/actions/runs/34121235202) includes all five Python lanes, migration verification, UI unit tests/build, lint, and the aggregate `test` check. Documentation CI also passed. These checks include the new PostgreSQL test and migration verifier changes from #306.

The subsequent RULES.md-only update passed link/path review, parity review against the classifier, pytest configuration, workflow, migration verifier, and UI runner, `uv run pytest --collect-only -qq --dependency-lane-report` (3,792 tests, unchanged lane counts), and `git diff --check`. The new commit triggers a separate CI run; the completed run above validates the unchanged implementation.

## Product and documentation impact

- [x] Public API, errors, streaming, authentication, or tenant scope reviewed
- [x] Settings, environment variables, defaults, secrets, and restart/reload behavior reviewed
- [x] Schema, migrations, mixed-version sequencing, and rollback safety reviewed
- [x] Provider capabilities, model metadata, pricing, and credentials reviewed
- [x] Admin UI workflow, permissions, states, and screenshots reviewed
- [x] Deployment, probes, metrics, alerts, security, backup, and runbooks reviewed
- [x] Public docs/nav/links and release/deprecation notes updated, or no-doc-impact reason below
- [x] Generated OpenAPI/config/provider artifacts regenerated and checked when their source changed

This PR changes test selection, CI orchestration, and contributor documentation. It makes no production API, schema, settings, UI, or deployment changes relative to main, and needs no generated public-artifact updates.

The explicitly requested RULES.md governance update is limited to test verification and its dated CI audit note: define lane responsibilities, document the detector's limits, preserve real-service coverage and aggregate-check behavior, and correct the stale UI-unit-test status. Existing behavioral verification requirements are retained; no test or workflow logic changes in that follow-up.

## Rollout and rollback

The existing `test`, `helm`, `lint`, and `ui-build` job names are retained. `test` now aggregates all Python lanes and migration verification; UI and lint remain separate checks. Inspect per-job timings and failures on this PR before merging. Reverting this PR restores the prior workflow and test selection; no deployment or data rollback is needed.
