### PR TITLE
fix: use stable IDs for model group admin URLs

### DIFF
--- a/docs/admin-ui/route-groups.md
+++ b/docs/admin-ui/route-groups.md
@@ -63,6 +63,11 @@ capacity state is read.
 
 ## What the Detail Page Lets You Do
 
+Group names may include slashes, spaces, Unicode, and other reserved URL characters.
+Opening a group uses its stable ID in the page address. The displayed name, call examples,
+and prompt bindings keep the original group key. Saved name-based links redirect to the
+current group address when that name can be recovered from the URL.
+
 - edit the basic group metadata
 - add and remove member deployments
 - see the current usage example for calling the group

--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -184,16 +184,32 @@ For full UI and `curl` examples, see [Admin UI: Named Credentials](../admin-ui/n
 
 ### Route Groups
 
+Use the `route_group_id` UUID returned by list/create responses to address an individual group.
+The key is a runtime model name and may contain `/`, `%`, spaces, Unicode, `?`, or `#`.
+It is preserved exactly in response bodies, prompt bindings, and inference requests.
+To resolve a known key, send it as the URL-encoded `group_key` query parameter to
+`GET /ui/api/route-groups/resolve/by-key`; the response contains `route_group_id` and `group_key`.
+
+The existing `/ui/api/route-groups/{group_key}` routes and their subresources remain
+compatibility endpoints for single-segment names. URL-encoding a slash is insufficient on
+those endpoints because servers decode paths before routing. New integrations should use
+the ID endpoints below. Unknown or deleted IDs return 404 and cannot select a new group
+created with the same key. IDs are never interpreted as keys.
+See the [addressing design](../project/route-group-addressing.md) for compatibility and rollback details.
+
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | `GET` | `/ui/api/route-groups` | List route groups |
-| `GET` | `/ui/api/route-groups/{group_key}` | Get one route group |
+| `GET` | `/ui/api/route-groups/by-id/{route_group_id}` | Get one route group |
 | `POST` | `/ui/api/route-groups` | Create a route group |
-| `PUT` | `/ui/api/route-groups/{group_key}` | Update a route group |
-| `DELETE` | `/ui/api/route-groups/{group_key}` | Delete a route group |
-| `GET` | `/ui/api/route-groups/{group_key}/members` | List group members |
-| `POST` | `/ui/api/route-groups/{group_key}/members` | Add a member |
-| `DELETE` | `/ui/api/route-groups/{group_key}/members/{deployment_id}` | Remove a member |
+| `PUT` | `/ui/api/route-groups/by-id/{route_group_id}` | Update a route group |
+| `DELETE` | `/ui/api/route-groups/by-id/{route_group_id}` | Delete a route group |
+| `GET` | `/ui/api/route-groups/by-id/{route_group_id}/members` | List group members |
+| `POST` | `/ui/api/route-groups/by-id/{route_group_id}/members` | Add a member |
+| `DELETE` | `/ui/api/route-groups/by-id/{route_group_id}/members/{deployment_id}` | Remove a member |
+
+Member `weight` and `priority` accept integers or null. Integer strings remain accepted
+for compatibility. Boolean values are rejected with 400 before any member is changed.
 
 An enabled route group owns a colliding callable key even when it has no enabled members. Deleting
 the group preserves callable-target bindings when a same-named model deployment exists; otherwise
@@ -242,16 +258,16 @@ Access-group binding upserts use this payload:
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| `GET` | `/ui/api/route-groups/{group_key}/policy` | Read current policy |
-| `GET` | `/ui/api/route-groups/{group_key}/policies` | Read policy history |
-| `POST` | `/ui/api/route-groups/{group_key}/policy/validate` | Validate a policy payload |
-| `POST` | `/ui/api/route-groups/{group_key}/policy/draft` | Save a draft policy |
-| `POST` | `/ui/api/route-groups/{group_key}/policy/publish` | Publish a policy |
-| `POST` | `/ui/api/route-groups/{group_key}/policy/rollback` | Roll back to an earlier policy |
-| `POST` | `/ui/api/route-groups/{group_key}/policy/simulate` | Simulate routing behavior |
+| `GET` | `/ui/api/route-groups/by-id/{route_group_id}/policy` | Read current policy |
+| `GET` | `/ui/api/route-groups/by-id/{route_group_id}/policies` | Read policy history |
+| `POST` | `/ui/api/route-groups/by-id/{route_group_id}/policy/validate` | Validate a policy payload |
+| `POST` | `/ui/api/route-groups/by-id/{route_group_id}/policy/draft` | Save a draft policy |
+| `POST` | `/ui/api/route-groups/by-id/{route_group_id}/policy/publish` | Publish a policy |
+| `POST` | `/ui/api/route-groups/by-id/{route_group_id}/policy/rollback` | Roll back to an earlier policy |
+| `POST` | `/ui/api/route-groups/by-id/{route_group_id}/policy/simulate` | Simulate routing behavior |
 | `PUT` | `/ui/api/route-groups/{group_key}/policy` | Deprecated compatibility endpoint for direct publication |
 
-Use `POST /ui/api/route-groups/{group_key}/policy/publish` for new integrations. A non-empty body
+Use `POST /ui/api/route-groups/by-id/{route_group_id}/policy/publish` for new integrations. A non-empty body
 publishes that document; an omitted or empty body publishes the latest draft. The legacy `PUT`
 endpoint always treats its body as an explicit document and returns a `Link` header identifying the
 POST successor.
@@ -307,6 +323,10 @@ does not mutate live routing state. When `policy` is present, it is the complete
 document rather than a patch: omitted `members` inherit the group's enabled membership, omitted
 `retry` and `timeouts` clear published overrides, and omitted `strategy` falls back to the route
 group's configured strategy.
+
+ID-addressed simulation verifies that the requested group still exists in its database
+snapshot. If the group was deleted before that snapshot, it returns 404, including when
+another group has since been created with the same key.
 
 ### Prompt Registry
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1378,6 +1378,7 @@
         "title": "InvitationTokenResponse",
         "type": "object"
       },
+      "JsonValue": {},
       "MCPToolDefinition": {
         "properties": {
           "allowed_tools": {
@@ -3614,6 +3615,82 @@
         "title": "ResponsesRequest",
         "type": "object"
       },
+      "RouteGroupBindingResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "group_key": {
+            "title": "Group Key",
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "route_group_binding_id": {
+            "title": "Route Group Binding Id",
+            "type": "string"
+          },
+          "route_group_id": {
+            "title": "Route Group Id",
+            "type": "string"
+          },
+          "scope_id": {
+            "title": "Scope Id",
+            "type": "string"
+          },
+          "scope_type": {
+            "title": "Scope Type",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "route_group_binding_id",
+          "route_group_id",
+          "group_key",
+          "scope_type",
+          "scope_id",
+          "enabled"
+        ],
+        "title": "RouteGroupBindingResponse",
+        "type": "object"
+      },
       "RouteGroupDeleteResponse": {
         "properties": {
           "deleted": {
@@ -3632,6 +3709,185 @@
           "deleted"
         ],
         "title": "RouteGroupDeleteResponse",
+        "type": "object"
+      },
+      "RouteGroupDetailMember": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "deployment_id": {
+            "title": "Deployment Id",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "healthy": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Healthy"
+          },
+          "membership_id": {
+            "title": "Membership Id",
+            "type": "string"
+          },
+          "mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mode"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Name"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "route_group_id": {
+            "title": "Route Group Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Warnings",
+            "type": "array"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          }
+        },
+        "required": [
+          "membership_id",
+          "route_group_id",
+          "deployment_id",
+          "enabled",
+          "weight",
+          "priority"
+        ],
+        "title": "RouteGroupDetailMember",
+        "type": "object"
+      },
+      "RouteGroupDetailResponse": {
+        "properties": {
+          "bindings": {
+            "items": {
+              "$ref": "#/components/schemas/RouteGroupBindingResponse"
+            },
+            "title": "Bindings",
+            "type": "array"
+          },
+          "group": {
+            "$ref": "#/components/schemas/RouteGroupResponse"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/RouteGroupDetailMember"
+            },
+            "title": "Members",
+            "type": "array"
+          },
+          "policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RoutePolicyResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "group",
+          "members",
+          "policy",
+          "bindings"
+        ],
+        "title": "RouteGroupDetailResponse",
+        "type": "object"
+      },
+      "RouteGroupErrorResponse": {
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "RouteGroupErrorResponse",
         "type": "object"
       },
       "RouteGroupMemberMutationResponse": {
@@ -3715,6 +3971,47 @@
           "priority"
         ],
         "title": "RouteGroupMemberMutationResponse",
+        "type": "object"
+      },
+      "RouteGroupMemberWriteRequest": {
+        "properties": {
+          "deployment_id": {
+            "minLength": 1,
+            "title": "Deployment Id",
+            "type": "string"
+          },
+          "enabled": {
+            "default": true,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          }
+        },
+        "required": [
+          "deployment_id"
+        ],
+        "title": "RouteGroupMemberWriteRequest",
         "type": "object"
       },
       "RouteGroupMutationResponse": {
@@ -3848,6 +4145,328 @@
         "title": "RouteGroupMutationResponse",
         "type": "object"
       },
+      "RouteGroupPolicyHistoryResponse": {
+        "properties": {
+          "group_key": {
+            "title": "Group Key",
+            "type": "string"
+          },
+          "policies": {
+            "items": {
+              "$ref": "#/components/schemas/RoutePolicyResponse"
+            },
+            "title": "Policies",
+            "type": "array"
+          }
+        },
+        "required": [
+          "group_key",
+          "policies"
+        ],
+        "title": "RouteGroupPolicyHistoryResponse",
+        "type": "object"
+      },
+      "RouteGroupPolicyResponse": {
+        "properties": {
+          "group_key": {
+            "title": "Group Key",
+            "type": "string"
+          },
+          "policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RoutePolicyResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "group_key",
+          "policy"
+        ],
+        "title": "RouteGroupPolicyResponse",
+        "type": "object"
+      },
+      "RouteGroupPolicyValidationResponse": {
+        "properties": {
+          "group_key": {
+            "title": "Group Key",
+            "type": "string"
+          },
+          "policy": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "title": "Policy",
+            "type": "object"
+          },
+          "valid": {
+            "title": "Valid",
+            "type": "boolean"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "group_key",
+          "valid",
+          "policy",
+          "warnings"
+        ],
+        "title": "RouteGroupPolicyValidationResponse",
+        "type": "object"
+      },
+      "RouteGroupResolutionResponse": {
+        "properties": {
+          "group_key": {
+            "title": "Group Key",
+            "type": "string"
+          },
+          "route_group_id": {
+            "title": "Route Group Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "route_group_id",
+          "group_key"
+        ],
+        "title": "RouteGroupResolutionResponse",
+        "type": "object"
+      },
+      "RouteGroupResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "default_prompt": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Prompt"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "group_key": {
+            "title": "Group Key",
+            "type": "string"
+          },
+          "member_count": {
+            "title": "Member Count",
+            "type": "integer"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "mode": {
+            "title": "Mode",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "owner_scope_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Scope Id"
+          },
+          "owner_scope_type": {
+            "default": "global",
+            "title": "Owner Scope Type",
+            "type": "string"
+          },
+          "route_group_id": {
+            "title": "Route Group Id",
+            "type": "string"
+          },
+          "routing_strategy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Routing Strategy"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "route_group_id",
+          "group_key",
+          "name",
+          "mode",
+          "routing_strategy",
+          "enabled",
+          "member_count",
+          "metadata"
+        ],
+        "title": "RouteGroupResponse",
+        "type": "object"
+      },
+      "RouteGroupUpdateRequest": {
+        "properties": {
+          "default_prompt": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Prompt"
+          },
+          "enabled": {
+            "default": true,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mode"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "owner_scope_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Scope Id"
+          },
+          "owner_scope_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Scope Type"
+          },
+          "strategy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strategy"
+          }
+        },
+        "title": "RouteGroupUpdateRequest",
+        "type": "object"
+      },
       "RoutePolicyMutationResponse": {
         "properties": {
           "group_key": {
@@ -3958,6 +4577,20 @@
           "published_by"
         ],
         "title": "RoutePolicyResponse",
+        "type": "object"
+      },
+      "RoutePolicyRollbackRequest": {
+        "properties": {
+          "version": {
+            "minimum": 1.0,
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "version"
+        ],
+        "title": "RoutePolicyRollbackRequest",
         "type": "object"
       },
       "RoutePolicyRollbackResponse": {
@@ -25798,6 +26431,2152 @@
           }
         },
         "summary": "Create Route Group",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}": {
