### PR TITLE
Fix documentation discovery URLs and first-request setup

### DIFF
--- a/CONTRIBUTING_DOCS.md
+++ b/CONTRIBUTING_DOCS.md
@@ -40,6 +40,18 @@ uv run mkdocs serve
 The preview includes only publishable pages. If a page is not ready for publication,
 keep it outside the public source tree.
 
+## Published URLs
+
+`mkdocs.yml` uses `READTHEDOCS_CANONICAL_URL` supplied by Read the Docs, with
+`https://docs.deltallm.io/en/latest/` as the local and CI fallback. Keep the language
+and version path: the root-level `/getting-started/` URL does not serve the page
+published at `/en/latest/getting-started/`.
+
+After changing the documentation domain or default version, inspect the generated
+canonical links and `sitemap.xml`, then verify that their destinations load on the
+published site. The Read the Docs custom domain must be marked as canonical in its
+project settings. See [Read the Docs canonical URL configuration](https://docs.readthedocs.com/platform/stable/intro/mkdocs.html#set-the-canonical-url).
+
 ## Run the documentation gate
 
 Use a temporary output directory so generated site files never enter the repository:

--- a/README.md
+++ b/README.md
@@ -20,9 +20,14 @@
 
 DeltaLLM is a self-hosted LLM gateway. Point OpenAI-compatible clients at one endpoint, then manage model deployments, routing, scoped API keys, budgets, guardrails, MCP tools, and usage from one control plane.
 
-For SaaS products and platform teams, [service tiers](docs/admin-ui/tiers.md) let you
+For hosting consultants, managed service providers, and platform teams,
+[service tiers](docs/admin-ui/tiers.md) let you
 define a model package once and assign it to multiple customer organizations, with
 per-model limits, pricing, and shared capacity. The gateway and Admin UI are MIT licensed.
+
+[SSO](docs/features/authentication.md#single-sign-on),
+[audit logs](docs/features/audit-log.md), and scoped administration are included
+without a gateway license fee. You cover your infrastructure and upstream model usage.
 
 ## One Endpoint For Your Apps
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 
 DeltaLLM is a self-hosted LLM gateway. Point OpenAI-compatible clients at one endpoint, then manage model deployments, routing, scoped API keys, budgets, guardrails, MCP tools, and usage from one control plane.
 
+For SaaS products and platform teams, [service tiers](docs/admin-ui/tiers.md) let you
+define a model package once and assign it to multiple customer organizations, with
+per-model limits, pricing, and shared capacity. The gateway and Admin UI are MIT licensed.
+
 ## One Endpoint For Your Apps
 
 ```python
@@ -41,6 +45,7 @@ Your application keeps its OpenAI request format. DeltaLLM handles provider cred
 
 - **Unified API** - Use one OpenAI-compatible endpoint across OpenAI, Anthropic, Azure OpenAI, Bedrock, Gemini, Groq, and other providers.
 - **Scoped API keys** - Issue virtual keys with model allowlists, rate limits, budgets, owners, and expiry.
+- **Customer plans** - Assign versioned model packages to organizations through service tiers, with model access, rate limits, and pricing managed together.
 - **Routing and failover** - Route by strategy, retry failed deployments, and separate provider credentials from application code.
 - **Batch API** - Run embeddings and non-streaming chat completions asynchronously through OpenAI-compatible files and batches, even when upstream providers are synchronous.
 - **MCP gateway** - Register external MCP servers and expose approved tools through controlled gateway flows.
@@ -96,10 +101,14 @@ Start the stack:
 docker compose --profile single up -d --build
 ```
 
-Check health and send a request:
+Wait for the health endpoint to return `{"status":"ok"}`, then send a request.
+In this terminal, export the same master key you put in `.env`: Compose reads that
+file for its containers, but it does not export variables into your shell.
 
 ```bash
 curl http://localhost:4002/health/liveliness
+
+export DELTALLM_MASTER_KEY='paste-your-generated-master-key'
 
 curl http://localhost:4002/v1/chat/completions \
   -H "Authorization: Bearer $DELTALLM_MASTER_KEY" \
@@ -146,6 +155,10 @@ production high-availability reference.
 - [Report a vulnerability privately](SECURITY.md)
 - PRs are welcome. Start with the [local installation guide](docs/getting-started/installation.md).
 - Documentation changes follow the [documentation contribution guide](CONTRIBUTING_DOCS.md).
+
+If DeltaLLM solves a problem for you, consider starring the repository. Share your
+use case in [Discussions](https://github.com/deltawi/deltallm/discussions) so we can
+improve the workflows that matter to you.
 
 ## License
 

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -37,71 +37,6 @@ general_settings:
 
 That seeds the sample `model_list` into the database on first startup. After the first successful boot, you can set `model_deployment_bootstrap_from_config` back to `false`.
 
-### Single instance
-
-The fastest way to get everything running:
-
-```bash
-# Edit config.yaml with your API keys and settings
-
-docker compose --profile single up -d --build
-```
-
-If you want the full Presidio engine for guardrails instead of the default regex fallback:
-
-```bash
-INSTALL_PRESIDIO=true docker compose --profile single up -d --build
-```
-
-Run the command from the repository root so Compose can read the project `.env` file automatically.
-
-On startup, the DeltaLLM container applies migrations with:
-
-```bash
-prisma migrate deploy --schema=./prisma/schema.prisma
-```
-
-Then it starts the API server.
-
-This starts:
-- DeltaLLM on port **4002** on the host (`4000` inside the container)
-- PostgreSQL 15 database
-- Redis 7 cache
-
-DeltaLLM is available at `http://localhost:4002`.
-
-Without `INSTALL_PRESIDIO=true`, Presidio guardrails still work, but DeltaLLM uses the built-in regex fallback for a smaller default image.
-
-Once a model is available, see [Quick Start](quickstart.md) for `curl`, Python, and JavaScript usage examples.
-
-### Multi-instance evaluation
-
-Run two DeltaLLM instances behind an Nginx load balancer:
-
-```bash
-docker compose --profile ha up -d --build
-```
-
-Each DeltaLLM container runs `prisma migrate deploy --schema=./prisma/schema.prisma` before
-starting the API. Concurrent startup is acceptable only for this evaluation profile. Production
-rollouts must run one coordinated migration job before starting replicas.
-
-This starts:
-- 2 DeltaLLM instances (load balanced)
-- Nginx reverse proxy on port 80
-- PostgreSQL database
-- Redis cache
-
-DeltaLLM is available at `http://localhost`.
-
-!!! warning "This profile is not highly available"
-    Nginx, PostgreSQL, Redis, storage, and both application containers share one host and one
-    failure domain. The profile does not provide production TLS, stateful-service redundancy,
-    coordinated migrations, or recovery automation. See [Docker and Compose
-    boundaries](../deployment/docker.md) before operating outside local evaluation.
-
-Once a model is available, see [Quick Start](quickstart.md) for `curl`, Python, and JavaScript usage examples.
-
 ## Environment Variables
 
 Create a `.env` file in the project root.
@@ -168,6 +103,71 @@ The starter config keeps the common optional features commented out with guidanc
 The container applies strict Prisma migrations automatically on boot, so you do not need a
 separate schema initialization step for the local Compose profiles. Do not extend this
 per-container behavior to a multi-replica production rollout.
+
+## Single instance
+
+The fastest way to get everything running:
+
+```bash
+# Edit config.yaml with your API keys and settings
+
+docker compose --profile single up -d --build
+```
+
+If you want the full Presidio engine for guardrails instead of the default regex fallback:
+
+```bash
+INSTALL_PRESIDIO=true docker compose --profile single up -d --build
+```
+
+Run the command from the repository root so Compose can read the project `.env` file automatically.
+
+On startup, the DeltaLLM container applies migrations with:
+
+```bash
+prisma migrate deploy --schema=./prisma/schema.prisma
+```
+
+Then it starts the API server.
+
+This starts:
+- DeltaLLM on port **4002** on the host (`4000` inside the container)
+- PostgreSQL 15 database
+- Redis 7 cache
+
+DeltaLLM is available at `http://localhost:4002`.
+
+Without `INSTALL_PRESIDIO=true`, Presidio guardrails still work, but DeltaLLM uses the built-in regex fallback for a smaller default image.
+
+Once a model is available, see [Quick Start](quickstart.md) for `curl`, Python, and JavaScript usage examples.
+
+## Multi-instance evaluation
+
+Run two DeltaLLM instances behind an Nginx load balancer:
+
+```bash
+docker compose --profile ha up -d --build
+```
+
+Each DeltaLLM container runs `prisma migrate deploy --schema=./prisma/schema.prisma` before
+starting the API. Concurrent startup is acceptable only for this evaluation profile. Production
+rollouts must run one coordinated migration job before starting replicas.
+
+This starts:
+- 2 DeltaLLM instances (load balanced)
+- Nginx reverse proxy on port 80
+- PostgreSQL database
+- Redis cache
+
+DeltaLLM is available at `http://localhost`.
+
+!!! warning "This profile is not highly available"
+    Nginx, PostgreSQL, Redis, storage, and both application containers share one host and one
+    failure domain. The profile does not provide production TLS, stateful-service redundancy,
+    coordinated migrations, or recovery automation. See [Docker and Compose
+    boundaries](../deployment/docker.md) before operating outside local evaluation.
+
+Once a model is available, see [Quick Start](quickstart.md) for `curl`, Python, and JavaScript usage examples.
 
 ## Custom Config
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,19 +6,23 @@ This page is the main "how do I call the gateway?" guide for first-time users.
 
 ## 1. Start the Gateway
 
-After completing [installation](installation.md) or [Docker](docker.md), make sure the backend is running:
+Complete the [Docker Compose setup](docker.md), including the `.env` file and initial
+model deployment. Compose starts the gateway, PostgreSQL, and Redis together; you do
+not need to start a second backend or Redis process.
 
-```bash
-# Optional: start Redis for distributed caching and rate limiting
-redis-server --daemonize yes
+The examples below use the single-instance Compose address, `http://localhost:4002`.
+If you followed the [manual installation](installation.md), substitute
+`http://localhost:8000`. For the multi-instance Compose evaluation profile, use
+`http://localhost`.
 
-python -m uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
-```
+Replace `YOUR_MASTER_KEY` with the `DELTALLM_MASTER_KEY` value you configured. The
+master key is for this local evaluation; create a scoped virtual key in step 6 for
+your application.
 
 ## 2. Verify It's Running
 
 ```bash
-curl http://localhost:8000/health/liveliness
+curl http://localhost:4002/health/liveliness
 ```
 
 Expected response:
@@ -32,7 +36,7 @@ Expected response:
 ## 3. List Available Models
 
 ```bash
-curl http://localhost:8000/v1/models \
+curl http://localhost:4002/v1/models \
   -H "Authorization: Bearer YOUR_MASTER_KEY"
 ```
 
@@ -48,7 +52,7 @@ curl http://localhost:8000/v1/models \
 Use the standard OpenAI chat completions format:
 
 ```bash
-curl -X POST http://localhost:8000/v1/chat/completions \
+curl -X POST http://localhost:4002/v1/chat/completions \
   -H "Authorization: Bearer YOUR_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -69,7 +73,7 @@ Point any OpenAI SDK client at DeltaLLM:
     from openai import OpenAI
 
     client = OpenAI(
-        base_url="http://localhost:8000/v1",
+        base_url="http://localhost:4002/v1",
         api_key="YOUR_MASTER_KEY",
     )
 
@@ -86,7 +90,7 @@ Point any OpenAI SDK client at DeltaLLM:
     import OpenAI from "openai";
 
     const client = new OpenAI({
-      baseURL: "http://localhost:8000/v1",
+      baseURL: "http://localhost:4002/v1",
       apiKey: "YOUR_MASTER_KEY",
     });
 
@@ -102,7 +106,7 @@ Point any OpenAI SDK client at DeltaLLM:
 Instead of sharing the master key, create scoped virtual keys:
 
 ```bash
-curl -X POST http://localhost:8000/ui/api/keys \
+curl -X POST http://localhost:4002/ui/api/keys \
   -H "Authorization: Bearer YOUR_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: DeltaLLM Documentation
 site_description: Open-source LLM gateway with unified API, RBAC, guardrails, and observability
-site_url: https://docs.deltallm.io/
+# Preserve the language/version path used by Read the Docs in canonical URLs and the sitemap.
+site_url: !ENV [READTHEDOCS_CANONICAL_URL, 'https://docs.deltallm.io/en/latest/']
 repo_url: https://github.com/deltawi/deltallm
 repo_name: deltallm
 

--- a/scripts/docs/report_health.py
+++ b/scripts/docs/report_health.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-import yaml
+from mkdocs.utils import yaml_load
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -32,7 +32,7 @@ def _nav_paths(value: Any) -> set[str]:
 
 
 def collect_health() -> dict[str, Any]:
-    config = yaml.safe_load(MKDOCS_CONFIG.read_text(encoding="utf-8"))
+    config = yaml_load(MKDOCS_CONFIG.read_text(encoding="utf-8"))
     nav_paths = _nav_paths(config.get("nav", []))
     pages = sorted(
         path.relative_to(DOCS_DIR).as_posix()


### PR DESCRIPTION
## Summary

Read the Docs serves pages under a language/version path, but the old canonical URLs and sitemap pointed to root paths that return 404. Use `READTHEDOCS_CANONICAL_URL` with an `/en/latest/` fallback, and make the docs health report accept MkDocs' environment-aware YAML.

The first-request guides now explain the required configuration before startup, consistently use Docker's port 4002, and clarify how to supply the gateway key. The README introduces client-hosting operators and links the included SSO, audit, and service-tier capabilities.

## Validation

- `.venv/bin/pytest -q --confcutdir=tests/docs tests/docs` — 9 passed.
- `.venv/bin/python scripts/docs/report_health.py --check` — passed; 81 public pages, all in navigation.
- `.venv/bin/python scripts/docs/export_openapi.py --check` — current.
- `.venv/bin/python scripts/docs/generate_config_reference.py --check` — current.
- `.venv/bin/python scripts/docs/generate_provider_reference.py --check` — current.
- `.venv/bin/ruff check scripts/docs/report_health.py` and `.venv/bin/ruff format --check scripts/docs/report_health.py` — passed.
- Strict MkDocs builds with the default URL and with `READTHEDOCS_CANONICAL_URL=https://docs.deltallm.io/en/stable/` — passed. All 81 sitemap URLs in each build resolve to generated HTML with the matching canonical.
- Public-site verification passed for both builds.
- `git diff --check` — passed.

No Docker deployment or real provider request was run. Command/configuration parity was checked against the current repository.

## Product and documentation impact

- [x] Public API, errors, streaming, authentication, or tenant scope reviewed
- [x] Settings, environment variables, defaults, secrets, and restart/reload behavior reviewed
- [x] Schema, migrations, mixed-version sequencing, and rollback safety reviewed
- [x] Provider capabilities, model metadata, pricing, and credentials reviewed
- [x] Admin UI workflow, permissions, states, and screenshots reviewed
- [x] Deployment, probes, metrics, alerts, security, backup, and runbooks reviewed
- [x] Public docs/nav/links and release/deprecation notes updated, or no-doc-impact reason below
- [x] Generated OpenAPI/config/provider artifacts regenerated and checked when their source changed

Documentation and docs tooling only. Runtime API, tenancy, configuration semantics, database schemas, and generated reference sources are unchanged. Existing Docker section anchors are preserved.

## Rollout and rollback

Publish through the existing Read the Docs build. Confirm that the configured canonical domain is `docs.deltallm.io`, inspect a deployed page canonical and sitemap, then resubmit the corrected sitemap in Search Console. Search visibility changes require recrawling and are not guaranteed.

Rollback by reverting these commits and rebuilding the docs. No database or runtime migration is required.