### PR TITLE
fix(auth): preserve access roles across SSO logins

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -277,8 +277,10 @@ general_settings:
   # sso_userinfo_url: https://idp.example.com/oauth2/userinfo
   # sso_redirect_uri: http://localhost:4002/auth/callback
   # sso_scope: openid email profile
+  # Initial admin role for verified new SSO accounts. Manage existing roles in People & Access.
   # sso_admin_email_list:
   #   - admin@example.com
+  # Create missing default memberships while preserving existing org/team roles.
   # sso_default_team_id: team-123
   # sso_state_ttl_seconds: 600
   #

--- a/docs/admin-ui/people-and-access.md
+++ b/docs/admin-ui/people-and-access.md
@@ -26,6 +26,16 @@ and the [access/identity API](../api/admin.md#access-and-identity).
 - Runtime user budgets, rate limits, and self-service key policy are visible from the account details drawer
 - Modals let admins add accounts, attach memberships, or edit runtime user asset access without leaving the page
 
+Platform role changes persist across SSO sign-ins. The configured
+`sso_admin_email_list` assigns an initial role only when SSO creates an account;
+it does not override promotions or demotions made here. Disabling an account
+also prevents SSO login until the account is reactivated.
+
+SSO default-team enrollment fills missing memberships and preserves existing
+organization and team roles. First-time SSO linking to an existing account
+requires the identity provider to verify the account's email; a known provider
+subject can continue signing in with its stored permissions.
+
 ## Invitations
 
 People & Access is the main invite-by-email surface.

--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -457,11 +457,17 @@ when a dynamic update attempts to change them.
 | `sso_userinfo_url` | — | OAuth user info URL |
 | `sso_redirect_uri` | — | OAuth redirect URI |
 | `sso_scope` | `openid email profile` | OAuth scopes |
-| `sso_admin_email_list` | `[]` | Emails that get platform admin role on first SSO login |
-| `sso_default_team_id` | — | Optional team automatically assigned to SSO users |
+| `sso_admin_email_list` | `[]` | Verified emails assigned platform admin when SSO creates a new account; existing roles are managed in People & Access |
+| `sso_default_team_id` | — | Optional team assigned to ordinary SSO accounts; missing memberships are created and existing organization/team roles are preserved |
 | `sso_state_ttl_seconds` | `600` | TTL for Redis-backed SSO callback state |
 
 SSO callback state is stored in Redis. If SSO is enabled but Redis is unavailable, DeltaLLM keeps SSO disabled instead of exposing a broken login flow.
+
+Attaching a new provider subject to an existing account always requires verified
+email ownership. Existing provider-subject bindings can authenticate without a
+verification claim; email-derived fallback subjects require verification on every
+login. See [Authentication and SSO](../features/authentication.md#auto-assign-platform-admins)
+for provider compatibility and rollout guidance.
 
 ## Self-Registration Settings
 
@@ -518,7 +524,7 @@ general_settings:
 | `self_registration.enabled` | `false` | Enable first-time SSO provisioning into the configured sandbox org/team |
 | `self_registration.mode` | `sso_allowed_domain` | Current supported production path for automatic provisioning |
 | `self_registration.allowed_domains` | `[]` | Bare email domains eligible for first-time SSO provisioning |
-| `self_registration.require_email_verification` | `true` | Require the identity provider to report a verified email before provisioning |
+| `self_registration.require_email_verification` | `true` | Require verified email for ordinary new-account provisioning; disabling this never bypasses existing-account linking or initial admin ownership checks |
 | `self_registration.require_admin_approval` | `false` | Reserved approval gate. When true, automatic sandbox provisioning is blocked |
 | `self_registration.default_org.*` | — | Organization ID, display name, budgets, and rate limits to seed |
 | `self_registration.default_team.*` | — | Team ID, alias, role, budgets, rate limits, and self-service key policy to seed |

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -229,7 +229,45 @@ The default organization, team, and runtime user values are applied once at prov
 
 ### Auto-Assign Platform Admins
 
-Add emails to `sso_admin_email_list` to grant `platform_admin` on first SSO login.
+Add emails to `general_settings.sso_admin_email_list` to assign `platform_admin`
+when SSO creates a new platform account. Existing accounts keep their stored
+platform role, including accounts linking SSO for the first time. This applies
+with self-registration enabled or disabled.
+
+The identity provider must report a verified email before SSO can grant an
+initial platform-admin role or attach a new provider subject to an existing
+account. This ownership check applies to all existing account roles, including
+when `self_registration.require_email_verification` is `false`. That setting
+controls ordinary new-account provisioning only.
+
+An established provider-subject binding can continue signing in without an
+email-verification claim. If the provider supplies no subject and DeltaLLM uses
+email as its fallback identifier, email verification is required on every login.
+Unverified email changes leave the stored account and identity email unchanged;
+a verified change is accepted only if another account does not own the address.
+
+Providers that cannot assert verified email ownership receive `403` when first
+linking to an existing account. Use an existing local login while configuring
+the provider's verified-email assertion. Existing provider-subject bindings
+continue to work; DeltaLLM does not provide an authenticated account-linking UI.
+
+Manage subsequent promotions and demotions in **People & Access**. Adding or
+removing an email from the list does not change an existing account's role.
+SSO login also preserves disabled status and rejects inactive accounts; complete
+invitation acceptance or reactivate the account through the admin workflow first.
+
+When `sso_default_team_id` applies, SSO creates missing default memberships and
+preserves existing organization and team roles. For example, demoting a platform
+admin to `org_user` leaves their `org_owner` and `team_admin` memberships intact.
+Explicit membership edits and invitation grants can still change those roles.
+
+Older versions reassigned roles from this list on subsequent SSO logins. When
+upgrading, finish the rollout across all API replicas before reapplying any lost
+platform or membership role changes in People & Access, then verify another SSO
+sign-in preserves them. Verify first-time email linking with your provider before
+rollout; unverified linking that older versions accepted is now denied.
+No database migration or automatic role restoration is performed. Rolling back
+to an affected version restores the old overwrite and unsafe email-linking behavior.
 
 ## Role-Based Access Control
 

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -23,6 +23,7 @@ from src.middleware.platform_auth import (
 )
 from src.models.errors import RateLimitError
 from src.auth.roles import PLATFORM_ROLE_PERMISSIONS, PlatformRole, TeamRole
+from src.auth.sso_identity import SSOIdentityAssertion, SSOIdentityOwnershipError
 from src.db.email_tokens import EmailTokenRepository
 from src.models.platform_auth import (
     ChangePasswordRequest,
@@ -179,21 +180,6 @@ def _normalized_email_domain(email: str) -> str | None:
     return domain
 
 
-def _sso_provider_subject(response_payload: dict[str, Any], *, fallback_email: str) -> str:
-    for key in ("provider_subject", "subject", "user_id"):
-        subject = str(response_payload.get(key) or "").strip()
-        if subject:
-            return subject
-    return fallback_email
-
-
-def _sso_email_verified(response_payload: dict[str, Any]) -> bool | None:
-    value = response_payload.get("email_verified")
-    if isinstance(value, bool):
-        return value
-    return None
-
-
 def _is_self_registration_enabled(settings: Any) -> bool:
     return bool(settings is not None and getattr(settings, "enabled", False))
 
@@ -229,7 +215,6 @@ def _is_allowed_self_registration_domain(settings: Any, *, email: str) -> bool:
 @dataclass(frozen=True)
 class _ExistingSSOAccountMatch:
     account: dict[str, Any]
-    matched_by_identity: bool
 
 
 async def _emit_self_registration_blocked(
@@ -313,14 +298,17 @@ async def _existing_sso_account(
     provider: str,
     subject: str,
 ) -> _ExistingSSOAccountMatch | None:
+    """Choose the provisioning route; the login transaction revalidates ownership."""
     if hasattr(identity_service, "get_account_by_sso_identity"):
-        account = await identity_service.get_account_by_sso_identity(provider=provider, subject=subject)
+        account = await identity_service.get_account_by_sso_identity(
+            provider=provider, subject=subject
+        )
         if account is not None:
-            return _ExistingSSOAccountMatch(account=dict(account), matched_by_identity=True)
+            return _ExistingSSOAccountMatch(account=dict(account))
     if hasattr(identity_service, "get_account_by_email"):
         account = await identity_service.get_account_by_email(email)
         if account is not None:
-            return _ExistingSSOAccountMatch(account=dict(account), matched_by_identity=False)
+            return _ExistingSSOAccountMatch(account=dict(account))
     return None
 
 
@@ -328,13 +316,13 @@ async def _create_sso_login_for_existing_account(
     *,
     identity_service: Any,
     account: dict[str, Any],
-    email: str,
-    provider: str,
-    subject: str,
+    identity: SSOIdentityAssertion,
 ) -> Any:
     account_id = str(account.get("account_id") or "").strip()
     if not account_id:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to establish session")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to establish session"
+        )
     if not bool(account.get("is_active", True)):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account is inactive")
 
@@ -348,9 +336,7 @@ async def _create_sso_login_for_existing_account(
 
         login = await create_sso_login(
             account_id=account_id,
-            email=email,
-            provider=provider,
-            subject=subject,
+            identity=identity,
         )
         if login is None:
             raise HTTPException(
@@ -358,8 +344,12 @@ async def _create_sso_login_for_existing_account(
                 detail="Failed to establish session",
             )
         return login
+    except SSOIdentityOwnershipError:
+        raise
     except AccountInactiveError as exc:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account is inactive") from exc
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Account is inactive"
+        ) from exc
     except LoginSessionCreationError as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -373,12 +363,11 @@ async def _create_self_registered_sso_login(
     *,
     request: Request,
     request_start: float,
-    email: str,
-    provider: str,
-    subject: str,
-    email_verified: bool | None,
+    identity: SSOIdentityAssertion,
     settings: Any,
 ) -> Any:
+    email, provider = identity.email, identity.provider
+    email_verified = identity.email_verified
     if getattr(settings, "mode", "sso_allowed_domain") != "sso_allowed_domain":
         detail = "Self-registration approval workflow is not available"
         await _emit_self_registration_blocked(
@@ -441,14 +430,25 @@ async def _create_self_registered_sso_login(
 
     try:
         sso_login = await provisioner.provision_sso_from_defaults(
-            email=email,
+            identity=identity,
             settings=settings,
-            provider=provider,
-            subject=subject,
-            is_active=True,
         )
         result = sso_login.provisioning
         login = sso_login.login
+    except SSOIdentityOwnershipError as exc:
+        await _emit_self_registration_blocked(
+            request=request,
+            request_start=request_start,
+            email=email,
+            provider=provider,
+            reason="email_not_verified",
+            detail=str(exc),
+        )
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except AccountInactiveError as exc:
+        raise HTTPException(status_code=401, detail="Account is inactive") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
     except Exception as exc:
         await _emit_self_registration_provisioning_failed(
             request=request,
@@ -461,6 +461,9 @@ async def _create_self_registered_sso_login(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to provision self-registration account",
         ) from exc
+
+    if result is None:
+        return login
 
     await emit_control_audit_event(
         request=request,
@@ -1286,9 +1289,13 @@ async def auth_login(
     handler = getattr(request.app.state, "sso_auth_handler", None)
     state_store = getattr(request.app.state, "sso_state_store", None)
     if handler is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO is not enabled")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO is not enabled"
+        )
     if state_store is None:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO state storage unavailable")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO state storage unavailable"
+        )
 
     if not state:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing state")
@@ -1301,21 +1308,30 @@ async def auth_login(
             return_to=_safe_return_to(return_to),
         )
     except SSOStateStoreError as exc:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO state storage unavailable") from exc
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO state storage unavailable"
+        ) from exc
 
     return {"authorize_url": handler.get_authorize_url(state, code_challenge=code_challenge)}
 
 
 @router.get("/callback")
-async def auth_callback(request: Request, code: str = Query(default=""), state: str = Query(default="")) -> Response:
+async def auth_callback(
+    request: Request, code: str = Query(default=""), state: str = Query(default="")
+) -> Response:
     request_start = perf_counter()
     try:
         handler = getattr(request.app.state, "sso_auth_handler", None)
         state_store = getattr(request.app.state, "sso_state_store", None)
         if handler is None:
-            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO is not enabled")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO is not enabled"
+            )
         if state_store is None:
-            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO state storage unavailable")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="SSO state storage unavailable",
+            )
 
         if not code:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing code")
@@ -1333,11 +1349,18 @@ async def auth_callback(request: Request, code: str = Query(default=""), state: 
         try:
             login_state = await state_store.pop_login_state(state=state)
         except SSOStateStoreError as exc:
-            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="SSO state storage unavailable") from exc
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="SSO state storage unavailable",
+            ) from exc
         if login_state is None:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired SSO state")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired SSO state"
+            )
 
-        response_payload = await handler.handle_callback(code, code_verifier=login_state.code_verifier)
+        response_payload = await handler.handle_callback(
+            code, code_verifier=login_state.code_verifier
+        )
         raw_email = response_payload.get("email")
         if not isinstance(raw_email, str) or not raw_email.strip():
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid SSO email")
@@ -1347,7 +1370,9 @@ async def auth_callback(request: Request, code: str = Query(default=""), state: 
         identity_service = getattr(request.app.state, "platform_identity_service", None)
 
         if identity_service is None:
-            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Auth service unavailable")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Auth service unavailable"
+            )
 
         normalized_email = (
             identity_service.normalize_email(raw_email)
@@ -1364,8 +1389,8 @@ async def auth_callback(request: Request, code: str = Query(default=""), state: 
         }
         is_platform_admin = normalized_email in admins
         provider = str(getattr(general_settings, "sso_provider", "sso") or "sso")
-        subject = _sso_provider_subject(response_payload, fallback_email=normalized_email)
-        email_verified = _sso_email_verified(response_payload)
+        identity = SSOIdentityAssertion.from_callback(response_payload, provider=provider)
+        subject = identity.subject
         self_registration_settings = getattr(general_settings, "self_registration", None)
 
         if _is_self_registration_enabled(self_registration_settings) and not is_platform_admin:
@@ -1379,39 +1404,38 @@ async def auth_callback(request: Request, code: str = Query(default=""), state: 
                 login = await _create_self_registered_sso_login(
                     request=request,
                     request_start=request_start,
-                    email=normalized_email,
-                    provider=provider,
-                    subject=subject,
-                    email_verified=email_verified,
+                    identity=identity,
                     settings=self_registration_settings,
                 )
             else:
-                if not existing_account.matched_by_identity:
-                    await _enforce_self_registration_email_verified(
+                try:
+                    login = await _create_sso_login_for_existing_account(
+                        identity_service=identity_service,
+                        account=existing_account.account,
+                        identity=identity,
+                    )
+                except SSOIdentityOwnershipError as exc:
+                    await _emit_self_registration_blocked(
                         request=request,
                         request_start=request_start,
                         email=normalized_email,
                         provider=provider,
-                        email_verified=email_verified,
-                        settings=self_registration_settings,
+                        reason="email_not_verified",
+                        detail=str(exc),
                     )
-                login = await _create_sso_login_for_existing_account(
-                    identity_service=identity_service,
-                    account=existing_account.account,
-                    email=normalized_email,
-                    provider=provider,
-                    subject=subject,
-                )
+                    raise HTTPException(status_code=403, detail=str(exc)) from exc
         else:
             try:
                 login = await identity_service.upsert_sso_account(
-                    email=normalized_email,
+                    identity=identity,
                     is_platform_admin=is_platform_admin,
-                    provider=provider,
-                    subject=subject,
                     team_id=response_payload.get("team_id"),
                     default_team_role=TeamRole.VIEWER,
                 )
+            except AccountInactiveError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED, detail="Account is inactive"
+                ) from exc
             except LoginSessionCreationError as exc:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1420,7 +1444,10 @@ async def auth_callback(request: Request, code: str = Query(default=""), state: 
             except ValueError as exc:
                 raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
         if login is None:
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to establish session")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to establish session",
+            )
 
         ttl = int(getattr(general_settings, "auth_session_ttl_hours", 12) * 3600)
 

--- a/src/auth/sso.py
+++ b/src/auth/sso.py
@@ -13,6 +13,7 @@ import httpx
 from fastapi import HTTPException, status
 
 from src.models.errors import RateLimitError
+from src.auth.sso_identity import SSOSubjectSource
 
 
 class SSOProvider(str, Enum):
@@ -102,18 +103,26 @@ class SSOAuthHandler:
         token_data = await self._exchange_code(code, code_verifier=code_verifier)
         access_token = token_data.get("access_token")
         if not access_token:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing access token")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="Missing access token"
+            )
 
         user_info = await self._get_userinfo(access_token)
         raw_email = user_info.get("email")
         email = str(raw_email or "").strip().lower()
         if not email:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email not provided by SSO provider")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="Email not provided by SSO provider"
+            )
         await self._enforce_callback_rate_limit(email)
 
-        provider_subject = self._extract_provider_subject(user_info, fallback_email=email)
+        provider_subject, subject_source = self._extract_provider_subject(
+            user_info, fallback_email=email
+        )
         email_verified = self._extract_email_verified(user_info)
-        admin_emails = {str(item or "").strip().lower() for item in (self.config.admin_email_list or [])}
+        admin_emails = {
+            str(item or "").strip().lower() for item in (self.config.admin_email_list or [])
+        }
         is_admin = email in admin_emails
         user = await self.users.get_or_create_by_email(
             email=email,
@@ -130,17 +139,20 @@ class SSOAuthHandler:
             "role": user.user_role,
             "team_id": user.team_id,
             "provider_subject": provider_subject,
+            "provider_subject_source": subject_source.value,
             "email_verified": email_verified,
             "token": self._generate_session_token(user),
         }
 
-    def _extract_provider_subject(self, user_info: dict[str, Any], *, fallback_email: str) -> str:
+    def _extract_provider_subject(
+        self, user_info: dict[str, Any], *, fallback_email: str
+    ) -> tuple[str, SSOSubjectSource]:
         for key in ("sub", "id", "oid", "user_id"):
             value = user_info.get(key)
             subject = str(value or "").strip()
             if subject:
-                return subject
-        return fallback_email
+                return subject, SSOSubjectSource.PROVIDER
+        return fallback_email, SSOSubjectSource.EMAIL
 
     def _extract_email_verified(self, user_info: dict[str, Any]) -> bool | None:
         for key in ("email_verified", "verified_email"):
@@ -173,13 +185,17 @@ class SSOAuthHandler:
         if self._http_client is not None:
             response = await self._http_client.post(self.config.token_url, data=payload)
             if response.status_code != 200:
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to exchange code")
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to exchange code"
+                )
             return response.json()
 
         async with httpx.AsyncClient(timeout=20) as client:
             response = await client.post(self.config.token_url, data=payload)
             if response.status_code != 200:
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to exchange code")
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to exchange code"
+                )
             return response.json()
 
     async def _get_userinfo(self, access_token: str) -> dict[str, Any]:
@@ -188,13 +204,17 @@ class SSOAuthHandler:
         if self._http_client is not None:
             response = await self._http_client.get(self.config.userinfo_url, headers=headers)
             if response.status_code != 200:
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to get user info")
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to get user info"
+                )
             return response.json()
 
         async with httpx.AsyncClient(timeout=20) as client:
             response = await client.get(self.config.userinfo_url, headers=headers)
             if response.status_code != 200:
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to get user info")
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to get user info"
+                )
             return response.json()
 
     async def _enforce_callback_rate_limit(self, email: str) -> None:
@@ -210,7 +230,9 @@ class SSOAuthHandler:
                 limit=10,
             )
         except RateLimitError as exc:
-            headers = {"Retry-After": str(exc.retry_after)} if getattr(exc, "retry_after", None) else None
+            headers = (
+                {"Retry-After": str(exc.retry_after)} if getattr(exc, "retry_after", None) else None
+            )
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail="Too many SSO login attempts; please try again later",

--- a/src/auth/sso_identity.py
+++ b/src/auth/sso_identity.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+
+from src.auth.roles import PlatformRole
+
+
+class SSOSubjectSource(str, Enum):
+    PROVIDER = "provider"
+    EMAIL = "email"
+
+
+class SSOAccountMatch(str, Enum):
+    SUBJECT = "subject"
+    EMAIL = "email"
+    CREATED = "created"
+
+
+class SSOIdentityOwnershipError(ValueError):
+    def __init__(self) -> None:
+        super().__init__("SSO email is not verified")
+
+
+class AccountInactiveError(RuntimeError):
+    pass
+
+
+class LoginSessionCreationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class SSOIdentityAssertion:
+    provider: str
+    subject: str
+    email: str
+    email_verified: bool | None
+    subject_source: SSOSubjectSource
+
+    def __post_init__(self) -> None:
+        for field in ("provider", "subject", "email"):
+            value = getattr(self, field).strip()
+            if field == "email":
+                value = value.lower()
+            if not value:
+                raise ValueError(f"{field} is required")
+            object.__setattr__(self, field, value)
+        object.__setattr__(self, "subject_source", SSOSubjectSource(self.subject_source))
+
+    @classmethod
+    def from_callback(cls, payload: Mapping[str, object], *, provider: str) -> SSOIdentityAssertion:
+        email = str(payload.get("email") or "").strip().lower()
+        source = payload.get("provider_subject_source")
+        subject = str(payload.get("provider_subject") or "").strip()
+        # A runtime user ID or an unclassified fallback is not provider ownership proof.
+        if source != SSOSubjectSource.PROVIDER or not subject:
+            source, subject = SSOSubjectSource.EMAIL, email
+        verified = payload.get("email_verified")
+        return cls(
+            provider=provider,
+            subject=subject,
+            email=email,
+            email_verified=verified if isinstance(verified, bool) else None,
+            subject_source=SSOSubjectSource(source),
+        )
+
+    def require_verified_email(self) -> None:
+        if self.email_verified is not True:
+            raise SSOIdentityOwnershipError()
+
+    def require_ownership(self, match: SSOAccountMatch, *, role: str) -> None:
+        if (
+            self.subject_source is SSOSubjectSource.EMAIL
+            or match is SSOAccountMatch.EMAIL
+            or (match is SSOAccountMatch.CREATED and role == PlatformRole.ADMIN)
+        ):
+            self.require_verified_email()

--- a/src/db/platform_accounts.py
+++ b/src/db/platform_accounts.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class PlatformAccountDatabase(Protocol):
+    async def execute_raw(self, query: str, *params: object) -> int: ...
+
+    async def query_raw(self, query: str, *params: object) -> list[dict[str, object]]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PlatformAccountRecord:
+    account_id: str
+    email: str
+    role: str
+    is_active: bool
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, object]) -> PlatformAccountRecord:
+        return cls(
+            account_id=str(row["account_id"]),
+            email=str(row["email"]),
+            role=str(row["role"]),
+            is_active=row.get("is_active") is True,
+        )
+
+
+async def insert_platform_account_if_absent(
+    db: PlatformAccountDatabase, *, email: str, role: str, is_active: bool
+) -> PlatformAccountRecord | None:
+    """An inserted row is proof of creation; a conflict grants no identity ownership."""
+    rows = await db.query_raw(
+        """
+        INSERT INTO deltallm_platformaccount (
+            account_id, email, role, is_active, force_password_change, mfa_enabled, created_at, updated_at
+        )
+        VALUES (gen_random_uuid(), $1, $2, $3, false, false, NOW(), NOW())
+        ON CONFLICT (email) DO NOTHING
+        RETURNING account_id, email, role, is_active
+        """,
+        email,
+        role,
+        is_active,
+    )
+    return PlatformAccountRecord.from_row(rows[0]) if rows else None
+
+
+async def refresh_sso_account(
+    db: PlatformAccountDatabase,
+    *,
+    account_id: str,
+    verified_email: str | None,
+    matched_email: str | None,
+) -> PlatformAccountRecord:
+    """Lock and return current authorization state without replacing admin decisions."""
+    rows = await db.query_raw(
+        """
+        UPDATE deltallm_platformaccount
+        SET email = COALESCE($2::text, email), updated_at = NOW()
+        WHERE account_id = $1
+          AND ($3::text IS NULL OR lower(email) = lower($3))
+        RETURNING account_id, email, role, is_active
+        """,
+        account_id,
+        verified_email,
+        matched_email,
+    )
+    if not rows:
+        raise ValueError("SSO account changed; please sign in again")
+    return PlatformAccountRecord.from_row(rows[0])
+
+
+async def ensure_platform_account(
+    db: PlatformAccountDatabase, *, email: str, role: str, is_active: bool
+) -> None:
+    """Seed account defaults without replacing durable administrator decisions."""
+    await db.execute_raw(
+        """
+        INSERT INTO deltallm_platformaccount (
+            account_id, email, role, is_active, force_password_change, mfa_enabled, created_at, updated_at
+        )
+        VALUES (gen_random_uuid(), $1, $2, $3, false, false, NOW(), NOW())
+        ON CONFLICT (email)
+        DO UPDATE SET updated_at = NOW()
+        """,
+        email,
+        role,
+        is_active,
+    )

--- a/src/db/platform_memberships.py
+++ b/src/db/platform_memberships.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from src.auth.roles import OrganizationRole
+from src.db.platform_accounts import PlatformAccountDatabase
+
+
+async def seed_organization_membership(
+    db: PlatformAccountDatabase, *, account_id: str, organization_id: str
+) -> None:
+    await db.execute_raw(
+        """
+        INSERT INTO deltallm_organizationmembership (
+            membership_id, account_id, organization_id, role, created_at, updated_at
+        )
+        VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
+        ON CONFLICT (account_id, organization_id) DO NOTHING
+        """,
+        account_id,
+        organization_id,
+        OrganizationRole.MEMBER,
+    )
+
+
+async def seed_team_membership(
+    db: PlatformAccountDatabase, *, account_id: str, team_id: str, role: str
+) -> None:
+    await db.execute_raw(
+        """
+        INSERT INTO deltallm_teammembership (
+            membership_id, account_id, team_id, role, created_at, updated_at
+        )
+        VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
+        ON CONFLICT (account_id, team_id) DO NOTHING
+        """,
+        account_id,
+        team_id,
+        role,
+    )
+
+
+async def lock_sso_default_team(db: PlatformAccountDatabase, *, team_id: str) -> str | None:
+    rows = await db.query_raw(
+        """
+        SELECT organization_id FROM deltallm_teamtable
+        WHERE team_id = $1
+        FOR SHARE
+        """,
+        team_id,
+    )
+    if not rows:
+        raise ValueError("SSO default team is unavailable")
+    return str(rows[0]["organization_id"]) if rows[0].get("organization_id") else None

--- a/src/services/platform_identity_service.py
+++ b/src/services/platform_identity_service.py
@@ -11,12 +11,24 @@ from typing import Any
 import urllib.parse
 
 from src.auth.roles import (
-    OrganizationRole,
     PLATFORM_ROLE_PERMISSIONS,
     Permission,
     PlatformRole,
     TeamRole,
 )
+from src.auth.sso_identity import (
+    AccountInactiveError as AccountInactiveError,
+    LoginSessionCreationError as LoginSessionCreationError,
+    SSOIdentityAssertion,
+)
+from src.db.platform_accounts import ensure_platform_account
+from src.db.platform_memberships import (
+    lock_sso_default_team,
+    seed_organization_membership,
+    seed_team_membership,
+)
+from src.services.organization_mutation_policy import OrganizationMutationPolicy
+from src.services.sso_account_service import SSOAccountService
 from src.models.platform_auth import PlatformAuthContext
 
 
@@ -34,14 +46,6 @@ class AccountAuthState:
     email: str
     has_local_password: bool
     has_sso_identity: bool
-
-
-class AccountInactiveError(RuntimeError):
-    pass
-
-
-class LoginSessionCreationError(RuntimeError):
-    pass
 
 
 class PlatformIdentityService:
@@ -156,191 +160,82 @@ class PlatformIdentityService:
 
     async def upsert_sso_account(
         self,
-        email: str,
+        *,
+        identity: SSOIdentityAssertion,
         is_platform_admin: bool,
-        provider: str = "sso",
-        subject: str | None = None,
         team_id: str | None = None,
         default_team_role: str = TeamRole.VIEWER,
     ) -> LoginResult | None:
         if self.db is None:
             return None
-
-        if hasattr(self.db, "tx"):
-            async with self.db.tx() as tx:
-                identity_service = self.with_db(tx)
-                return await identity_service._upsert_sso_account(
-                    email=email,
-                    is_platform_admin=is_platform_admin,
-                    provider=provider,
-                    subject=subject,
-                    team_id=team_id,
-                    default_team_role=default_team_role,
-                )
-
-        return await self._upsert_sso_account(
-            email=email,
-            is_platform_admin=is_platform_admin,
-            provider=provider,
-            subject=subject,
-            team_id=team_id,
-            default_team_role=default_team_role,
-        )
+        async with self.db.tx() as tx:
+            return await self.with_db(tx)._upsert_sso_account(
+                identity=identity,
+                is_platform_admin=is_platform_admin,
+                team_id=team_id,
+                default_team_role=default_team_role,
+            )
 
     async def _upsert_sso_account(
         self,
-        email: str,
+        *,
+        identity: SSOIdentityAssertion,
         is_platform_admin: bool,
-        provider: str,
-        subject: str | None,
         team_id: str | None,
         default_team_role: str,
-    ) -> LoginResult | None:
-        role = PlatformRole.ADMIN if is_platform_admin else PlatformRole.ORG_USER
-        normalized_email = self.normalize_email(email)
-        if not normalized_email:
-            raise ValueError("email is required")
-        normalized_provider = str(provider or "sso").strip() or "sso"
-        normalized_subject = str(subject or normalized_email).strip()
-        if not normalized_subject:
-            raise ValueError("subject is required")
-
-        linked_account = await self.get_account_by_sso_identity(
-            provider=normalized_provider,
-            subject=normalized_subject,
+    ) -> LoginResult:
+        resolved = await SSOAccountService(self.db, self).resolve(
+            identity,
+            initial_role=PlatformRole.ADMIN if is_platform_admin else PlatformRole.ORG_USER,
         )
-        if linked_account is not None:
-            linked_account_id = str(linked_account.get("account_id") or "").strip()
-            if not linked_account_id:
-                raise RuntimeError("linked SSO account is invalid")
-            await self._reconcile_sso_identity_for_account(
-                account_id=linked_account_id,
-                email=normalized_email,
-                provider=normalized_provider,
-                subject=normalized_subject,
-                role=role,
-                is_active=True,
-            )
-            account_id = linked_account_id
-        else:
-            await self.db.execute_raw(
-                """
-                INSERT INTO deltallm_platformaccount (
-                    account_id, email, role, is_active, force_password_change,
-                    mfa_enabled, created_at, updated_at
-                )
-                VALUES (gen_random_uuid(), $1, $2, true, false, false, NOW(), NOW())
-                ON CONFLICT (email)
-                DO UPDATE SET role = EXCLUDED.role, is_active = true, updated_at = NOW()
-                """,
-                normalized_email,
-                role,
-            )
-            account = await self.get_account_by_email(normalized_email)
-            if account is None:
-                raise LoginSessionCreationError("Failed to establish session")
-            account_id = str(account.get("account_id") or "").strip()
-            if not account_id:
-                raise RuntimeError("failed to load SSO account")
-
-            await self.link_sso_identity(
-                account_id=account_id,
-                email=normalized_email,
-                provider=normalized_provider,
-                subject=normalized_subject,
-            )
-        if not is_platform_admin and team_id:
-            await self.db.execute_raw(
-                """
-                INSERT INTO deltallm_teammembership (membership_id, account_id, team_id, role, created_at, updated_at)
-                VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
-                ON CONFLICT (account_id, team_id)
-                DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
-                """,
-                account_id,
-                team_id,
-                default_team_role,
-            )
-            org_rows = await self.db.query_raw(
-                "SELECT organization_id FROM deltallm_teamtable WHERE team_id = $1 LIMIT 1",
-                team_id,
-            )
-            organization_id = org_rows[0].get("organization_id") if org_rows else None
+        account = resolved.account
+        if account.role == PlatformRole.ORG_USER and team_id:
+            organization_id = await lock_sso_default_team(self.db, team_id=team_id)
             if organization_id:
-                await self.db.execute_raw(
-                    """
-                    INSERT INTO deltallm_organizationmembership (membership_id, account_id, organization_id, role, created_at, updated_at)
-                    VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
-                    ON CONFLICT (account_id, organization_id)
-                    DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()
-                    """,
-                    account_id,
-                    organization_id,
-                    OrganizationRole.MEMBER,
+                await OrganizationMutationPolicy.for_database(self.db).require_active(
+                    organization_id
                 )
-
-        login = await self.create_login_result_for_account(account_id)
-        if login is None:
-            raise LoginSessionCreationError("Failed to establish session")
-        await self.mark_last_login(account_id)
-        return login
+                await seed_organization_membership(
+                    self.db, account_id=account.account_id, organization_id=organization_id
+                )
+            await seed_team_membership(
+                self.db, account_id=account.account_id, team_id=team_id, role=default_team_role
+            )
+        return await self.finish_sso_login(account.account_id)
 
     async def create_sso_login_for_existing_account(
         self,
         *,
         account_id: str,
-        email: str,
-        provider: str = "sso",
-        subject: str | None = None,
+        identity: SSOIdentityAssertion,
     ) -> LoginResult | None:
         if self.db is None:
             return None
-
-        if hasattr(self.db, "tx"):
-            async with self.db.tx() as tx:
-                identity_service = self.with_db(tx)
-                return await identity_service._create_sso_login_for_existing_account(
-                    account_id=account_id,
-                    email=email,
-                    provider=provider,
-                    subject=subject,
-                )
-
-        return await self._create_sso_login_for_existing_account(
-            account_id=account_id,
-            email=email,
-            provider=provider,
-            subject=subject,
-        )
+        async with self.db.tx() as tx:
+            return await self.with_db(tx)._create_sso_login_for_existing_account(
+                account_id=account_id, identity=identity
+            )
 
     async def _create_sso_login_for_existing_account(
         self,
         *,
         account_id: str,
-        email: str,
-        provider: str = "sso",
-        subject: str | None = None,
+        identity: SSOIdentityAssertion,
     ) -> LoginResult:
-        normalized_account_id = str(account_id or "").strip()
+        normalized_account_id = account_id.strip()
         if not normalized_account_id:
             raise ValueError("account_id is required")
-
-        account = await self.get_account_by_id(normalized_account_id)
-        if account is None:
-            raise RuntimeError("SSO account not found")
-        if not bool(account.get("is_active", True)):
-            raise AccountInactiveError("Account is inactive")
-
-        await self._reconcile_sso_identity_for_account(
-            account_id=normalized_account_id,
-            email=email,
-            provider=provider,
-            subject=subject,
+        resolved = await SSOAccountService(self.db, self).resolve(
+            identity, expected_account_id=normalized_account_id
         )
-        login = await self.create_login_result_for_account(normalized_account_id)
+        return await self.finish_sso_login(resolved.account.account_id)
+
+    async def finish_sso_login(self, account_id: str) -> LoginResult:
+        """Finish a validated SSO login inside its account-resolution transaction."""
+        login = await self.create_login_result_for_account(account_id)
         if login is None:
             raise LoginSessionCreationError("Failed to establish session")
-        await self.mark_last_login(normalized_account_id)
+        await self.mark_last_login(account_id)
         return login
 
     async def reconcile_sso_identity_for_account(
@@ -796,18 +691,8 @@ class PlatformIdentityService:
                 "role": role,
                 "is_active": is_active,
             }
-        await self.db.execute_raw(
-            """
-            INSERT INTO deltallm_platformaccount (
-                account_id, email, role, is_active, force_password_change, mfa_enabled, created_at, updated_at
-            )
-            VALUES (gen_random_uuid(), $1, $2, $3, false, false, NOW(), NOW())
-            ON CONFLICT (email)
-            DO UPDATE SET updated_at = NOW()
-            """,
-            normalized_email,
-            role,
-            is_active,
+        await ensure_platform_account(
+            self.db, email=normalized_email, role=role, is_active=is_active
         )
         account = await self.get_account_by_email(normalized_email)
         if account is None:

--- a/src/services/self_registration_provisioning.py
+++ b/src/services/self_registration_provisioning.py
@@ -4,9 +4,14 @@ from dataclasses import dataclass
 import json
 from typing import Any
 
-from src.auth.roles import OrganizationRole, PlatformRole
+from src.auth.roles import PlatformRole
+from src.auth.sso_identity import SSOAccountMatch, SSOIdentityAssertion
+from src.db.platform_accounts import PlatformAccountRecord
+from src.db.platform_memberships import seed_organization_membership, seed_team_membership
+from src.services.organization_mutation_policy import OrganizationMutationPolicy
+from src.services.sso_account_service import SSOAccountService
 from src.config import SelfRegistrationSettings
-from src.services.platform_identity_service import PlatformIdentityService
+from src.services.platform_identity_service import LoginResult, PlatformIdentityService
 
 
 _SELF_REGISTRATION_SOURCE = "self_registration"
@@ -37,8 +42,8 @@ class SelfRegistrationProvisioningResult:
 
 @dataclass(frozen=True)
 class SelfRegistrationSSOLoginResult:
-    provisioning: SelfRegistrationProvisioningResult
-    login: Any
+    provisioning: SelfRegistrationProvisioningResult | None
+    login: LoginResult
 
 
 class SelfRegistrationProvisioningService:
@@ -89,69 +94,34 @@ class SelfRegistrationProvisioningService:
     async def provision_sso_from_defaults(
         self,
         *,
-        email: str,
+        identity: SSOIdentityAssertion,
         settings: SelfRegistrationSettings,
-        provider: str,
-        subject: str,
-        is_active: bool = True,
     ) -> SelfRegistrationSSOLoginResult:
         if not settings.enabled:
             raise ValueError("self-registration is disabled")
         if self.db is None:
             raise RuntimeError("database is required for self-registration provisioning")
-
-        normalized_email = self.platform_identity_service.normalize_email(email)
-        normalized_provider = str(provider or "sso").strip() or "sso"
-        normalized_subject = str(subject or normalized_email).strip()
-        if not normalized_email:
-            raise ValueError("email is required")
-        if not normalized_subject:
-            raise ValueError("subject is required")
-
         if not hasattr(self.db, "tx"):
-            raise RuntimeError("database transactions are required for SSO self-registration provisioning")
-
+            raise RuntimeError(
+                "database transactions are required for SSO self-registration provisioning"
+            )
         async with self.db.tx() as tx:
             identity_service = self.platform_identity_service.with_db(tx)
-            return await self._provision_sso_with_dependencies(
-                db_client=tx,
-                identity_service=identity_service,
-                email=normalized_email,
-                settings=settings,
-                provider=normalized_provider,
-                subject=normalized_subject,
-                is_active=is_active,
-            )
-
-    async def _provision_sso_with_dependencies(
-        self,
-        *,
-        db_client: Any,
-        identity_service: PlatformIdentityService,
-        email: str,
-        settings: SelfRegistrationSettings,
-        provider: str,
-        subject: str,
-        is_active: bool,
-    ) -> SelfRegistrationSSOLoginResult:
-        provisioning = await self._provision_with_dependencies(
-            db_client=db_client,
-            identity_service=identity_service,
-            email=email,
-            settings=settings,
-            is_active=is_active,
-        )
-        await identity_service.link_sso_identity(
-            account_id=provisioning.account_id,
-            email=email,
-            provider=provider,
-            subject=subject,
-        )
-        login = await identity_service.create_login_result_for_account(provisioning.account_id)
-        if login is None:
-            raise RuntimeError("failed to establish self-registration session")
-        await identity_service.mark_last_login(provisioning.account_id)
-        return SelfRegistrationSSOLoginResult(provisioning=provisioning, login=login)
+            resolved = await SSOAccountService(tx, identity_service).resolve(identity)
+            provisioning = None
+            if resolved.match is SSOAccountMatch.CREATED:
+                if settings.require_email_verification:
+                    identity.require_verified_email()
+                provisioning = await self._provision_with_dependencies(
+                    db_client=tx,
+                    identity_service=identity_service,
+                    email=identity.email,
+                    settings=settings,
+                    is_active=True,
+                    account=resolved.account,
+                )
+            login = await identity_service.finish_sso_login(resolved.account.account_id)
+            return SelfRegistrationSSOLoginResult(provisioning=provisioning, login=login)
 
     async def _provision_with_dependencies(
         self,
@@ -161,6 +131,7 @@ class SelfRegistrationProvisioningService:
         email: str,
         settings: SelfRegistrationSettings,
         is_active: bool,
+        account: PlatformAccountRecord | None = None,
     ) -> SelfRegistrationProvisioningResult:
         organization_id = str(settings.default_org.id or "").strip()
         team_id = str(settings.default_team.id or "").strip()
@@ -173,14 +144,15 @@ class SelfRegistrationProvisioningService:
             organization_id=organization_id,
         )
         await self._insert_default_org(db_client, settings=settings)
+        await OrganizationMutationPolicy.for_database(db_client).require_active(organization_id)
         await self._insert_default_team(db_client, settings=settings)
 
-        account = await identity_service.ensure_account(
-            email=email,
-            role=PlatformRole.ORG_USER,
-            is_active=is_active,
-        )
-        account_id = str(account.get("account_id") or "").strip()
+        if account is None:
+            row = await identity_service.ensure_account(
+                email=email, role=PlatformRole.ORG_USER, is_active=is_active
+            )
+            account = PlatformAccountRecord.from_row(row)
+        account_id = account.account_id
         if not account_id:
             raise RuntimeError("failed to provision account")
 
@@ -191,12 +163,12 @@ class SelfRegistrationProvisioningService:
             team_id=team_id,
             settings=settings,
         )
-        await self._insert_org_membership(
+        await seed_organization_membership(
             db_client,
             account_id=account_id,
             organization_id=organization_id,
         )
-        await self._insert_team_membership(
+        await seed_team_membership(
             db_client,
             account_id=account_id,
             team_id=team_id,
@@ -211,12 +183,12 @@ class SelfRegistrationProvisioningService:
 
         return SelfRegistrationProvisioningResult(
             account_id=account_id,
-            email=str(account.get("email") or email),
+            email=account.email,
             organization_id=organization_id,
             team_id=team_id,
             user_id=user_id,
             team_role=settings.default_team.role,
-            account_is_active=bool(account.get("is_active", is_active)),
+            account_is_active=account.is_active,
         )
 
     async def _ensure_team_can_belong_to_org(
@@ -241,7 +213,9 @@ class SelfRegistrationProvisioningService:
         if existing_org_id != organization_id:
             raise ValueError("default team already belongs to a different organization")
 
-    async def _insert_default_org(self, db_client: Any, *, settings: SelfRegistrationSettings) -> None:
+    async def _insert_default_org(
+        self, db_client: Any, *, settings: SelfRegistrationSettings
+    ) -> None:
         default_org = settings.default_org
         await db_client.execute_raw(
             """
@@ -276,7 +250,9 @@ class SelfRegistrationProvisioningService:
             self._metadata_json("organization"),
         )
 
-    async def _insert_default_team(self, db_client: Any, *, settings: SelfRegistrationSettings) -> None:
+    async def _insert_default_team(
+        self, db_client: Any, *, settings: SelfRegistrationSettings
+    ) -> None:
         default_team = settings.default_team
         await db_client.execute_raw(
             """
@@ -321,47 +297,6 @@ class SelfRegistrationProvisioningService:
             default_team.self_service_budget_ceiling,
             default_team.self_service_require_expiry,
             default_team.self_service_max_expiry_days,
-        )
-
-    async def _insert_org_membership(
-        self,
-        db_client: Any,
-        *,
-        account_id: str,
-        organization_id: str,
-    ) -> None:
-        await db_client.execute_raw(
-            """
-            INSERT INTO deltallm_organizationmembership (
-                membership_id, account_id, organization_id, role, created_at, updated_at
-            )
-            VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
-            ON CONFLICT (account_id, organization_id) DO NOTHING
-            """,
-            account_id,
-            organization_id,
-            OrganizationRole.MEMBER,
-        )
-
-    async def _insert_team_membership(
-        self,
-        db_client: Any,
-        *,
-        account_id: str,
-        team_id: str,
-        role: str,
-    ) -> None:
-        await db_client.execute_raw(
-            """
-            INSERT INTO deltallm_teammembership (
-                membership_id, account_id, team_id, role, created_at, updated_at
-            )
-            VALUES (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
-            ON CONFLICT (account_id, team_id) DO NOTHING
-            """,
-            account_id,
-            team_id,
-            role,
         )
 
     async def _mark_account_self_registered(

--- a/src/services/sso_account_service.py
+++ b/src/services/sso_account_service.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.auth.roles import PlatformRole
+from src.auth.sso_identity import (
+    AccountInactiveError,
+    LoginSessionCreationError,
+    SSOAccountMatch,
+    SSOIdentityAssertion,
+)
+from src.db.platform_accounts import (
+    PlatformAccountDatabase,
+    PlatformAccountRecord,
+    insert_platform_account_if_absent,
+    refresh_sso_account,
+)
+
+
+class SSOIdentityStore(Protocol):
+    async def get_account_by_sso_identity(
+        self, *, provider: str, subject: str
+    ) -> Mapping[str, object] | None: ...
+
+    async def get_account_by_email(self, email: str) -> Mapping[str, object] | None: ...
+
+    async def get_account_by_id(self, account_id: str) -> Mapping[str, object] | None: ...
+
+    async def link_sso_identity(
+        self, *, account_id: str, email: str, provider: str, subject: str
+    ) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SSOAccountResolution:
+    account: PlatformAccountRecord
+    match: SSOAccountMatch
+
+
+class SSOAccountService:
+    """Resolve and bind an SSO account inside the caller's login transaction."""
+
+    def __init__(self, db: PlatformAccountDatabase, identities: SSOIdentityStore) -> None:
+        self.db = db
+        self.identities = identities
+
+    async def resolve(
+        self,
+        identity: SSOIdentityAssertion,
+        *,
+        initial_role: str = PlatformRole.ORG_USER,
+        expected_account_id: str | None = None,
+    ) -> SSOAccountResolution:
+        linked = await self.identities.get_account_by_sso_identity(
+            provider=identity.provider, subject=identity.subject
+        )
+        if linked is not None:
+            account = PlatformAccountRecord.from_row(linked)
+            match = SSOAccountMatch.SUBJECT
+            if expected_account_id is not None and account.account_id != expected_account_id:
+                raise ValueError("SSO identity is already linked to another account")
+        else:
+            resolved = await self._resolve_unlinked(
+                identity, initial_role=initial_role, expected_account_id=expected_account_id
+            )
+            account, match = resolved.account, resolved.match
+        self._require_active(account)
+        identity.require_ownership(match, role=account.role)
+        if match is not SSOAccountMatch.CREATED:
+            account = await self._refresh_existing(identity, account, match=match)
+            self._require_active(account)
+        await self.identities.link_sso_identity(
+            account_id=account.account_id,
+            email=account.email,
+            provider=identity.provider,
+            subject=identity.subject,
+        )
+        return SSOAccountResolution(account=account, match=match)
+
+    async def _resolve_unlinked(
+        self,
+        identity: SSOIdentityAssertion,
+        *,
+        initial_role: str,
+        expected_account_id: str | None,
+    ) -> SSOAccountResolution:
+        if expected_account_id is not None:
+            row = await self.identities.get_account_by_id(expected_account_id)
+            if row is None:
+                raise RuntimeError("SSO account not found")
+            account = PlatformAccountRecord.from_row(row)
+            self._require_active(account)
+            if account.email.strip().lower() != identity.email:
+                raise ValueError("SSO email does not match account")
+        else:
+            created = await insert_platform_account_if_absent(
+                self.db, email=identity.email, role=initial_role, is_active=True
+            )
+            if created is not None:
+                return SSOAccountResolution(created, SSOAccountMatch.CREATED)
+            row = await self.identities.get_account_by_email(identity.email)
+            if row is None:
+                raise LoginSessionCreationError("Failed to establish session")
+            account = PlatformAccountRecord.from_row(row)
+        return SSOAccountResolution(account, SSOAccountMatch.EMAIL)
+
+    async def _refresh_existing(
+        self,
+        identity: SSOIdentityAssertion,
+        account: PlatformAccountRecord,
+        *,
+        match: SSOAccountMatch,
+    ) -> PlatformAccountRecord:
+        verified_email = identity.email if identity.email_verified is True else None
+        if verified_email is not None and verified_email != account.email:
+            owner = await self.identities.get_account_by_email(verified_email)
+            if owner is not None and owner["account_id"] != account.account_id:
+                raise ValueError("SSO email is already linked to another account")
+        return await refresh_sso_account(
+            self.db,
+            account_id=account.account_id,
+            verified_email=verified_email,
+            matched_email=identity.email if match is SSOAccountMatch.EMAIL else None,
+        )
+
+    @staticmethod
+    def _require_active(account: PlatformAccountRecord) -> None:
+        if not account.is_active:
+            raise AccountInactiveError("Account is inactive")

--- a/tests/auth/test_sso.py
+++ b/tests/auth/test_sso.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+from src.auth.sso_identity import (
+    SSOAccountMatch,
+    SSOIdentityAssertion,
+    SSOIdentityOwnershipError,
+    SSOSubjectSource,
+)
+
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -85,12 +92,15 @@ async def test_sso_callback_creates_user_and_returns_session_token():
         http_client=http_client,
     )
 
-    response = await handler.handle_callback("authorization-code", code_verifier="pkce-verifier-123")
+    response = await handler.handle_callback(
+        "authorization-code", code_verifier="pkce-verifier-123"
+    )
 
     assert response["email"] == "admin@example.com"
     assert response["role"] == "proxy_admin"
     assert response["team_id"] == "default-team"
     assert response["provider_subject"] == "admin@example.com"
+    assert response["provider_subject_source"] == "email"
     assert response["email_verified"] is None
     assert response["token"].startswith("sso:")
     assert len(response["token"].split(":")[-1]) >= 43
@@ -124,6 +134,7 @@ async def test_sso_callback_returns_provider_subject_from_userinfo_sub():
 
     assert response["email"] == "user@example.com"
     assert response["provider_subject"] == "provider-subject-123"
+    assert response["provider_subject_source"] == "provider"
     assert response["email_verified"] is True
 
 
@@ -140,7 +151,9 @@ async def test_sso_callback_normalizes_string_email_verified_claim():
             redirect_uri="https://proxy.example.com/auth/callback",
         ),
         user_repository=InMemoryUserRepository(),
-        http_client=MockSSOHTTPClient(userinfo={"email": "user@example.com", "verified_email": "false"}),
+        http_client=MockSSOHTTPClient(
+            userinfo={"email": "user@example.com", "verified_email": "false"}
+        ),
     )
 
     response = await handler.handle_callback("authorization-code")
@@ -176,3 +189,36 @@ async def test_sso_callback_is_rate_limited_by_email():
 
     assert exc_info.value.status_code == 429
     assert exc_info.value.headers == {"Retry-After": "42"}
+
+
+@pytest.mark.parametrize("verified", [False, None, "true", "false", 1, [], {}])
+def test_callback_assertion_requires_boolean_verification_for_email_link(verified) -> None:
+    identity = SSOIdentityAssertion.from_callback(
+        {
+            "email": "USER@example.com",
+            "provider_subject": "subject",
+            "provider_subject_source": "provider",
+            "email_verified": verified,
+        },
+        provider="oidc",
+    )
+    assert identity.email == "user@example.com"
+    with pytest.raises(SSOIdentityOwnershipError):
+        identity.require_ownership(SSOAccountMatch.EMAIL, role="platform_admin")
+
+
+@pytest.mark.parametrize("source", [None, "email", "unknown"])
+def test_runtime_user_id_or_unclassified_subject_cannot_prove_ownership(source) -> None:
+    identity = SSOIdentityAssertion.from_callback(
+        {
+            "email": "person@example.com",
+            "user_id": "runtime-user-id",
+            "provider_subject": "unclassified",
+            "provider_subject_source": source,
+        },
+        provider="oidc",
+    )
+    assert identity.subject == "person@example.com"
+    assert identity.subject_source is SSOSubjectSource.EMAIL
+    with pytest.raises(SSOIdentityOwnershipError):
+        identity.require_ownership(SSOAccountMatch.SUBJECT, role="org_user")

--- a/tests/db/test_sso_account_roles.py
+++ b/tests/db/test_sso_account_roles.py
@@ -1,0 +1,711 @@
+from __future__ import annotations
+
+from src.auth.sso_identity import SSOIdentityAssertion, SSOSubjectSource
+
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+import os
+from uuid import uuid4
+
+import pytest
+from prisma import Prisma
+
+from src.services.platform_identity_service import (
+    AccountInactiveError,
+    LoginResult,
+    LoginSessionCreationError,
+    PlatformIdentityService,
+)
+from src.auth.sso_identity import SSOIdentityOwnershipError
+from src.services.self_registration_provisioning import SelfRegistrationProvisioningService
+from tests.services.test_self_registration_provisioning import _enabled_settings
+
+pytestmark = pytest.mark.postgres
+
+
+@dataclass
+class SSODatabases:
+    login: Prisma
+    writer: Prisma
+    email: str
+    other_email: str
+    subject: str
+    organization_id: str
+    team_id: str
+
+
+@pytest.fixture
+async def databases() -> AsyncIterator[SSODatabases]:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        pytest.skip("DATABASE_URL is required for PostgreSQL SSO tests")
+    login = Prisma(datasource={"url": url})
+    writer = Prisma(datasource={"url": url})
+    suffix = uuid4().hex
+    context = SSODatabases(
+        login=login,
+        writer=writer,
+        email=f"sso-{suffix}@example.com",
+        other_email=f"sso-other-{suffix}@example.com",
+        subject=f"subject-{suffix}",
+        organization_id=f"org-{suffix}",
+        team_id=f"team-{suffix}",
+    )
+    await login.connect()
+    try:
+        await writer.connect()
+        try:
+            yield context
+        finally:
+            await login.execute_raw(
+                "DELETE FROM deltallm_platformaccount WHERE email IN ($1, $2)",
+                context.email,
+                context.other_email,
+            )
+            await login.execute_raw(
+                "DELETE FROM deltallm_usertable WHERE user_email IN ($1, $2)",
+                context.email,
+                context.other_email,
+            )
+            await login.execute_raw(
+                "DELETE FROM deltallm_teamtable WHERE team_id = $1", context.team_id
+            )
+            await login.execute_raw(
+                "DELETE FROM deltallm_organizationtable WHERE organization_id = $1",
+                context.organization_id,
+            )
+            await writer.disconnect()
+    finally:
+        await login.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("linked", [False, True])
+@pytest.mark.parametrize("initial_role", ["org_user", "platform_admin"])
+async def test_sso_login_preserves_concurrent_role_edit(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+    linked: bool,
+    initial_role: str,
+) -> None:
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    account = await service.ensure_account(email=databases.email, role=initial_role, is_active=True)
+    account_id = account["account_id"]
+    prior_login = await service.create_login_result_for_account(account_id)
+    assert prior_login is not None
+    if linked:
+        await service.link_sso_identity(
+            account_id=account_id,
+            email=databases.email,
+            provider="oidc",
+            subject=databases.subject,
+        )
+    edited_role = "platform_admin" if initial_role == "org_user" else "org_user"
+    lookup = PlatformIdentityService.get_account_by_sso_identity
+
+    async def lookup_then_edit(
+        identity: PlatformIdentityService, *, provider: str, subject: str
+    ) -> dict[str, object] | None:
+        snapshot = await lookup(identity, provider=provider, subject=subject)
+        # Commit the admin edit on a different connection after the login's read.
+        await databases.writer.execute_raw(
+            "UPDATE deltallm_platformaccount SET role = $2 WHERE account_id = $1",
+            account_id,
+            edited_role,
+        )
+        return snapshot
+
+    monkeypatch.setattr(PlatformIdentityService, "get_account_by_sso_identity", lookup_then_edit)
+    result = await service.upsert_sso_account(
+        identity=SSOIdentityAssertion(
+            email=databases.email,
+            provider="oidc",
+            subject=databases.subject,
+            email_verified=True,
+            subject_source=SSOSubjectSource.PROVIDER,
+        ),
+        is_platform_admin=initial_role == "platform_admin",
+    )
+    assert result is not None and result.context.role == edited_role
+    persisted = await service.get_account_by_id(account_id)
+    assert persisted is not None and persisted["role"] == edited_role
+    existing_session = await service.get_context_for_session(prior_login.session_token)
+    assert existing_session is not None and existing_session.role == edited_role
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_logins_share_one_account_and_initial_role(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    barrier = asyncio.Barrier(2)
+    lookup = PlatformIdentityService.get_account_by_sso_identity
+
+    async def lookup_before_insert(
+        identity: PlatformIdentityService, *, provider: str, subject: str
+    ) -> dict[str, object] | None:
+        snapshot = await lookup(identity, provider=provider, subject=subject)
+        assert snapshot is None
+        await asyncio.wait_for(barrier.wait(), timeout=5)
+        return snapshot
+
+    monkeypatch.setattr(
+        PlatformIdentityService, "get_account_by_sso_identity", lookup_before_insert
+    )
+    services = [
+        PlatformIdentityService(databases.login, salt="test-salt"),
+        PlatformIdentityService(databases.writer, salt="test-salt"),
+    ]
+    async with asyncio.TaskGroup() as group:
+        tasks = [
+            group.create_task(
+                service.upsert_sso_account(
+                    identity=SSOIdentityAssertion(
+                        email=databases.email,
+                        provider="oidc",
+                        subject=databases.subject,
+                        email_verified=True,
+                        subject_source=SSOSubjectSource.PROVIDER,
+                    ),
+                    is_platform_admin=listed,
+                )
+            )
+            for service, listed in zip(services, [False, True], strict=True)
+        ]
+    first, second = (task.result() for task in tasks)
+    assert first is not None and second is not None
+    assert first.context.account_id == second.context.account_id
+    assert first.context.role == second.context.role
+    accounts = await databases.login.query_raw(
+        "SELECT account_id, role FROM deltallm_platformaccount WHERE email = $1", databases.email
+    )
+    assert accounts == [{"account_id": first.context.account_id, "role": first.context.role}]
+    identities = await databases.login.query_raw(
+        "SELECT account_id FROM deltallm_platformidentity WHERE provider = $1 AND subject = $2",
+        "oidc",
+        databases.subject,
+    )
+    assert identities == [{"account_id": first.context.account_id}]
+
+
+@pytest.mark.asyncio
+async def test_racing_identity_claim_rolls_back_losing_account(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    barrier = asyncio.Barrier(2)
+    lookup = PlatformIdentityService.get_account_by_sso_identity
+
+    async def lookup_before_claim(
+        identity: PlatformIdentityService, *, provider: str, subject: str
+    ) -> dict[str, object] | None:
+        snapshot = await lookup(identity, provider=provider, subject=subject)
+        assert snapshot is None
+        await asyncio.wait_for(barrier.wait(), timeout=5)
+        return snapshot
+
+    monkeypatch.setattr(PlatformIdentityService, "get_account_by_sso_identity", lookup_before_claim)
+    first = PlatformIdentityService(databases.login, salt="test-salt")
+    second = PlatformIdentityService(databases.writer, salt="test-salt")
+    outcomes = await asyncio.gather(
+        first.upsert_sso_account(
+            identity=SSOIdentityAssertion(
+                email=databases.email,
+                provider="oidc",
+                subject=databases.subject,
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
+            is_platform_admin=True,
+        ),
+        second.upsert_sso_account(
+            identity=SSOIdentityAssertion(
+                email=databases.other_email,
+                provider="oidc",
+                subject=databases.subject,
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
+            is_platform_admin=False,
+        ),
+        return_exceptions=True,
+    )
+    successes = [outcome for outcome in outcomes if isinstance(outcome, LoginResult)]
+    failures = [outcome for outcome in outcomes if isinstance(outcome, ValueError)]
+    assert len(successes) == len(failures) == 1
+    assert "already linked" in str(failures[0])
+    accounts = await databases.login.query_raw(
+        "SELECT account_id FROM deltallm_platformaccount WHERE email IN ($1, $2)",
+        databases.email,
+        databases.other_email,
+    )
+    assert accounts == [{"account_id": successes[0].context.account_id}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("linked", [False, True])
+async def test_concurrent_account_disable_is_not_undone_by_login(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+    linked: bool,
+) -> None:
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    account = await service.ensure_account(email=databases.email, is_active=True)
+    account_id = account["account_id"]
+    if linked:
+        await service.link_sso_identity(
+            account_id=account_id,
+            email=databases.email,
+            provider="oidc",
+            subject=databases.subject,
+        )
+    lookup = PlatformIdentityService.get_account_by_sso_identity
+
+    async def lookup_then_disable(
+        identity: PlatformIdentityService, *, provider: str, subject: str
+    ) -> dict[str, object] | None:
+        snapshot = await lookup(identity, provider=provider, subject=subject)
+        await databases.writer.execute_raw(
+            "UPDATE deltallm_platformaccount SET is_active = false WHERE account_id = $1",
+            account_id,
+        )
+        return snapshot
+
+    monkeypatch.setattr(PlatformIdentityService, "get_account_by_sso_identity", lookup_then_disable)
+    with pytest.raises((AccountInactiveError, LoginSessionCreationError)):
+        await service.upsert_sso_account(
+            identity=SSOIdentityAssertion(
+                email=databases.email,
+                provider="oidc",
+                subject=databases.subject,
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
+            is_platform_admin=True,
+        )
+    persisted = await service.get_account_by_id(account_id)
+    assert persisted is not None
+    assert persisted["is_active"] is False and persisted["role"] == "org_user"
+    assert (
+        await databases.login.query_raw(
+            "SELECT session_id FROM deltallm_platformsession WHERE account_id = $1", account_id
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [TimeoutError, asyncio.CancelledError])
+async def test_failed_login_rolls_back_identity_changes(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[BaseException],
+) -> None:
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    account = await service.ensure_account(
+        email=databases.email, role="platform_admin", is_active=True
+    )
+    await service.link_sso_identity(
+        account_id=account["account_id"],
+        email=databases.email,
+        provider="oidc",
+        subject=databases.subject,
+    )
+
+    async def fail_session(
+        identity: PlatformIdentityService,
+        *,
+        account_id: str,
+        mfa_verified: bool,
+    ) -> str:
+        raise error_type("session interrupted")
+
+    monkeypatch.setattr(PlatformIdentityService, "create_session_for_account", fail_session)
+    with pytest.raises(error_type, match="session interrupted"):
+        await service.upsert_sso_account(
+            identity=SSOIdentityAssertion(
+                email=databases.other_email,
+                provider="oidc",
+                subject=databases.subject,
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
+            is_platform_admin=False,
+        )
+    assert await service.get_account_by_id(account["account_id"]) == account
+    identities = await databases.login.query_raw(
+        "SELECT email FROM deltallm_platformidentity WHERE provider = $1 AND subject = $2",
+        "oidc",
+        databases.subject,
+    )
+    assert identities == [{"email": databases.email}]
+
+
+def identity_for(databases: SSODatabases, *, verified: bool | None = True) -> SSOIdentityAssertion:
+    return SSOIdentityAssertion(
+        provider="oidc",
+        subject=databases.subject,
+        email=databases.email,
+        email_verified=verified,
+        subject_source=SSOSubjectSource.PROVIDER,
+    )
+
+
+async def create_default_targets(databases: SSODatabases) -> None:
+    await databases.login.execute_raw(
+        "INSERT INTO deltallm_organizationtable (id, organization_id, updated_at) "
+        "VALUES (gen_random_uuid(), $1, NOW())",
+        databases.organization_id,
+    )
+    await databases.login.execute_raw(
+        "INSERT INTO deltallm_teamtable (team_id, organization_id, models, updated_at) "
+        "VALUES ($1, $2, ARRAY[]::text[], NOW())",
+        databases.team_id,
+        databases.organization_id,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("self_registration", [False, True])
+@pytest.mark.parametrize("verified", [False, None])
+async def test_unverified_login_cannot_adopt_racing_admin(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+    self_registration: bool,
+    verified: bool | None,
+) -> None:
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    writer = PlatformIdentityService(databases.writer, salt="test-salt")
+    lookup = PlatformIdentityService.get_account_by_sso_identity
+
+    async def lookup_then_create(identity, *, provider: str, subject: str):
+        snapshot = await lookup(identity, provider=provider, subject=subject)
+        assert snapshot is None
+        await writer.ensure_account(email=databases.email, role="platform_admin", is_active=True)
+        return snapshot
+
+    monkeypatch.setattr(PlatformIdentityService, "get_account_by_sso_identity", lookup_then_create)
+    with pytest.raises(SSOIdentityOwnershipError):
+        if self_registration:
+            settings = _enabled_settings()
+            settings.require_email_verification = False
+            settings.default_org.id = databases.organization_id
+            settings.default_team.id = databases.team_id
+            provisioner = SelfRegistrationProvisioningService(
+                db_client=databases.login, platform_identity_service=service
+            )
+            await provisioner.provision_sso_from_defaults(
+                identity=identity_for(databases, verified=verified), settings=settings
+            )
+        else:
+            await service.upsert_sso_account(
+                identity=identity_for(databases, verified=verified), is_platform_admin=False
+            )
+    account = await service.get_account_by_email(databases.email)
+    assert (
+        account is not None and account["role"] == "platform_admin" and account["is_active"] is True
+    )
+    assert (
+        await databases.login.query_raw(
+            "SELECT identity_id FROM deltallm_platformidentity WHERE subject = $1",
+            databases.subject,
+        )
+        == []
+    )
+    assert (
+        await databases.login.query_raw(
+            "SELECT session_id FROM deltallm_platformsession WHERE account_id = $1",
+            account["account_id"],
+        )
+        == []
+    )
+    assert (
+        await databases.login.query_raw(
+            "SELECT user_id FROM deltallm_usertable WHERE user_email = $1", databases.email
+        )
+        == []
+    )
+    metadata = await databases.login.query_raw(
+        "SELECT metadata FROM deltallm_platformaccount WHERE account_id = $1", account["account_id"]
+    )
+    assert metadata == [{"metadata": None}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("linked", [False, True])
+@pytest.mark.parametrize("edit_timing", ["before", "after"])
+async def test_default_memberships_preserve_concurrent_admin_edits(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+    linked: bool,
+    edit_timing: str,
+) -> None:
+    import src.services.platform_identity_service as platform_module
+
+    await create_default_targets(databases)
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    writer = PlatformIdentityService(databases.writer, salt="test-salt")
+    account = await service.ensure_account(email=databases.email, role="org_user", is_active=True)
+    account_id = account["account_id"]
+    await service.upsert_team_membership(
+        account_id=account_id, team_id=databases.team_id, role="team_viewer"
+    )
+    await service.upsert_organization_membership(
+        account_id=account_id, organization_id=databases.organization_id, role="org_member"
+    )
+    if linked:
+        await service.link_sso_identity(
+            account_id=account_id, email=databases.email, provider="oidc", subject=databases.subject
+        )
+
+    async def edit_roles() -> None:
+        # Change existing rows without reacquiring the account FK lock through an INSERT.
+        await databases.writer.execute_raw(
+            "UPDATE deltallm_teammembership SET role = 'team_admin' WHERE account_id = $1 AND team_id = $2",
+            account_id,
+            databases.team_id,
+        )
+        await databases.writer.execute_raw(
+            "UPDATE deltallm_organizationmembership SET role = 'org_owner' WHERE account_id = $1 AND organization_id = $2",
+            account_id,
+            databases.organization_id,
+        )
+
+    if edit_timing == "before":
+        lock_team = platform_module.lock_sso_default_team
+
+        async def lock_then_edit(db, *, team_id: str):
+            result = await lock_team(db, team_id=team_id)
+            await edit_roles()
+            return result
+
+        monkeypatch.setattr(platform_module, "lock_sso_default_team", lock_then_edit)
+    else:
+        seed_team = platform_module.seed_team_membership
+
+        async def seed_then_edit(db, **kwargs):
+            await seed_team(db, **kwargs)
+            await edit_roles()
+
+        monkeypatch.setattr(platform_module, "seed_team_membership", seed_then_edit)
+
+    result = await service.upsert_sso_account(
+        identity=identity_for(databases), is_platform_admin=True, team_id=databases.team_id
+    )
+    assert result is not None and result.context.role == "org_user"
+    assert result.context.team_memberships == [{"team_id": databases.team_id, "role": "team_admin"}]
+    assert result.context.organization_memberships == [
+        {"organization_id": databases.organization_id, "role": "org_owner"}
+    ]
+    persisted = await writer.get_context_for_session(result.session_token)
+    assert persisted is not None and persisted.team_memberships == result.context.team_memberships
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [RuntimeError, TimeoutError, asyncio.CancelledError])
+async def test_failure_after_org_membership_seed_rolls_back_login(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[BaseException],
+) -> None:
+    import src.services.platform_identity_service as platform_module
+
+    await create_default_targets(databases)
+
+    async def fail_team(db, **kwargs):
+        rows = await db.query_raw(
+            "SELECT membership_id FROM deltallm_organizationmembership WHERE organization_id = $1",
+            databases.organization_id,
+        )
+        assert len(rows) == 1
+        raise error_type("team write interrupted")
+
+    monkeypatch.setattr(platform_module, "seed_team_membership", fail_team)
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    with pytest.raises(error_type, match="team write interrupted"):
+        await service.upsert_sso_account(
+            identity=identity_for(databases), is_platform_admin=False, team_id=databases.team_id
+        )
+    assert await service.get_account_by_email(databases.email) is None
+    assert (
+        await databases.login.query_raw(
+            "SELECT membership_id FROM deltallm_organizationmembership WHERE organization_id = $1",
+            databases.organization_id,
+        )
+        == []
+    )
+    assert (
+        await databases.login.query_raw(
+            "SELECT identity_id FROM deltallm_platformidentity WHERE subject = $1",
+            databases.subject,
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_unverified_callback_does_not_undo_concurrent_email_edit(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    account = await service.ensure_account(
+        email=databases.email, role="platform_admin", is_active=True
+    )
+    await service.link_sso_identity(
+        account_id=account["account_id"],
+        email=databases.email,
+        provider="oidc",
+        subject=databases.subject,
+    )
+    lookup = PlatformIdentityService.get_account_by_sso_identity
+
+    async def lookup_then_edit(identity, *, provider: str, subject: str):
+        snapshot = await lookup(identity, provider=provider, subject=subject)
+        await databases.writer.execute_raw(
+            "UPDATE deltallm_platformaccount SET email = $2 WHERE account_id = $1",
+            account["account_id"],
+            databases.other_email,
+        )
+        return snapshot
+
+    monkeypatch.setattr(PlatformIdentityService, "get_account_by_sso_identity", lookup_then_edit)
+    result = await service.upsert_sso_account(
+        identity=identity_for(databases, verified=False), is_platform_admin=False
+    )
+    assert result is not None and result.context.email == databases.other_email
+    assert result.context.role == "platform_admin"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["org_user", "platform_admin"])
+async def test_verified_self_registration_race_logs_into_existing_account_without_reprovisioning(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+    role: str,
+) -> None:
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    writer = PlatformIdentityService(databases.writer, salt="test-salt")
+    lookup = PlatformIdentityService.get_account_by_sso_identity
+
+    async def lookup_then_create(identity, *, provider: str, subject: str):
+        snapshot = await lookup(identity, provider=provider, subject=subject)
+        assert snapshot is None
+        await writer.ensure_account(email=databases.email, role=role, is_active=True)
+        return snapshot
+
+    monkeypatch.setattr(PlatformIdentityService, "get_account_by_sso_identity", lookup_then_create)
+    provisioner = SelfRegistrationProvisioningService(
+        db_client=databases.login, platform_identity_service=service
+    )
+    settings = _enabled_settings()
+    settings.default_org.id = databases.organization_id
+    settings.default_team.id = databases.team_id
+    result = await provisioner.provision_sso_from_defaults(
+        identity=identity_for(databases), settings=settings
+    )
+    assert result.provisioning is None
+    assert result.login.context.role == role
+    assert (
+        result.login.context.organization_memberships == result.login.context.team_memberships == []
+    )
+    assert await databases.login.query_raw(
+        "SELECT metadata FROM deltallm_platformaccount WHERE email = $1", databases.email
+    ) == [{"metadata": None}]
+    assert (
+        await databases.login.query_raw(
+            "SELECT user_id FROM deltallm_usertable WHERE user_email = $1", databases.email
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("require_verification", [False, True])
+async def test_new_self_registration_respects_creation_verification_policy(
+    databases: SSODatabases,
+    require_verification: bool,
+) -> None:
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    provisioner = SelfRegistrationProvisioningService(
+        db_client=databases.login, platform_identity_service=service
+    )
+    settings = _enabled_settings()
+    settings.default_org.id = databases.organization_id
+    settings.default_team.id = databases.team_id
+    settings.require_email_verification = require_verification
+    if require_verification:
+        with pytest.raises(SSOIdentityOwnershipError):
+            await provisioner.provision_sso_from_defaults(
+                identity=identity_for(databases, verified=False), settings=settings
+            )
+        assert await service.get_account_by_email(databases.email) is None
+        assert (
+            await databases.login.query_raw(
+                "SELECT identity_id FROM deltallm_platformidentity WHERE subject = $1",
+                databases.subject,
+            )
+            == []
+        )
+    else:
+        result = await provisioner.provision_sso_from_defaults(
+            identity=identity_for(databases, verified=False), settings=settings
+        )
+        assert result.provisioning is not None
+        assert result.login.context.role == "org_user"
+        assert result.login.context.team_memberships == [
+            {"team_id": databases.team_id, "role": "team_developer"}
+        ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("existing_entrypoint", [False, True])
+async def test_email_match_must_still_belong_to_account_when_binding(
+    databases: SSODatabases,
+    monkeypatch: pytest.MonkeyPatch,
+    existing_entrypoint: bool,
+) -> None:
+    import src.services.sso_account_service as account_module
+
+    service = PlatformIdentityService(databases.login, salt="test-salt")
+    account = await service.ensure_account(
+        email=databases.email, role="platform_admin", is_active=True
+    )
+    refresh = account_module.refresh_sso_account
+
+    async def edit_then_refresh(db, **kwargs):
+        await databases.writer.execute_raw(
+            "UPDATE deltallm_platformaccount SET email = $2 WHERE account_id = $1",
+            account["account_id"],
+            databases.other_email,
+        )
+        return await refresh(db, **kwargs)
+
+    monkeypatch.setattr(account_module, "refresh_sso_account", edit_then_refresh)
+    with pytest.raises(ValueError, match="SSO account changed"):
+        if existing_entrypoint:
+            await service.create_sso_login_for_existing_account(
+                account_id=account["account_id"], identity=identity_for(databases)
+            )
+        else:
+            await service.upsert_sso_account(
+                identity=identity_for(databases), is_platform_admin=False
+            )
+    persisted = await service.get_account_by_id(account["account_id"])
+    assert persisted is not None and persisted["email"] == databases.other_email
+    assert persisted["role"] == "platform_admin"
+    assert (
+        await databases.login.query_raw(
+            "SELECT identity_id FROM deltallm_platformidentity WHERE subject = $1",
+            databases.subject,
+        )
+        == []
+    )
+    assert (
+        await databases.login.query_raw(
+            "SELECT session_id FROM deltallm_platformsession WHERE account_id = $1",
+            account["account_id"],
+        )
+        == []
+    )

--- a/tests/services/test_platform_identity_service.py
+++ b/tests/services/test_platform_identity_service.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from src.auth.sso_identity import SSOIdentityAssertion, SSOSubjectSource
+
+import asyncio
 import copy
 from types import SimpleNamespace
 
@@ -27,12 +30,36 @@ class FakePlatformIdentityDB:
         self.accounts: dict[str, dict[str, object]] = {}
         self.identities: dict[tuple[str, str], dict[str, object]] = {}
         self.sessions: dict[str, dict[str, object]] = {}
+        self.teams: dict[str, dict[str, object]] = {}
+        self.organizations: dict[str, dict[str, object]] = {}
+        self.team_memberships: dict[tuple[str, str], dict[str, object]] = {}
+        self.organization_memberships: dict[tuple[str, str], dict[str, object]] = {}
         self.fail_session_insert = False
         self.fail_last_login_update = False
         self.hide_next_email_lookup = False
 
+    def tx(self) -> "_FakeTransaction":
+        return _FakeTransaction(self)
+
     async def query_raw(self, query: str, *params):  # noqa: ANN201
         normalized = " ".join(query.lower().split())
+        if "insert into deltallm_platformaccount" in normalized and "returning" in normalized:
+            if self._account_id_for_email(str(params[0])) is not None:
+                return []
+            await self.execute_raw(query, *params)
+            return [dict(self.accounts[self._account_id_for_email(str(params[0]))])]
+        if "set email = coalesce" in normalized:
+            row = self.accounts.get(str(params[0]))
+            if row is None:
+                return []
+            if params[2] is not None and str(row["email"]).lower() != str(params[2]).lower():
+                return []
+            if params[1] is not None:
+                owner = self._account_id_for_email(str(params[1]))
+                if owner is not None and owner != params[0]:
+                    raise ValueError("duplicate email")
+                row["email"] = params[1]
+            return [dict(row)]
         if "from deltallm_platformsession s join deltallm_platformaccount a" in normalized:
             token_hash = str(params[0])
             session = self.sessions.get(token_hash)
@@ -70,7 +97,7 @@ class FakePlatformIdentityDB:
             account_id = str(params[0])
             account = self.accounts.get(account_id)
             return [dict(account)] if account else []
-        if "WHERE lower(email) = lower($1)" in query:
+        if "where lower(email)" in normalized:
             if self.hide_next_email_lookup:
                 self.hide_next_email_lookup = False
                 return []
@@ -80,13 +107,37 @@ class FakePlatformIdentityDB:
                     return [dict(row)]
             return []
         if "from deltallm_organizationmembership" in normalized:
-            return []
+            return [
+                dict(row)
+                for (account_id, _), row in self.organization_memberships.items()
+                if account_id == params[0]
+            ]
         if "from deltallm_teammembership" in normalized:
-            return []
+            return [
+                dict(row)
+                for (account_id, _), row in self.team_memberships.items()
+                if account_id == params[0]
+            ]
+        if "from deltallm_teamtable" in normalized:
+            row = self.teams.get(str(params[0]))
+            return [dict(row)] if row else []
+        if "from deltallm_organizationtable" in normalized:
+            row = self.organizations.get(str(params[0]))
+            return [dict(row)] if row else []
         return []
 
     async def execute_raw(self, query: str, *params):  # noqa: ANN201
         normalized = " ".join(query.lower().split())
+        for table, memberships, scope in (
+            ("deltallm_teammembership", self.team_memberships, "team_id"),
+            ("deltallm_organizationmembership", self.organization_memberships, "organization_id"),
+        ):
+            if f"insert into {table}" in normalized:
+                key = (str(params[0]), str(params[1]))
+                if key in memberships and "do nothing" in normalized:
+                    return 0
+                memberships[key] = {scope: params[1], "role": params[2]}
+                return 1
         if "insert into deltallm_platformsession" in normalized:
             if self.fail_session_insert:
                 raise RuntimeError("session insert failed")
@@ -119,8 +170,9 @@ class FakePlatformIdentityDB:
             is_active = bool(params[2]) if len(params) > 2 else True
             existing_account_id = self._account_id_for_email(email)
             if existing_account_id is not None and "on conflict (email)" in normalized:
-                self.accounts[existing_account_id]["role"] = role
-                self.accounts[existing_account_id]["is_active"] = is_active
+                if "do update set role =" in normalized:
+                    self.accounts[existing_account_id]["role"] = role
+                    self.accounts[existing_account_id]["is_active"] = is_active
                 return 1
             account_id = f"acct-{len(self.accounts) + 1}"
             self.add_account(account_id=account_id, email=email, role=role, is_active=is_active)
@@ -229,6 +281,8 @@ class _FakeTransaction:
             "accounts": copy.deepcopy(self.db.accounts),
             "identities": copy.deepcopy(self.db.identities),
             "sessions": copy.deepcopy(self.db.sessions),
+            "team_memberships": copy.deepcopy(self.db.team_memberships),
+            "organization_memberships": copy.deepcopy(self.db.organization_memberships),
         }
         return self.db
 
@@ -237,6 +291,8 @@ class _FakeTransaction:
             self.db.accounts = self.snapshot["accounts"]
             self.db.identities = self.snapshot["identities"]
             self.db.sessions = self.snapshot["sessions"]
+            self.db.team_memberships = self.snapshot["team_memberships"]
+            self.db.organization_memberships = self.snapshot["organization_memberships"]
         return False
 
 
@@ -250,6 +306,11 @@ class LoginRecordingIdentityService(PlatformIdentityService):
     def __init__(self, *, db_client, salt: str = "salt-key") -> None:  # noqa: ANN001
         super().__init__(db_client=db_client, salt=salt)
         self.login_account_ids: list[str] = []
+
+    def with_db(self, db_client):
+        service = LoginRecordingIdentityService(db_client=db_client, salt=self.salt)
+        service.login_account_ids = self.login_account_ids
+        return service
 
     async def create_login_result_for_account(self, account_id: str):  # noqa: ANN201
         self.login_account_ids.append(account_id)
@@ -335,10 +396,14 @@ async def test_upsert_sso_account_rejects_claimed_subject_before_mutating_accoun
 
     with pytest.raises(ValueError, match="already linked"):
         await service.upsert_sso_account(
-            email="user@example.com",
+            identity=SSOIdentityAssertion(
+                email="user@example.com",
+                provider="oidc",
+                subject="subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             is_platform_admin=True,
-            provider="oidc",
-            subject="subject-1",
         )
 
     assert db.accounts["acct-1"]["role"] == "org_user"
@@ -348,7 +413,9 @@ async def test_upsert_sso_account_rejects_claimed_subject_before_mutating_accoun
 @pytest.mark.asyncio
 async def test_upsert_sso_account_uses_linked_subject_when_provider_email_changes() -> None:
     db = FakePlatformIdentityDB()
-    db.add_account(account_id="acct-1", email="old@example.com", role="org_user", is_active=False)
+    db.add_account(
+        account_id="acct-1", email="old@example.com", role="platform_admin", is_active=True
+    )
     db.identities[("oidc", "subject-1")] = {
         "account_id": "acct-1",
         "provider": "oidc",
@@ -358,17 +425,21 @@ async def test_upsert_sso_account_uses_linked_subject_when_provider_email_change
     service = LoginRecordingIdentityService(db_client=db)
 
     login = await service.upsert_sso_account(
-        email="New@Example.com",
+        identity=SSOIdentityAssertion(
+            email="New@Example.com",
+            provider="oidc",
+            subject="subject-1",
+            email_verified=True,
+            subject_source=SSOSubjectSource.PROVIDER,
+        ),
         is_platform_admin=False,
-        provider="oidc",
-        subject="subject-1",
     )
 
     assert login is not None
     assert login.session_token == "session-acct-1"
     assert service.login_account_ids == ["acct-1"]
     assert db.accounts["acct-1"]["email"] == "new@example.com"
-    assert db.accounts["acct-1"]["role"] == "org_user"
+    assert db.accounts["acct-1"]["role"] == "platform_admin"
     assert db.accounts["acct-1"]["is_active"] is True
     assert db.accounts["acct-1"]["last_login_at"] == "now"
     assert db.identities[("oidc", "subject-1")] == {
@@ -382,7 +453,7 @@ async def test_upsert_sso_account_uses_linked_subject_when_provider_email_change
 @pytest.mark.asyncio
 async def test_upsert_sso_account_rejects_linked_subject_email_owned_by_other_account() -> None:
     db = FakePlatformIdentityDB()
-    db.add_account(account_id="acct-1", email="old@example.com", role="org_user", is_active=False)
+    db.add_account(account_id="acct-1", email="old@example.com", role="org_user", is_active=True)
     db.add_account(account_id="acct-2", email="new@example.com", role="org_user", is_active=True)
     db.identities[("oidc", "subject-1")] = {
         "account_id": "acct-1",
@@ -394,16 +465,20 @@ async def test_upsert_sso_account_rejects_linked_subject_email_owned_by_other_ac
 
     with pytest.raises(ValueError, match="email is already linked"):
         await service.upsert_sso_account(
-            email="new@example.com",
+            identity=SSOIdentityAssertion(
+                email="new@example.com",
+                provider="oidc",
+                subject="subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             is_platform_admin=True,
-            provider="oidc",
-            subject="subject-1",
         )
 
     assert service.login_account_ids == []
     assert db.accounts["acct-1"]["email"] == "old@example.com"
     assert db.accounts["acct-1"]["role"] == "org_user"
-    assert db.accounts["acct-1"]["is_active"] is False
+    assert db.accounts["acct-1"]["is_active"] is True
     assert db.accounts["acct-2"]["email"] == "new@example.com"
     assert db.identities[("oidc", "subject-1")]["email"] == "old@example.com"
 
@@ -440,12 +515,19 @@ async def test_create_sso_login_for_existing_account_reconciles_and_creates_sess
     db = TransactionalFakePlatformIdentityDB()
     db.add_account(account_id="acct-1", email="old@example.com", role="org_user", is_active=True)
     service = PlatformIdentityService(db_client=db, salt="salt-key")
+    await service.link_sso_identity(
+        account_id="acct-1", email="old@example.com", provider="oidc", subject="subject-1"
+    )
 
     login = await service.create_sso_login_for_existing_account(
+        identity=SSOIdentityAssertion(
+            email="New@Example.com",
+            provider="oidc",
+            subject="subject-1",
+            email_verified=True,
+            subject_source=SSOSubjectSource.PROVIDER,
+        ),
         account_id="acct-1",
-        email="New@Example.com",
-        provider="oidc",
-        subject="subject-1",
     )
 
     assert login is not None
@@ -471,18 +553,26 @@ async def test_create_sso_login_for_existing_account_rolls_back_reconcile_when_s
     db.add_account(account_id="acct-1", email="old@example.com", role="org_user", is_active=True)
     db.fail_session_insert = True
     service = PlatformIdentityService(db_client=db, salt="salt-key")
+    await service.link_sso_identity(
+        account_id="acct-1", email="old@example.com", provider="oidc", subject="subject-1"
+    )
+    identities_before = copy.deepcopy(db.identities)
 
     with pytest.raises(RuntimeError, match="session insert failed"):
         await service.create_sso_login_for_existing_account(
+            identity=SSOIdentityAssertion(
+                email="New@Example.com",
+                provider="oidc",
+                subject="subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             account_id="acct-1",
-            email="New@Example.com",
-            provider="oidc",
-            subject="subject-1",
         )
 
     assert db.accounts["acct-1"]["email"] == "old@example.com"
     assert db.accounts["acct-1"]["last_login_at"] is None
-    assert db.identities == {}
+    assert db.identities == identities_before
     assert db.sessions == {}
 
 
@@ -496,10 +586,14 @@ async def test_create_sso_login_for_existing_account_rejects_inactive_account_be
 
     with pytest.raises(AccountInactiveError, match="Account is inactive"):
         await service.create_sso_login_for_existing_account(
+            identity=SSOIdentityAssertion(
+                email="New@Example.com",
+                provider="oidc",
+                subject="subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             account_id="acct-1",
-            email="New@Example.com",
-            provider="oidc",
-            subject="subject-1",
         )
 
     assert db.accounts["acct-1"]["email"] == "old@example.com"
@@ -510,7 +604,7 @@ async def test_create_sso_login_for_existing_account_rejects_inactive_account_be
 @pytest.mark.asyncio
 async def test_upsert_sso_account_rolls_back_if_identity_conflict_races() -> None:
     db = TransactionalFakePlatformIdentityDB()
-    db.add_account(account_id="acct-1", email="user@example.com", role="org_user", is_active=False)
+    db.add_account(account_id="acct-1", email="user@example.com", role="org_user", is_active=True)
     db.add_account(account_id="acct-2", email="other@example.com")
     db.identities[("oidc", "subject-1")] = {
         "account_id": "acct-2",
@@ -523,14 +617,18 @@ async def test_upsert_sso_account_rolls_back_if_identity_conflict_races() -> Non
 
     with pytest.raises(ValueError, match="already linked"):
         await service.upsert_sso_account(
-            email="user@example.com",
+            identity=SSOIdentityAssertion(
+                email="user@example.com",
+                provider="oidc",
+                subject="subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             is_platform_admin=True,
-            provider="oidc",
-            subject="subject-1",
         )
 
     assert db.accounts["acct-1"]["role"] == "org_user"
-    assert db.accounts["acct-1"]["is_active"] is False
+    assert db.accounts["acct-1"]["is_active"] is True
     assert db.identities[("oidc", "subject-1")]["account_id"] == "acct-2"
 
 
@@ -542,10 +640,14 @@ async def test_upsert_sso_account_rolls_back_if_last_login_update_fails() -> Non
 
     with pytest.raises(RuntimeError, match="last login update failed"):
         await service.upsert_sso_account(
-            email="user@example.com",
+            identity=SSOIdentityAssertion(
+                email="user@example.com",
+                provider="oidc",
+                subject="subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             is_platform_admin=False,
-            provider="oidc",
-            subject="subject-1",
         )
 
     assert db.accounts == {}
@@ -554,19 +656,131 @@ async def test_upsert_sso_account_rolls_back_if_last_login_update_fails() -> Non
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [RuntimeError, TimeoutError, asyncio.CancelledError])
+async def test_upsert_sso_account_rolls_back_if_session_creation_fails(
+    monkeypatch: pytest.MonkeyPatch, error_type: type[BaseException]
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    execute_raw = db.execute_raw
+
+    async def fail_session_creation(query: str, *params: object) -> int:
+        if "insert into deltallm_platformsession" in query.lower():
+            raise error_type("session unavailable")
+        return await execute_raw(query, *params)
+
+    monkeypatch.setattr(db, "execute_raw", fail_session_creation)
+    service = PlatformIdentityService(db_client=db, salt="salt-key")
+    with pytest.raises(error_type, match="session unavailable"):
+        await service.upsert_sso_account(
+            identity=SSOIdentityAssertion(
+                email="user@example.com",
+                provider="oidc",
+                subject="subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
+            is_platform_admin=True,
+        )
+
+    assert db.accounts == {}
+    assert db.identities == {}
+    assert db.sessions == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("listed", [False, True])
+async def test_upsert_sso_account_seeds_initial_role_only(listed: bool) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    service = PlatformIdentityService(db_client=db, salt="salt-key")
+
+    first = await service.upsert_sso_account(
+        identity=SSOIdentityAssertion(
+            email="User@Example.com",
+            provider="oidc",
+            subject="subject-1",
+            email_verified=True,
+            subject_source=SSOSubjectSource.PROVIDER,
+        ),
+        is_platform_admin=listed,
+    )
+    assert first is not None
+    expected_role = "platform_admin" if listed else "org_user"
+    assert first.context.role == expected_role
+    assert first.context.email == "user@example.com"
+
+    second = await service.upsert_sso_account(
+        identity=SSOIdentityAssertion(
+            email="User@Example.com",
+            provider="oidc",
+            subject="subject-1",
+            email_verified=True,
+            subject_source=SSOSubjectSource.PROVIDER,
+        ),
+        is_platform_admin=not listed,
+    )
+    assert second is not None
+    assert second.context.role == expected_role
+    assert second.context.account_id == first.context.account_id
+    assert len(db.accounts) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["org_user", "platform_admin"])
+async def test_sso_default_team_uses_stored_platform_role(
+    monkeypatch: pytest.MonkeyPatch, role: str
+) -> None:
+    db = FakePlatformIdentityDB()
+    db.add_account(account_id="acct-1", email="user@example.com", role=role)
+    db.teams["team-1"] = {"team_id": "team-1", "organization_id": None}
+    execute_raw = db.execute_raw
+    membership_writes: list[tuple[object, ...]] = []
+
+    async def record_memberships(query: str, *params: object) -> int:
+        if "insert into deltallm_teammembership" in query.lower():
+            membership_writes.append(params)
+            return 1
+        return await execute_raw(query, *params)
+
+    monkeypatch.setattr(db, "execute_raw", record_memberships)
+    service = PlatformIdentityService(db_client=db, salt="salt-key")
+    login = await service.upsert_sso_account(
+        identity=SSOIdentityAssertion(
+            email="user@example.com",
+            provider="oidc",
+            subject="subject-1",
+            email_verified=True,
+            subject_source=SSOSubjectSource.PROVIDER,
+        ),
+        is_platform_admin=role != "platform_admin",
+        team_id="team-1",
+    )
+    assert login is not None
+    assert login.context.role == role
+    assert membership_writes == (
+        [("acct-1", "team-1", "team_viewer")] if role == "org_user" else []
+    )
+
+
+@pytest.mark.asyncio
 async def test_upsert_sso_account_rolls_back_if_account_reload_fails() -> None:
     db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="acct-1", email="user@example.com")
+    accounts_before = copy.deepcopy(db.accounts)
     db.hide_next_email_lookup = True
     service = PlatformIdentityService(db_client=db, salt="salt-key")
 
     with pytest.raises(LoginSessionCreationError, match="Failed to establish session"):
         await service.upsert_sso_account(
-            email="user@example.com",
+            identity=SSOIdentityAssertion(
+                email="user@example.com",
+                provider="oidc",
+                subject="subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             is_platform_admin=False,
-            provider="oidc",
-            subject="subject-1",
         )
 
-    assert db.accounts == {}
+    assert db.accounts == accounts_before
     assert db.identities == {}
     assert db.sessions == {}

--- a/tests/services/test_self_registration_provisioning.py
+++ b/tests/services/test_self_registration_provisioning.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from src.auth.sso_identity import SSOIdentityAssertion, SSOSubjectSource
+
 import copy
 import json
 from types import SimpleNamespace
@@ -8,7 +10,10 @@ from typing import Any
 import pytest
 
 from src.config import AppConfig, SelfRegistrationSettings
-from src.services.platform_identity_service import PlatformIdentityService
+from src.services.platform_identity_service import (
+    LoginSessionCreationError,
+    PlatformIdentityService,
+)
 from src.services.self_registration_provisioning import SelfRegistrationProvisioningService
 
 
@@ -80,10 +85,30 @@ class FakeSelfRegistrationDB:
 
     async def query_raw(self, query: str, *params):  # noqa: ANN201
         normalized = _normalize_sql(query)
+        if "insert into deltallm_platformaccount" in normalized and "returning" in normalized:
+            if self._account_by_email(str(params[0])) is not None:
+                return []
+            await self.execute_raw(query, *params)
+            return [dict(self._account_by_email(str(params[0])))]
+        if "set email = coalesce" in normalized:
+            account = self.accounts.get(str(params[0]))
+            if account is None:
+                return []
+            if params[2] is not None and str(account["email"]).lower() != str(params[2]).lower():
+                return []
+            if params[1] is not None:
+                account["email"] = params[1]
+            return [dict(account)]
+        if "from deltallm_organizationtable" in normalized:
+            org = self.organizations.get(str(params[0]))
+            return [{"lifecycle_state": "active", **org}] if org else []
         if "from deltallm_teamtable" in normalized and "where team_id = $1" in normalized:
             team = self.teams.get(str(params[0]))
             return [dict(team)] if team else []
-        if "from deltallm_platformaccount" in normalized and "lower(email) = lower($1)" in normalized:
+        if (
+            "from deltallm_platformaccount" in normalized
+            and "lower(email) = lower($1)" in normalized
+        ):
             email = str(params[0]).strip().lower()
             account = self._account_by_email(email)
             return [dict(account)] if account else []
@@ -283,7 +308,10 @@ class FakeSelfRegistrationDB:
         normalized_email = user_email.strip().lower()
         if user_id in self.users:
             return 0
-        if any(str(user.get("user_email") or "").lower() == normalized_email for user in self.users.values()):
+        if any(
+            str(user.get("user_email") or "").lower() == normalized_email
+            for user in self.users.values()
+        ):
             return 0
         self.users[user_id] = {
             "user_id": user_id,
@@ -302,12 +330,16 @@ class FakeSelfRegistrationDB:
         }
         return 1
 
-    def _update_platform_account_metadata(self, account_id: str, metadata_key: str, metadata: str) -> int:
+    def _update_platform_account_metadata(
+        self, account_id: str, metadata_key: str, metadata: str
+    ) -> int:
         account = self.accounts.get(account_id)
         if account is None:
             return 0
 
-        account_metadata = account.get("metadata") if isinstance(account.get("metadata"), dict) else {}
+        account_metadata = (
+            account.get("metadata") if isinstance(account.get("metadata"), dict) else {}
+        )
         current_value = account_metadata.get(metadata_key)
         current_obj = dict(current_value) if isinstance(current_value, dict) else {}
         account_metadata[metadata_key] = {**current_obj, **json.loads(metadata)}
@@ -348,7 +380,9 @@ class _FakeTransaction:
 
 
 class SuccessfulSSOIdentityService(PlatformIdentityService):
-    def __init__(self, *, db_client: Any, salt: str = "salt-key", session_ttl_hours: int = 12) -> None:
+    def __init__(
+        self, *, db_client: Any, salt: str = "salt-key", session_ttl_hours: int = 12
+    ) -> None:
         super().__init__(db_client=db_client, salt=salt, session_ttl_hours=session_ttl_hours)
         self.identity_links: list[dict[str, str]] = []
         self.last_logins: list[str] = []
@@ -433,7 +467,8 @@ def _service(
 ) -> SelfRegistrationProvisioningService:
     return SelfRegistrationProvisioningService(
         db_client=db,
-        platform_identity_service=identity_service or PlatformIdentityService(db_client=db, salt="salt-key"),
+        platform_identity_service=identity_service
+        or PlatformIdentityService(db_client=db, salt="salt-key"),
     )
 
 
@@ -469,7 +504,10 @@ async def test_provision_from_defaults_seeds_sandbox_records() -> None:
     assert db.users["acct-1"]["user_email"] == "developer@example.com"
     assert db.users["acct-1"]["max_budget"] == 10
     assert db.users["acct-1"]["team_id"] == "team-self-serve"
-    assert db.accounts["acct-1"]["metadata"]["self_registration"] == _expected_account_self_registration_metadata()
+    assert (
+        db.accounts["acct-1"]["metadata"]["self_registration"]
+        == _expected_account_self_registration_metadata()
+    )
 
 
 @pytest.mark.asyncio
@@ -562,7 +600,9 @@ async def test_provision_from_defaults_rejects_existing_runtime_user_outside_def
 
 
 @pytest.mark.asyncio
-async def test_provision_from_defaults_returns_existing_runtime_user_in_default_team_for_same_email() -> None:
+async def test_provision_from_defaults_returns_existing_runtime_user_in_default_team_for_same_email() -> (
+    None
+):
     db = FakeSelfRegistrationDB()
     db.users["legacy-user"] = {
         "user_id": "legacy-user",
@@ -582,20 +622,29 @@ async def test_provision_from_defaults_returns_existing_runtime_user_in_default_
     assert "acct-1" not in db.users
     assert db.users["legacy-user"]["max_budget"] == 500
     assert db.users["legacy-user"]["team_id"] == "team-self-serve"
-    assert db.accounts["acct-1"]["metadata"]["self_registration"] == _expected_account_self_registration_metadata()
+    assert (
+        db.accounts["acct-1"]["metadata"]["self_registration"]
+        == _expected_account_self_registration_metadata()
+    )
 
 
 @pytest.mark.asyncio
-async def test_provision_sso_from_defaults_links_identity_and_creates_login_in_transaction() -> None:
+async def test_provision_sso_from_defaults_links_identity_and_creates_login_in_transaction() -> (
+    None
+):
     db = TransactionalFakeSelfRegistrationDB()
     identity_service = SuccessfulSSOIdentityService(db_client=db)
     service = _service(db, identity_service)
 
     result = await service.provision_sso_from_defaults(
-        email="Developer@Example.com",
+        identity=SSOIdentityAssertion(
+            email="Developer@Example.com",
+            provider="oidc",
+            subject="provider-subject-1",
+            email_verified=True,
+            subject_source=SSOSubjectSource.PROVIDER,
+        ),
         settings=_enabled_settings(),
-        provider="oidc",
-        subject="provider-subject-1",
     )
 
     assert result.provisioning.account_id == "acct-1"
@@ -620,10 +669,14 @@ async def test_provision_sso_from_defaults_requires_transaction_support() -> Non
 
     with pytest.raises(RuntimeError, match="transactions are required"):
         await service.provision_sso_from_defaults(
-            email="developer@example.com",
+            identity=SSOIdentityAssertion(
+                email="developer@example.com",
+                provider="oidc",
+                subject="provider-subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             settings=_enabled_settings(),
-            provider="oidc",
-            subject="provider-subject-1",
         )
 
     assert db.accounts == {}
@@ -639,10 +692,14 @@ async def test_provision_sso_from_defaults_rolls_back_when_identity_link_fails()
 
     with pytest.raises(RuntimeError, match="identity link failed"):
         await service.provision_sso_from_defaults(
-            email="developer@example.com",
+            identity=SSOIdentityAssertion(
+                email="developer@example.com",
+                provider="oidc",
+                subject="provider-subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             settings=_enabled_settings(),
-            provider="oidc",
-            subject="provider-subject-1",
         )
 
     assert db.accounts == {}
@@ -658,12 +715,16 @@ async def test_provision_sso_from_defaults_rolls_back_when_login_session_creatio
     db = TransactionalFakeSelfRegistrationDB()
     service = _service(db, SessionFailingSSOIdentityService(db_client=db))
 
-    with pytest.raises(RuntimeError, match="failed to establish self-registration session"):
+    with pytest.raises(LoginSessionCreationError, match="Failed to establish session"):
         await service.provision_sso_from_defaults(
-            email="developer@example.com",
+            identity=SSOIdentityAssertion(
+                email="developer@example.com",
+                provider="oidc",
+                subject="provider-subject-1",
+                email_verified=True,
+                subject_source=SSOSubjectSource.PROVIDER,
+            ),
             settings=_enabled_settings(),
-            provider="oidc",
-            subject="provider-subject-1",
         )
 
     assert db.accounts == {}

--- a/tests/services/test_sso_identity_ownership.py
+++ b/tests/services/test_sso_identity_ownership.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from src.auth.sso_identity import SSOIdentityAssertion, SSOSubjectSource
+
+import copy
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import replace
+
+import pytest
+
+from src.auth.sso_identity import SSOIdentityOwnershipError
+from src.services.platform_identity_service import PlatformIdentityService
+from tests.services.test_platform_identity_service import TransactionalFakePlatformIdentityDB
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("linked", [False, True])
+async def test_demoted_listed_admin_keeps_scoped_roles(linked: bool) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="account", email="admin@example.com", role="org_user")
+    db.teams["team"] = {"team_id": "team", "organization_id": "org"}
+    db.organizations["org"] = {"organization_id": "org", "lifecycle_state": "active"}
+    service = PlatformIdentityService(db, salt="test-salt")
+    await service.upsert_team_membership(account_id="account", team_id="team", role="team_admin")
+    await service.upsert_organization_membership(
+        account_id="account", organization_id="org", role="org_owner"
+    )
+    if linked:
+        await service.link_sso_identity(
+            account_id="account", email="admin@example.com", provider="oidc", subject="subject"
+        )
+
+    login = await service.upsert_sso_account(
+        identity=SSOIdentityAssertion(
+            email="admin@example.com",
+            provider="oidc",
+            subject="subject",
+            email_verified=True,
+            subject_source=SSOSubjectSource.PROVIDER,
+        ),
+        is_platform_admin=True,
+        team_id="team",
+    )
+
+    assert login is not None and login.context.role == "org_user"
+    assert db.team_memberships[("account", "team")]["role"] == "team_admin"
+    assert db.organization_memberships[("account", "org")]["role"] == "org_owner"
+
+
+def assertion(
+    *,
+    email: str = "person@example.com",
+    verified: bool | None = True,
+    source: SSOSubjectSource = SSOSubjectSource.PROVIDER,
+) -> SSOIdentityAssertion:
+    return SSOIdentityAssertion(
+        provider="oidc",
+        subject="subject" if source is SSOSubjectSource.PROVIDER else email,
+        email=email,
+        email_verified=verified,
+        subject_source=source,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("existing_entrypoint", [False, True])
+@pytest.mark.parametrize("other_subject", [False, True])
+@pytest.mark.parametrize("role", ["org_user", "platform_admin"])
+@pytest.mark.parametrize("verified", [False, None])
+async def test_unverified_email_cannot_bind_existing_account(
+    existing_entrypoint: bool,
+    other_subject: bool,
+    role: str,
+    verified: bool | None,
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="account", email="person@example.com", role=role)
+    service = PlatformIdentityService(db, salt="test-salt")
+    if other_subject:
+        await service.link_sso_identity(
+            account_id="account", email="person@example.com", provider="oidc", subject="original"
+        )
+    accounts_before, identities_before = copy.deepcopy(db.accounts), copy.deepcopy(db.identities)
+    with pytest.raises(SSOIdentityOwnershipError):
+        if existing_entrypoint:
+            await service.create_sso_login_for_existing_account(
+                account_id="account", identity=assertion(verified=verified)
+            )
+        else:
+            await service.upsert_sso_account(
+                identity=assertion(verified=verified), is_platform_admin=False
+            )
+    assert db.accounts == accounts_before
+    assert db.identities == identities_before
+    assert db.sessions == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verified", [False, None])
+@pytest.mark.parametrize("existing_entrypoint", [False, True])
+async def test_established_subject_preserves_unverified_recovery_email(
+    verified: bool | None,
+    existing_entrypoint: bool,
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="account", email="old@example.com", role="platform_admin")
+    service = PlatformIdentityService(db, salt="test-salt")
+    await service.link_sso_identity(
+        account_id="account", email="old@example.com", provider="oidc", subject="subject"
+    )
+    identity = assertion(email="unverified@example.com", verified=verified)
+    if existing_entrypoint:
+        login = await service.create_sso_login_for_existing_account(
+            account_id="account", identity=identity
+        )
+    else:
+        login = await service.upsert_sso_account(identity=identity, is_platform_admin=False)
+    assert login is not None
+    assert login.context.email == "old@example.com"
+    assert login.context.role == "platform_admin"
+    assert db.accounts["account"]["email"] == "old@example.com"
+    assert db.identities[("oidc", "subject")]["email"] == "old@example.com"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("linked", [False, True])
+@pytest.mark.parametrize("verified", [False, None])
+async def test_email_fallback_never_bypasses_verification(
+    linked: bool, verified: bool | None
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    service = PlatformIdentityService(db, salt="test-salt")
+    identity = assertion(source=SSOSubjectSource.EMAIL, verified=verified)
+    if linked:
+        await service.upsert_sso_account(
+            identity=replace(identity, email_verified=True), is_platform_admin=False
+        )
+    accounts_before, sessions_before = copy.deepcopy(db.accounts), copy.deepcopy(db.sessions)
+    identities_before = copy.deepcopy(db.identities)
+    with pytest.raises(SSOIdentityOwnershipError):
+        await service.upsert_sso_account(identity=identity, is_platform_admin=False)
+    assert db.accounts == accounts_before
+    assert db.identities == identities_before
+    assert db.sessions == sessions_before
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verified", [False, None])
+async def test_new_admin_requires_verified_email(verified: bool | None) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    service = PlatformIdentityService(db, salt="test-salt")
+    with pytest.raises(SSOIdentityOwnershipError):
+        await service.upsert_sso_account(
+            identity=assertion(verified=verified), is_platform_admin=True
+        )
+    assert db.accounts == db.identities == db.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_new_ordinary_account_with_stable_subject_uses_legacy_signup_policy() -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    service = PlatformIdentityService(db, salt="test-salt")
+    for _ in range(2):
+        login = await service.upsert_sso_account(
+            identity=assertion(verified=None), is_platform_admin=False
+        )
+        assert login is not None and login.context.role == "org_user"
+    assert len(db.accounts) == len(db.identities) == 1
+
+
+@pytest.mark.asyncio
+async def test_existing_account_id_is_not_proof_of_email_ownership() -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="account", email="victim@example.com", role="platform_admin")
+    service = PlatformIdentityService(db, salt="test-salt")
+    with pytest.raises(ValueError, match="does not match account"):
+        await service.create_sso_login_for_existing_account(
+            account_id="account", identity=assertion()
+        )
+    assert db.identities == db.sessions == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing", ["team", "org", "both"])
+async def test_defaults_seed_only_missing_memberships(missing: str) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="account", email="person@example.com")
+    db.teams["team"] = {"team_id": "team", "organization_id": "org"}
+    db.organizations["org"] = {"organization_id": "org", "lifecycle_state": "active"}
+    service = PlatformIdentityService(db, salt="test-salt")
+    if missing == "org":
+        await service.upsert_team_membership(
+            account_id="account", team_id="team", role="team_developer"
+        )
+    if missing == "team":
+        await service.upsert_organization_membership(
+            account_id="account", organization_id="org", role="org_admin"
+        )
+    for _ in range(2):
+        await service.upsert_sso_account(
+            identity=assertion(), is_platform_admin=False, team_id="team"
+        )
+    assert db.team_memberships[("account", "team")]["role"] == (
+        "team_developer" if missing == "org" else "team_viewer"
+    )
+    assert db.organization_memberships[("account", "org")]["role"] == (
+        "org_admin" if missing == "team" else "org_member"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target", ["missing_team", "missing_org", "inactive_org"])
+async def test_invalid_default_target_rolls_back_login(target: str) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    if target != "missing_team":
+        db.teams["team"] = {"team_id": "team", "organization_id": "org"}
+    if target == "inactive_org":
+        db.organizations["org"] = {"organization_id": "org", "lifecycle_state": "deleting"}
+    service = PlatformIdentityService(db, salt="test-salt")
+    from src.services.organization_mutation_policy import OrganizationMutationError
+
+    with pytest.raises((ValueError, OrganizationMutationError)):
+        await service.upsert_sso_account(
+            identity=assertion(), is_platform_admin=False, team_id="team"
+        )
+    assert db.accounts == db.identities == db.sessions == {}
+    assert db.team_memberships == db.organization_memberships == {}
+
+
+class CountingIdentityDatabase:
+    def __init__(self, db: TransactionalFakePlatformIdentityDB, statements: list[str]) -> None:
+        self.db = db
+        self.statements = statements
+
+    async def query_raw(self, query: str, *params: object) -> list[dict[str, object]]:
+        self.statements.append(query.split()[0].upper())
+        return await self.db.query_raw(query, *params)
+
+    async def execute_raw(self, query: str, *params: object) -> int:
+        self.statements.append(query.split()[0].upper())
+        return await self.db.execute_raw(query, *params)
+
+    @asynccontextmanager
+    async def tx(self) -> AsyncIterator[CountingIdentityDatabase]:
+        async with self.db.tx() as db:
+            yield CountingIdentityDatabase(db, self.statements)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "statement_budget"),
+    [
+        ("new", 10),
+        ("email_match", 12),
+        ("linked", 10),
+        ("linked_email_change", 11),
+        ("linked_default_team", 14),
+    ],
+)
+async def test_sso_login_stays_within_measured_database_budget(
+    case: str, statement_budget: int
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    setup = PlatformIdentityService(db, salt="test-salt")
+    if case != "new":
+        db.add_account(account_id="account", email="person@example.com")
+        if case.startswith("linked"):
+            await setup.link_sso_identity(
+                account_id="account", email="person@example.com", provider="oidc", subject="subject"
+            )
+    email = "changed@example.com" if case == "linked_email_change" else "person@example.com"
+    team_id = None
+    if case == "linked_default_team":
+        team_id = "team"
+        db.teams["team"] = {"team_id": "team", "organization_id": "org"}
+        db.organizations["org"] = {"organization_id": "org", "lifecycle_state": "active"}
+    statements: list[str] = []
+    service = PlatformIdentityService(CountingIdentityDatabase(db, statements), salt="test-salt")
+
+    login = await service.upsert_sso_account(
+        identity=assertion(email=email), is_platform_admin=False, team_id=team_id
+    )
+
+    assert login is not None and login.context.role == "org_user"
+    # Budgets were measured against PostgreSQL; count driver calls, not fake internals.
+    assert len(statements) <= statement_budget, statements

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.audit.actions import AuditAction
 from src.config import AppConfig
+from src.auth.sso_identity import SSOAccountMatch, SSOIdentityAssertion
 from src.models.platform_auth import PlatformAuthContext
 from src.models.errors import RateLimitError
 from src.services.platform_identity_service import AccountInactiveError, LoginSessionCreationError
@@ -27,10 +28,12 @@ class _StubSSOHandler:
         email: str = "user@example.com",
         subject: str = "subject-1",
         email_verified: bool | None = True,
+        subject_source: str = "provider",
     ) -> None:
         self.email = email
         self.subject = subject
         self.email_verified = email_verified
+        self.subject_source = subject_source
 
     def generate_pkce_pair(self):
         return ("pkce-verifier", "pkce-challenge")
@@ -47,6 +50,7 @@ class _StubSSOHandler:
             "email": self.email,
             "role": "internal_user",
             "provider_subject": self.subject,
+            "provider_subject_source": self.subject_source,
             "email_verified": self.email_verified,
             "token": "provider-session-token",
         }
@@ -139,10 +143,21 @@ class _StubIdentityService:
         self,
         *,
         account_id: str,
-        email: str,
-        provider: str = "sso",
-        subject: str | None = None,
+        identity: SSOIdentityAssertion,
     ):
+        email, provider, subject = identity.email, identity.provider, identity.subject
+        account = self.accounts[account_id]
+        if not account["is_active"]:
+            raise AccountInactiveError("Account is inactive")
+        linked = self.identities.get((provider, subject))
+        if linked is not None and linked != account_id:
+            raise ValueError("SSO identity is already linked to another account")
+        identity.require_ownership(
+            SSOAccountMatch.SUBJECT if linked else SSOAccountMatch.EMAIL,
+            role=str(account["role"]),
+        )
+        if identity.email_verified is not True:
+            email = str(account["email"])
         self.sso_login_calls.append(
             {
                 "account_id": account_id,
@@ -177,10 +192,21 @@ class _StubIdentityService:
         self.last_logins.append(account_id)
 
     async def upsert_sso_account(self, **kwargs):
+        identity = kwargs.pop("identity")
+        kwargs.update(email=identity.email, provider=identity.provider, subject=identity.subject)
         self.legacy_upserts.append(dict(kwargs))
         email = self.normalize_email(kwargs["email"])
         existing = await self.get_account_by_email(email)
         account_id = str(existing.get("account_id")) if existing else "acct-legacy"
+        linked = self.identities.get((identity.provider, identity.subject))
+        identity.require_ownership(
+            SSOAccountMatch.SUBJECT
+            if linked
+            else (SSOAccountMatch.EMAIL if existing else SSOAccountMatch.CREATED),
+            role=str(existing["role"])
+            if existing
+            else ("platform_admin" if kwargs.get("is_platform_admin") else "org_user"),
+        )
         if existing is None:
             self.add_account(
                 account_id=account_id,
@@ -215,12 +241,11 @@ class _StubSelfRegistrationProvisioner:
     async def provision_sso_from_defaults(
         self,
         *,
-        email: str,
+        identity: SSOIdentityAssertion,
         settings,
-        provider: str,
-        subject: str,
-        is_active: bool = True,
     ):  # noqa: ANN001
+        email, provider, subject = identity.email, identity.provider, identity.subject
+        is_active = True
         self.calls.append({"email": email, "settings": settings, "is_active": is_active})
         if self.error is not None:
             raise self.error
@@ -353,11 +378,13 @@ async def _start_sso_and_callback(
     email: str,
     subject: str = "subject-1",
     email_verified: bool | None = True,
+    subject_source: str = "provider",
 ):
     test_app.state.sso_auth_handler = _StubSSOHandler(
         email=email,
         subject=subject,
         email_verified=email_verified,
+        subject_source=subject_source,
     )
     test_app.state.sso_state_store = SSOStateStore(
         redis_client=test_app.state.redis, ttl_seconds=600
@@ -1143,7 +1170,11 @@ async def test_sso_callback_self_registration_existing_account_inactive_service_
     client, test_app
 ):
     class InactiveDuringLoginIdentityService(_StubIdentityService):
-        async def create_sso_login_for_existing_account(self, **kwargs):  # noqa: ANN003, ANN201
+        async def create_sso_login_for_existing_account(self, **kwargs):
+            identity = kwargs.pop("identity")
+            kwargs.update(
+                email=identity.email, provider=identity.provider, subject=identity.subject
+            )  # noqa: ANN003, ANN201
             self.sso_login_calls.append(
                 {
                     "account_id": str(kwargs["account_id"]),

--- a/tests/test_sso_account_roles.py
+++ b/tests/test_sso_account_roles.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.platform_identity_service import PlatformIdentityService
+from tests.services.test_platform_identity_service import TransactionalFakePlatformIdentityDB
+from tests.test_auth import _self_registration_app_config, _start_sso_and_callback
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("self_registration", [False, True])
+@pytest.mark.parametrize("linked", [False, True])
+@pytest.mark.parametrize(
+    ("initial_role", "edited_role", "listed"),
+    [("org_user", "platform_admin", False), ("platform_admin", "org_user", True)],
+)
+async def test_people_access_role_edit_survives_sso_login(
+    client,
+    test_app,
+    self_registration: bool,
+    linked: bool,
+    initial_role: str,
+    edited_role: str,
+    listed: bool,
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="acct-1", email="person@example.com", role=initial_role)
+    service = PlatformIdentityService(db_client=db, salt="test-salt")
+    test_app.state.platform_identity_service = service
+    test_app.state.prisma_manager = SimpleNamespace(client=db)
+    config = _self_registration_app_config(
+        enabled=self_registration,
+        admin_emails=["person@example.com"] if listed else [],
+    )
+    config.general_settings.master_key = "test-master-key"
+    test_app.state.app_config = config
+    if linked:
+        await service.link_sso_identity(
+            account_id="acct-1", email="person@example.com", provider="oidc", subject="subject-1"
+        )
+
+    saved = await client.post(
+        "/ui/api/rbac/accounts",
+        headers={"X-Master-Key": "test-master-key"},
+        json={"email": "person@example.com", "role": edited_role, "is_active": True},
+    )
+    assert saved.status_code == 200
+    assert saved.json()["role"] == edited_role
+
+    for attempt in range(2):
+        response = await _start_sso_and_callback(
+            client=client,
+            test_app=test_app,
+            state=f"role-edit-{attempt}",
+            email="Person@Example.com",
+        )
+        assert response.status_code == 302
+        assert db.accounts["acct-1"]["role"] == edited_role
+        me = await client.get("/auth/me")
+        assert me.status_code == 200
+        assert me.json()["role"] == edited_role
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("self_registration", [False, True])
+@pytest.mark.parametrize("linked", [False, True])
+@pytest.mark.parametrize("listed", [False, True])
+async def test_sso_login_cannot_reactivate_disabled_account(
+    client,
+    test_app,
+    self_registration: bool,
+    linked: bool,
+    listed: bool,
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="acct-1", email="person@example.com", is_active=False)
+    service = PlatformIdentityService(db_client=db, salt="test-salt")
+    test_app.state.platform_identity_service = service
+    test_app.state.app_config = _self_registration_app_config(
+        enabled=self_registration,
+        admin_emails=["person@example.com"] if listed else [],
+    )
+    if linked:
+        await service.link_sso_identity(
+            account_id="acct-1", email="person@example.com", provider="oidc", subject="subject-1"
+        )
+    identities_before = dict(db.identities)
+
+    response = await _start_sso_and_callback(
+        client=client,
+        test_app=test_app,
+        state="disabled-account",
+        email="person@example.com",
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Account is inactive"
+    assert db.accounts["acct-1"]["is_active"] is False
+    assert db.accounts["acct-1"]["role"] == "org_user"
+    assert db.identities == identities_before
+    assert db.sessions == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("email_verified", [False, None])
+async def test_unverified_new_subject_cannot_claim_existing_admin(
+    client, test_app, email_verified: bool | None
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="admin", email="admin@example.com", role="platform_admin")
+    before = copy.deepcopy(db.accounts)
+    test_app.state.platform_identity_service = PlatformIdentityService(db, salt="test-salt")
+    test_app.state.app_config = _self_registration_app_config(enabled=False, admin_emails=[])
+
+    response = await _start_sso_and_callback(
+        client=client,
+        test_app=test_app,
+        state="unverified-claim",
+        email="admin@example.com",
+        subject="unknown-subject",
+        email_verified=email_verified,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "SSO email is not verified"
+    assert "deltallm_session=" not in response.headers.get("set-cookie", "")
+    assert db.accounts == before
+    assert db.identities == {}
+    assert db.sessions == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("self_registration", [False, True])
+@pytest.mark.parametrize("listed", [False, True])
+@pytest.mark.parametrize("role", ["platform_admin", "org_user"])
+async def test_signup_verification_setting_cannot_bypass_existing_account_ownership(
+    client,
+    test_app,
+    self_registration: bool,
+    listed: bool,
+    role: str,
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="person", email="person@example.com", role=role)
+    service = PlatformIdentityService(db, salt="test-salt")
+    await service.link_sso_identity(
+        account_id="person", email="person@example.com", provider="oidc", subject="original"
+    )
+    before = copy.deepcopy(db.identities)
+    test_app.state.platform_identity_service = service
+    config = _self_registration_app_config(
+        enabled=self_registration,
+        admin_emails=["person@example.com"] if listed else [],
+    )
+    config.general_settings.self_registration.require_email_verification = False
+    test_app.state.app_config = config
+    response = await _start_sso_and_callback(
+        client=client,
+        test_app=test_app,
+        state="additional-unverified-identity",
+        email="person@example.com",
+        subject="unknown",
+        email_verified=False,
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "SSO email is not verified"
+    assert db.identities == before
+    assert db.accounts["person"]["role"] == role
+    assert db.sessions == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("self_registration", [False, True])
+async def test_email_fallback_existing_binding_requires_verification(
+    client,
+    test_app,
+    self_registration: bool,
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="person", email="person@example.com", role="platform_admin")
+    service = PlatformIdentityService(db, salt="test-salt")
+    await service.link_sso_identity(
+        account_id="person",
+        email="person@example.com",
+        provider="oidc",
+        subject="person@example.com",
+    )
+    test_app.state.platform_identity_service = service
+    test_app.state.app_config = _self_registration_app_config(enabled=self_registration)
+    response = await _start_sso_and_callback(
+        client=client,
+        test_app=test_app,
+        state="fallback-binding",
+        email="person@example.com",
+        subject="person@example.com",
+        subject_source="email",
+        email_verified=False,
+    )
+    assert response.status_code == 403
+    assert db.sessions == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("self_registration", [False, True])
+async def test_established_subject_with_missing_verification_keeps_admin_role(
+    client,
+    test_app,
+    self_registration: bool,
+) -> None:
+    db = TransactionalFakePlatformIdentityDB()
+    db.add_account(account_id="person", email="person@example.com", role="platform_admin")
+    service = PlatformIdentityService(db, salt="test-salt")
+    await service.link_sso_identity(
+        account_id="person", email="person@example.com", provider="oidc", subject="subject-1"
+    )
+    test_app.state.platform_identity_service = service
+    test_app.state.app_config = _self_registration_app_config(enabled=self_registration)
+    response = await _start_sso_and_callback(
+        client=client,
+        test_app=test_app,
+        state="established-subject",
+        email="person@example.com",
+        email_verified=None,
+    )
+    assert response.status_code == 302
+    me = await client.get("/auth/me")
+    assert me.status_code == 200 and me.json()["role"] == "platform_admin"
+
+
+@pytest.mark.asyncio
+async def test_self_registration_ownership_denial_is_not_a_provisioning_error(
+    client, test_app
+) -> None:
+    from src.auth.sso_identity import SSOIdentityOwnershipError
+    from tests.test_auth import _StubSelfRegistrationProvisioner
+
+    db = TransactionalFakePlatformIdentityDB()
+    test_app.state.platform_identity_service = PlatformIdentityService(db, salt="test-salt")
+    test_app.state.self_registration_provisioning_service = _StubSelfRegistrationProvisioner(
+        error=SSOIdentityOwnershipError()
+    )
+    config = _self_registration_app_config(enabled=True)
+    config.general_settings.self_registration.require_email_verification = False
+    test_app.state.app_config = config
+    response = await _start_sso_and_callback(
+        client=client,
+        test_app=test_app,
+        state="provisioning-race-denial",
+        email="person@example.com",
+        email_verified=False,
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "SSO email is not verified"
+    assert db.sessions == {}


### PR DESCRIPTION
## Summary

Promoting an account in People & Access could be undone on its next SSO login because the callback reassigned its role from `sso_admin_email_list`. SSO now preserves the database role and active status; the list supplies the initial role only when an account is created.

- Share typed identity ownership enforcement across legacy SSO and self-registration. Attaching a new subject to an existing account and granting an initial admin role require verified email.
- Preserve established provider-subject login when the verification claim is missing, while retaining stored recovery email on unverified changes. Email fallback identifiers require verification on every login.
- Seed missing default organization/team memberships without overwriting existing roles.
- Resolve, bind, provision, and create sessions transactionally. Revalidate concurrent account/email changes, reject conflicting identity claims, and avoid treating an insert conflict as a newly self-registered account.

## Validation

- Affected authentication, RBAC, invitation, and service suite: **311 passed**, including a final review rerun; 19 existing HTTPX cookie deprecation warnings.
- Real PostgreSQL SSO suite: **28 passed**, using isolated PostgreSQL 16 with the generated Prisma client and all 86 migrations applied. Covers concurrent creation, role edits, disablement, identity/email conflicts, scoped role preservation, timeout, cancellation, and rollback.
- Dependency classifier: **15 passed**. Full collection: **3,949 tests**, exclusively classified as hermetic 2,600 / app 1,080 / postgres 194 / redis 16 / helm 59.
- Repository-wide Ruff lint and `git diff --check`: passed.
- Touched-file formatting: 14 files pass. `src/api/auth.py` retains pre-existing formatting outside changed lines; formatter change groups decreased from 58 to 44, with no remaining formatter changes intersecting edited lines.

<details>
<summary>Commands run from the worktree</summary>

Local commands used the existing development environment with `PYTHONPATH=.`, `UV_CACHE_DIR=/private/tmp/deltallm-uv-cache`, and `UV_PROJECT_ENVIRONMENT` pointing to the repository's shared `.venv`.

```sh
uv run --no-sync python -m pytest -q tests/auth tests/services/test_platform_identity_service.py tests/services/test_sso_identity_ownership.py tests/services/test_invitation_service.py tests/services/test_self_registration_provisioning.py tests/bootstrap/test_auth_bootstrap.py tests/test_auth.py tests/test_sso_account_roles.py tests/test_auth_invitation_recovery.py tests/test_ui_auth.py tests/test_ui_authorization.py tests/test_ui_rbac_scoping.py tests/test_ui_rbac_principals.py tests/test_ui_access_provisioning.py tests/test_ui_invitations.py --tb=line

uv run --no-sync python -m pytest -q tests/test_dependency_lanes.py --tb=short
uv run --no-sync python -m pytest --collect-only -qq --dependency-lane-report
uv run --no-sync ruff check .
uv run --no-sync ruff format --check src/auth/sso.py src/auth/sso_identity.py src/db/platform_accounts.py src/db/platform_memberships.py src/services/sso_account_service.py src/services/platform_identity_service.py src/services/self_registration_provisioning.py src/api/auth.py tests/services/test_platform_identity_service.py tests/services/test_sso_identity_ownership.py tests/services/test_self_registration_provisioning.py tests/test_auth.py tests/test_sso_account_roles.py tests/db/test_sso_account_roles.py tests/auth/test_sso.py
git diff --check
```

Against the isolated database, with this worktree mounted read-only in the dependency runner:

```sh
docker exec deltallm-sso-fix-runner prisma generate --schema=./prisma/schema.prisma
docker exec deltallm-sso-fix-runner prisma migrate deploy --schema=./prisma/schema.prisma
docker exec deltallm-sso-fix-runner python -m pytest -q tests/db/test_sso_account_roles.py -p no:cacheprovider --tb=short
```

Temporary database and runner containers were removed after verification.

</details>

The new SQL is bounded by existing account/team keys and unique constraints. Five regression cases cap application SQL statements at 10 for new accounts, 12 for existing email matches, 10 for established subjects, 11 for verified email changes, and 14 for default-team enrollment. No provider or Redis calls were added.

## Product and documentation impact

- [x] Public API, errors, streaming, authentication, or tenant scope reviewed
- [x] Settings, environment variables, defaults, secrets, and restart/reload behavior reviewed
- [x] Schema, migrations, mixed-version sequencing, and rollback safety reviewed
- [x] Provider capabilities, model metadata, pricing, and credentials reviewed
- [x] Admin UI workflow, permissions, states, and screenshots reviewed
- [x] Deployment, probes, metrics, alerts, security, backup, and runbooks reviewed
- [x] Public docs/nav/links and release/deprecation notes updated, or no-doc-impact reason below
- [x] Generated OpenAPI/config/provider artifacts regenerated and checked when their source changed

Authentication, People & Access, general-settings documentation, and example comments describe the new behavior. Provider verification compatibility and multi-replica rollout are documented. There are no UI layout/API shape, schema, dependency, new setting, generated-contract, or deployment-manifest changes; screenshots and generated-contract updates are therefore not applicable.

## Rollout and rollback

Before rollout, smoke-test established-subject login, verified first linking, denied unverified linking, and retained scoped roles with a representative configured provider. This live-provider check has not been performed locally.

Providers without a verified-email assertion now receive 403 when attaching a new subject to an existing account or granting an initial admin role. Existing provider-subject bindings continue to work; email-derived subjects require verification on every login. Ordinary new-account self-registration retains its configured verification policy.

Complete rollout across all API replicas before reapplying lost platform or membership roles in People & Access. No migration, automatic role restoration, or existing identity-binding repair is performed. Rolling back to an affected version restores role overwrites and unsafe email linking; prefer a forward fix.