+      "delete": {
+        "operationId": "delete_route_group_by_id_ui_api_route_groups_by_id__route_group_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Delete Route Group By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      },
+      "get": {
+        "operationId": "get_route_group_by_id_ui_api_route_groups_by_id__route_group_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get Route Group By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      },
+      "put": {
+        "operationId": "update_route_group_by_id_ui_api_route_groups_by_id__route_group_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RouteGroupUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupMutationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Update Route Group By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}/members": {
+      "get": {
+        "operationId": "list_route_group_members_by_id_ui_api_route_groups_by_id__route_group_id__members_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RouteGroupMemberMutationResponse"
+                  },
+                  "title": "Response List Route Group Members By Id Ui Api Route Groups By Id  Route Group Id  Members Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "List Route Group Members By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      },
+      "post": {
+        "operationId": "upsert_route_group_member_by_id_ui_api_route_groups_by_id__route_group_id__members_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RouteGroupMemberWriteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupMemberMutationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Upsert Route Group Member By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}/members/{deployment_id}": {
+      "delete": {
+        "operationId": "remove_route_group_member_by_id_ui_api_route_groups_by_id__route_group_id__members__deployment_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "deployment_id",
+            "required": true,
+            "schema": {
+              "title": "Deployment Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Remove Route Group Member By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}/policies": {
+      "get": {
+        "operationId": "list_route_group_policies_by_id_ui_api_route_groups_by_id__route_group_id__policies_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupPolicyHistoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "List Route Group Policies By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}/policy": {
+      "get": {
+        "operationId": "get_route_group_policy_by_id_ui_api_route_groups_by_id__route_group_id__policy_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupPolicyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get Route Group Policy By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}/policy/draft": {
+      "post": {
+        "operationId": "save_route_group_policy_draft_by_id_ui_api_route_groups_by_id__route_group_id__policy_draft_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutePolicyMutationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Save Route Group Policy Draft By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}/policy/publish": {
+      "post": {
+        "operationId": "publish_route_group_policy_by_id_ui_api_route_groups_by_id__route_group_id__policy_publish_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "additionalProperties": {
+                      "$ref": "#/components/schemas/JsonValue"
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutePolicyMutationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Publish Route Group Policy By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}/policy/rollback": {
+      "post": {
+        "operationId": "rollback_route_group_policy_by_id_ui_api_route_groups_by_id__route_group_id__policy_rollback_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoutePolicyRollbackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutePolicyRollbackResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Rollback Route Group Policy By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}/policy/simulate": {
+      "post": {
+        "operationId": "simulate_route_group_policy_by_id_ui_api_route_groups_by_id__route_group_id__policy_simulate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RoutePolicySimulationRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutePolicySimulationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Simulate Route Group Policy By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/by-id/{route_group_id}/policy/validate": {
+      "post": {
+        "operationId": "validate_route_group_policy_by_id_ui_api_route_groups_by_id__route_group_id__policy_validate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "route_group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Route Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupPolicyValidationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Validate Route Group Policy By Id",
+        "tags": [
+          "Admin Route Groups"
+        ]
+      }
+    },
+    "/ui/api/route-groups/resolve/by-key": {
+      "get": {
+        "operationId": "resolve_route_group_key_ui_api_route_groups_resolve_by_key_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "group_key",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Group Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Organization Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Team Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Master-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Master-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupResolutionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGroupErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Resolve Route Group Key",
         "tags": [
           "Admin Route Groups"
         ]

--- a/docs/project/route-group-addressing.md
+++ b/docs/project/route-group-addressing.md
@@ -1,0 +1,103 @@
+# Route-group admin addressing
+
+Issue: [#308](https://github.com/deltawi/deltallm/issues/308).
+
+## Decision
+
+Use the existing PostgreSQL `route_group_id` UUID for canonical admin addresses:
+`/route-groups/by-id/{route_group_id}` in the UI and
+`/ui/api/route-groups/by-id/{route_group_id}` in the API.
+Keep `group_key` as the exact runtime model name, prompt scope, and audit identity.
+No database schema, key normalization, inference contract, or routing-policy change is required.
+
+Encoding a key with `encodeURIComponent` only fixes the browser route. ASGI servers decode
+`%2F` before matching backend path parameters. A greedy `{group_key:path}` would also
+make names such as `team/policy` ambiguous with policy subresources. Replacing slashes
+or slugifying names would lose identity. UUID addresses avoid both problems.
+
+## Ownership and failure behavior
+
+The existing admin permission dependencies run before ID resolution. The resolver makes
+one additional indexed PostgreSQL group lookup on each ID-addressed control-plane request;
+it introduces no Redis state or inference-path calls. It returns 404 for an unknown ID,
+including an ID belonging to a deleted group, and preserves 401/403/503 failure meanings.
+The UI decodes a legacy pathname once, resolves its name through a query parameter,
+and replaces browser history with the canonical address.
+
+A request-local repository clone pins the resolved primary key. Transactions retain this
+identity, and subsequent reads, row locks, and writes use it. Deleting a group and recreating
+its key cannot redirect an in-flight ID request to the replacement. Simulation lookups
+for other fallback keys retain their independent identities. The shared repository is
+never modified with request state.
+
+Simulation checks the pinned UUID and key in the same SQL snapshot that supplies its
+runtime groups, before the snapshot is converted to runtime keys. A missing identity
+becomes the existing simulation 404. This adds no database round trips or locks and
+retains other groups for fallback resolution. Unpinned runtime reloads and legacy
+key-addressed simulation retain their existing behavior.
+
+The new HTTP adapters reuse the established route-group operations, validators,
+publication service, transactional deletion service, audit, and refresh behavior.
+The existing endpoint module still contains orchestration; this is a bounded compatibility
+seam owned by the route-group admin API. Extract those shared operations into application
+services when that orchestration is next changed, then make both routers depend on the
+same extracted owner. Duplicating policy or performing that broader extraction as part
+of an addressing fix would make behavior preservation harder to review.
+
+ID changes remount the detail page and cancel its reads and pending mutation handlers.
+Late completions cannot navigate, toast, or refresh a different group. Duplicate clicks
+are locked synchronously. Aborting a browser request does not undo a server-side mutation
+that has already committed.
+
+## Compatibility and rollout
+
+Collection list/create URLs and existing key-addressed API endpoints remain available.
+The `by-id` segment and a UUID path converter keep UUID-shaped keys distinct from IDs
+and preserve legacy subresources of a group literally named `by-id`.
+The query resolver preserves slashes, literal percent sequences, Unicode, spaces,
+question marks, and fragments as data. Old links that already lost part of a key to
+an unescaped query or fragment cannot recover that missing data.
+
+Deploy the backend and UI together. Rollback requires only the previous application/UI
+artifact; no data rollback is needed. ID bookmarks require the new backend. Keep legacy
+API routes until a separately announced compatibility removal with a supported client
+migration window; no removal is scheduled by this change.
+
+Member weight and priority reject booleans before integer coercion. Integer, integer-string,
+omitted, and null inputs retain their accepted behavior; rejected writes leave members intact.
+
+## Verification
+
+- HTTP regression tests exercise every ID operation, exact keys, legacy compatibility,
+  authentication/permission denial, malformed/unknown IDs, typed OpenAPI responses,
+  deletion before simulation snapshots, and member-number validation without mutation.
+- Real PostgreSQL tests cover transaction identity, fallback independence, and deleting
+  and recreating a key across two connections between lookup and snapshot;
+  existing publication/concurrency invariants remain covered.
+- UI tests exercise exact query encoding, legacy redirects, duplicate deletion clicks,
+  navigation during pending deletion, stale completion, and permission/error recovery.
+- Production build: initial gzip decreases from 379.49 KB to 374.14 KB by loading the
+  group list as a route chunk. Full lint retains its 122-finding baseline; changed files
+  must pass independently.
+
+Validated on 2026-09-07:
+
+- `uv run --no-sync pytest -q tests/test_ui_route_group_addresses.py tests/test_ui_route_group_simulation_identity.py tests/test_ui_route_groups.py tests/db/test_route_policy_repository.py tests/services/test_route_group_mutations.py tests/services/test_route_groups.py tests/services/test_route_group_refresh.py tests/services/test_route_policy_publication.py tests/test_route_policy_validation.py tests/test_routing_runtime_generation.py tests/docs/test_generated_references.py`: 153 passed.
+- `uv run --no-sync pytest -q tests/db/test_route_group_identity.py tests/db/test_route_policy_publication_invariants.py`
+  against a disposable PostgreSQL 16 database with current migrations: 7 passed.
+- `uv run --no-sync python -m scripts.docs.export_openapi --check`: current; the validation
+  fix preserves the existing generated schema.
+- `npm --prefix ui run test:unit`: 201 passed.
+- `npm --prefix ui run build`: passed; detail route chunk 19.81 KB gzip, list chunk 4.25 KB gzip.
+- `npm --prefix ui run lint`: existing 118 errors and 4 warnings, unchanged from baseline.
+  Direct ESLint on all 17 changed UI source/test/runner files: zero findings.
+- `uv run --no-sync ruff check` and `uv run --no-sync ruff format --check` on all changed
+  Python files passed; `git diff --check` passed.
+
+Chromium smoke checks used the production bundle served by the existing FastAPI static
+routes, with mocked API responses (HTTP and SQL behavior are verified separately above).
+At 1280px and 390px: slash/percent/Unicode/reserved names, legacy redirects, direct refresh,
+empty members, loading, 403/404/503 and retry, and settings updates passed. Keyboard Enter
+opened Edit and the delete dialog; focus stayed in the dialog and Escape restored focus.
+List navigation, create redirect, deletion, anonymous root redirect, and login returning
+to a nested group address also passed. Screenshots were visually checked at both sizes.

--- a/docs/project/route-group-addressing.md
+++ b/docs/project/route-group-addressing.md
@@ -1,3 +1,10 @@
+---
+title: Route-group Admin Addressing
+description: Stable group identities, URL compatibility, and rollout behavior for the admin API and UI.
+status: stable
+audience: administrators, contributors
+---
+
 # Route-group admin addressing
 
 Issue: [#308](https://github.com/deltawi/deltallm/issues/308).
@@ -93,6 +100,21 @@ Validated on 2026-09-07:
   Direct ESLint on all 17 changed UI source/test/runner files: zero findings.
 - `uv run --no-sync ruff check` and `uv run --no-sync ruff format --check` on all changed
   Python files passed; `git diff --check` passed.
+
+Additional CI gates validated on 2026-09-08:
+
+- `uv run --no-sync python -m pytest -q -m hermetic --durations=25`: 2542 passed,
+  1290 deselected. Raw HTTP retry-classification tests use deterministic backoff;
+  the dedicated retry-deadline regression retains the real wait.
+- `uv run --no-sync python -m pytest -q --confcutdir=tests/docs tests/docs`: 9 passed.
+- `uv run --no-sync python -m scripts.docs.report_health --check`: 81 public pages,
+  all in navigation, with no missing headings or images.
+- `uv run --no-sync python -m scripts.docs.export_openapi --check`,
+  `uv run --no-sync python -m scripts.docs.generate_config_reference --check`, and
+  `uv run --no-sync python -m scripts.docs.generate_provider_reference --check`: current.
+- `uv run --no-sync python -m mkdocs build --strict --site-dir /private/tmp/issue308-ci-docs-site`
+  and `uv run --no-sync python -m scripts.docs.verify_public_site /private/tmp/issue308-ci-docs-site`:
+  passed, with no internal pages in the public artifact.
 
 Chromium smoke checks used the production bundle served by the existing FastAPI static
 routes, with mocked API responses (HTTP and SQL behavior are verified separately above).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
       - Versions, Compatibility & Deprecation: project/versioning-and-compatibility.md
       - Documentation Governance: project/documentation-governance.md
       - Context-capacity Routing Decision: project/context-routing-design.md
+      - Route-group Admin Addressing: project/route-group-addressing.md
 
 extra:
   social:

--- a/src/api/admin/endpoints/route_groups.py
+++ b/src/api/admin/endpoints/route_groups.py
@@ -30,6 +30,10 @@ from src.api.admin.route_group_contracts import (
     RoutePolicyRollbackResponse,
 )
 from src.api.admin.request_validation import BadRequestValidationRoute
+from src.api.admin.route_group_dependencies import (
+    route_group_context,
+    route_group_repository as _repository_or_503,
+)
 from src.db.prompt_registry import PromptRegistryRepository
 from src.db.route_policy_lifecycle import RoutePolicyStateConflictError
 from src.db.route_groups import RouteGroupRepository
@@ -76,19 +80,9 @@ logger = logging.getLogger(__name__)
 _ALLOWED_BINDING_SCOPE_TYPES = {"api_key", "key", "team", "organization", "org", "user"}
 
 
-def _repository_or_503(request: Request) -> RouteGroupRepository:
-    repository = getattr(request.app.state, "route_group_repository", None)
-    if repository is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Route group repository unavailable",
-        )
-    return repository
-
-
 def _mutation_service(request: Request) -> RouteGroupMutationService:
     service = getattr(request.app.state, "route_group_mutation_service", None)
-    if isinstance(service, RouteGroupMutationService):
+    if isinstance(service, RouteGroupMutationService) and route_group_context(request) is None:
         return service
     return RouteGroupMutationService(
         route_groups=_repository_or_503(request),

--- a/src/api/admin/endpoints/route_groups_by_id.py
+++ b/src/api/admin/endpoints/route_groups_by_id.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import JsonValue
+
+from src.api.admin.endpoints import route_groups as operations
+from src.api.admin.request_validation import BadRequestValidationRoute
+from src.api.admin.route_group_contracts import (
+    RouteGroupDeleteResponse,
+    RouteGroupDetailResponse,
+    RouteGroupErrorResponse,
+    RouteGroupMemberMutationResponse,
+    RouteGroupMemberWriteRequest,
+    RouteGroupMutationResponse,
+    RouteGroupPolicyHistoryResponse,
+    RouteGroupPolicyResponse,
+    RouteGroupPolicyValidationResponse,
+    RouteGroupResolutionResponse,
+    RouteGroupUpdateRequest,
+    RoutePolicyMutationResponse,
+    RoutePolicyRollbackRequest,
+    RoutePolicyRollbackResponse,
+    RoutePolicySimulationRequest,
+    RoutePolicySimulationResponse,
+)
+from src.api.admin.route_group_dependencies import resolve_route_group_id, route_group_repository
+from src.auth.roles import Permission
+from src.middleware.admin import require_admin_permission
+
+router = APIRouter(
+    tags=["Admin Route Groups"],
+    route_class=BadRequestValidationRoute,
+    responses={
+        401: {"description": "Authentication required"},
+        403: {"description": "Permission denied"},
+        404: {"model": RouteGroupErrorResponse},
+        409: {"model": RouteGroupErrorResponse},
+        503: {"model": RouteGroupErrorResponse},
+        400: {"description": "Invalid request"},
+    },
+)
+
+GroupKey = Annotated[str, Depends(resolve_route_group_id)]
+_READ = [Depends(require_admin_permission(Permission.CONFIG_READ))]
+_WRITE = [Depends(require_admin_permission(Permission.CONFIG_UPDATE))]
+_BASE = "/ui/api/route-groups/by-id/{route_group_id:uuid}"
+
+
+@router.get(
+    "/ui/api/route-groups/resolve/by-key",
+    response_model=RouteGroupResolutionResponse,
+    dependencies=_READ,
+)
+async def resolve_route_group_key(
+    request: Request, group_key: Annotated[str, Query(min_length=1)]
+) -> RouteGroupResolutionResponse:
+    group = await route_group_repository(request).get_group(group_key)
+    if group is None:
+        raise HTTPException(status_code=404, detail="Route group not found")
+    return RouteGroupResolutionResponse(
+        route_group_id=group.route_group_id, group_key=group.group_key
+    )
+
+
+# These transport adapters share the established operation owners with the key
+# compatibility routes. The dependency pins repository access to the requested ID.
+
+
+@router.get(_BASE, response_model=RouteGroupDetailResponse, dependencies=_READ)
+async def get_route_group_by_id(request: Request, group_key: GroupKey) -> RouteGroupDetailResponse:
+    return RouteGroupDetailResponse.model_validate(
+        await operations.get_route_group(request, group_key)
+    )
+
+
+@router.put(_BASE, response_model=RouteGroupMutationResponse, dependencies=_WRITE)
+async def update_route_group_by_id(
+    request: Request, group_key: GroupKey, payload: RouteGroupUpdateRequest
+) -> RouteGroupMutationResponse:
+    return RouteGroupMutationResponse.model_validate(
+        await operations.update_route_group(
+            request, group_key, payload.model_dump(exclude_unset=True)
+        )
+    )
+
+
+@router.delete(_BASE, response_model=RouteGroupDeleteResponse, dependencies=_WRITE)
+async def delete_route_group_by_id(
+    request: Request, group_key: GroupKey
+) -> RouteGroupDeleteResponse:
+    return RouteGroupDeleteResponse.model_validate(
+        await operations.delete_route_group(request, group_key)
+    )
+
+
+@router.get(
+    _BASE + "/members", response_model=list[RouteGroupMemberMutationResponse], dependencies=_READ
+)
+async def list_route_group_members_by_id(
+    request: Request, group_key: GroupKey
+) -> list[RouteGroupMemberMutationResponse]:
+    members = await operations.list_route_group_members(request, group_key)
+    return [RouteGroupMemberMutationResponse.model_validate(member) for member in members]
+
+
+@router.post(
+    _BASE + "/members", response_model=RouteGroupMemberMutationResponse, dependencies=_WRITE
+)
+async def upsert_route_group_member_by_id(
+    request: Request, group_key: GroupKey, payload: RouteGroupMemberWriteRequest
+) -> RouteGroupMemberMutationResponse:
+    return RouteGroupMemberMutationResponse.model_validate(
+        await operations.upsert_route_group_member(
+            request, group_key, payload.model_dump(exclude_unset=True)
+        )
+    )
+
+
+@router.delete(
+    _BASE + "/members/{deployment_id:path}",
+    response_model=RouteGroupDeleteResponse,
+    dependencies=_WRITE,
+)
+async def remove_route_group_member_by_id(
+    request: Request, group_key: GroupKey, deployment_id: str
+) -> RouteGroupDeleteResponse:
+    return RouteGroupDeleteResponse.model_validate(
+        await operations.delete_route_group_member(request, group_key, deployment_id)
+    )
+
+
+@router.get(_BASE + "/policy", response_model=RouteGroupPolicyResponse, dependencies=_READ)
+async def get_route_group_policy_by_id(
+    request: Request, group_key: GroupKey
+) -> RouteGroupPolicyResponse:
+    return RouteGroupPolicyResponse.model_validate(
+        await operations.get_route_group_policy(request, group_key)
+    )
+
+
+@router.get(_BASE + "/policies", response_model=RouteGroupPolicyHistoryResponse, dependencies=_READ)
+async def list_route_group_policies_by_id(
+    request: Request, group_key: GroupKey
+) -> RouteGroupPolicyHistoryResponse:
+    return RouteGroupPolicyHistoryResponse.model_validate(
+        await operations.list_route_group_policies(request, group_key)
+    )
+
+
+@router.post(
+    _BASE + "/policy/validate",
+    response_model=RouteGroupPolicyValidationResponse,
+    dependencies=_WRITE,
+)
+async def validate_route_group_policy_by_id(
+    request: Request, group_key: GroupKey, payload: dict[str, JsonValue]
+) -> RouteGroupPolicyValidationResponse:
+    return RouteGroupPolicyValidationResponse.model_validate(
+        await operations.validate_route_group_policy(request, group_key, payload)
+    )
+
+
+@router.post(
+    _BASE + "/policy/draft", response_model=RoutePolicyMutationResponse, dependencies=_WRITE
+)
+async def save_route_group_policy_draft_by_id(
+    request: Request, group_key: GroupKey, payload: dict[str, JsonValue]
+) -> RoutePolicyMutationResponse:
+    return RoutePolicyMutationResponse.model_validate(
+        await operations.save_route_group_policy_draft(request, group_key, payload)
+    )
+
+
+@router.post(
+    _BASE + "/policy/publish", response_model=RoutePolicyMutationResponse, dependencies=_WRITE
+)
+async def publish_route_group_policy_by_id(
+    request: Request, group_key: GroupKey, payload: dict[str, JsonValue] | None = None
+) -> RoutePolicyMutationResponse:
+    return RoutePolicyMutationResponse.model_validate(
+        await operations.publish_route_group_policy_v2(request, group_key, payload)
+    )
+
+
+@router.post(
+    _BASE + "/policy/rollback", response_model=RoutePolicyRollbackResponse, dependencies=_WRITE
+)
+async def rollback_route_group_policy_by_id(
+    request: Request, group_key: GroupKey, payload: RoutePolicyRollbackRequest
+) -> RoutePolicyRollbackResponse:
+    return RoutePolicyRollbackResponse.model_validate(
+        await operations.rollback_route_group_policy(
+            request, group_key, payload.model_dump(exclude_unset=True)
+        )
+    )
+
+
+@router.post(
+    _BASE + "/policy/simulate", response_model=RoutePolicySimulationResponse, dependencies=_READ
+)
+async def simulate_route_group_policy_by_id(
+    request: Request, group_key: GroupKey, payload: RoutePolicySimulationRequest | None = None
+) -> RoutePolicySimulationResponse:
+    return RoutePolicySimulationResponse.model_validate(
+        await operations.simulate_route_group_policy(request, group_key, payload)
+    )

--- a/src/api/admin/route_group_contracts.py
+++ b/src/api/admin/route_group_contracts.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, JsonValue, StrictBool, field_validator
+from pydantic_core import PydanticCustomError
 
 
-class RouteGroupMutationResponse(BaseModel):
+class RouteGroupResponse(BaseModel):
     route_group_id: str
     group_key: str
     name: str | None
@@ -20,6 +21,9 @@ class RouteGroupMutationResponse(BaseModel):
     owner_scope_id: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
+
+
+class RouteGroupMutationResponse(RouteGroupResponse):
     warnings: list[str] = Field(default_factory=list)
 
 
@@ -143,3 +147,86 @@ class RoutePolicySimulationResponse(BaseModel):
     terminal_outcomes: dict[str, int]
     sample_decision: dict[str, Any] | None = None
     sample_attempts: list[RoutePolicySimulationAttempt] = Field(default_factory=list)
+
+
+class RouteGroupDetailMember(RouteGroupMemberMutationResponse):
+    model_name: str | None = None
+    provider: str | None = None
+    mode: str | None = None
+    healthy: bool | None = None
+
+
+class RouteGroupBindingResponse(BaseModel):
+    route_group_binding_id: str
+    route_group_id: str
+    group_key: str
+    scope_type: str
+    scope_id: str
+    enabled: bool
+    metadata: dict[str, JsonValue] | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class RouteGroupDetailResponse(BaseModel):
+    group: RouteGroupResponse
+    members: list[RouteGroupDetailMember]
+    policy: RoutePolicyResponse | None
+    bindings: list[RouteGroupBindingResponse]
+
+
+class RouteGroupResolutionResponse(BaseModel):
+    route_group_id: str
+    group_key: str
+
+
+class RouteGroupPolicyResponse(BaseModel):
+    group_key: str
+    policy: RoutePolicyResponse | None
+
+
+class RouteGroupPolicyHistoryResponse(BaseModel):
+    group_key: str
+    policies: list[RoutePolicyResponse]
+
+
+class RouteGroupPolicyValidationResponse(BaseModel):
+    group_key: str
+    valid: bool
+    policy: dict[str, JsonValue]
+    warnings: list[str]
+
+
+class RouteGroupUpdateRequest(BaseModel):
+    name: str | None = None
+    mode: str | None = None
+    strategy: str | None = None
+    enabled: StrictBool = True
+    metadata: dict[str, JsonValue] | None = None
+    default_prompt: dict[str, str | None] | None = None
+    owner_scope_type: str | None = None
+    owner_scope_id: str | None = None
+
+
+class RouteGroupMemberWriteRequest(BaseModel):
+    deployment_id: str = Field(min_length=1)
+    enabled: StrictBool = True
+    weight: int | None = None
+    priority: int | None = None
+
+    @field_validator("weight", "priority", mode="before")
+    @classmethod
+    def reject_boolean_numbers(cls, value: object) -> object:
+        # Reject before Pydantic turns True/False into 1/0. Retain numeric-string
+        # compatibility with the existing member endpoint.
+        if isinstance(value, bool):
+            raise PydanticCustomError("int_type", "Input should be a valid integer")
+        return value
+
+
+class RoutePolicyRollbackRequest(BaseModel):
+    version: int = Field(ge=1, strict=True)
+
+
+class RouteGroupErrorResponse(BaseModel):
+    detail: str

--- a/src/api/admin/route_group_dependencies.py
+++ b/src/api/admin/route_group_dependencies.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from fastapi import HTTPException, Request
+
+from src.db.route_group_identity import RouteGroupIdentity
+from src.db.route_groups import RouteGroupRepository
+
+
+@dataclass(frozen=True)
+class RouteGroupRequestContext:
+    group_key: str
+    repository: RouteGroupRepository
+
+
+def route_group_context(request: Request) -> RouteGroupRequestContext | None:
+    return getattr(request.state, "route_group_context", None)
+
+
+def route_group_repository(request: Request) -> RouteGroupRepository:
+    context = route_group_context(request)
+    if context is not None:
+        return context.repository
+    repository = getattr(request.app.state, "route_group_repository", None)
+    if repository is None:
+        raise HTTPException(status_code=503, detail="Route group repository unavailable")
+    return repository
+
+
+async def resolve_route_group_id(request: Request, route_group_id: UUID) -> str:
+    repository = route_group_repository(request)
+    group = await repository.get_group_by_id(str(route_group_id))
+    if group is None:
+        raise HTTPException(status_code=404, detail="Route group not found")
+    request.state.route_group_context = RouteGroupRequestContext(
+        group_key=group.group_key,
+        repository=repository.for_identity(
+            RouteGroupIdentity(group.group_key, group.route_group_id)
+        ),
+    )
+    return group.group_key

--- a/src/api/admin/router.py
+++ b/src/api/admin/router.py
@@ -30,6 +30,7 @@ from src.api.admin.endpoints import (
     tiers_router,
     users_router,
 )
+from src.api.admin.endpoints.route_groups_by_id import router as route_groups_by_id_router
 from src.ui.routes import ui_router as legacy_ui_router
 
 admin_router = APIRouter()
@@ -58,6 +59,7 @@ admin_router.include_router(guardrails_router)
 admin_router.include_router(tier_capacity_router)
 admin_router.include_router(tiers_router)
 admin_router.include_router(tier_policy_preview_router)
+admin_router.include_router(route_groups_by_id_router)
 admin_router.include_router(route_groups_router)
 admin_router.include_router(prompt_registry_router)
 admin_router.include_router(config_router)

--- a/src/db/route_group_identity.py
+++ b/src/db/route_group_identity.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+class RouteGroupIdentityNotFoundError(LookupError):
+    """The requested group is absent from a subsequent database snapshot."""
+
+
+@dataclass(frozen=True)
+class RouteGroupIdentity:
+    group_key: str
+    route_group_id: str
+
+
+@dataclass(frozen=True)
+class RouteGroupLookup:
+    column: Literal["group_key", "route_group_id"]
+    value: str
+
+
+class RouteGroupIdentityMixin:
+    _identity: RouteGroupIdentity | None = None
+
+    def _group_lookup(self, group_key: str) -> RouteGroupLookup:
+        # An ID-addressed request must not follow a deleted group's reused key.
+        # Other keys (for example simulation fallbacks) retain their own identity.
+        if self._identity is not None and self._identity.group_key == group_key:
+            return RouteGroupLookup("route_group_id", self._identity.route_group_id)
+        return RouteGroupLookup("group_key", group_key)

--- a/src/db/route_groups.py
+++ b/src/db/route_groups.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from src.db.route_group_identity import (
+    RouteGroupIdentity,
+    RouteGroupIdentityNotFoundError,
+    RouteGroupLookup,
+)
 from src.db.route_policy_lifecycle import (
     RoutePolicyLifecycleMixin,
     RoutePolicyRecord,
@@ -128,7 +133,17 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
         self._use_transactions = use_transactions
 
     def with_db(self, prisma_client: Any) -> RouteGroupRepository:
-        return RouteGroupRepository(prisma_client, use_transactions=False)
+        repository = RouteGroupRepository(prisma_client, use_transactions=False)
+        repository._identity = self._identity
+        return repository
+
+    def for_identity(self, identity: RouteGroupIdentity) -> RouteGroupRepository:
+        repository = RouteGroupRepository(self.prisma, use_transactions=self._use_transactions)
+        repository._identity = identity
+        return repository
+
+    async def get_group_by_id(self, route_group_id: str) -> RouteGroupRecord | None:
+        return await self._get_group(RouteGroupLookup("route_group_id", route_group_id))
 
     def supports_transactions(self) -> bool:
         return bool(
@@ -188,11 +203,14 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
         return [self._to_group_record(row) for row in rows], total
 
     async def get_group(self, group_key: str) -> RouteGroupRecord | None:
+        return await self._get_group(self._group_lookup(group_key))
+
+    async def _get_group(self, lookup: RouteGroupLookup) -> RouteGroupRecord | None:
         if self.prisma is None:
             return None
 
         rows = await self.prisma.query_raw(
-            """
+            f"""
             SELECT
                 g.route_group_id,
                 g.group_key,
@@ -209,10 +227,10 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
                     WHERE m.route_group_id = g.route_group_id
                 ) AS member_count
             FROM deltallm_routegroup g
-            WHERE g.group_key = $1
+            WHERE g.{lookup.column} = $1
             LIMIT 1
             """,
-            group_key,
+            lookup.value,
         )
         if not rows:
             return None
@@ -221,14 +239,15 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
     async def get_default_prompt(self, group_key: str) -> dict[str, str] | None:
         if self.prisma is None:
             return None
+        lookup = self._group_lookup(group_key)
         rows = await self.prisma.query_raw(
-            """
+            f"""
             SELECT metadata
             FROM deltallm_routegroup
-            WHERE group_key = $1
+            WHERE {lookup.column} = $1
             LIMIT 1
             """,
-            group_key,
+            lookup.value,
         )
         if not rows:
             return None
@@ -325,7 +344,7 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
                 enabled = $5,
                 metadata = $6::jsonb,
                 updated_at = NOW()
-            WHERE group_key = $1
+            WHERE route_group_id = $1
             RETURNING route_group_id, group_key, name, mode, routing_strategy, enabled, metadata, created_at, updated_at,
                 (
                     SELECT COUNT(*)::int
@@ -333,7 +352,7 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
                     WHERE m.route_group_id = deltallm_routegroup.route_group_id
                 ) AS member_count
             """,
-            group_key,
+            group_id,
             name,
             mode,
             routing_strategy,
@@ -365,10 +384,10 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
         rows = await self.prisma.query_raw(
             """
             DELETE FROM deltallm_routegroup
-            WHERE group_key = $1
+            WHERE route_group_id = $1
             RETURNING route_group_id
             """,
-            group_key,
+            group_id,
         )
         if not rows:
             return False
@@ -390,8 +409,9 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
         clauses: list[str] = []
         params: list[Any] = []
         if group_key:
-            params.append(group_key)
-            clauses.append(f"g.group_key = ${len(params)}")
+            lookup = self._group_lookup(group_key)
+            params.append(lookup.value)
+            clauses.append(f"g.{lookup.column} = ${len(params)}")
         if scope_type:
             params.append(scope_type)
             clauses.append(f"b.scope_type = ${len(params)}")
@@ -524,15 +544,16 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
         if self.prisma is None:
             return []
 
+        lookup = self._group_lookup(group_key)
         rows = await self.prisma.query_raw(
-            """
+            f"""
             SELECT m.membership_id, m.route_group_id, m.deployment_id, m.enabled, m.weight, m.priority, m.created_at, m.updated_at
             FROM deltallm_routegroupmember m
             JOIN deltallm_routegroup g ON g.route_group_id = m.route_group_id
-            WHERE g.group_key = $1
+            WHERE g.{lookup.column} = $1
             ORDER BY m.created_at ASC, m.deployment_id ASC
             """,
-            group_key,
+            lookup.value,
         )
         return [self._to_member_record(row) for row in rows]
 
@@ -608,11 +629,11 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
             DELETE FROM deltallm_routegroupmember m
             USING deltallm_routegroup g
             WHERE g.route_group_id = m.route_group_id
-              AND g.group_key = $1
+              AND g.route_group_id = $1
               AND m.deployment_id = $2
             RETURNING m.membership_id
             """,
-            group_key,
+            group_id,
             deployment_id,
         )
         if not rows:
@@ -678,6 +699,14 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
             """,
             ROUTING_RUNTIME_STATE_KEY,
         )
+        # Validate against this query's snapshot, before its IDs are discarded.
+        # A separate existence check could race with deletion and key reuse.
+        if self._identity is not None and not any(
+            row.get("route_group_id") == self._identity.route_group_id
+            and row.get("group_key") == self._identity.group_key
+            for row in groups
+        ):
+            raise RouteGroupIdentityNotFoundError("Route group not found")
         if not groups:
             return RouteGroupRuntimeSnapshot(revision=0, groups=[])
 
@@ -816,14 +845,15 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
             ) from exc
 
     async def _resolve_group_id(self, group_key: str) -> str | None:
+        lookup = self._group_lookup(group_key)
         rows = await self.prisma.query_raw(
-            """
+            f"""
             SELECT route_group_id
             FROM deltallm_routegroup
-            WHERE group_key = $1
+            WHERE {lookup.column} = $1
             LIMIT 1
             """,
-            group_key,
+            lookup.value,
         )
         if not rows:
             return None

--- a/src/db/route_policy_lifecycle.py
+++ b/src/db/route_policy_lifecycle.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from src.db.route_group_identity import RouteGroupIdentityMixin
 from src.router.policy_validation import (
     CURRENT_POLICY_SEMANTICS_VERSION,
     PolicyMemberInventoryItem,
@@ -71,24 +72,25 @@ def to_policy_record(row: dict[str, Any]) -> RoutePolicyRecord:
     )
 
 
-class RoutePolicyLifecycleMixin:
+class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
     prisma: Any | None
 
     async def get_published_policy(self, group_key: str) -> RoutePolicyRecord | None:
         if self.prisma is None:
             return None
+        lookup = self._group_lookup(group_key)
         rows = await self.prisma.query_raw(
-            """
+            f"""
             SELECT p.route_policy_id, p.route_group_id, p.version, p.semantics_version, p.status,
                    p.policy_json, p.published_at, p.published_by, p.created_at, p.updated_at
             FROM deltallm_routepolicy p
             JOIN deltallm_routegroup g ON g.route_group_id = p.route_group_id
-            WHERE g.group_key = $1
+            WHERE g.{lookup.column} = $1
               AND p.status = 'published'
             ORDER BY p.version DESC
             LIMIT 1
             """,
-            group_key,
+            lookup.value,
         )
         return to_policy_record(rows[0]) if rows else None
 
@@ -331,28 +333,30 @@ class RoutePolicyLifecycleMixin:
     async def list_policies(self, group_key: str) -> list[RoutePolicyRecord]:
         if self.prisma is None:
             return []
+        lookup = self._group_lookup(group_key)
         rows = await self.prisma.query_raw(
-            """
+            f"""
             SELECT p.route_policy_id, p.route_group_id, p.version, p.semantics_version, p.status,
                    p.policy_json, p.published_at, p.published_by, p.created_at, p.updated_at
             FROM deltallm_routepolicy p
             JOIN deltallm_routegroup g ON g.route_group_id = p.route_group_id
-            WHERE g.group_key = $1
+            WHERE g.{lookup.column} = $1
             ORDER BY p.version DESC
             """,
-            group_key,
+            lookup.value,
         )
         return [to_policy_record(row) for row in rows]
 
     async def _lock_group_id(self, group_key: str) -> str | None:
+        lookup = self._group_lookup(group_key)
         rows = await self.prisma.query_raw(
-            """
+            f"""
             SELECT route_group_id
             FROM deltallm_routegroup
-            WHERE group_key = $1
+            WHERE {lookup.column} = $1
             FOR UPDATE
             """,
-            group_key,
+            lookup.value,
         )
         return str(rows[0]["route_group_id"]) if rows else None
 

--- a/src/services/route_policy_simulation.py
+++ b/src/services/route_policy_simulation.py
@@ -13,6 +13,7 @@ from src.api.admin.route_group_contracts import (
     RoutePolicySimulationSummary,
 )
 from src.db.prompt_registry import PromptRegistryRepository
+from src.db.route_group_identity import RouteGroupIdentityNotFoundError
 from src.db.route_groups import RouteGroupRepository
 from src.models.errors import RateLimitError, ServiceUnavailableError, TimeoutError
 from src.router import (
@@ -133,7 +134,10 @@ class RoutePolicySimulationService:
         if group is None:
             raise RoutePolicySimulationNotFoundError("Route group not found")
 
-        runtime_groups = await self._route_groups.list_runtime_groups()
+        try:
+            runtime_groups = await self._route_groups.list_runtime_groups()
+        except RouteGroupIdentityNotFoundError as exc:
+            raise RoutePolicySimulationNotFoundError("Route group not found") from exc
         membership = await self._policy_membership(group_key)
         warnings: list[str] = []
         if request.policy is not None:

--- a/tests/db/test_route_group_identity.py
+++ b/tests/db/test_route_group_identity.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from src.db.route_group_identity import RouteGroupIdentity, RouteGroupIdentityNotFoundError
+from src.db.route_groups import RouteGroupRepository
+from src.services.route_group_mutations import RouteGroupMutationService
+from tests.db.test_route_policy_publication_invariants import _cleanup_group, _seed_group
+from tests.db.tier_migration_helpers import connect_prisma
+
+pytestmark = pytest.mark.postgres
+
+
+@pytest.mark.asyncio
+async def test_id_lookup_preserves_exact_keys_and_separate_fallback_identity() -> None:
+    db = await connect_prisma()
+    group_id, fallback_id = str(uuid4()), str(uuid4())
+    group_key = f"vendor/%2F?model#مجموعة/{group_id}"
+    fallback_key = group_id
+    try:
+        await _seed_group(db, group_id=group_id, group_key=group_key)
+        await _seed_group(db, group_id=fallback_id, group_key=fallback_key)
+        repository = RouteGroupRepository(db)
+        group = await repository.get_group_by_id(group_id)
+        assert group is not None
+        assert group.group_key == group_key
+        keyed = await repository.get_group(fallback_key)
+        assert keyed is not None and keyed.route_group_id == fallback_id
+        pinned = repository.for_identity(RouteGroupIdentity(group_key, group_id))
+        assert (await pinned.get_group(group_key)).route_group_id == group_id
+        assert (await pinned.get_group(fallback_key)).route_group_id == fallback_id
+        policy = await pinned.publish_policy(group_key, {"strategy": "weighted"})
+        assert policy is not None and policy.route_group_id == group_id
+        snapshot = await pinned.load_runtime_snapshot()
+        assert {group_key, fallback_key} <= {group["key"] for group in snapshot.groups}
+        updated = await pinned.update_group(
+            group_key,
+            name="Display name",
+            mode="chat",
+            routing_strategy="weighted",
+            enabled=True,
+            metadata=None,
+        )
+        assert updated is not None and updated.group_key == group_key
+        assert updated.name == "Display name"
+        assert (await pinned.list_members(group_key))[0].route_group_id == group_id
+    finally:
+        await _cleanup_group(db, group_id)
+        await _cleanup_group(db, fallback_id)
+        await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_deleted_id_cannot_read_or_mutate_a_reused_key() -> None:
+    db = await connect_prisma()
+    writer = await connect_prisma()
+    old_id, new_id = str(uuid4()), str(uuid4())
+    group_key = f"vendor/reused/{old_id}"
+    try:
+        await _seed_group(db, group_id=old_id, group_key=group_key)
+        repository = RouteGroupRepository(db)
+        pinned = repository.for_identity(RouteGroupIdentity(group_key, old_id))
+        # Interleave another connection's committed replacement between the
+        # requested-ID lookup and the simulation's runtime snapshot.
+        original = await pinned.get_group(group_key)
+        assert original is not None and original.route_group_id == old_id
+        assert await RouteGroupRepository(writer).delete_group(group_key)
+        await _seed_group(writer, group_id=new_id, group_key=group_key)
+        with pytest.raises(RouteGroupIdentityNotFoundError, match="Route group not found"):
+            await pinned.load_runtime_snapshot()
+        replacement_snapshot = await repository.for_identity(
+            RouteGroupIdentity(group_key, new_id)
+        ).load_runtime_snapshot()
+        assert group_key in {group["key"] for group in replacement_snapshot.groups}
+        await db.execute_raw(
+            """UPDATE deltallm_routegroup
+               SET metadata = '{"default_prompt":{"template_key":"replacement-prompt"}}'::jsonb
+               WHERE route_group_id = $1""",
+            new_id,
+        )
+        assert await repository.get_default_prompt(group_key) == {
+            "template_key": "replacement-prompt"
+        }
+        published = await repository.publish_policy(group_key, {"strategy": "weighted"})
+        assert published is not None
+        assert await repository.get_group_by_id(old_id) is None
+        assert await pinned.get_group(group_key) is None
+        assert await pinned.get_default_prompt(group_key) is None
+        assert await pinned.list_members(group_key) == []
+        assert await pinned.get_published_policy(group_key) is None
+        assert await pinned.list_policies(group_key) == []
+        assert await pinned.list_bindings(group_key=group_key) == ([], 0)
+        assert (
+            await pinned.update_group(
+                group_key,
+                name="Wrong group",
+                mode="chat",
+                routing_strategy=None,
+                enabled=False,
+                metadata=None,
+            )
+            is None
+        )
+        assert (
+            await pinned.upsert_member(
+                group_key,
+                deployment_id=f"{new_id}-deployment",
+                enabled=True,
+                weight=None,
+                priority=None,
+            )
+            is None
+        )
+        assert not await pinned.remove_member(group_key, f"{new_id}-deployment")
+        assert await pinned.save_draft_policy(group_key, {"strategy": "least-busy"}) is None
+        assert await pinned.publish_policy(group_key, {"strategy": "least-busy"}) is None
+        assert await pinned.publish_latest_draft(group_key) is None
+        assert await pinned.rollback_policy(group_key, target_version=1) is None
+        deletion = await RouteGroupMutationService(
+            route_groups=pinned, callable_bindings=None
+        ).delete_group(group_key)
+        assert not deletion.deleted
+        replacement = await repository.get_group_by_id(new_id)
+        assert replacement is not None and replacement.enabled and replacement.name is None
+        assert len(await repository.list_members(group_key)) == 1
+        assert (
+            await repository.get_published_policy(group_key)
+        ).route_policy_id == published.route_policy_id
+    finally:
+        await _cleanup_group(db, old_id)
+        await _cleanup_group(db, new_id)
+        await writer.disconnect()
+        await db.disconnect()

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -2275,7 +2275,7 @@ async def test_failover_applies_timeout_resolver_to_classified_fallbacks():
     ],
 )
 async def test_failover_retries_transient_raw_http_errors(
-    status_code: int, headers: dict[str, str]
+    status_code: int, headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ):
     state = RedisStateBackend(redis=None)
     primary = _deployment("dep-a")
@@ -2285,6 +2285,9 @@ async def test_failover_retries_transient_raw_http_errors(
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
+    # Test retry classification without random backoff consuming the deadline.
+    # test_total_deadline_bounds_retry_backoff covers the real wait budget.
+    monkeypatch.setattr(manager, "_compute_backoff", lambda *_: 0.0)
     attempts = {"count": 0}
 
     async def run(_deployment: Deployment) -> str:
@@ -2314,7 +2317,9 @@ async def test_failover_retries_transient_raw_http_errors(
 
 
 @pytest.mark.asyncio
-async def test_failover_retries_raw_http_timeout_when_route_policy_targets_timeout():
+async def test_failover_retries_raw_http_timeout_when_route_policy_targets_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+):
     state = RedisStateBackend(redis=None)
     primary = _deployment("dep-a")
     manager = FailoverManager(
@@ -2323,6 +2328,8 @@ async def test_failover_retries_raw_http_timeout_when_route_policy_targets_timeo
         state_backend=state,
         cooldown_manager=CooldownManager(state),
     )
+    # Timeout classification uses the same deterministic retry seam as HTTP errors.
+    monkeypatch.setattr(manager, "_compute_backoff", lambda *_: 0.0)
     attempts = {"count": 0}
 
     async def run(_deployment: Deployment) -> str:

--- a/tests/test_ui_route_group_addresses.py
+++ b/tests/test_ui_route_group_addresses.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from uuid import UUID
+
+from fastapi import FastAPI
+import httpx
+import pytest
+
+from src.db.route_group_identity import RouteGroupIdentity
+from src.db.route_groups import RouteGroupRecord
+from src.models.platform_auth import PlatformAuthContext
+from tests.test_ui_route_groups import _FakeHotReload, _FakeRouteGroupRepository
+
+
+class AddressableGroups(_FakeRouteGroupRepository):
+    async def create_group(self, **payload: object) -> RouteGroupRecord:
+        group = await super().create_group(**payload)
+        group = replace(group, route_group_id=str(UUID(int=self._group_counter)))
+        self.groups[group.group_key] = group
+        return group
+
+    async def get_group_by_id(self, route_group_id: str) -> RouteGroupRecord | None:
+        return next(
+            (group for group in self.groups.values() if group.route_group_id == route_group_id),
+            None,
+        )
+
+    def for_identity(self, identity: RouteGroupIdentity) -> AddressableGroups:
+        # These HTTP tests exercise addressing. SQL identity fencing has real-DB coverage.
+        assert self.groups[identity.group_key].route_group_id == identity.route_group_id
+        return self
+
+
+@pytest.fixture
+def addressable_groups(test_app: FastAPI) -> AddressableGroups:
+    test_app.state.settings.master_key = "mk-test"
+    repository = AddressableGroups()
+    test_app.state.route_group_repository = repository
+    test_app.state.model_hot_reload_manager = _FakeHotReload()
+    return repository
+
+
+HEADERS = {"Authorization": "Bearer mk-test"}
+BASE = "/ui/api/route-groups"
+KEYS = [
+    "support",
+    "vendor/model",
+    "vendor/model/v2",
+    "vendor%2Fmodel",
+    "support / eu",
+    "مجموعة/نموذج",
+    "model?variant#1",
+    "team/members",
+    "team/policy",
+    "by-id",
+    "00000000-0000-0000-0000-000000000001",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("group_key", KEYS)
+async def test_group_id_addresses_all_admin_operations(
+    client: httpx.AsyncClient,
+    addressable_groups: AddressableGroups,
+    group_key: str,
+) -> None:
+    created = await client.post(
+        BASE, headers=HEADERS, json={"group_key": group_key, "mode": "chat"}
+    )
+    assert created.status_code == 200, created.text
+    group_id = created.json()["route_group_id"]
+    path = f"{BASE}/by-id/{group_id}"
+    resolved = await client.get(
+        f"{BASE}/resolve/by-key", headers=HEADERS, params={"group_key": group_key}
+    )
+    assert resolved.json() == {"route_group_id": group_id, "group_key": group_key}
+
+    # A group whose name looks like a subresource must not select another group.
+    if group_key.startswith("team/"):
+        await client.post(BASE, headers=HEADERS, json={"group_key": "team", "mode": "chat"})
+
+    detail = await client.get(path, headers=HEADERS)
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["group"]["group_key"] == group_key
+    assert detail.json()["group"]["route_group_id"] == group_id
+    assert detail.json()["members"] == []
+    updated = await client.put(path, headers=HEADERS, json={"name": "Renamed display"})
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["group_key"] == group_key
+    assert updated.json()["name"] == "Renamed display"
+
+    member = await client.post(
+        path + "/members", headers=HEADERS, json={"deployment_id": "dep-a", "weight": 5}
+    )
+    assert member.status_code == 200, member.text
+    members = await client.get(path + "/members", headers=HEADERS)
+    assert members.status_code == 200
+    assert members.json()[0]["route_group_id"] == group_id
+    for suffix in ["validate", "draft"]:
+        response = await client.post(
+            path + "/policy/" + suffix, headers=HEADERS, json={"strategy": "weighted"}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["group_key"] == group_key
+    published = await client.post(path + "/policy/publish", headers=HEADERS, json={})
+    assert published.status_code == 200, published.text
+    for suffix in ["/policy", "/policies"]:
+        response = await client.get(path + suffix, headers=HEADERS)
+        assert response.status_code == 200, response.text
+        assert response.json()["group_key"] == group_key
+    simulation = await client.post(
+        path + "/policy/simulate", headers=HEADERS, json={"iterations": 1}
+    )
+    assert simulation.status_code == 200, simulation.text
+    assert simulation.json()["group_key"] == group_key
+    rollback = await client.post(path + "/policy/rollback", headers=HEADERS, json={"version": 1})
+    assert rollback.status_code == 200, rollback.text
+    removed = await client.delete(path + "/members/dep-a", headers=HEADERS)
+    assert removed.status_code == 200, removed.text
+    deleted = await client.delete(path, headers=HEADERS)
+    assert deleted.status_code == 200, deleted.text
+    assert group_key not in addressable_groups.groups
+    assert (await client.get(path, headers=HEADERS)).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_legacy_keys_and_ids_do_not_alias(
+    client: httpx.AsyncClient, addressable_groups: AddressableGroups
+) -> None:
+    first = await client.post(BASE, headers=HEADERS, json={"group_key": "vendor/model"})
+    first_id = first.json()["route_group_id"]
+    second = await client.post(BASE, headers=HEADERS, json={"group_key": first_id})
+    third = await client.post(BASE, headers=HEADERS, json={"group_key": "vendor%2Fmodel"})
+    legacy = await client.get(f"{BASE}/{first_id}", headers=HEADERS)
+    assert legacy.json()["group"]["route_group_id"] == second.json()["route_group_id"]
+    canonical = await client.get(f"{BASE}/by-id/{first_id}", headers=HEADERS)
+    assert canonical.json()["group"]["group_key"] == "vendor/model"
+    literal = await client.get(
+        f"{BASE}/resolve/by-key", headers=HEADERS, params={"group_key": "vendor%2Fmodel"}
+    )
+    assert literal.json()["route_group_id"] == third.json()["route_group_id"]
+    await client.post(BASE, headers=HEADERS, json={"group_key": "by-id"})
+    legacy_members = await client.get(f"{BASE}/by-id/members", headers=HEADERS)
+    assert legacy_members.status_code == 200
+    assert legacy_members.json() == []
+    legacy_policy = await client.get(f"{BASE}/by-id/policy", headers=HEADERS)
+    assert legacy_policy.json()["group_key"] == "by-id"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method,suffix,payload",
+    [
+        ("GET", "", None),
+        ("PUT", "", {}),
+        ("DELETE", "", None),
+        ("GET", "/members", None),
+        ("POST", "/members", {"deployment_id": "dep-a"}),
+        ("DELETE", "/members/dep-a", None),
+        ("GET", "/policy", None),
+        ("GET", "/policies", None),
+        ("POST", "/policy/validate", {}),
+        ("POST", "/policy/draft", {}),
+        ("POST", "/policy/publish", {}),
+        ("POST", "/policy/rollback", {"version": 1}),
+        ("POST", "/policy/simulate", {}),
+    ],
+)
+async def test_id_routes_authenticate_before_repository_lookup(
+    client: httpx.AsyncClient,
+    test_app: FastAPI,
+    method: str,
+    suffix: str,
+    payload: dict[str, object] | None,
+) -> None:
+    test_app.state.route_group_repository = None
+    response = await client.request(method, f"{BASE}/by-id/{UUID(int=1)}{suffix}", json=payload)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_scoped_user_cannot_resolve_or_mutate_groups(
+    client: httpx.AsyncClient, test_app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    context = PlatformAuthContext(
+        account_id="reader",
+        email="reader@example.test",
+        role="org_user",
+        organization_memberships=[{"organization_id": "org-a", "role": "org_owner"}],
+    )
+    monkeypatch.setattr("src.middleware.admin.get_platform_auth_context", lambda request: context)
+    test_app.state.route_group_repository = None
+    for method, path in [
+        ("GET", f"{BASE}/resolve/by-key?group_key=vendor%2Fmodel"),
+        ("GET", f"{BASE}/by-id/{UUID(int=1)}"),
+        ("DELETE", f"{BASE}/by-id/{UUID(int=1)}"),
+        ("POST", f"{BASE}/by-id/{UUID(int=1)}/policy/publish"),
+    ]:
+        response = await client.request(method, path)
+        assert response.status_code == 403, response.text
+
+
+@pytest.mark.asyncio
+async def test_id_errors_preserve_failure_meaning(
+    client: httpx.AsyncClient, test_app: FastAPI, addressable_groups: AddressableGroups
+) -> None:
+    assert (await client.get(f"{BASE}/by-id/{UUID(int=99)}", headers=HEADERS)).status_code == 404
+    assert (await client.get(f"{BASE}/by-id/not-a-uuid", headers=HEADERS)).status_code == 404
+    created = await client.post(BASE, headers=HEADERS, json={"group_key": "test/key"})
+    path = f"{BASE}/by-id/{created.json()['route_group_id']}"
+    invalid = await client.post(path + "/policy/simulate", headers=HEADERS, json={"iterations": 0})
+    assert invalid.status_code == 400
+    invalid = await client.put(path, headers=HEADERS, json={"enabled": "false"})
+    assert invalid.status_code == 400
+    test_app.state.route_group_repository = None
+    assert (await client.get(path, headers=HEADERS)).status_code == 503
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["weight", "priority"])
+@pytest.mark.parametrize("value", [True, False])
+async def test_member_numbers_reject_booleans_without_mutating(
+    client: httpx.AsyncClient, addressable_groups: AddressableGroups, field: str, value: bool
+) -> None:
+    created = await client.post(BASE, headers=HEADERS, json={"group_key": "numeric-validation"})
+    group_id = created.json()["route_group_id"]
+    payload = {"deployment_id": "dep-a", "weight": 7, "priority": 3}
+    path = f"{BASE}/by-id/{group_id}/members"
+    seeded = await client.post(path, headers=HEADERS, json=payload)
+    assert seeded.status_code == 200, seeded.text
+    for target in [f"{BASE}/numeric-validation/members", path]:
+        response = await client.post(target, headers=HEADERS, json={**payload, field: value})
+        assert response.status_code == 400, response.text
+    members = await client.get(path, headers=HEADERS)
+    assert members.json()[0]["weight"] == 7
+    assert members.json()[0]["priority"] == 3
+
+
+@pytest.mark.asyncio
+async def test_member_numbers_keep_accepted_numeric_and_null_inputs(
+    client: httpx.AsyncClient, addressable_groups: AddressableGroups
+) -> None:
+    created = await client.post(BASE, headers=HEADERS, json={"group_key": "numeric-compatibility"})
+    path = f"{BASE}/by-id/{created.json()['route_group_id']}/members"
+    for value, expected in [(0, 0), (7, 7), ("7", 7), (None, None)]:
+        response = await client.post(
+            path,
+            headers=HEADERS,
+            json={"deployment_id": "dep-a", "weight": value, "priority": value},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["weight"] == expected
+        assert response.json()["priority"] == expected
+    omitted = await client.post(path, headers=HEADERS, json={"deployment_id": "dep-a"})
+    assert omitted.status_code == 200
+    assert omitted.json()["weight"] is None and omitted.json()["priority"] is None
+
+
+def test_id_route_openapi_contract(test_app: FastAPI) -> None:
+    schema = test_app.openapi()
+    operation = schema["paths"][f"{BASE}/by-id/{{route_group_id}}"]["get"]
+    path_parameters = [param for param in operation["parameters"] if param["in"] == "path"]
+    assert len(path_parameters) == 1
+    assert path_parameters[0]["name"] == "route_group_id"
+    assert path_parameters[0]["schema"]["format"] == "uuid"
+    assert operation["responses"]["200"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/RouteGroupDetailResponse"
+    )
+    assert "404" in operation["responses"]
+    query = schema["paths"][f"{BASE}/resolve/by-key"]["get"]
+    assert any(
+        param["name"] == "group_key" and param["in"] == "query" for param in query["parameters"]
+    )

--- a/tests/test_ui_route_group_simulation_identity.py
+++ b/tests/test_ui_route_group_simulation_identity.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+import httpx
+from pydantic import JsonValue
+import pytest
+
+from src.db.route_groups import RouteGroupRepository
+
+GROUP_KEY = "vendor/model"
+OLD_ID = "00000000-0000-0000-0000-000000000001"
+NEW_ID = "00000000-0000-0000-0000-000000000002"
+MEMBER = {
+    "deployment_id": "gpt-4o-mini-0",
+    "enabled": True,
+    "weight": 1,
+    "priority": None,
+}
+
+
+class InterleavedSnapshotDB:
+    """Delete/recreate after lookup, as the simulation reads its SQL snapshot."""
+
+    def __init__(self, *, replacement: bool, group_key: str = GROUP_KEY) -> None:
+        self.replacement = replacement
+        self.group_key = group_key
+        self.deleted = False
+        self.snapshot_reads = 0
+
+    async def query_raw(self, query: str, *args: object) -> list[dict[str, JsonValue]]:
+        if "runtime.revision AS runtime_revision" in query:
+            self.deleted = True
+            self.snapshot_reads += 1
+            return [
+                {
+                    "runtime_revision": 2,
+                    "route_groups_initialized": True,
+                    "route_group_id": NEW_ID if self.replacement else None,
+                    "group_key": self.group_key,
+                    "mode": "chat",
+                    "enabled": True,
+                    "routing_strategy": "weighted",
+                    "metadata": None,
+                    "policy_version": None,
+                    "policy_semantics_version": None,
+                    "policy_json": None,
+                    "members": [MEMBER] if self.replacement else [],
+                }
+            ]
+        if "JOIN deltallm_routegroup g" in query:
+            assert self.deleted
+            if args == (OLD_ID,) or not self.replacement:
+                return []
+            assert args == (self.group_key,)
+            return [
+                {
+                    **MEMBER,
+                    "route_group_id": NEW_ID,
+                    "membership_id": "replacement-member",
+                }
+            ]
+        if "FROM deltallm_routegroup g" in query:
+            assert args in [(OLD_ID,), (self.group_key,)]
+            if self.deleted:
+                return []
+            return [
+                {
+                    "route_group_id": OLD_ID,
+                    "group_key": self.group_key,
+                    "name": "Original",
+                    "mode": "chat",
+                    "enabled": True,
+                    "routing_strategy": "weighted",
+                    "metadata": None,
+                    "member_count": 1,
+                }
+            ]
+        raise AssertionError(f"Unexpected database operation: {query}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replacement", [True, False])
+@pytest.mark.parametrize("policy", [None, {"strategy": "weighted"}])
+async def test_simulation_rejects_id_deleted_before_runtime_snapshot(
+    client: httpx.AsyncClient,
+    test_app: FastAPI,
+    replacement: bool,
+    policy: dict[str, str] | None,
+) -> None:
+    db = InterleavedSnapshotDB(replacement=replacement)
+    test_app.state.settings.master_key = "mk-test"
+    test_app.state.route_group_repository = RouteGroupRepository(db)
+    response = await client.post(
+        f"/ui/api/route-groups/by-id/{OLD_ID}/policy/simulate",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"iterations": 1, "policy": policy},
+    )
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "Route group not found"}
+    assert db.snapshot_reads == 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_simulation_retains_key_addressing(
+    client: httpx.AsyncClient, test_app: FastAPI
+) -> None:
+    # Use a single-segment key for the legacy route's existing URL contract.
+    group_key = "legacy-group"
+    test_app.state.settings.master_key = "mk-test"
+    test_app.state.route_group_repository = RouteGroupRepository(
+        InterleavedSnapshotDB(replacement=True, group_key=group_key)
+    )
+    response = await client.post(
+        f"/ui/api/route-groups/{group_key}/policy/simulate",
+        headers={"Authorization": "Bearer mk-test"},
+        json={"iterations": 1},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["selections"][0]["deployment_id"] == MEMBER["deployment_id"]

--- a/ui/scripts/run-unit-tests.mjs
+++ b/ui/scripts/run-unit-tests.mjs
@@ -36,6 +36,7 @@ const testSources = [
   'tests/reportingRequest.test.ts',
   'tests/reportingRefresh.test.ts',
   'tests/routeGroupsApi.test.ts',
+  'tests/routeGroupNavigation.test.tsx',
   'tests/routeGroupsPolicy.test.ts',
   'tests/policyGuidedEditor.test.ts',
   'tests/routeGroupPolicySimulationPanel.test.ts',
@@ -62,6 +63,7 @@ await build({
     'react-router-dom',
   ],
   jsx: 'automatic',
+  loader: { '.svg': 'dataurl' },
   platform: 'node',
   format: 'esm',
 });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -24,7 +24,6 @@ import TeamDetail from './pages/TeamDetail';
 import ModelDetail from './pages/ModelDetail';
 import NamedCredentials from './pages/NamedCredentials';
 import AuditLogs from './pages/AuditLogs';
-import RouteGroups from './pages/RouteGroups';
 import PromptRegistry from './pages/PromptRegistry';
 import PromptTemplateDetail from './pages/PromptTemplateDetail';
 import MCPServers from './pages/MCPServers';
@@ -42,7 +41,8 @@ const Organizations = lazy(() => import('./pages/Organizations'));
 const OrganizationDetail = lazy(() => import('./pages/OrganizationDetail'));
 const OrganizationCreate = lazy(() => import('./pages/OrganizationCreate'));
 const TeamCreate = lazy(() => import('./pages/TeamCreate'));
-const RouteGroupDetail = lazy(() => import('./pages/RouteGroupDetail'));
+const RouteGroupRoute = lazy(() => import('./pages/RouteGroupRoute'));
+const RouteGroups = lazy(() => import('./pages/RouteGroups'));
 const ModelCreate = lazy(() => import('./pages/ModelCreate'));
 const ModelEdit = lazy(() => import('./pages/ModelEdit'));
 
@@ -199,8 +199,9 @@ function AppRoutes() {
         <Route path="/tiers" element={uiAccess.tiers ? <Tiers /> : <Navigate to="/" replace />} />
         <Route path="/tiers/:tierId" element={uiAccess.tiers ? <TierDetail /> : <Navigate to="/" replace />} />
         <Route path="/named-credentials" element={uiAccess.named_credentials ? <NamedCredentials /> : <Navigate to="/" replace />} />
-        <Route path="/route-groups" element={uiAccess.route_groups ? <RouteGroups /> : <Navigate to="/" replace />} />
-        <Route path="/route-groups/:groupKey" element={uiAccess.route_groups ? <ChunkedRoute><RouteGroupDetail /></ChunkedRoute> : <Navigate to="/" replace />} />
+        <Route path="/route-groups" element={uiAccess.route_groups ? <ChunkedRoute><RouteGroups /></ChunkedRoute> : <Navigate to="/" replace />} />
+        <Route path="/route-groups/by-id/:routeGroupId" element={uiAccess.route_groups ? <ChunkedRoute><RouteGroupRoute /></ChunkedRoute> : <Navigate to="/" replace />} />
+        <Route path="/route-groups/*" element={uiAccess.route_groups ? <ChunkedRoute><RouteGroupRoute /></ChunkedRoute> : <Navigate to="/" replace />} />
         <Route path="/prompts" element={uiAccess.prompts ? <PromptRegistry /> : <Navigate to="/" replace />} />
         <Route path="/prompts/:templateKey" element={uiAccess.prompts ? <PromptTemplateDetail /> : <Navigate to="/" replace />} />
         <Route path="/mcp-servers" element={uiAccess.mcp_servers ? <MCPServers /> : <Navigate to="/" replace />} />

--- a/ui/src/components/route-groups/RouteGroupAdvancedTab.tsx
+++ b/ui/src/components/route-groups/RouteGroupAdvancedTab.tsx
@@ -107,7 +107,7 @@ interface RouteGroupAdvancedTabProps {
   onDeleteBinding: (binding: PromptBinding) => void;
 
   /* Routing Policy */
-  groupKey: string;
+  routeGroupId: string;
   workloadMode: string;
   guidedPolicy: PolicyGuidedValues;
   members: RouteGroupMemberDetail[];
@@ -163,7 +163,7 @@ export default function RouteGroupAdvancedTab({
   onBindingFormChange,
   onSaveBinding,
   onDeleteBinding,
-  groupKey,
+  routeGroupId,
   workloadMode,
   guidedPolicy,
   members,
@@ -513,7 +513,7 @@ export default function RouteGroupAdvancedTab({
       >
         <div className="px-5 py-5">
           <RouteGroupPolicySimulationPanel
-            groupKey={groupKey}
+            routeGroupId={routeGroupId}
             policy={simulationPolicy}
             policyError={simulationPolicyError}
             members={members}

--- a/ui/src/components/route-groups/RouteGroupPolicySimulationPanel.tsx
+++ b/ui/src/components/route-groups/RouteGroupPolicySimulationPanel.tsx
@@ -9,7 +9,7 @@ import { effectivePolicyMemberIds } from '../../lib/routeGroups';
 import { useRoutePolicySimulation } from '../../lib/useRoutePolicySimulation';
 
 interface RouteGroupPolicySimulationPanelProps {
-  groupKey: string;
+  routeGroupId: string;
   policy: Record<string, unknown> | null;
   policyError: string | null;
   members: RouteGroupMemberDetail[];
@@ -73,7 +73,7 @@ function SelectionList({
 }
 
 export default function RouteGroupPolicySimulationPanel({
-  groupKey,
+  routeGroupId,
   policy,
   policyError,
   members,
@@ -114,7 +114,7 @@ export default function RouteGroupPolicySimulationPanel({
     outcome: outcomes[member.deployment_id] || 'success' as RoutePolicySimulationOutcome,
   }));
   const fingerprint = JSON.stringify({
-    groupKey,
+    routeGroupId,
     policy,
     promptRef,
     iterations,
@@ -123,7 +123,7 @@ export default function RouteGroupPolicySimulationPanel({
     tags,
     outcomes: scenarioOutcomes,
   });
-  const simulation = useRoutePolicySimulation(groupKey, fingerprint);
+  const simulation = useRoutePolicySimulation(routeGroupId, fingerprint);
 
   const handleRun = () => {
     if (!policy) {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,3 +1,5 @@
+import type { Paginated, Pagination } from './api/pagination';
+export type { Paginated, Pagination } from './api/pagination';
 import { apiFetch, withQuery } from './api/transport';
 import {
   organizationRecordsApi,
@@ -24,15 +26,6 @@ export function reportingRequestInit(signal: AbortSignal, forceRefresh = false):
     : { signal };
 }
 
-export interface Pagination {
-  total: number;
-  limit: number;
-  offset: number;
-  has_more: boolean;
-  after_line_number?: number | null;
-  next_after_line_number?: number | null;
-}
-
 export interface SpendLogsPagination {
   total?: number;
   limit: number;
@@ -41,11 +34,6 @@ export interface SpendLogsPagination {
   has_more: boolean;
   next_cursor?: string | null;
   mode?: 'offset' | 'cursor';
-}
-
-export interface Paginated<T> {
-  data: T[];
-  pagination: Pagination;
 }
 
 export interface HealthResponse {
@@ -846,110 +834,7 @@ export type {
   RoutePolicySimulationSelection,
 } from './api/routeGroups';
 
-export interface PromptTemplate {
-  prompt_template_id: string;
-  template_key: string;
-  name: string;
-  description: string | null;
-  owner_scope: string | null;
-  metadata: Record<string, unknown> | null;
-  version_count: number;
-  label_count: number;
-  binding_count: number;
-  created_at?: string | null;
-  updated_at?: string | null;
-}
-
-export interface PromptVersion {
-  prompt_version_id: string;
-  prompt_template_id: string;
-  template_key: string;
-  version: number;
-  status: string;
-  template_body: Record<string, unknown>;
-  variables_schema: Record<string, unknown> | null;
-  model_hints: Record<string, unknown> | null;
-  route_preferences: Record<string, unknown> | null;
-  published_at?: string | null;
-  published_by?: string | null;
-  archived_at?: string | null;
-  created_at?: string | null;
-  updated_at?: string | null;
-}
-
-export interface PromptLabel {
-  prompt_label_id: string;
-  prompt_template_id: string;
-  template_key: string;
-  label: string;
-  prompt_version_id: string;
-  version: number;
-  created_at?: string | null;
-  updated_at?: string | null;
-}
-
-export interface PromptBinding {
-  prompt_binding_id: string;
-  scope_type: 'key' | 'team' | 'org' | 'group';
-  scope_id: string;
-  prompt_template_id: string;
-  template_key: string;
-  label: string;
-  priority: number;
-  enabled: boolean;
-  metadata: Record<string, unknown> | null;
-  created_at?: string | null;
-  updated_at?: string | null;
-}
-
-export interface PromptResolutionCandidate {
-  template_key?: string;
-  [key: string]: unknown;
-}
-
-export const promptRegistry = {
-  listTemplates: (params?: { search?: string; limit?: number; offset?: number }) =>
-    apiFetch<Paginated<PromptTemplate>>(withQuery('/ui/api/prompt-registry/templates', params)),
-  getTemplate: (templateKey: string) =>
-    apiFetch<{ template: PromptTemplate; versions: PromptVersion[]; labels: PromptLabel[]; bindings: PromptBinding[] }>(
-      `/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}`
-    ),
-  createTemplate: (payload: object) =>
-    apiFetch<PromptTemplate>('/ui/api/prompt-registry/templates', { method: 'POST', json: payload }),
-  updateTemplate: (templateKey: string, payload: object) =>
-    apiFetch<PromptTemplate>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}`, { method: 'PUT', json: payload }),
-  deleteTemplate: (templateKey: string) =>
-    apiFetch<{ deleted: boolean }>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}`, { method: 'DELETE' }),
-  createVersion: (templateKey: string, payload: object) =>
-    apiFetch<PromptVersion>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/versions`, { method: 'POST', json: payload }),
-  publishVersion: (templateKey: string, version: number) =>
-    apiFetch<PromptVersion>(
-      `/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/versions/${encodeURIComponent(String(version))}/publish`,
-      { method: 'POST' }
-    ),
-  listLabels: (templateKey: string) =>
-    apiFetch<PromptLabel[]>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/labels`),
-  assignLabel: (templateKey: string, payload: object) =>
-    apiFetch<PromptLabel>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/labels`, { method: 'POST', json: payload }),
-  deleteLabel: (templateKey: string, label: string) =>
-    apiFetch<{ deleted: boolean }>(
-      `/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/labels/${encodeURIComponent(label)}`,
-      { method: 'DELETE' }
-    ),
-  listBindings: (params?: { scope_type?: string; scope_id?: string; template_key?: string; limit?: number; offset?: number }) =>
-    apiFetch<Paginated<PromptBinding>>(withQuery('/ui/api/prompt-registry/bindings', params)),
-  upsertBinding: (payload: object) =>
-    apiFetch<PromptBinding>('/ui/api/prompt-registry/bindings', { method: 'POST', json: payload }),
-  deleteBinding: (bindingId: string) =>
-    apiFetch<{ deleted: boolean }>(`/ui/api/prompt-registry/bindings/${encodeURIComponent(bindingId)}`, { method: 'DELETE' }),
-  dryRunRender: (payload: object) =>
-    apiFetch<Record<string, unknown>>('/ui/api/prompt-registry/render', { method: 'POST', json: payload }),
-  previewResolution: (payload: object) =>
-    apiFetch<{
-      winner: PromptResolutionCandidate | null;
-      candidates: PromptResolutionCandidate[];
-    }>('/ui/api/prompt-registry/preview-resolution', { method: 'POST', json: payload }),
-};
+export * from './api/promptRegistry';
 
 export interface Tier {
   tier_id: string;

--- a/ui/src/lib/api/pagination.ts
+++ b/ui/src/lib/api/pagination.ts
@@ -1,0 +1,13 @@
+export interface Pagination {
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+  after_line_number?: number | null;
+  next_after_line_number?: number | null;
+}
+
+export interface Paginated<T> {
+  data: T[];
+  pagination: Pagination;
+}

--- a/ui/src/lib/api/promptRegistry.ts
+++ b/ui/src/lib/api/promptRegistry.ts
@@ -1,0 +1,107 @@
+import { apiFetch, withQuery } from './transport';
+import type { Paginated } from './pagination';
+
+export interface PromptTemplate {
+  prompt_template_id: string;
+  template_key: string;
+  name: string;
+  description: string | null;
+  owner_scope: string | null;
+  metadata: Record<string, unknown> | null;
+  version_count: number;
+  label_count: number;
+  binding_count: number;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface PromptVersion {
+  prompt_version_id: string;
+  prompt_template_id: string;
+  template_key: string;
+  version: number;
+  status: string;
+  template_body: Record<string, unknown>;
+  variables_schema: Record<string, unknown> | null;
+  model_hints: Record<string, unknown> | null;
+  route_preferences: Record<string, unknown> | null;
+  published_at?: string | null;
+  published_by?: string | null;
+  archived_at?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface PromptLabel {
+  prompt_label_id: string;
+  prompt_template_id: string;
+  template_key: string;
+  label: string;
+  prompt_version_id: string;
+  version: number;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface PromptBinding {
+  prompt_binding_id: string;
+  scope_type: 'key' | 'team' | 'org' | 'group';
+  scope_id: string;
+  prompt_template_id: string;
+  template_key: string;
+  label: string;
+  priority: number;
+  enabled: boolean;
+  metadata: Record<string, unknown> | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface PromptResolutionCandidate {
+  template_key?: string;
+  [key: string]: unknown;
+}
+
+export const promptRegistry = {
+  listTemplates: (params?: { search?: string; limit?: number; offset?: number }, signal?: AbortSignal) =>
+    apiFetch<Paginated<PromptTemplate>>(withQuery('/ui/api/prompt-registry/templates', params), { signal }),
+  getTemplate: (templateKey: string, signal?: AbortSignal) =>
+    apiFetch<{ template: PromptTemplate; versions: PromptVersion[]; labels: PromptLabel[]; bindings: PromptBinding[] }>(
+      `/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}`, { signal }
+    ),
+  createTemplate: (payload: object) =>
+    apiFetch<PromptTemplate>('/ui/api/prompt-registry/templates', { method: 'POST', json: payload }),
+  updateTemplate: (templateKey: string, payload: object) =>
+    apiFetch<PromptTemplate>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}`, { method: 'PUT', json: payload }),
+  deleteTemplate: (templateKey: string) =>
+    apiFetch<{ deleted: boolean }>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}`, { method: 'DELETE' }),
+  createVersion: (templateKey: string, payload: object) =>
+    apiFetch<PromptVersion>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/versions`, { method: 'POST', json: payload }),
+  publishVersion: (templateKey: string, version: number) =>
+    apiFetch<PromptVersion>(
+      `/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/versions/${encodeURIComponent(String(version))}/publish`,
+      { method: 'POST' }
+    ),
+  listLabels: (templateKey: string) =>
+    apiFetch<PromptLabel[]>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/labels`),
+  assignLabel: (templateKey: string, payload: object) =>
+    apiFetch<PromptLabel>(`/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/labels`, { method: 'POST', json: payload }),
+  deleteLabel: (templateKey: string, label: string) =>
+    apiFetch<{ deleted: boolean }>(
+      `/ui/api/prompt-registry/templates/${encodeURIComponent(templateKey)}/labels/${encodeURIComponent(label)}`,
+      { method: 'DELETE' }
+    ),
+  listBindings: (params?: { scope_type?: string; scope_id?: string; template_key?: string; limit?: number; offset?: number }, signal?: AbortSignal) =>
+    apiFetch<Paginated<PromptBinding>>(withQuery('/ui/api/prompt-registry/bindings', params), { signal }),
+  upsertBinding: (payload: object, signal?: AbortSignal) =>
+    apiFetch<PromptBinding>('/ui/api/prompt-registry/bindings', { method: 'POST', json: payload, signal }),
+  deleteBinding: (bindingId: string, signal?: AbortSignal) =>
+    apiFetch<{ deleted: boolean }>(`/ui/api/prompt-registry/bindings/${encodeURIComponent(bindingId)}`, { method: 'DELETE', signal }),
+  dryRunRender: (payload: object) =>
+    apiFetch<Record<string, unknown>>('/ui/api/prompt-registry/render', { method: 'POST', json: payload }),
+  previewResolution: (payload: object, signal?: AbortSignal) =>
+    apiFetch<{
+      winner: PromptResolutionCandidate | null;
+      candidates: PromptResolutionCandidate[];
+    }>('/ui/api/prompt-registry/preview-resolution', { method: 'POST', json: payload, signal }),
+};

--- a/ui/src/lib/api/routeGroups.ts
+++ b/ui/src/lib/api/routeGroups.ts
@@ -169,61 +169,65 @@ export const routeGroups = {
     params?: { search?: string; limit?: number; offset?: number },
     signal?: AbortSignal,
   ) => apiFetch<RouteGroupListResponse>(withQuery('/ui/api/route-groups', params), { signal }),
-  get: (groupKey: string, signal?: AbortSignal) =>
+  resolveKey: (groupKey: string, signal?: AbortSignal) =>
+    apiFetch<{ route_group_id: string; group_key: string }>(
+      withQuery('/ui/api/route-groups/resolve/by-key', { group_key: groupKey }), { signal },
+    ),
+  get: (routeGroupId: string, signal?: AbortSignal) =>
     apiFetch<{
       group: RouteGroup;
       members: RouteGroupMemberDetail[];
       policy: RoutePolicy | null;
       bindings: RouteGroupBinding[];
-    }>(`/ui/api/route-groups/${encodeURIComponent(groupKey)}`, { signal }),
+    }>(`/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}`, { signal }),
   create: (payload: RouteGroupWritePayload, signal?: AbortSignal) =>
     apiFetch<RouteGroupMutationResponse>('/ui/api/route-groups', {
       method: 'POST',
       json: payload,
       signal,
     }),
-  update: (groupKey: string, payload: RouteGroupWritePayload, signal?: AbortSignal) =>
-    apiFetch<RouteGroupMutationResponse>(`/ui/api/route-groups/${encodeURIComponent(groupKey)}`, {
+  update: (routeGroupId: string, payload: RouteGroupWritePayload, signal?: AbortSignal) =>
+    apiFetch<RouteGroupMutationResponse>(`/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}`, {
       method: 'PUT',
       json: payload,
       signal,
     }),
-  delete: (groupKey: string, signal?: AbortSignal) =>
-    apiFetch<DeleteRouteGroupResponse>(`/ui/api/route-groups/${encodeURIComponent(groupKey)}`, {
+  delete: (routeGroupId: string, signal?: AbortSignal) =>
+    apiFetch<DeleteRouteGroupResponse>(`/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}`, {
       method: 'DELETE',
       signal,
     }),
-  members: (groupKey: string, signal?: AbortSignal) =>
+  members: (routeGroupId: string, signal?: AbortSignal) =>
     apiFetch<RouteGroupMember[]>(
-      `/ui/api/route-groups/${encodeURIComponent(groupKey)}/members`,
+      `/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/members`,
       { signal },
     ),
   upsertMember: (
-    groupKey: string,
+    routeGroupId: string,
     payload: RouteGroupMemberWritePayload,
     signal?: AbortSignal,
   ) =>
     apiFetch<RouteGroupMemberMutationResponse>(
-      `/ui/api/route-groups/${encodeURIComponent(groupKey)}/members`,
+      `/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/members`,
       { method: 'POST', json: payload, signal },
     ),
-  removeMember: (groupKey: string, deploymentId: string, signal?: AbortSignal) =>
+  removeMember: (routeGroupId: string, deploymentId: string, signal?: AbortSignal) =>
     apiFetch<DeleteRouteGroupResponse>(
-      `/ui/api/route-groups/${encodeURIComponent(groupKey)}/members/${encodeURIComponent(deploymentId)}`,
+      `/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/members/${encodeURIComponent(deploymentId)}`,
       { method: 'DELETE', signal },
     ),
-  getPolicy: (groupKey: string, signal?: AbortSignal) =>
+  getPolicy: (routeGroupId: string, signal?: AbortSignal) =>
     apiFetch<{ group_key: string; policy: RoutePolicy | null }>(
-      `/ui/api/route-groups/${encodeURIComponent(groupKey)}/policy`,
+      `/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/policy`,
       { signal },
     ),
-  listPolicies: (groupKey: string, signal?: AbortSignal) =>
+  listPolicies: (routeGroupId: string, signal?: AbortSignal) =>
     apiFetch<{ group_key: string; policies: RoutePolicy[] }>(
-      `/ui/api/route-groups/${encodeURIComponent(groupKey)}/policies`,
+      `/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/policies`,
       { signal },
     ),
   validatePolicy: (
-    groupKey: string,
+    routeGroupId: string,
     payload: Record<string, unknown>,
     signal?: AbortSignal,
   ) =>
@@ -232,40 +236,40 @@ export const routeGroups = {
       valid: boolean;
       policy: Record<string, unknown>;
       warnings: string[];
-    }>(`/ui/api/route-groups/${encodeURIComponent(groupKey)}/policy/validate`, {
+    }>(`/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/policy/validate`, {
       method: 'POST',
       json: payload,
       signal,
     }),
   savePolicyDraft: (
-    groupKey: string,
+    routeGroupId: string,
     payload: Record<string, unknown>,
     signal?: AbortSignal,
   ) =>
     apiFetch<RoutePolicyMutationResponse>(
-      `/ui/api/route-groups/${encodeURIComponent(groupKey)}/policy/draft`,
+      `/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/policy/draft`,
       { method: 'POST', json: payload, signal },
     ),
   publishPolicy: (
-    groupKey: string,
+    routeGroupId: string,
     payload?: Record<string, unknown>,
     signal?: AbortSignal,
   ) =>
     apiFetch<RoutePolicyMutationResponse>(
-      `/ui/api/route-groups/${encodeURIComponent(groupKey)}/policy/publish`,
+      `/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/policy/publish`,
       { method: 'POST', json: payload ?? {}, signal },
     ),
-  rollbackPolicy: (groupKey: string, version: number, signal?: AbortSignal) =>
+  rollbackPolicy: (routeGroupId: string, version: number, signal?: AbortSignal) =>
     apiFetch<RollbackRoutePolicyResponse>(
-      `/ui/api/route-groups/${encodeURIComponent(groupKey)}/policy/rollback`,
+      `/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/policy/rollback`,
       { method: 'POST', json: { version }, signal },
     ),
   simulatePolicy: (
-    groupKey: string,
+    routeGroupId: string,
     payload: RoutePolicySimulationRequest,
     signal?: AbortSignal,
   ) => apiFetch<RoutePolicySimulationResponse>(
-    `/ui/api/route-groups/${encodeURIComponent(groupKey)}/policy/simulate`,
+    `/ui/api/route-groups/by-id/${encodeURIComponent(routeGroupId)}/policy/simulate`,
     { method: 'POST', json: payload, signal },
   ),
 };

--- a/ui/src/lib/routeGroupRoutes.ts
+++ b/ui/src/lib/routeGroupRoutes.ts
@@ -1,0 +1,15 @@
+export function routeGroupDetailPath(routeGroupId: string): string {
+  return `/route-groups/by-id/${encodeURIComponent(routeGroupId)}`;
+}
+
+export function legacyRouteGroupKey(pathname: string): string | null {
+  const prefix = '/route-groups/';
+  if (!pathname.startsWith(prefix)) return null;
+  try {
+    // Read the original pathname once: router params can already have decoded
+    // literal percent sequences, making "vendor%2Fmodel" look like "vendor/model".
+    return decodeURIComponent(pathname.slice(prefix.length)) || null;
+  } catch {
+    return null;
+  }
+}

--- a/ui/src/lib/useRouteGroupMutationScope.ts
+++ b/ui/src/lib/useRouteGroupMutationScope.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export function useRouteGroupMutationScope() {
+  const pending = useRef<AbortController | null>(null);
+
+  useEffect(() => () => {
+    pending.current?.abort();
+    pending.current = null;
+  }, []);
+
+  const begin = useCallback(() => {
+    if (pending.current) return null;
+    const controller = new AbortController();
+    pending.current = controller;
+    return controller;
+  }, []);
+
+  const isCurrent = useCallback((controller: AbortController) => (
+    pending.current === controller && !controller.signal.aborted
+  ), []);
+
+  const finish = useCallback((controller: AbortController) => {
+    if (!isCurrent(controller)) return false;
+    pending.current = null;
+    return true;
+  }, [isCurrent]);
+
+  return { begin, isCurrent, finish };
+}

--- a/ui/src/lib/useRoutePolicySimulation.ts
+++ b/ui/src/lib/useRoutePolicySimulation.ts
@@ -6,7 +6,7 @@ import {
 } from './api';
 
 interface SimulationIdentity {
-  groupKey: string;
+  routeGroupId: string;
   fingerprint: string;
 }
 
@@ -16,13 +16,13 @@ interface SimulationResult extends SimulationIdentity {
 
 function sameIdentity(
   identity: SimulationIdentity | null,
-  groupKey: string,
+  routeGroupId: string,
   fingerprint: string,
 ): boolean {
-  return identity?.groupKey === groupKey && identity.fingerprint === fingerprint;
+  return identity?.routeGroupId === routeGroupId && identity.fingerprint === fingerprint;
 }
 
-export function useRoutePolicySimulation(groupKey: string, fingerprint: string) {
+export function useRoutePolicySimulation(routeGroupId: string, fingerprint: string) {
   const [result, setResult] = useState<SimulationResult | null>(null);
   const [error, setError] = useState<unknown>(null);
   const [pending, setPending] = useState<SimulationIdentity | null>(null);
@@ -44,19 +44,19 @@ export function useRoutePolicySimulation(groupKey: string, fingerprint: string) 
     requestIdRef.current += 1;
     controllerRef.current?.abort();
     controllerRef.current = null;
-  }, [groupKey, fingerprint]);
+  }, [routeGroupId, fingerprint]);
 
   const run = useCallback(async (request: RoutePolicySimulationRequest) => {
     controllerRef.current?.abort();
     const controller = new AbortController();
     controllerRef.current = controller;
     const requestId = ++requestIdRef.current;
-    const identity = { groupKey, fingerprint };
+    const identity = { routeGroupId, fingerprint };
     setPending(identity);
     setError(null);
 
     try {
-      const data = await routeGroups.simulatePolicy(groupKey, request, controller.signal);
+      const data = await routeGroups.simulatePolicy(routeGroupId, request, controller.signal);
       if (
         requestId !== requestIdRef.current
         || !mountedRef.current
@@ -75,7 +75,7 @@ export function useRoutePolicySimulation(groupKey: string, fingerprint: string) 
       if (requestId === requestIdRef.current && mountedRef.current) setPending(null);
       if (controllerRef.current === controller) controllerRef.current = null;
     }
-  }, [fingerprint, groupKey]);
+  }, [fingerprint, routeGroupId]);
 
   const reset = useCallback(() => {
     requestIdRef.current += 1;
@@ -89,8 +89,8 @@ export function useRoutePolicySimulation(groupKey: string, fingerprint: string) 
   return {
     data: result?.data ?? null,
     error,
-    loading: sameIdentity(pending, groupKey, fingerprint),
-    stale: result !== null && !sameIdentity(result, groupKey, fingerprint),
+    loading: sameIdentity(pending, routeGroupId, fingerprint),
+    stale: result !== null && !sameIdentity(result, routeGroupId, fingerprint),
     run,
     reset,
   };

--- a/ui/src/pages/RouteGroupDetail.tsx
+++ b/ui/src/pages/RouteGroupDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   ArrowLeft,
   Brain,
@@ -19,9 +19,10 @@ import {
 import ConfirmDialog from '../components/ConfirmDialog';
 import { useToast } from '../components/ToastProvider';
 import { useAuth } from '../lib/auth';
-import { models, promptRegistry, routeGroups, type PromptBinding } from '../lib/api';
+import { ApiError, models, promptRegistry, routeGroups, type PromptBinding } from '../lib/api';
 import { resolveUiAccess } from '../lib/authorization';
 import { useApi } from '../lib/hooks';
+import { useRouteGroupMutationScope } from '../lib/useRouteGroupMutationScope';
 import {
   buildPolicyFromGuided,
   GUIDED_POLICY_DEFAULTS,
@@ -99,8 +100,8 @@ function mutationErrorMessage(error: unknown, fallback: string): string {
 
 /* ─── Page ───────────────────────────────────────────────────────────────── */
 
-export default function RouteGroupDetail() {
-  const { groupKey } = useParams<{ groupKey: string }>();
+export default function RouteGroupDetail({ routeGroupId }: { routeGroupId: string }) {
+  const mutations = useRouteGroupMutationScope();
   const navigate = useNavigate();
   const { pushToast } = useToast();
   const { authMode, session } = useAuth();
@@ -129,17 +130,18 @@ export default function RouteGroupDetail() {
   const [policyText, setPolicyText] = useState('{\n  "strategy": "weighted"\n}');
 
   /* API */
-  const detail = useApi((signal) => routeGroups.get(groupKey!, signal), [groupKey]);
+  const detail = useApi((signal) => routeGroups.get(routeGroupId, signal), [routeGroupId]);
+  const groupKey = detail.data?.group.group_key;
   const policyHistory = useApi(
-    (signal) => routeGroups.listPolicies(groupKey!, signal),
-    [groupKey],
+    (signal) => routeGroups.listPolicies(routeGroupId, signal),
+    [routeGroupId],
   );
   const groupBindings = useApi(
-    () => promptRegistry.listBindings({ scope_type: 'group', scope_id: groupKey!, limit: 20, offset: 0 }),
+    (signal) => groupKey ? promptRegistry.listBindings({ scope_type: 'group', scope_id: groupKey, limit: 20, offset: 0 }, signal) : Promise.resolve(null),
     [groupKey],
   );
-  const promptTemplates = useApi(() => promptRegistry.listTemplates({ limit: 100, offset: 0 }), []);
-  const bindingPreview = useApi(() => promptRegistry.previewResolution({ route_group_key: groupKey! }), [groupKey]);
+  const promptTemplates = useApi((signal) => promptRegistry.listTemplates({ limit: 100, offset: 0 }, signal), []);
+  const bindingPreview = useApi((signal) => groupKey ? promptRegistry.previewResolution({ route_group_key: groupKey }, signal) : Promise.resolve(null), [groupKey]);
   const deploymentCandidates = useApi(
     (signal) => models.list(
       { search: memberSearch, mode: form.mode, limit: 20, offset: 0 },
@@ -161,7 +163,7 @@ export default function RouteGroupDetail() {
   const draftPolicy = useMemo(() => policies.find((p) => p.status === 'draft') || null, [policies]);
   const winningPrompt = bindingPreview.data?.winner || null;
   const winningPromptDetail = useApi(
-    () => (winningPrompt?.template_key ? promptRegistry.getTemplate(String(winningPrompt.template_key)) : Promise.resolve(null)),
+    (signal) => (winningPrompt?.template_key ? promptRegistry.getTemplate(String(winningPrompt.template_key), signal) : Promise.resolve(null)),
     [winningPrompt?.template_key],
   );
 
@@ -293,29 +295,39 @@ export default function RouteGroupDetail() {
   };
 
   const handleSaveGroup = async () => {
+    const operation = mutations.begin();
+    if (!operation) return;
     setSavingGroup(true);
     try {
-      const result = await routeGroups.update(groupKey!, { name: form.name.trim() || null, mode: form.mode, enabled: form.enabled });
+      const result = await routeGroups.update(routeGroupId, { name: form.name.trim() || null, mode: form.mode, enabled: form.enabled }, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       detail.refetch();
       const outcome = routeGroupMutationOutcome('Route group settings were saved.', result.warnings);
       pushToast({ tone: outcome.tone, title: 'Group updated', message: outcome.message });
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'error', title: 'Update failed', message: mutationErrorMessage(error, 'Failed to update route group.') });
     } finally {
-      setSavingGroup(false);
+      if (mutations.finish(operation)) setSavingGroup(false);
     }
   };
 
   const handleDeleteGroup = async () => {
+    const operation = mutations.begin();
+    if (!operation) return;
     setDeletingGroup(true);
     try {
-      const result = await routeGroups.delete(groupKey!);
+      const result = await routeGroups.delete(routeGroupId, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       const outcome = routeGroupMutationOutcome(`"${groupKey}" was deleted.`, result.warnings);
       pushToast({ tone: outcome.tone, title: 'Group deleted', message: outcome.message });
       navigate('/route-groups');
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'error', title: 'Delete failed', message: mutationErrorMessage(error, 'Failed to delete route group.') });
       setDeletingGroup(false);
+    } finally {
+      mutations.finish(operation);
     }
   };
 
@@ -324,14 +336,17 @@ export default function RouteGroupDetail() {
       pushToast({ tone: 'error', title: 'Missing deployment', message: 'Select or enter a deployment ID before adding.' });
       return;
     }
+    const operation = mutations.begin();
+    if (!operation) return;
     setAddingMember(true);
     try {
-      const result = await routeGroups.upsertMember(groupKey!, {
+      const result = await routeGroups.upsertMember(routeGroupId, {
         deployment_id: memberForm.deployment_id.trim(),
         enabled: memberForm.enabled,
         weight: memberForm.weight ? Number(memberForm.weight) : null,
         priority: memberForm.priority ? Number(memberForm.priority) : null,
-      });
+      }, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       setMemberForm({ deployment_id: '', weight: '', priority: '', enabled: true });
       setMemberSearchInput('');
       setMemberSearch('');
@@ -343,9 +358,10 @@ export default function RouteGroupDetail() {
       pushToast({ tone: outcome.tone, title: 'Member added', message: outcome.message });
       detail.refetch();
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'error', title: 'Add member failed', message: mutationErrorMessage(error, 'Failed to add deployment to group.') });
     } finally {
-      setAddingMember(false);
+      if (mutations.finish(operation)) setAddingMember(false);
     }
   };
 
@@ -354,6 +370,8 @@ export default function RouteGroupDetail() {
       pushToast({ tone: 'error', title: 'Missing prompt', message: 'Select a prompt before saving the binding.' });
       return;
     }
+    const operation = mutations.begin();
+    if (!operation) return;
     setSavingBinding(true);
     try {
       await promptRegistry.upsertBinding({
@@ -363,90 +381,111 @@ export default function RouteGroupDetail() {
         label: bindingForm.label.trim() || 'production',
         priority: Number(bindingForm.priority || 100),
         enabled: bindingForm.enabled,
-      });
+      }, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'success', title: 'Prompt bound', message: 'This group will now resolve the selected prompt binding.' });
       groupBindings.refetch();
       bindingPreview.refetch();
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'error', title: 'Bind prompt failed', message: mutationErrorMessage(error, 'Failed to save prompt binding.') });
     } finally {
-      setSavingBinding(false);
+      if (mutations.finish(operation)) setSavingBinding(false);
     }
   };
 
   const handleDeleteBinding = async (binding: PromptBinding) => {
+    const operation = mutations.begin();
+    if (!operation) return;
     setDeletingBinding(binding.prompt_binding_id);
     try {
-      await promptRegistry.deleteBinding(binding.prompt_binding_id);
+      await promptRegistry.deleteBinding(binding.prompt_binding_id, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'success', title: 'Binding removed', message: 'The prompt is no longer bound to this group.' });
       groupBindings.refetch();
       bindingPreview.refetch();
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'error', title: 'Remove binding failed', message: mutationErrorMessage(error, 'Failed to remove prompt binding.') });
     } finally {
-      setDeletingBinding(null);
+      if (mutations.finish(operation)) setDeletingBinding(null);
     }
   };
 
   const handleRemoveMember = async () => {
     if (!memberToRemove) return;
+    const operation = mutations.begin();
+    if (!operation) return;
     setRemovingMember(true);
     try {
-      const result = await routeGroups.removeMember(groupKey!, memberToRemove);
+      const result = await routeGroups.removeMember(routeGroupId, memberToRemove, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       const outcome = routeGroupMutationOutcome(`"${memberToRemove}" was removed.`, result.warnings);
       pushToast({ tone: outcome.tone, title: 'Member removed', message: outcome.message });
       setMemberToRemove(null);
       detail.refetch();
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'error', title: 'Remove member failed', message: mutationErrorMessage(error, 'Failed to remove member.') });
     } finally {
-      setRemovingMember(false);
+      if (mutations.finish(operation)) setRemovingMember(false);
     }
   };
 
   const handleValidatePolicy = async () => {
     const parsed = parsePolicy();
     if (!parsed) return;
+    const operation = mutations.begin();
+    if (!operation) return;
     setPolicyAction('validate');
     try {
-      const result = await routeGroups.validatePolicy(groupKey!, parsed);
+      const result = await routeGroups.validatePolicy(routeGroupId, parsed, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       setPolicyText(JSON.stringify(result.policy, null, 2));
       setGuidedPolicy(toGuidedPolicy(result.policy, members));
       setPolicyMessage(result.warnings?.length ? `Valid with warnings: ${result.warnings.join(' ')}` : 'Policy is valid.');
       setPolicyError(null);
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       setPolicyError(mutationErrorMessage(error, 'Policy validation failed'));
       setPolicyMessage(null);
     } finally {
-      setPolicyAction(null);
+      if (mutations.finish(operation)) setPolicyAction(null);
     }
   };
 
   const handleSaveDraft = async () => {
     const parsed = parsePolicy();
     if (!parsed) return;
+    const operation = mutations.begin();
+    if (!operation) return;
     setPolicyAction('save-draft');
     try {
-      const result = await routeGroups.savePolicyDraft(groupKey!, parsed);
+      const result = await routeGroups.savePolicyDraft(routeGroupId, parsed, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       setPolicyMessage(
         routeGroupMutationOutcome(`Draft saved (v${result.policy.version}).`, result.warnings).message,
       );
       setPolicyError(null);
       policyHistory.refetch();
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       setPolicyError(mutationErrorMessage(error, 'Failed to save draft'));
       setPolicyMessage(null);
     } finally {
-      setPolicyAction(null);
+      if (mutations.finish(operation)) setPolicyAction(null);
     }
   };
 
   const handlePublish = async () => {
     const parsed = parsePolicy();
     if (!parsed) return;
+    const operation = mutations.begin();
+    if (!operation) return;
     setPolicyAction('publish-json');
     try {
-      const result = await routeGroups.publishPolicy(groupKey!, parsed);
+      const result = await routeGroups.publishPolicy(routeGroupId, parsed, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       setPolicyMessage(
         routeGroupMutationOutcome(
           `Published policy version ${result.policy.version}.`,
@@ -457,18 +496,22 @@ export default function RouteGroupDetail() {
       detail.refetch();
       policyHistory.refetch();
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       setPolicyError(mutationErrorMessage(error, 'Failed to publish policy'));
       setPolicyMessage(null);
     } finally {
-      setPolicyAction(null);
+      if (mutations.finish(operation)) setPolicyAction(null);
     }
   };
 
   const handleRollback = async () => {
     if (!selectedRollbackVersion) return;
+    const operation = mutations.begin();
+    if (!operation) return;
     setPolicyAction('rollback');
     try {
-      const result = await routeGroups.rollbackPolicy(groupKey!, selectedRollbackVersion);
+      const result = await routeGroups.rollbackPolicy(routeGroupId, selectedRollbackVersion, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       setPolicyMessage(
         routeGroupMutationOutcome(
           `Rolled back to new published version ${result.policy.version}.`,
@@ -479,10 +522,11 @@ export default function RouteGroupDetail() {
       detail.refetch();
       policyHistory.refetch();
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       setPolicyError(mutationErrorMessage(error, 'Failed to rollback policy'));
       setPolicyMessage(null);
     } finally {
-      setPolicyAction(null);
+      if (mutations.finish(operation)) setPolicyAction(null);
     }
   };
 
@@ -495,7 +539,7 @@ export default function RouteGroupDetail() {
             <ArrowLeft className="h-4 w-4" /> Back to Model Groups
           </button>
         </div>
-        <div className="flex min-h-[400px] items-center justify-center">
+        <div className="flex min-h-[400px] items-center justify-center" role="status" aria-label="Loading model group">
           <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-brand-primary" />
         </div>
       </div>
@@ -511,8 +555,11 @@ export default function RouteGroupDetail() {
           </button>
         </div>
         <div className="p-6">
-          <div className="mb-3 rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-700">
-            Failed to load route group details.
+          <div role="alert" className="mb-3 rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {detail.error instanceof ApiError && detail.error.status === 403
+              ? 'You do not have permission to view this model group.'
+              : detail.error instanceof ApiError && detail.error.status === 404
+                ? 'Model group not found.' : 'Failed to load route group details.'}
           </div>
           <button onClick={detail.refetch} className="rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">
             Retry
@@ -645,7 +692,7 @@ export default function RouteGroupDetail() {
             />
           ) : activeTab === 'advanced' ? (
             <RouteGroupAdvancedTab
-              groupKey={group.group_key}
+              routeGroupId={group.route_group_id}
               workloadMode={workloadMode}
               bindings={bindings}
               templates={promptTemplates.data?.data || []}

--- a/ui/src/pages/RouteGroupRoute.tsx
+++ b/ui/src/pages/RouteGroupRoute.tsx
@@ -1,0 +1,31 @@
+import { Navigate, Link, useLocation, useParams } from 'react-router-dom';
+import { ApiError, routeGroups } from '../lib/api';
+import { useApi } from '../lib/hooks';
+import { legacyRouteGroupKey, routeGroupDetailPath } from '../lib/routeGroupRoutes';
+import RouteGroupDetail from './RouteGroupDetail';
+
+function LegacyRouteGroup({ groupKey }: { groupKey: string }) {
+  const resolution = useApi((signal) => routeGroups.resolveKey(groupKey, signal), [groupKey]);
+  if (resolution.data) return <Navigate to={routeGroupDetailPath(resolution.data.route_group_id)} replace />;
+  const message = resolution.error instanceof ApiError && resolution.error.status === 403
+    ? 'You do not have permission to view this model group.'
+    : resolution.error instanceof ApiError && resolution.error.status === 404
+      ? 'Model group not found.'
+      : resolution.error ? 'Could not load this model group.' : 'Loading model group…';
+  return (
+    <div className="space-y-4 p-6">
+      <Link to="/route-groups" className="text-sm text-brand-primary">Back to Model Groups</Link>
+      <p role={resolution.error ? 'alert' : 'status'}>{message}</p>
+      {!!resolution.error && <button onClick={resolution.refetch} className="rounded border px-3 py-2">Retry</button>}
+    </div>
+  );
+}
+
+export default function RouteGroupRoute() {
+  const { routeGroupId } = useParams<{ routeGroupId: string }>();
+  const { pathname } = useLocation();
+  if (routeGroupId) return <RouteGroupDetail key={routeGroupId} routeGroupId={routeGroupId} />;
+  const groupKey = legacyRouteGroupKey(pathname);
+  if (groupKey === null) return <p role="alert" className="p-6">Invalid model group link.</p>;
+  return <LegacyRouteGroup key={groupKey} groupKey={groupKey} />;
+}

--- a/ui/src/pages/RouteGroups.tsx
+++ b/ui/src/pages/RouteGroups.tsx
@@ -21,6 +21,8 @@ import { routeGroups } from '../lib/api';
 import type { RouteGroup } from '../lib/api';
 import { routeGroupMutationOutcome, ROUTE_GROUP_MODE_OPTIONS } from '../lib/routeGroups';
 import { useApi } from '../lib/hooks';
+import { routeGroupDetailPath } from '../lib/routeGroupRoutes';
+import { useRouteGroupMutationScope } from '../lib/useRouteGroupMutationScope';
 import { useToast } from '../components/ToastProvider';
 import { useBranding } from '../lib/brandingContext';
 
@@ -207,6 +209,7 @@ function CreateDrawer({ open, onClose, form, setForm, formError, setFormError, c
 
 /* ─── Page ───────────────────────────────────────────────────────────────── */
 export default function RouteGroups() {
+  const mutations = useRouteGroupMutationScope();
   const { branding } = useBranding();
   const navigate = useNavigate();
   const { pushToast } = useToast();
@@ -217,7 +220,7 @@ export default function RouteGroups() {
   const [createOpen, setCreateOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<RouteGroup | null>(null);
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
   const [form, setForm] = useState({ group_key: '', name: '', mode: 'chat' });
 
@@ -244,13 +247,16 @@ export default function RouteGroups() {
       return;
     }
     setFormError(null);
+    const operation = mutations.begin();
+    if (!operation) return;
     setCreating(true);
     try {
       const created = await routeGroups.create({
         group_key: groupKey,
         name: form.name.trim() || null,
         mode: form.mode,
-      });
+      }, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
       setCreateOpen(false);
       resetForm();
       const outcome = routeGroupMutationOutcome(
@@ -258,27 +264,32 @@ export default function RouteGroups() {
         created.warnings,
       );
       pushToast({ tone: outcome.tone, title: 'Model group created', message: outcome.message });
-      navigate(`/route-groups/${created.group_key}`);
+      navigate(routeGroupDetailPath(created.route_group_id));
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'error', title: 'Create failed', message: mutationErrorMessage(error, 'Failed to create model group.') });
     } finally {
-      setCreating(false);
+      if (mutations.finish(operation)) setCreating(false);
     }
   };
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
-    setDeletingKey(deleteTarget);
+    const operation = mutations.begin();
+    if (!operation) return;
+    setDeletingKey(deleteTarget.route_group_id);
     try {
-      const result = await routeGroups.delete(deleteTarget);
-      const outcome = routeGroupMutationOutcome(`"${deleteTarget}" was deleted.`, result.warnings);
+      const result = await routeGroups.delete(deleteTarget.route_group_id, operation.signal);
+      if (!mutations.isCurrent(operation)) return;
+      const outcome = routeGroupMutationOutcome(`"${deleteTarget.group_key}" was deleted.`, result.warnings);
       pushToast({ tone: outcome.tone, title: 'Model group deleted', message: outcome.message });
       setDeleteTarget(null);
       refetch();
     } catch (error: unknown) {
+      if (!mutations.isCurrent(operation)) return;
       pushToast({ tone: 'error', title: 'Delete failed', message: mutationErrorMessage(error, 'Failed to delete model group.') });
     } finally {
-      setDeletingKey(null);
+      if (mutations.finish(operation)) setDeletingKey(null);
     }
   };
 
@@ -389,7 +400,7 @@ export default function RouteGroups() {
           {!loading && groups.map((g, i) => (
             <div
               key={g.group_key}
-              onClick={() => navigate(`/route-groups/${g.group_key}`)}
+              onClick={() => navigate(routeGroupDetailPath(g.route_group_id))}
               className={`group grid cursor-pointer items-center gap-4 px-4 py-3 transition hover:bg-blue-50/40 ${i < groups.length - 1 ? 'border-b border-gray-100' : ''}`}
               style={{ gridTemplateColumns: '1fr 130px 110px 110px 72px 48px' }}
             >
@@ -431,8 +442,8 @@ export default function RouteGroups() {
               {/* Actions */}
               <div className="flex items-center justify-end gap-1 opacity-0 transition group-hover:opacity-100">
                 <button
-                  onClick={(e) => { e.stopPropagation(); setDeleteTarget(g.group_key); }}
-                  disabled={deletingKey === g.group_key}
+                  onClick={(e) => { e.stopPropagation(); setDeleteTarget(g); }}
+                  disabled={deletingKey === g.route_group_id}
                   className="rounded-lg p-1 hover:bg-red-50 disabled:opacity-40"
                   title="Delete group"
                 >
@@ -493,7 +504,7 @@ export default function RouteGroups() {
       <ConfirmDialog
         open={!!deleteTarget}
         title="Delete model group"
-        description={deleteTarget ? `Delete "${deleteTarget}"? This removes all members and policy history references for this group.` : ''}
+        description={deleteTarget ? `Delete "${deleteTarget.group_key}"? This removes all members and policy history references for this group.` : ''}
         confirmLabel="Delete Group"
         destructive
         confirming={!!deletingKey}

--- a/ui/tests/routeGroupNavigation.test.tsx
+++ b/ui/tests/routeGroupNavigation.test.tsx
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { act, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate, type NavigateFunction } from 'react-router-dom';
+import { JSDOM } from 'jsdom';
+
+import { AuthProvider } from '../src/lib/auth';
+import { ToastProvider } from '../src/components/ToastProvider';
+import RouteGroupRoute from '../src/pages/RouteGroupRoute';
+import { legacyRouteGroupKey, routeGroupDetailPath } from '../src/lib/routeGroupRoutes';
+import { routeGroups } from '../src/lib/api/routeGroups';
+
+const GROUP_ID = '12f410b2-641f-40fb-9ba8-4281b70bc8ca';
+const NEXT_ID = '12f410b2-641f-40fb-9ba8-4281b70bc8cb';
+const KEYS = ['vendor/model', 'vendor/model/v2', 'vendor%2Fmodel', 'support / eu',
+  'مجموعة/نموذج', 'model?variant#1', 'team/policy', 'team/members'];
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), {
+  status, headers: { 'content-type': 'application/json' },
+});
+
+test('legacy names decode once and the query resolver preserves the exact key', async () => {
+  const previousFetch = globalThis.fetch;
+  try {
+    for (const key of KEYS) {
+      assert.equal(legacyRouteGroupKey('/route-groups/' + encodeURIComponent(key)), key);
+      const controller = new AbortController();
+      globalThis.fetch = async (input, init) => {
+        const url = new URL(String(input), 'http://localhost');
+        assert.equal(url.pathname, '/ui/api/route-groups/resolve/by-key');
+        assert.equal(url.searchParams.get('group_key'), key);
+        assert.equal(init?.signal, controller.signal);
+        return json({ route_group_id: GROUP_ID, group_key: key });
+      };
+      await routeGroups.resolveKey(key, controller.signal);
+    }
+    assert.equal(legacyRouteGroupKey('/route-groups/vendor/model'), 'vendor/model');
+    assert.equal(legacyRouteGroupKey('/route-groups/bad%2'), null);
+    assert.equal(legacyRouteGroupKey('/route-groups/'), null);
+    assert.equal(routeGroupDetailPath(GROUP_ID), '/route-groups/by-id/' + GROUP_ID);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('detail navigation preserves names, redirects old links, and ignores a stale delete', async () => {
+  const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+    url: 'http://localhost',
+  });
+  const previous = Object.getOwnPropertyDescriptors(globalThis);
+  for (const [key, value] of Object.entries({
+    window: dom.window, document: dom.window.document, HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })) Object.defineProperty(globalThis, key, { configurable: true, value });
+  const previousFetch = globalThis.fetch;
+  const requests: Array<{ url: URL; init?: RequestInit }> = [];
+  let key = KEYS[0];
+  let detailStatus = 200;
+  let deleteResponse: ((response: Response) => void) | undefined;
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input), 'http://localhost');
+    requests.push({ url, init });
+    if (url.pathname === '/auth/me') return json({ authenticated: true, auth_mode: 'master_key' });
+    if (url.pathname.endsWith('/resolve/by-key')) return json({
+      group_key: url.searchParams.get('group_key'), route_group_id: GROUP_ID,
+    });
+    if (init?.method === 'DELETE') return new Promise((resolve) => { deleteResponse = resolve; });
+    if (url.pathname.endsWith('/policies')) return json({ group_key: key, policies: [] });
+    if (url.pathname.includes('/route-groups/by-id/')) {
+      if (detailStatus !== 200) return json({ detail: 'Unavailable' }, detailStatus);
+      return json({
+        group: { route_group_id: url.pathname.split('/').at(-1), group_key: key,
+          name: null, mode: 'chat', routing_strategy: null, enabled: true,
+          member_count: 0, metadata: null },
+        members: [], policy: null, bindings: [],
+      });
+    }
+    if (url.pathname.includes('/resolve')) return json({ winner: null, candidates: [] });
+    return json({ data: [], pagination: { total: 0, limit: 20, offset: 0, has_more: false } });
+  };
+  let navigate: NavigateFunction;
+  function Probe() {
+    const routerNavigate = useNavigate();
+    useEffect(() => { navigate = routerNavigate; }, [routerNavigate]);
+    return <output id="location">{useLocation().pathname}</output>;
+  }
+  const root = createRoot(document.getElementById('root')!);
+  const render = (initialPath: string) => root.render(
+    <MemoryRouter initialEntries={[initialPath]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <AuthProvider><ToastProvider>
+        <Probe />
+        <Routes>
+          <Route path="/route-groups/by-id/:routeGroupId" element={<RouteGroupRoute />} />
+          <Route path="/route-groups/*" element={<RouteGroupRoute />} />
+          <Route path="/route-groups" element={<p>Group list</p>} />
+        </Routes>
+      </ToastProvider></AuthProvider>
+    </MemoryRouter>,
+  );
+  try {
+    await act(async () => render('/route-groups/vendor/model'));
+    assert.equal(document.getElementById('location')?.textContent, routeGroupDetailPath(GROUP_ID));
+    assert.ok(document.body.textContent?.includes(key));
+    for (key of KEYS.slice(1)) {
+      await act(async () => navigate('/route-groups/' + encodeURIComponent(key)));
+      assert.equal(document.getElementById('location')?.textContent, routeGroupDetailPath(GROUP_ID));
+      assert.ok(document.body.textContent?.includes(key), key);
+      const resolution = requests.filter((r) => r.url.pathname.endsWith('/resolve/by-key')).at(-1);
+      assert.equal(resolution?.url.searchParams.get('group_key'), key);
+      const binding = requests.filter((r) => r.url.searchParams.has('scope_id')).at(-1);
+      assert.equal(binding?.url.searchParams.get('scope_id'), key);
+    }
+    await act(async () => document.querySelector<HTMLButtonElement>('button[title="Delete group"]')!.click());
+    const confirm = [...document.querySelectorAll('button')].find((b) => b.textContent === 'Delete Group')!;
+    assert.ok(confirm);
+    await act(async () => { confirm.click(); confirm.click(); });
+    const deletions = requests.filter((r) => r.init?.method === 'DELETE');
+    assert.equal(deletions.length, 1);
+    assert.equal(deletions[0].url.pathname, '/ui/api/route-groups/by-id/' + GROUP_ID);
+    key = 'next/group';
+    await act(async () => navigate(routeGroupDetailPath(NEXT_ID)));
+    assert.equal(deletions[0].init?.signal?.aborted, true);
+    assert.ok(document.body.textContent?.includes(key));
+    await act(async () => deleteResponse!(json({ deleted: true, warnings: [] })));
+    assert.equal(document.getElementById('location')?.textContent, routeGroupDetailPath(NEXT_ID));
+    assert.ok(!document.body.textContent?.includes('Group deleted'));
+
+    for (const status of [403, 404, 503]) {
+      detailStatus = status;
+      await act(async () => navigate(routeGroupDetailPath(GROUP_ID)));
+      assert.ok(document.body.textContent?.includes(status === 403 ? 'permission' :
+        status === 404 ? 'Model group not found.' : 'Failed to load route group details.'));
+      detailStatus = 200;
+      const retry = [...document.querySelectorAll('button')].find((b) => b.textContent?.trim() === 'Retry')!;
+      await act(async () => retry.click());
+      assert.ok(document.body.textContent?.includes(key));
+      await act(async () => navigate(routeGroupDetailPath(NEXT_ID)));
+    }
+  } finally {
+    await act(async () => root.unmount());
+    globalThis.fetch = previousFetch;
+    dom.window.close();
+    for (const name of ['window', 'document', 'HTMLElement', 'IS_REACT_ACT_ENVIRONMENT']) {
+      if (previous[name]) Object.defineProperty(globalThis, name, previous[name]);
+      else Reflect.deleteProperty(globalThis, name);
+    }
+  }
+});

--- a/ui/tests/routeGroupPolicySimulationPanel.test.ts
+++ b/ui/tests/routeGroupPolicySimulationPanel.test.ts
@@ -87,7 +87,7 @@ test('policy simulation panel covers permission, loading, results, stale, error,
   const root = createRoot(rootNode);
   const renderPanel = (canSimulate: boolean, policy: Record<string, unknown>) => (
     root.render(createElement(RouteGroupPolicySimulationPanel, {
-      groupKey: 'support',
+      routeGroupId: '12f410b2-641f-40fb-9ba8-4281b70bc8ca',
       policy,
       policyError: null,
       members: MEMBERS,

--- a/ui/tests/routeGroupsApi.test.ts
+++ b/ui/tests/routeGroupsApi.test.ts
@@ -4,6 +4,8 @@ import test from 'node:test';
 import { routeGroups } from '../src/lib/api';
 import { routeGroupMutationOutcome } from '../src/lib/routeGroups';
 
+const GROUP_ID = '12f410b2-641f-40fb-9ba8-4281b70bc8ca';
+
 test('route-group policy responses preserve semantics and post-commit warnings', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () => new Response(JSON.stringify({
@@ -22,7 +24,7 @@ test('route-group policy responses preserve semantics and post-commit warnings',
   }), { headers: { 'content-type': 'application/json' } })) as typeof fetch;
 
   try {
-    const result = await routeGroups.publishPolicy('support', { strategy: 'weighted' });
+    const result = await routeGroups.publishPolicy(GROUP_ID, { strategy: 'weighted' });
 
     assert.equal(result.policy.semantics_version, 2);
     assert.deepEqual(result.warnings, ['Runtime refresh is pending']);
@@ -70,7 +72,7 @@ test('route-group policy mutations pass AbortSignal to the shared transport', as
 
   try {
     const controller = new AbortController();
-    await routeGroups.publishPolicy('support', {}, controller.signal);
+    await routeGroups.publishPolicy(GROUP_ID, {}, controller.signal);
     assert.equal(capturedSignal, controller.signal);
   } finally {
     globalThis.fetch = originalFetch;
@@ -111,7 +113,7 @@ test('route-group policy simulation sends the typed scenario and AbortSignal', a
 
   try {
     const controller = new AbortController();
-    const result = await routeGroups.simulatePolicy('support / eu', {
+    const result = await routeGroups.simulatePolicy(GROUP_ID, {
       iterations: 2,
       input_tokens: 9_000,
       requested_output_tokens: 1_000,
@@ -120,7 +122,7 @@ test('route-group policy simulation sends the typed scenario and AbortSignal', a
       outcomes: [{ deployment_id: 'dep-a', outcome: 'timeout' }],
     }, controller.signal);
 
-    assert.equal(capturedPath, '/ui/api/route-groups/support%20%2F%20eu/policy/simulate');
+    assert.equal(capturedPath, `/ui/api/route-groups/by-id/${GROUP_ID}/policy/simulate`);
     assert.equal(capturedInit?.method, 'POST');
     assert.equal(capturedInit?.signal, controller.signal);
     assert.deepEqual(JSON.parse(String(capturedInit?.body)), {


### PR DESCRIPTION
## Summary

Model groups such as `vendor/model` fail to open because their names are used as URL path segments. Address individual groups by their existing `route_group_id` UUID in the UI and admin API, preserving the exact model name in runtime requests, prompt scopes, and response bodies.

- Add authenticated ID routes and a query-based key resolver; retain legacy key API routes and redirect recoverable UI bookmarks.
- Pin reads and mutations to the requested identity, including the simulation SQL snapshot, so deletion followed by reuse of a name cannot select the replacement group.
- Reject boolean member weights/priorities before integer coercion; preserve accepted integer, integer-string, omitted, and null inputs.
- Cancel obsolete UI requests and mutation completions, prevent duplicate submissions, and load the group pages as route chunks.
- Register the addressing decision in public documentation navigation and make HTTP retry-classification tests deterministic while retaining dedicated deadline coverage.

Fixes #308.

## Validation

- `uv run --no-sync python -m pytest -q -m hermetic --durations=25`: **2542 passed, 1290 deselected**. Maximum-jitter reproduction also passes all three retry cases and the existing retry-deadline test.
- `uv run --no-sync python -m pytest -q --confcutdir=tests/docs tests/docs`: **9 passed**.
- `uv run --no-sync python -m scripts.docs.report_health --check`: **passed**, with all 81 public pages in navigation and no missing headings or images.
- `uv run --no-sync python -m mkdocs build --strict --site-dir /private/tmp/issue308-ci-docs-site` and `uv run --no-sync python -m scripts.docs.verify_public_site /private/tmp/issue308-ci-docs-site`: **passed**. Generated configuration and provider reference checks also pass.
- `uv run --no-sync pytest -q tests/test_ui_route_group_addresses.py tests/test_ui_route_group_simulation_identity.py tests/test_ui_route_groups.py tests/db/test_route_policy_repository.py tests/services/test_route_group_mutations.py tests/services/test_route_groups.py tests/services/test_route_group_refresh.py tests/services/test_route_policy_publication.py tests/test_route_policy_validation.py tests/test_routing_runtime_generation.py tests/docs/test_generated_references.py`: **153 passed**.
- `uv run --no-sync pytest -q tests/db/test_route_group_identity.py tests/db/test_route_policy_publication_invariants.py`: **7 passed**, using a disposable PostgreSQL 16 database with current migrations; covers identity across transactions and delete/recreate across two connections.
- `uv run --no-sync python -m scripts.docs.export_openapi --check`: **passed**. The generated change adds 11 paths and 13 schemas; existing paths and schemas are unchanged.
- `npm --prefix ui run test:unit`: **201 passed**, including URL encoding, redirects, stale completion, duplicate deletion, and permission/error recovery.
- `npm --prefix ui run build`: **passed**. Initial gzip: **379.49 → 374.14 KB**; detail route: **19.81 KB**, list route: **4.25 KB**.
- Ruff check and format check: **passed on all 13 changed Python files**. Direct ESLint: **zero findings across all 17 changed UI source/test/runner files**.
- `npm --prefix ui run lint`: **118 errors and 4 warnings**, unchanged from the existing baseline.
- `git diff --check`: **passed**.
- Chromium smoke checks of the production bundle at 1280px and 390px covered nested refresh, login return, list/create/delete, loading/empty/error states, retry, and keyboard/dialog focus. API responses were mocked for browser checks; HTTP and PostgreSQL behavior have separate coverage above.

## Product and documentation impact

- [x] Public API, errors, streaming, authentication, or tenant scope reviewed: additive admin routes reuse existing permissions and operation owners; inference behavior is unchanged.
- [x] Settings, environment variables, defaults, secrets, and restart/reload behavior reviewed: existing mutation refresh behavior is retained.
- [x] Schema, migrations, mixed-version sequencing, and rollback safety reviewed: existing UUIDs are reused; no migration is required.
- [x] Provider capabilities, model metadata, pricing, and credentials reviewed: model keys and provider behavior are preserved.
- [x] Admin UI workflow, permissions, states, and screenshots reviewed: desktop/mobile and keyboard checks completed.
- [x] Deployment, probes, metrics, alerts, security, backup, and runbooks reviewed: one additional indexed lookup per ID-addressed admin request; no additional inference-path calls.
- [x] Public docs/nav/links and release/deprecation notes updated: admin API, Model Groups UI, and addressing design/compatibility documentation.
- [x] Generated OpenAPI/config/provider artifacts regenerated and checked when their source changed: OpenAPI regenerated and verified.

The [addressing decision and validation record](https://github.com/deltawi/deltallm/blob/fix/issue-308-model-group-urls/docs/project/route-group-addressing.md) documents ownership, compatibility boundaries, and failure behavior.

## Rollout and rollback

Deploy the backend and UI together. Legacy key API routes remain available with no removal scheduled. New ID bookmarks require the new backend. Roll back by restoring the previous application/UI artifact; no data rollback is needed. Bookmarks that already lost name data to an unescaped query or fragment cannot recover it.
