### PR TITLE
feat(router): add selector accounting and runtime prerequisites (PR 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, master, feature/org-tiers]
+    branches: [main, master, feature/org-tiers, feature/issue-304-model-router]
   pull_request:
-    branches: [main, master, feature/org-tiers]
+    branches: [main, master, feature/org-tiers, feature/issue-304-model-router]
 
 jobs:
   ui-build:
@@ -104,6 +104,7 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/deltallm_test
           REDIS_URL: redis://localhost:6379/0
+          DELTALLM_TEST_REDIS_URL: redis://localhost:6379/0
           DELTALLM_MASTER_KEY: sk-test-master-key-for-ci-only-0000
           DELTALLM_SALT_KEY: ci-salt-key-for-testing-only-do-not-use-in-production
         run: uv run pytest -v --ignore=tests/test_provider_presets_smoke.py

--- a/docs/project/model-router-design.md
+++ b/docs/project/model-router-design.md
@@ -4,6 +4,11 @@ Status: accepted design for [issue #304](https://github.com/deltawi/deltallm/iss
 The implementation is split into six reviewable PRs. PRs 1–3 define prerequisites and must not
 activate a selector. PR 4 is the first activation boundary.
 
+Current PR 3 status: prerequisite code is implemented locally; real PostgreSQL/Redis,
+migration and production-capacity qualification are still open. The
+[current completion record](#pr-3-completion-decision--2026-09-08) supersedes the older
+partial-implementation checkpoints below. This is not a merge-readiness sign-off.
+
 ## Goal and non-goals
 
 An optional Route-Group selector classifies a normalized text request into a bounded
@@ -356,6 +361,79 @@ opaque non-routing metadata. Equivalent normalized snapshots therefore share a f
 member/lane/strategy/selector change produces a different identity. PR 3 adds this value to the
 versioned response-cache key; PR 1 only defines and tests the pure canonical function.
 
+### PR 3 cache identity decision
+
+The routing generation owns a read-only map of `route-response-v1` fingerprints, computed
+synchronously while constructing that generation, before publication. Each response identity
+composes the existing canonical `route-policy-v1` fingerprint with concrete deployment configuration,
+inherited execution settings, and configured fallback dependencies. The durable policy fingerprint
+and its version-aware selector/lane normalization are unchanged. Legacy callable model groups also
+receive an identity. This projection does not execute eligibility, strategy, or fallback policy.
+
+Concrete deployment identity includes normalized provider/upstream model, endpoint and provider
+version/region, configured timeouts/output bounds, authentication-header configuration, stable
+credential reference, workload mode, forwarded defaults, context limits, tags, token/request prices
+used for ordering, and provider RPM/TPM limits. Raw credential values, health incarnation, live
+health/capacity, and opaque operator metadata are excluded. Only digests survive publication; no
+configuration or topology is added to public headers or logs. The existing default-parameter facade
+and identity projection share `src/providers/request_defaults.py`, so UI-only `available_voices`
+does not invalidate responses or reach providers. Caller parameters still take precedence.
+
+`src/router/fallback_identity.py` projects ordinary, context-window, and content-policy fallback
+edges from the generation's `FallbackConfig`. Target order and edge kind matter. Missing targets
+participate so later target creation invalidates ancestors. The graph conservatively includes
+transitive configured dependencies; the failover owner still decides which can actually execute.
+Iterative strongly-connected-component condensation handles cycles and deep/shared chains without
+recursion or path enumeration. Graph work and temporary storage are O(V + E), plus canonical sorting
+of cycle members; hashing occurs once per component and once per callable group. Truly unrelated
+groups do not affect a root's identity. No new global cache or lifecycle is introduced.
+
+After authenticated preflight, cache middleware resolves the final model through the pinned router
+and supplies its fingerprint as a mandatory response-identity dimension. Custom cache keys replace
+only the caller-selected payload portion; they cannot remove the server's routing dimension. Both
+custom content and routing identity are hashed, preserving existing tenant/key, endpoint, and
+stream/JSON separation without adding topology to response headers. The response-cache namespace
+moves from `v2` (and the incomplete local `v3` checkpoint) to `v4`. Equivalent generations and
+rollback to equivalent policy can reuse `v4` entries; reload UUIDs, revision numbers, and unrelated
+groups do not invalidate an entry.
+
+This projection has no SQL, Redis, provider, filesystem, queue, or task work. Its retained size is
+one digest per configured callable group in the existing disposable generation; each request does
+one map lookup instead of serializing all members. Cache reads/writes and their failure policy
+retain their existing owner and call counts. Snapshot construction is the only producer; consumers
+must not mutate policy/registry objects inside a published generation to update cache identity.
+
+Rollout naturally leaves old `v2`/`v3` entries to expire under their existing TTL; no wildcard deletion
+or database migration is required. The namespace bump causes a one-time cold response cache and
+must be included in capacity planning. Rolling back this prerequisite binary restores its old
+namespace; this is not a supported rollback of an activated selector (see the rollout section).
+This slice does not activate selectors or implement atomic budget reservation or unknown-usage
+reconciliation. The subsequently approved charging policy is recorded below.
+
+### PR 3 selector charging decision — 2026-09-08
+
+The product owner confirmed that **customers pay the selector's cost**, in addition to answer
+cost. Interpret this as pass-through actual provider cost with no new markup. Keep provider cost
+and customer charge as separate exact monetary amounts, even when they are equal. Freeze the
+concrete selector deployment, provider/model, pricing source/version, USD token rates, attribution,
+and `NUMERIC(38,18)` / `ROUND_HALF_EVEN` rounding inputs with the component event. Do not look up
+current prices when replaying a receipt. Existing answer-pricing policy is unchanged.
+
+Only a provider-reported receipt establishes a selector charge; invalid selector output does not
+erase incurred usage. Answer failure, cancellation, disconnect, or retry must not erase or repeat
+the selector charge. The selector uses a deterministic `selector:v1` child identity derived from
+the server-owned outer billing event, not the client correlation ID. Public OpenAI response usage
+continues to describe the answer only; admin reporting must distinguish components from external
+requests.
+
+Unknown usage remains durably pending reconciliation and conservatively retains its allowance;
+it is neither zero actual cost nor permission to charge an estimated upper bound as observed cost.
+Recovery must not re-execute the provider call to reconstruct a lost receipt. A not-attempted
+component can release its selector allowance only when non-dispatch is durably established.
+Budget admission must cover the answer plus selector across every applicable scope. Existing
+read-only budget checks are soft controls, not a substitute for atomic reservation. Activation
+remains blocked until these economic and recovery prerequisites have been implemented and proven.
+
 ## Database, API, and file configuration
 
 Database draft validation uses one group/member/deployment-mode inventory query inside the existing
@@ -616,3 +694,700 @@ cancellation. Ruff check and format check passed for `src/providers/chat_hop.py`
 The post-fix full backend command `uv run pytest -q --tb=short --disable-warnings` passed
 3,908 tests with 205 environment-gated skips and 26,946 warnings in 271.87 seconds. Skipped tests
 are not counted as real-service integration proof. `git diff --check` also passed.
+
+## PR 3 partial implementation record — 2026-09-08
+
+Only the response-cache identity slice was implemented at this first checkpoint. It did not
+complete PR 3, activate a selector, introduce billing changes, or settle who pays the selector's
+cost. The subsequent charging decision above and receipt checkpoint below supersede that open choice.
+Capacity integration, atomic budget reservation, durable component accounting/reconciliation,
+the typed miss-only execution boundary, and selector/admin telemetry remain outstanding.
+The temporary implementation plan is retained until those parts and their verification finish.
+
+The cache slice includes the generation-owned canonical fingerprint map, final-model alias
+resolution from the pinned generation, hashed routing-aware ordinary/custom keys, and the `v3`
+response-cache namespace. Tests cover effective weights, strategy/context/retry/timeout changes,
+selector/lane semantics without activation, historical opaque-field behavior, equivalent reloads,
+rollback reuse, alias retargeting, in-flight preflight reload, Chat/Responses/Completions,
+stream replay, old namespace isolation, and the existing no-production-selector-wiring guard.
+
+Verification completed:
+
+- Unchanged PR 2 tree (`ff15a5f4`, tree-identical to merge base `eb33826e`):
+  `uv run --frozen --extra dev pytest tests/test_cache.py tests/test_routing_runtime_generation.py -q --tb=short --disable-warnings`
+  — 30 passed, 272 warnings.
+- New focused cache/runtime suite:
+  `uv run --frozen pytest tests/test_routing_cache_identity.py tests/test_cache.py tests/test_routing_runtime_generation.py -q --tb=short --disable-warnings`
+  — 61 passed, 371 warnings. The first run exposed insufficient RPM in the new multi-request
+  fixture; only that fixture's key allowance was increased, with rate admission still enabled.
+- Affected suite:
+  `uv run --frozen pytest tests/router/selection tests/test_route_policy_selector_contract.py tests/test_route_policy_validation.py tests/test_routing.py tests/test_routing_runtime_generation.py tests/bootstrap/test_routing_bootstrap.py tests/test_chat.py tests/test_text_endpoints.py tests/test_cache.py tests/test_routing_cache_identity.py tests/test_metrics.py -q --tb=short --disable-warnings -o faulthandler_timeout=45`
+  — 455 passed, 2,471 warnings. These counts overlap the focused suite; they are not additive.
+- Real Redis, using the existing disposable loopback test container:
+  `DELTALLM_TEST_REDIS_URL=redis://127.0.0.1:56390/0 uv run --frozen pytest tests/test_cache_routing_redis_integration.py tests/test_cache_redis_integration.py -q --tb=short --disable-warnings -o faulthandler_timeout=45`
+  — 3 passed, 29 warnings, no skips. The container was stopped afterward, with data retained.
+  This proves cache cross-client/version/policy isolation and TTL round trips, not selector
+  capacity or billing recovery.
+- Ruff check and format check passed for the eight touched Python paths. OpenAPI export check
+  remained current at 215 paths / 280 operations. `git diff --check` passed.
+
+No schema, dependency, configuration setting, admin API/UI shape, or deployment manifest changed.
+The full backend/real-PostgreSQL economic gates have not been run for the unfinished PR 3 work.
+
+The checked-in `tests/performance/routing_cache_profile.py` uses the canonical constant-arrival
+generator with the existing ASGI test application, fake Redis, no database, and a fixed provider
+mock. Run the same script in each checkout's locked environment with `PYTHONPATH` set to that
+checkout, `--label before` or `--label after`, and `--output-dir` pointing to a temporary artifact
+directory. Each cache-hit/miss case warms once, then offers 10 RPS for 20 seconds, bounded at 16
+in flight. It records raw samples, actual offered/completed rates, latency distributions, provider
+time, in-flight slope, and dependency method counts; assertions enforce the baseline counts.
+This is a narrow cache-path regression profile, not production latency, SQL/Redis load, TTFT,
+multi-replica capacity, or the proposed 50-RPS release certificate.
+
+Raw samples are retained locally under `/private/tmp/deltallm-pr3-cache-profile.QnToYX`;
+`control/` contains the fresh comparison. Every measured case completed 200/200 requests at
+10 RPS with no generator drops, maximum observed in-flight of one, and zero sampled queue slope.
+The mock dependency counts were identical between revisions: a cache miss made one cache get,
+one cache set, and one provider post per request; a hit made one cache get and no provider post.
+Fake-Redis method counts also matched exactly, including nested fake implementation calls:
+misses used `get=1, eval=6, hgetall=1, mget=1, zadd=2, incr=1, expire=2, incrby=1,
+zremrangebyscore=1, pexpire=1`; hits used `get=1, eval=3` per request. These are not claims about
+real Redis wire-command counts or real SQL operations.
+
+The original before/after pair was separated by almost nine hours and showed p95 increasing
+from 3.13 to 14.10 ms on misses and 2.20 to 6.89 ms on hits. It is retained, not discarded.
+A fresh sequential control, taken a few minutes apart on 2026-09-08, measured:
+
+| Cache path | Revision | p50 (ms) | p95 (ms) | p99 (ms) |
+| --- | --- | ---: | ---: | ---: |
+| Miss | PR 2 base | 2.98 | 7.44 | 8.69 |
+| Miss | PR 3 cache slice | 4.59 | 6.20 | 7.14 |
+| Hit | PR 2 base | 4.54 | 6.73 | 11.51 |
+| Hit | PR 3 cache slice | 3.17 | 6.18 | 7.58 |
+
+The control supports unchanged dependency counts and shows no p95/p99 increase in this narrow
+profile, but miss p50 was higher. Variation in the unchanged baseline means the original latency
+difference cannot be attributed solely to this change. These short, sequential, in-process runs
+do not establish a production SLO or replace the remaining PR 3 integration/performance gates.
+
+### Selector receipt checkpoint — 2026-09-08
+
+The approved pass-through charging policy now has an isolated, typed receipt-to-outbox path.
+This is **partial PR 3 implementation**, not completed durable selector execution or permission
+to activate the feature.
+
+- `src/billing/selector_charge.py` owns immutable pricing, reported token receipt, frozen
+  attribution, deterministic UUIDv5 child identity (`selector:v1` within the server operation
+  UUID), and mapping to the existing spend payload. Customer charge equals provider cost.
+  Unknown/unattempted usage is not a billable receipt. Missing rates, invalid counts, unsupported
+  currency, unrepresentable amounts, and missing cached-input usage when a discount applies
+  fail validation. An explicitly configured zero price remains valid.
+- Monetary arithmetic uses `Decimal` with a local precision of 80 and canonical
+  `NUMERIC(38,18)` rounding. The legacy answer calculator rounds float results to ten decimals;
+  reusing it would lose the approved receipt's precision. The new exact calculation is limited
+  to frozen token/request rates, including observed input-cache discounts, inside the existing
+  billing owner. It neither resolves live prices nor changes answer pricing. Provider-specific
+  or tiered pricing without enough frozen evidence remains unsupported; the future binding
+  must reject it before dispatch, not omit it from the receipt and guess a charge.
+- `SpendIngestionService.log_selector_charge` requires durable ingestion, a database, an open
+  service, and a supplied monotonic acceptance deadline. Acceptance is bounded by the earlier
+  supplied deadline and a fixed two-second ceiling. It reuses the same bounded outbox and
+  synchronous transactional overload fallback. Capacity denial propagates. Other dependency
+  failures become a sanitized `selector_accounting_unavailable` error, never the provider
+  `TimeoutError` caught by safe-default routing. Cancellation propagates without detached work.
+- The method introduces no worker, pool, independent ledger, schema, or settings. Normal enqueue
+  reuses the existing advisory admission lock plus bounded insert/capacity statement in one
+  transaction; fallback and consumption reuse the existing event writer and five scoped ledger
+  updates. Database statement/lock-deadline and integration evidence remain open. No production
+  request calls this method, so selector-free request dependency counts are unchanged.
+- Spend preparation was extracted from the oversized writer into
+  `src/billing/spend_preparation.py`; the original method delegates to the single mapper.
+  Its historical dynamic outbox representation is a named compatibility boundary, not a new
+  domain interface. Keep it bounded and remove that dynamic shape when accepted spend events
+  migrate together to a typed representation. The new receipt contract has no dynamic fields
+  or HTTP/database dependencies. Size and dependency tests guard both seams.
+- Accepted `cost_exact` and `provider_cost_exact` are authoritative; float columns are only
+  reporting mirrors. Batch ledger addition also uses an explicit Decimal context so ambient
+  precision cannot drop fractional units before PostgreSQL receives them. The transactional
+  writer and outbox fencing/idempotency ownership are unchanged.
+
+Verification at this checkpoint (overlapping suites; do not add their counts):
+
+- `.venv/bin/python -m pytest tests/test_selector_charge.py tests/test_spend_ingestion.py -q
+  --tb=short --disable-warnings`: **68 passed**, 371 warnings, 1.30 seconds.
+- Affected suite: **632 passed**, 3,344 warnings, 36.22 seconds, with the command below.
+- Ruff check and format check passed for all 14 touched Python paths. OpenAPI parity passed:
+  215 paths / 280 operations. `git diff --check` passed. No API/UI shape changed.
+- `DATABASE_URL=postgresql://pr2:pr2-local-only@127.0.0.1:55440/deltallm_pr2_test
+  .venv/bin/python -m pytest tests/test_selector_charge_db_integration.py -q --tb=short
+  --disable-warnings -o faulthandler_timeout=30`: **4 setup errors**, 38 warnings, 0.33 seconds.
+  Prisma's engine cannot bind its local socket in the current sandbox (`PermissionError:
+  Operation not permitted`). No integration test body ran; this is not PostgreSQL proof.
+  The tests cover five-scope exact ledger effects, duplicate/concurrent delivery, fresh-service
+  outbox recovery followed by answer failure, and transactional error/cancellation rollback.
+  They must be executed in a session permitting the local Prisma engine before acceptance.
+  The disposable test database was stopped again afterward, preserving its data.
+- The `uv run --frozen` retry was also blocked by the default user-cache directory's permissions;
+  local checks above used the worktree environment installed from the frozen lock at the cache
+  checkpoint. No dependencies or lockfiles were changed.
+
+```sh
+.venv/bin/python -m pytest \
+  tests/test_selector_charge.py tests/test_spend_ingestion.py \
+  tests/test_billing.py tests/test_billing_tier_pricing.py \
+  tests/test_telemetry_ingestion_admin.py tests/test_spend_visibility.py \
+  tests/test_spend_reporting_cache.py tests/router/selection \
+  tests/test_route_policy_selector_contract.py tests/test_route_policy_validation.py \
+  tests/test_routing.py tests/test_routing_runtime_generation.py \
+  tests/bootstrap/test_routing_bootstrap.py tests/test_chat.py tests/test_text_endpoints.py \
+  tests/test_cache.py tests/test_routing_cache_identity.py tests/test_metrics.py \
+  -q --tb=short --disable-warnings -o faulthandler_timeout=30
+```
+
+Still required before PR 3 is complete: pre-dispatch durable intent and unknown-usage
+reconciliation, conservative answer-plus-selector allowance and atomic reservations, provider
+capacity integration, typed miss-only execution eligibility, and component-aware admin
+aggregation/metrics. In particular, `model_router_selector` is a child spend event, not an
+additional external request: existing request-count aggregations must become component-aware
+before this writer is activated. The receipt mapper alone does not guarantee recovery if a
+process dies before durable acceptance, and its type alone does not authorize attribution IDs.
+Future composition must supply verified attribution and durably freeze it before the provider.
+Publication/runtime guards remain closed; the local plan remains until implementation and
+required verification finish. No PR 3 commit, push, remote issue update, or PR has been made.
+
+### Cache review remediation — 2026-09-08
+
+Scope: the two cache-invalidation P2 findings, not the unfinished capacity/economic/telemetry
+prerequisites. The generation remains the source of truth and the only identity publisher.
+Tenant/key scoping, preflight ordering, cache degradation, retry ownership, and selector activation
+guards are unchanged. There are no new settings, schema changes, dependency clients, tasks, or
+request-path SQL/Redis/provider awaits.
+
+- [x] Invalidate when an unchanged concrete deployment ID is retargeted or its response-affecting
+  configuration changes; preserve equivalent reload and rollback reuse.
+- [x] Invalidate originating groups when ordinary or specialized fallback targets, membership,
+  policy, or transitive dependencies change; preserve unrelated-group reuse.
+- [x] Bump response-cache identity to `v4`, excluding both old `v2` and incomplete local `v3` entries.
+- [ ] Rerun real-Redis cache integration in an environment permitting loopback socket connections.
+- [ ] Update remote issue #304 when GitHub write approval is available. No issue edit was made.
+
+The original 12 HTTP reproductions failed before the implementation, with an unexpected cache hit
+after deployment retargeting or fallback member replacement. The final tests cover ordinary/custom
+keys, chat/Responses/completions, streaming, embeddings, equivalent reloads, rollback, and the
+admin registry-rebuild path. Pure tests cover concrete configuration/defaults, secret and opaque
+metadata exclusion, inherited execution settings, fallback edge kinds/order/removal, missing target
+creation, cycles, and 2,000-node shared chains with linear hash counts and no recursive traversal.
+Configured fallback target spelling is preserved because failover looks plans up with that spelling;
+the cache projection must not normalize a spelling change into an equivalent execution contract.
+
+Final verification (overlapping suites, not additive):
+
+- Focused command:
+  `.venv/bin/python -m pytest tests/test_routing_identity_dependencies.py
+  tests/test_routing_cache_invalidation.py tests/test_routing_cache_identity.py tests/test_cache.py
+  tests/test_routing_runtime_generation.py -q --tb=short --disable-warnings
+  -o faulthandler_timeout=45` — **122 passed**, 515 warnings, 12.92 seconds.
+- Expanded affected suite below — **1,025 passed**, 6,152 warnings, 69.18 seconds. This includes
+  hot reload, admin models, provider/default-parameter consumers, multimodal execution,
+  billing/ingestion, selector guards, and cache/routing regressions.
+- Ruff check and format check passed for all 19 touched Python paths. OpenAPI check
+  (`.venv/bin/python scripts/docs/export_openapi.py --check`) reports the existing artifact
+  current: 215 paths / 280 operations. `git diff --check` passed.
+- Without a Redis URL, the cache integration suite reported four environment-gated skips.
+  The explicit attempt below instead reported **4 failures**, 38 warnings, 0.82 seconds:
+  socket connections to loopback were denied with `PermissionError: Operation not permitted`.
+  Both existing Redis tests and the version-isolation tests failed for the same environmental
+  reason; no Redis round-trip proof is claimed. The existing disposable Redis container was
+  started for this attempt and stopped afterward, preserving its data. No production dependency
+  was used and no sandbox permission was bypassed.
+
+```sh
+.venv/bin/python -m pytest \
+  tests/test_routing_identity_dependencies.py \
+  tests/test_routing_cache_invalidation.py \
+  tests/test_routing_cache_identity.py \
+  tests/test_selector_charge.py \
+  tests/test_spend_ingestion.py \
+  tests/test_billing.py \
+  tests/test_billing_tier_pricing.py \
+  tests/test_telemetry_ingestion_admin.py \
+  tests/test_spend_visibility.py \
+  tests/test_spend_reporting_cache.py \
+  tests/router/selection \
+  tests/test_route_policy_selector_contract.py \
+  tests/test_route_policy_validation.py \
+  tests/test_routing.py \
+  tests/test_context_routing.py \
+  tests/test_routing_runtime_generation.py \
+  tests/bootstrap/test_routing_bootstrap.py \
+  tests/config/test_dynamic.py \
+  tests/test_chat.py \
+  tests/test_text_endpoints.py \
+  tests/test_embeddings.py \
+  tests/test_embeddings_batch.py \
+  tests/test_cache.py \
+  tests/test_metrics.py \
+  tests/test_chat_hop_compatibility.py \
+  tests/test_provider_compat.py \
+  tests/test_provider_resolution.py \
+  tests/test_ui_models.py \
+  tests/test_ui_legacy_models.py \
+  tests/test_route_decision_multimodal.py \
+  tests/test_elevenlabs_tts.py \
+  tests/test_uniformity_hardening.py \
+  tests/test_data_plane_audit_extended.py \
+  -q --tb=short --disable-warnings -o faulthandler_timeout=45
+
+DELTALLM_TEST_REDIS_URL=redis://127.0.0.1:56390/0 \
+  .venv/bin/python -m pytest tests/test_cache_routing_redis_integration.py \
+  tests/test_cache_redis_integration.py -q --tb=short --disable-warnings \
+  -o faulthandler_timeout=30
+```
+
+The existing constant-arrival profile was run before and after the fix using:
+
+```sh
+.venv/bin/python -m tests.performance.routing_cache_profile --label before \
+  --output-dir /private/tmp/deltallm-routing-identity-fix.mK7sVJ
+.venv/bin/python -m tests.performance.routing_cache_profile --label after \
+  --output-dir /private/tmp/deltallm-routing-identity-fix.mK7sVJ
+```
+
+Each case offered 10 RPS for 20 seconds: all 200 requests succeeded, zero generator drops,
+maximum one observed in-flight request, and zero sampled in-flight slope. Raw samples and
+dependency counts remain in the output directory. Per-request dependency counts were identical:
+a miss made one cache get, one cache set, and one provider post; a hit made one cache get and
+zero provider posts. The profile's exact fake-Redis command-count assertions also passed.
+
+| Case | Before p50 / p95 / p99 (ms) | After p50 / p95 / p99 (ms) |
+| --- | --- | --- |
+| Miss | 7.88 / 11.99 / 13.28 | 9.10 / 11.90 / 15.01 |
+| Hit | 4.75 / 6.96 / 9.70 | 4.48 / 6.15 / 7.96 |
+
+These are short sequential local-mock samples, not a production latency or TTFT certificate.
+Miss p50 and p99 increased (p99 by about 1.72 ms); hit latency decreased. No general latency
+improvement is claimed. The new graph work remains off requests and adds only snapshot-owned
+digests; the small shared-defaults extraction adds no dependency calls.
+
+The broader PR 3 completion checklist above remains open. The implementation plan is retained
+because PR 3 and its required verification are not finished. No commit, push, or merge was made.
+## PR 3 completion decision — 2026-09-08
+
+The remaining prerequisites are implemented as dormant, request-free capabilities, not
+production selector activation. The existing selection service, router attempt owner,
+spend-ingestion lifecycle, response cache and protected spend reporting remain the owners.
+
+Implementation slices and verification gates:
+
+- [x] Extend canonical attempt admission with optional atomic RPM/TPM consumption and a
+  concurrency ceiling. Selector admission fails closed on coordination failure, uses an
+  owner token known before acquisition, and never consumes caller RPM or changes health.
+- [x] Extend canonical billing with durable all-scope operation reservations and component
+  dispatch intent; frozen exact pricing, ownership and server operation identity survive
+  process loss. No provider request runs inside a database transaction.
+- [x] Bind the isolated selector hop to admission, intent and receipt finalization. An
+  uncertain dispatch is never replayed; unknown usage remains visibly pending and retains
+  its conservative hold until authoritative reconciliation. A proved unattempted component
+  releases its hold. Actual selector cost is passed through without markup.
+- [x] Require typed cache miss/bypass evidence for the future execution boundary; missing
+  evidence and a response hit cannot invoke selection. The existing cache owns this signal.
+- [x] Add enum-only metrics, redacted protected decision metadata and component-aware
+  reporting, with unknown/partial savings rather than invented counterfactuals.
+- [ ] Verify isolated prerequisites, closed activation guards, affected application paths,
+  real dependency/migration behavior and before/after dependency/latency budgets.
+
+Budget ownership is a prerequisite, not a claim that legacy read-only budget checks become
+hard caps before PR 4 integrates reservation into real execution. PR 4 must route every
+cost-incurring attempt in a reserved operation through the same dispatch/finalization
+boundary, including answer retries and managed continuations. Configurations without a
+provable complete answer-plus-selector cost bound must fail closed; token estimates are
+not cost ceilings. Existing unrelated selector-free execution is not activated or migrated
+by this PR. Reservation and intent persistence belong to billing and use the existing
+PostgreSQL client and spend worker, without another queue, ledger or background lifecycle.
+
+The capacity extension is opt-in, preserving existing attempt behavior and dependency
+counts. Its counters share the existing routing keyspace and supported standalone Redis
+topology. Bounded selector work reserves provider usage conservatively before dispatch;
+unknown usage does not refund consumption. Leases expire after the bounded attempt plus
+cleanup grace, and release is owner guarded even after an ambiguous acquisition response.
+
+Database rollout is additive through the normal release migration owner. Do not drop
+economic state on rollback; drain/reconcile it using compatible code before removing the
+schema. Pending uncertain records must not be expired into zero spend. Keep their storage
+bounded by admission capacity, emit pending visibility, and use operator-authorized,
+receipt-backed reconciliation rather than automatic provider replay or estimated charges.
+
+### Implemented ownership and economic transitions
+
+The isolated composition is `admitted_selector_service`: cache/budget admission, canonical
+Redis attempt capacity, durable selector dispatch intent, direct provider invocation,
+receipt acceptance and owner-guarded release. It constructs no clients or tasks. Production
+bootstrap does not construct this factory or the optional billing recovery capability.
+There is no new endpoint, setting, UI workflow, selector-decision cache or shadow mode.
+
+`OperationReservation` freezes the full selector-plus-answer allowance before any paid
+selector work. `ProviderEnforcedSelectorCeiling` is a **trusted, qualified deployment
+capability**, not a user-provided token estimate: the quote reserves at least the provider's
+entire enforced context window, including its hidden framing. It also requires a provider
+contract that enforces the existing 64-output-token cap and has only the supported input,
+output, cache-read and per-request billing dimensions. Unknown provider limits, custom
+templates without a qualified bound, cache-write pricing or uncapped reasoning/output
+cannot be enabled by merely supplying `max_input_chars`. PR 4 must bind this capability
+to the actual frozen deployment configuration; PR 3 does not infer or certify provider
+limits from model names. Test fixtures explicitly qualify only their deterministic mock.
+
+Answer quotes cover maximum rates across eligible candidates and every allowed attempt
+and continuation. Each attempt is rounded upward to 18 decimal places before multiplying
+by its attempt bound. Input allowance uses the larger cached/uncached rate. Actual
+selector charges retain canonical half-even rounding and equal actual provider cost,
+without customer markup. A reported provider violation of its ceiling is durably accepted
+before rejecting further work; it is not discarded to make the reservation look correct.
+
+The additive billing-operation journal extends canonical spend accounting; it does not
+replace the spend ledger or outbox. State and authoritative receipts belong in PostgreSQL.
+
+| Component transition | Economic effect |
+| --- | --- |
+| New operation → reserved | Atomically hold selector plus complete answer allowance across key, user, team, organization and team/model scopes |
+| Reserved → dispatched | Fenced, non-replayable intent; provider may run only after commit |
+| Reserved → unattempted | Release only this component's hold; no charge |
+| Dispatched → unattempted | Only the same owner with explicit pre-send rejection evidence may release |
+| Dispatched/pending → accepted | Freeze an authoritative selector receipt independently of answer outcome |
+| Accepted → settled | Canonical outbox writes the unique event and all ledgers; release the reserved component once |
+| Expired reserved → unattempted | Reclaim work proved not dispatched |
+| Expired dispatched → pending | Keep the hold and unknown cost; never replay the provider or finalize estimated/zero usage |
+
+Every mutation checks the operation ID, owner token and frozen snapshot. Replaying an
+accepted receipt is idempotent; changing its receipt, ownership or prices fails closed.
+The parent operation ID and deterministic `selector:v1` UUID are distinct unique events.
+The operation lifetime is database-bounded to 15 minutes; longer execution plans are not
+supported by this prerequisite. Expiry controls execution ownership, not financial truth.
+The final closed row retains economic deduplication identity.
+
+The existing spend worker optionally runs recovery, prioritizing one known receipt and
+then one other open operation in separate short transactions. Each lane excludes durable
+quarantines, and a transient failure in the first lane does not skip the second or revisit
+the same selected row in that slice. Cancellation stops immediately. Each transaction
+is capped at 250 ms; the two-operation slice is at most 500 ms. Dependency failure is
+reported after both lanes and does not prevent the canonical outbox from draining.
+Receipt/outbox capacity exhaustion retains the original receipt. Fair open-row rotation
+finds late answer receipts, including direct-writer
+receipts. A failed-request log or default zero-token record is **not** a reported answer
+receipt: settlement requires a server-owned `usage_snapshot.kind=reported` spend record.
+PR 4 must supply that evidence for actual answer execution. Unknown costs remain pending
+until authoritative receipt-backed reconciliation, even if the user disconnects.
+
+Reservations acquire locks in this order: unique operation, canonical key/user/team/
+organization/team-model rows, then global operation capacity. Concurrent duplicate
+insertion uses `ON CONFLICT DO NOTHING RETURNING`; the losing caller locks and compares
+the existing frozen snapshot without changing holds or capacity. A full/missing capacity
+row rolls back insertion and all five holds. Recovery reconciles accounts **before**
+outbox admission, so it cannot hold spend capacity while waiting for a ledger row.
+The canonical spend writer preserves operation -> ledger -> operation capacity ->
+outbox/spend capacity order. No global capacity lock precedes an operation/account wait.
+
+Missing maintained counters
+fail closed; no request-path history scan initializes or repairs them. PR 4 activation
+readiness must verify/backfill missing team/model counters off-path against canonical
+spend history. Revocation can block/expire a key immediately, but physical deletion of a
+row with a nonzero economic hold is database-guarded until reconciliation. Financial
+history is retained like the canonical ledger; this is not a prompt-content archive.
+
+Legacy selector-free traffic still uses its existing admission implementation. **These
+reservations cannot establish hard shared budgets while other traffic in the same budget
+scope bypasses reservation.** PR 4 must qualify the common admission boundary for all
+traffic sharing a protected scope before claiming hard-budget support. It must not just
+open the selector gate and treat this prerequisite as proof of whole-gateway hard caps.
+
+### Dependency, storage and rollout budgets
+
+- Existing selector-free requests: zero added SQL, Redis or provider awaits. All new
+  execution/recovery dependencies are optional and unconstructed in production.
+- One isolated reported selector: three bounded billing transactions (reserve, dispatch,
+  accept), eight application SQL statements total on the fresh-success path, plus transaction
+  protocol; two router Redis EVALs (acquire/release); at most one provider POST. No awaited
+  request-path loop or provider retry. Known receipt acceptance may repeat identically once
+  on cancellation within the same 250 ms cleanup deadline.
+  The review fix reduces fresh reservation from six to four statements including timeout
+  setup; duplicate reservation uses three. Hermetic repository tests assert the count and
+  ordering. These counts are not a substitute for real PostgreSQL contention/latency data.
+- Admission/dispatch transactions use the earlier request/selector deadline and a 250 ms
+  local maximum including pool wait, statements, locks and transaction duration. Provider
+  work remains inside the earlier selector/parent deadline. Receipt cleanup has 250 ms;
+  capacity cleanup has 50 ms and a token-owned TTL fallback. These cleanup bounds must be
+  included in PR 4 streaming/disconnect/shutdown budgets.
+- Provider RPM consumes one and TPM consumes the conservative token allowance atomically
+  with concurrency admission. Consumption is not refunded after uncertain dispatch and
+  must not be incremented again by the ordinary provider-usage recorder. Existing minute
+  buckets retain their 120-second TTL. This extends the existing **standalone Redis**
+  contract, not Redis Cluster support. The owner uses EVAL directly, so NOSCRIPT is not a
+  new script-cache failure mode.
+- No new pool or worker is created: added production connection/task count is currently
+  zero. PR 4 must allocate admission/recovery/reporting capacity from the existing owners,
+  validate replica × process × pool arithmetic and measure contention before activation.
+  The operation-capacity row is intentionally a single atomic admission serialization
+  point; throughput at maximum replica count is an open real-PostgreSQL qualification gate.
+- Pending operations are capped at 100,000 by durable admission capacity; a full journal
+  denies admission. Each completed operation adds one retained financial identity/snapshot.
+  The table has nine indexes including its primary/unique identities, two recovery
+  predicates, four visibility/time access paths and terminal history. The added write
+  amplification must be measured with real database samples before production enablement.
+  Provision storage using selector RPS × 86,400 × measured bytes per operation/day, including
+  indexes/WAL, in addition to canonical spend storage. Active-count limits are **not** a
+  bound on lifetime terminal-history size.
+- Retention decision: retain operation identities and frozen financial evidence with the
+  canonical spend ledger; do not independently TTL/delete them and thereby permit replay.
+  This version has no automatic archival or partitioning. Operators must monitor volume,
+  index growth and dead tuples, keep autovacuum/analyze enabled, and qualify retention/
+  archive capacity before activation. Future archival must preserve idempotency lookup
+  and cannot release unknown holds. No new prompt/body content is stored.
+- Migration `20260908100000_billing_operation_reservations` is an additive transaction,
+  with a 2-second DDL lock timeout and 30-second statement timeout. It adds exact hold
+  counters, the operation journal, predicates and deletion guards. No history backfill
+  runs inline. Coordinate migration through the existing release job; a timeout rolls
+  back for a later coordinated retry. Fresh, last-release and shared-feature verifier
+  paths now explicitly check its objects and monetary precision. Roll back application
+  activation, not the economic schema; retain a compatible spend/recovery owner until all
+  accepted and pending operations have been reconciled.
+
+### PR 3 review correction: durable recovery isolation
+
+`deltallm_recover_operation` remains strict: a frozen receipt mismatch raises SQLSTATE
+`PBR01`, rolling back a spend event and every ledger delta in the writer transaction.
+The existing spend batch error classifier treats this as record-specific, so valid
+neighbors can commit while the conflicting outbox record follows its existing bounded
+retry/blocked lifecycle. Infrastructure failures are not classified as bad records.
+
+Background recovery alone uses `deltallm_recover_operation_isolated`. Its PostgreSQL
+exception subtransaction rolls back all failed reconciliation effects before persisting
+`recovery_blocked_at` and one fixed `recovery_error_code`: `receipt_conflict` or
+`integrity_failure`. Data/constraint/missing-counter failures can be quarantined;
+connection failures, deadlocks, lock/statement timeouts and cancellation propagate.
+The operation row remains locked through this decision. Both existing partial recovery
+indexes exclude blocked rows; their index count is unchanged. No provider is replayed,
+no receipt is discarded, and no unknown hold or global operation capacity is released.
+Quarantines count toward the existing 100,000 pending-operation ceiling.
+
+Committed quarantines emit `billing_operation_recovery_blocked` with an allowlisted
+`cause`, and `deltallm_spend_ingestion_failures_total` with fixed stages
+`operation_recovery_receipt_conflict` / `operation_recovery_integrity_failure`. Neither
+logs nor metric labels include operation IDs, keys, tenant identity or receipt contents.
+Uncommitted quarantine attempts do not emit successful-quarantine observations.
+
+Operator runbook (protected control plane, not an inference-path repair):
+
+1. Investigate the blocked operation under existing billing/reporting authorization;
+   retain its receipt, frozen snapshot, canonical events and exact balances as evidence.
+2. Reconcile the inconsistency through the canonical billing owner. Do not release a hold,
+   invent zero usage, alter frozen prices/attribution, or call a provider to clear the alert.
+3. Only after authoritative evidence is consistent, requeue the exact operation in an
+   audited bounded transaction by clearing both quarantine fields with an operation-ID
+   and observed-quarantine-state fence. This changes scheduling only. A still-conflicting
+   operation is quarantined again; idempotent event identity prevents duplicate charging.
+
+No new admin repair endpoint is introduced in this dormant prerequisite. PR 4 must retain
+operator visibility and a compatible recovery owner before activation. Roll back activation,
+not the financial journal or quarantine evidence. The quarantine columns/function/predicates
+are included in the original **unshared and unapplied** local PR 3 migration; once shared,
+any further database change must use a new migration. Fresh/last-release/shared-feature
+verification now checks the paired fields and both index predicates as well as the helper.
+
+### Review-fix verification — 2026-09-08
+
+The two review fixes are implemented; real-database qualification is still an open gate.
+No selector activation, external issue mutation, commit, push or PR creation was performed.
+
+Final affected billing/selector/admin/reporting run after Prisma regeneration:
+
+```bash
+.venv/bin/python -u -m pytest \
+  tests/test_billing_operation_repository.py \
+  tests/test_operation_recovery.py \
+  tests/test_billing_receipt_errors.py \
+  tests/test_operation_reservation.py \
+  tests/test_spend_ingestion.py \
+  tests/test_billing.py \
+  tests/test_billing_cost.py \
+  tests/test_billing_tier_pricing.py \
+  tests/test_selector_charge.py \
+  tests/test_selector_observability.py \
+  tests/test_routing_costs.py \
+  tests/test_migration_verifier.py \
+  tests/test_selector_prerequisite_structure.py \
+  tests/router/selection \
+  tests/test_billing_operations_postgres.py \
+  tests/test_billing_operation_locking_postgres.py \
+  tests/test_billing_operation_quarantine_postgres.py \
+  tests/test_selector_charge_db_integration.py \
+  tests/test_telemetry_ingestion_admin.py \
+  tests/test_telemetry_ingestion_db_integration.py \
+  tests/test_spend_visibility.py \
+  tests/test_spend_reporting_cache.py \
+  tests/test_spend_reporting_readiness.py \
+  -q --tb=short --disable-warnings -rs -o faulthandler_timeout=45
+```
+
+Result: **453 passed, 55 skipped, 2,399 warnings in 5.51 seconds**. All 55 skipped
+cases require PostgreSQL: 19 earlier selector/billing cases, 16 new locking/quarantine
+cases, and 20 existing telemetry-ingestion cases. `DATABASE_URL` and
+`MIGRATION_TEST_ADMIN_DATABASE_URL` were unset. No database connection or migration
+was attempted through an alternative mechanism after the previously recorded denial.
+These skips do not prove SQL constraints, contention, crash recovery or query plans.
+
+Additional completed checks:
+
+- `.venv/bin/ruff check` and `.venv/bin/ruff format --check` over all 69 touched Python
+  paths passed. The focused pre-integration run had 46 passing tests; the broader
+  intermediate run had 407 passing tests and 31 PostgreSQL skips.
+- With this worktree's `.venv/bin` prepended to `PATH`, `.venv/bin/prisma generate
+  --schema=./prisma/schema.prisma` passed (Prisma Client Python 0.15.0, generator 815 ms).
+  The existing Python 3.14/Pydantic-v1 compatibility warning remains; it was not suppressed.
+- `git diff --check` passed. The temporary review-fix plan was removed after implementation;
+  ownership, lock order, quarantine semantics and the operator runbook remain above.
+- An earlier test invocation accidentally named the nonexistent
+  `tests/test_spend_ingestion_service.py` and exited 4 before running tests. The corrected
+  final command above includes the actual spend-ingestion suite and passed.
+
+Before merge/activation, run the checked-in real PostgreSQL tests and the existing
+fresh/last-release/shared-feature migration verifier in an authorized disposable database.
+Qualify the four-statement admission bound, both lock-contention schedules, quarantine
+rollback/isolation, partial-index plans and recovery throughput there. No fresh real-DB
+latency or contention certificate is claimed by this fix; the earlier performance gates
+remain open. Redis/provider/API/UI protocols and the selector-free execution path were
+not changed by these review fixes.
+
+### Cache and protected reporting
+
+Cache v4 uses the immutable effective response fingerprint, including transitive fallback
+dependencies, rather than a reload counter. Equivalent snapshots/rollback reuse the same
+identity. The cache owner emits typed hit/miss/bypass evidence after the existing policy
+preflight. A hit or unresolved outcome cannot enter admitted selector execution.
+
+Fixed-enum metrics cover decision/rank, defaults, provider/parse/capacity failures,
+cancellation, deadline, invariant/accounting failures and bounded cleanup failure.
+Terminal-lane/escalation/streaming contribution hooks exist but do not emit production
+answer observations until PR 4 supplies those lifecycle boundaries. Protected decision
+metadata is allowlisted; no classifier output, prompt, credentials or topology headers
+are added. Public OpenAI usage stays answer-only.
+
+Cost-report prerequisites use canonical `SpendVisibility`, a time range of at most 31
+days and a cursor page of at most 1,000 operations before unique selector/answer event
+joins. They expose exact provider/customer component costs, answer-model distribution,
+pending reconciliation and explicit coverage/truncation. Savings are a labeled
+**counterfactual estimate**, using frozen reference-model prices applied to reported
+answer token counts with an uncached-input basis, minus actual answer/selector provider
+cost and a known measurable switch penalty. Missing evidence stays unknown; negative
+savings are not clamped. Arbitrary answer metadata cannot set the baseline. This is
+internal admin aggregation support, not the PR 5 analytics endpoint or UI.
+
+Existing spend summary/timeseries/grouped reports include component spend/tokens but
+exclude selector child events from external request/success/failure counts. Their report
+cache schema is bumped; no public response shape changed. Reporting remains off the
+inference path and must use the existing bounded reporting owner when wired in PR 5.
+
+### Completion verification and remaining sign-off gates
+
+Local checks:
+
+- Broad affected routing/chat/Responses/cache/billing/providers/reporting and activation
+  regression run: **1,099 passed**, 6,287 warnings, 72.60 seconds.
+- Final focused selector/economics/recovery/spend/migration-verifier and structural run:
+  **247 passed**, 1,139 warnings, 4.70 seconds. This includes the final regression proving
+  a reservation timeout cannot default into answer execution without confirmed admission.
+- Full collection before the final added migration-verifier test: **4,345 tests collected**.
+  The feature branch predates main's dependency-lane classifier. New real-service tests
+  carry explicit postgres/redis markers; this PR does not copy the newer classifier or
+  rewrite unrelated main-branch CI. Existing full-suite CI is retained and now also runs
+  for `feature/issue-304-model-router`, with both Redis URL variables supplied.
+- Focused runs include unchanged activation rejection, cache hit/unresolved refusal,
+  receipt cancellation, malformed output with billable usage, unknown/partial cost,
+  strict shared-capacity bounds and outbox progress after recovery failure.
+- Prisma generation succeeded with the worktree virtualenv on PATH. OpenAPI check remains
+  current: 215 paths, 280 operations. Final Ruff check and format check passed for all
+  63 touched Python files; `git diff --check` passed. The final Prisma client generation
+  succeeded with v0.15.0 after schema changes; unrelated formatter churn was removed
+  after verifying identical schema tokens and attributes.
+  The environment is Python 3.14.3 and warns about Prisma's Pydantic-v1 compatibility;
+  generated-client import/GC time is not included in pytest's reported test duration.
+
+The final focused command, run from the PR 3 worktree using the existing virtualenv:
+
+```bash
+.venv/bin/python -u -m pytest \
+  tests/test_operation_recovery.py tests/test_operation_reservation.py \
+  tests/test_routing_costs.py tests/test_selector_prerequisite_structure.py \
+  tests/test_spend_ingestion.py tests/test_migration_verifier.py \
+  tests/router/selection -q --tb=short --disable-warnings -o faulthandler_timeout=45
+.venv/bin/python -u scripts/docs/export_openapi.py --check
+```
+
+The broader 1,099-test command additionally covered `tests/test_selector_observability.py`,
+`tests/test_provider_token_receipt.py`, `tests/test_cache_execution_eligibility.py`,
+`tests/test_selector_charge.py`, `tests/test_billing.py`, `tests/test_billing_tier_pricing.py`,
+`tests/test_spend_visibility.py`, `tests/test_spend_reporting_cache.py`, `tests/test_routing.py`,
+`tests/test_context_routing.py`, `tests/test_routing_runtime_generation.py`,
+`tests/test_routing_cache_identity.py`, `tests/test_routing_cache_invalidation.py`,
+`tests/test_routing_identity_dependencies.py`, `tests/test_cache.py`, `tests/test_chat.py`,
+`tests/test_text_endpoints.py`, `tests/test_embeddings.py`, `tests/test_embeddings_batch.py`,
+`tests/test_route_policy_selector_contract.py`, `tests/test_route_policy_validation.py`,
+`tests/test_metrics.py`, `tests/test_chat_hop_compatibility.py`, `tests/test_provider_compat.py`,
+`tests/test_provider_resolution.py`, `tests/bootstrap/test_routing_bootstrap.py`,
+`tests/config/test_dynamic.py`, `tests/test_telemetry_ingestion_admin.py`,
+`tests/test_ui_models.py`, `tests/test_ui_legacy_models.py`,
+`tests/test_route_decision_multimodal.py`, `tests/test_elevenlabs_tts.py`,
+`tests/test_uniformity_hardening.py` and `tests/test_data_plane_audit_extended.py`, with the
+same pytest flags. It preceded the last recovery/migration-verifier test additions, which
+are covered by the final focused run rather than counted twice as new coverage.
+
+**Not verified / not a merge-readiness certificate:**
+
+- Real-service collection contains 25 new/affected cases (19 PostgreSQL, 6 Redis).
+  With dependency URLs unset these all skip; that is not correctness evidence. Against
+  the existing disposable loopback services, Prisma migrate deploy failed P1001 and Redis
+  failed with `PermissionError: Operation not permitted`. No migration was applied.
+  The disposable containers were stopped again; no data was deleted. Do not use production
+  services or route around the environment's connection restriction.
+- Run fresh/last-release/shared-feature migration verification and all affected real
+  PostgreSQL/Redis suites in an authorized environment. Added tests cover five-scope
+  concurrent reservations, rollback/cancellation, frozen-owner/receipt rejection,
+  exactly-once settlement, unknown failure retention, late receipts, physical deletion
+  guards, and a representative recovery-index plan; these database test bodies have
+  **not run here**. Redis tests include multi-client admission, owner replay, actual lease
+  expiry and client reconnect; its transport-outage case injects the connection failure
+  against retained real Redis state, not a full Redis server restart.
+- Qualify actual SQL lock/statement/transaction bounds, deadlocks/contention, recovery
+  drain capacity, storage/index amplification, reporting visibility plans and maximum
+  replica arithmetic. No fake-based test substitutes for these gates.
+
+Constant-arrival artifacts: `/private/tmp/deltallm-pr3-completion.gfnlbh/`.
+The checked-in harnesses reproduce 10 RPS, 20-second hit/miss profiles with a fixed provider
+mock and fake Redis; the selector harness uses fake billing and a fixed 1 ms provider.
+Both routing cases received 200/200 requests with no generator drops and zero sampled
+queue slope. Dependency counts are unchanged: cache hit has zero provider calls; miss
+has one provider POST, one cache get/set, and the same Redis operation counts as PR 2.
+
+| Initial local profile | Before p50/p95/p99 ms | After p50/p95/p99 ms |
+| --- | --- | --- |
+| Cache miss | 7.842 / 11.613 / 15.916 | 9.601 / 13.483 / 20.659 |
+| Cache hit | 3.495 / 4.795 / 6.038 | 4.993 / 8.760 / 13.616 |
+
+These short sequential measurements show a latency increase, not latency parity. Host
+noise is a possible contributor, not a demonstrated explanation. They establish unchanged
+dependency counts but do not certify the release SLO. The isolated selector profile had
+200/200 successes, exactly one reserve/dispatch/accept/provider call per operation, zero
+sampled queue slope and p50/p95/p99 of 4.884 / 7.179 / 8.653 ms. This is selector contribution,
+not a streaming TTFT or real-database benchmark. Production latency and capacity gates
+remain open independently of code completion.
+
+A repeat pair is retained under `repeat/`, not substituted for the initial samples:
+miss before p50/p95/p99 was 9.514 / 14.517 / 17.610 ms and after was
+3.500 / 5.163 / 7.077 ms; hit before was 4.246 / 8.532 / 11.354 ms and after was
+2.064 / 2.563 / 2.936 ms. Both again completed 200/200 per case with identical dependency
+counts, no drops, maximum observed in-flight of one and zero sampled queue slope. The
+opposite latency movement between short pairs demonstrates that this local setup is too
+variable to attribute a latency change confidently; it does not replace production
+qualification. Raw runs and every comparison are preserved.
+
+The temporary ignored kickoff plan has been deleted as requested. This permanent record
+retains implementation decisions and the outstanding verification gates; no commit,
+push, merge, production activation or remote issue mutation was performed in this turn.

--- a/prisma/migrations/20260908100000_billing_operation_reservations/migration.sql
+++ b/prisma/migrations/20260908100000_billing_operation_reservations/migration.sql
@@ -1,0 +1,229 @@
+-- Additive dormant billing prerequisites. All mutations use short primary transactions.
+BEGIN;
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+
+ALTER TABLE deltallm_verificationtoken ADD COLUMN reserved_spend_exact NUMERIC(38,18) NOT NULL DEFAULT 0
+    CHECK (reserved_spend_exact >= 0);
+ALTER TABLE deltallm_usertable ADD COLUMN reserved_spend_exact NUMERIC(38,18) NOT NULL DEFAULT 0
+    CHECK (reserved_spend_exact >= 0);
+ALTER TABLE deltallm_teamtable ADD COLUMN reserved_spend_exact NUMERIC(38,18) NOT NULL DEFAULT 0
+    CHECK (reserved_spend_exact >= 0);
+ALTER TABLE deltallm_organizationtable ADD COLUMN reserved_spend_exact NUMERIC(38,18) NOT NULL DEFAULT 0
+    CHECK (reserved_spend_exact >= 0);
+ALTER TABLE deltallm_teammodelspend ADD COLUMN reserved_spend_exact NUMERIC(38,18) NOT NULL DEFAULT 0
+    CHECK (reserved_spend_exact >= 0);
+
+CREATE TABLE deltallm_billing_operations (
+    operation_id TEXT PRIMARY KEY,
+    owner_token TEXT NOT NULL,
+    api_key TEXT NOT NULL,
+    user_id TEXT,
+    team_id TEXT,
+    organization_id TEXT,
+    model TEXT NOT NULL,
+    snapshot JSONB NOT NULL,
+    selector_event_id TEXT NOT NULL UNIQUE,
+    selector_allowance NUMERIC(38,18) NOT NULL CHECK (selector_allowance >= 0),
+    answer_allowance NUMERIC(38,18) NOT NULL CHECK (answer_allowance >= 0),
+    selector_state TEXT NOT NULL DEFAULT 'reserved',
+    answer_state TEXT NOT NULL DEFAULT 'reserved',
+    selector_receipt JSONB,
+    answer_receipt JSONB,
+    closed_at TIMESTAMPTZ,
+    recovery_blocked_at TIMESTAMPTZ,
+    recovery_error_code TEXT CHECK (recovery_error_code IN ('receipt_conflict','integrity_failure')),
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (selector_state IN ('reserved','dispatched','pending','accepted','settled','unattempted')),
+    CHECK (answer_state IN ('reserved','dispatched','pending','accepted','settled','unattempted')),
+    CHECK ((selector_state IN ('accepted','settled')) = (selector_receipt IS NOT NULL)),
+    CHECK ((answer_state IN ('accepted','settled')) = (answer_receipt IS NOT NULL)),
+    CHECK ((recovery_blocked_at IS NULL) = (recovery_error_code IS NULL)),
+    CHECK (expires_at > created_at AND expires_at <= created_at + interval '15 minutes')
+);
+-- Round-robin bounded open-row recovery also finds late receipts after process loss.
+CREATE INDEX deltallm_billing_operations_recovery_idx ON deltallm_billing_operations(updated_at, operation_id)
+    WHERE closed_at IS NULL AND recovery_blocked_at IS NULL;
+CREATE INDEX deltallm_billing_operations_receipt_idx ON deltallm_billing_operations(updated_at, operation_id)
+    WHERE selector_state='accepted' AND recovery_blocked_at IS NULL;
+CREATE INDEX deltallm_billing_operations_org_time_idx ON deltallm_billing_operations(organization_id, created_at, operation_id);
+CREATE INDEX deltallm_billing_operations_time_idx ON deltallm_billing_operations(created_at, operation_id);
+CREATE INDEX deltallm_billing_operations_team_time_idx ON deltallm_billing_operations(team_id, created_at, operation_id);
+CREATE INDEX deltallm_billing_operations_owner_time_idx ON deltallm_billing_operations(
+    (snapshot #>> '{attribution,owner_account_id}'), created_at, operation_id);
+CREATE INDEX deltallm_billing_operations_terminal_idx ON deltallm_billing_operations(closed_at, operation_id)
+    WHERE closed_at IS NOT NULL;
+INSERT INTO deltallm_telemetry_ingestion_capacity(queue_name,pending_count)
+    VALUES ('billing_operations',0) ON CONFLICT DO NOTHING;
+
+-- Revocation can still block/expire credentials. Economic holds cannot be orphaned
+-- by physical entity deletion; settle/reconcile the existing operation first.
+CREATE FUNCTION deltallm_guard_reserved_spend_delete() RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    IF OLD.reserved_spend_exact <> 0 THEN
+        RAISE EXCEPTION 'billing_operation_hold_requires_reconciliation';
+    END IF;
+    RETURN OLD;
+END;
+$$;
+CREATE TRIGGER deltallm_key_hold_delete_guard BEFORE DELETE ON deltallm_verificationtoken
+    FOR EACH ROW EXECUTE FUNCTION deltallm_guard_reserved_spend_delete();
+CREATE TRIGGER deltallm_user_hold_delete_guard BEFORE DELETE ON deltallm_usertable
+    FOR EACH ROW EXECUTE FUNCTION deltallm_guard_reserved_spend_delete();
+CREATE TRIGGER deltallm_team_hold_delete_guard BEFORE DELETE ON deltallm_teamtable
+    FOR EACH ROW EXECUTE FUNCTION deltallm_guard_reserved_spend_delete();
+CREATE TRIGGER deltallm_org_hold_delete_guard BEFORE DELETE ON deltallm_organizationtable
+    FOR EACH ROW EXECUTE FUNCTION deltallm_guard_reserved_spend_delete();
+CREATE TRIGGER deltallm_model_hold_delete_guard BEFORE DELETE ON deltallm_teammodelspend
+    FOR EACH ROW EXECUTE FUNCTION deltallm_guard_reserved_spend_delete();
+
+-- Caller owns operation first, then ledger order: key, user, team, organization,
+-- team/model. Global operation capacity is always acquired AFTER these account rows.
+-- A missing authoritative counter is unavailable, never a history scan or implicit zero.
+CREATE FUNCTION deltallm_adjust_operation_hold(p_id TEXT, p_delta NUMERIC) RETURNS VOID
+LANGUAGE plpgsql AS $$
+DECLARE
+    op deltallm_billing_operations%ROWTYPE;
+    row_key deltallm_verificationtoken%ROWTYPE;
+    row_user deltallm_usertable%ROWTYPE;
+    row_team deltallm_teamtable%ROWTYPE;
+    row_org deltallm_organizationtable%ROWTYPE;
+    row_model deltallm_teammodelspend%ROWTYPE;
+    model_limit NUMERIC;
+BEGIN
+    SELECT * INTO STRICT op FROM deltallm_billing_operations WHERE operation_id = p_id;
+    SELECT * INTO STRICT row_key FROM deltallm_verificationtoken WHERE token = op.api_key FOR UPDATE;
+    IF op.user_id IS NOT NULL THEN
+        SELECT * INTO STRICT row_user FROM deltallm_usertable WHERE user_id = op.user_id FOR UPDATE;
+    END IF;
+    IF op.team_id IS NOT NULL THEN
+        SELECT * INTO STRICT row_team FROM deltallm_teamtable WHERE team_id = op.team_id FOR UPDATE;
+    END IF;
+    IF op.organization_id IS NOT NULL THEN
+        SELECT * INTO STRICT row_org FROM deltallm_organizationtable WHERE organization_id = op.organization_id FOR UPDATE;
+    END IF;
+    IF op.team_id IS NOT NULL THEN
+        SELECT * INTO STRICT row_model FROM deltallm_teammodelspend
+            WHERE team_id = op.team_id AND model = op.model FOR UPDATE;
+        model_limit := (row_team.model_max_budget ->> op.model)::NUMERIC;
+    END IF;
+    IF p_delta >= 0 THEN
+        IF row_key.user_id IS DISTINCT FROM op.user_id OR row_key.team_id IS DISTINCT FROM op.team_id
+           OR row_key.owner_account_id IS DISTINCT FROM (op.snapshot #>> '{attribution,owner_account_id}')
+           OR row_team.organization_id IS DISTINCT FROM op.organization_id
+           OR row_user.blocked IS TRUE OR row_team.blocked IS TRUE
+           OR (op.organization_id IS NOT NULL AND row_org.lifecycle_state <> 'active')
+           OR row_key.expires <= CURRENT_TIMESTAMP THEN
+            RAISE EXCEPTION 'billing_operation_scope_unavailable' USING ERRCODE = 'P0001';
+        END IF;
+        IF COALESCE(row_key.spend_exact,row_key.spend::NUMERIC,0) + row_key.reserved_spend_exact + p_delta > row_key.max_budget::NUMERIC
+           OR COALESCE(row_user.spend_exact,row_user.spend::NUMERIC,0) + row_user.reserved_spend_exact + p_delta > row_user.max_budget::NUMERIC
+           OR COALESCE(row_team.spend_exact,row_team.spend::NUMERIC,0) + row_team.reserved_spend_exact + p_delta > row_team.max_budget::NUMERIC
+           OR COALESCE(row_org.spend_exact,row_org.spend::NUMERIC,0) + row_org.reserved_spend_exact + p_delta > row_org.max_budget::NUMERIC
+           OR COALESCE(row_model.spend_exact,row_model.spend::NUMERIC,0) + row_model.reserved_spend_exact + p_delta > model_limit THEN
+            RAISE EXCEPTION 'billing_operation_budget_unavailable' USING ERRCODE = 'P0001';
+        END IF;
+    END IF;
+    UPDATE deltallm_verificationtoken SET reserved_spend_exact = reserved_spend_exact + p_delta WHERE token = op.api_key;
+    UPDATE deltallm_usertable SET reserved_spend_exact = reserved_spend_exact + p_delta WHERE user_id = op.user_id;
+    UPDATE deltallm_teamtable SET reserved_spend_exact = reserved_spend_exact + p_delta WHERE team_id = op.team_id;
+    UPDATE deltallm_organizationtable SET reserved_spend_exact = reserved_spend_exact + p_delta WHERE organization_id = op.organization_id;
+    UPDATE deltallm_teammodelspend SET reserved_spend_exact = reserved_spend_exact + p_delta
+        WHERE team_id = op.team_id AND model = op.model;
+END;
+$$;
+
+-- Called only by the bounded existing spend worker/recovery owner. Never retries providers.
+CREATE FUNCTION deltallm_recover_operation(p_id TEXT) RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE
+    op deltallm_billing_operations%ROWTYPE;
+    selector_event deltallm_spendlog_events%ROWTYPE;
+    answer_event deltallm_spendlog_events%ROWTYPE;
+    released NUMERIC := 0;
+BEGIN
+    SELECT * INTO STRICT op FROM deltallm_billing_operations WHERE operation_id=p_id FOR UPDATE;
+    IF op.closed_at IS NOT NULL THEN RETURN; END IF;
+    SELECT * INTO selector_event FROM deltallm_spendlog_events WHERE id=op.selector_event_id;
+    SELECT * INTO answer_event FROM deltallm_spendlog_events WHERE id=op.operation_id;
+    IF selector_event.id IS NOT NULL AND op.selector_state='accepted' THEN
+        IF selector_event.api_key IS DISTINCT FROM op.api_key
+           OR selector_event.organization_id IS DISTINCT FROM op.organization_id
+           OR selector_event.user_id IS DISTINCT FROM op.user_id
+           OR selector_event.team_id IS DISTINCT FROM op.team_id
+           OR selector_event.owner_account_id IS DISTINCT FROM (op.snapshot #>> '{attribution,owner_account_id}')
+           OR selector_event.model IS DISTINCT FROM op.model
+           OR selector_event.call_type <> 'model_router_selector'
+           OR selector_event.provider_cost_exact IS DISTINCT FROM (op.selector_receipt->>'provider_cost_exact')::numeric
+           OR selector_event.spend_exact IS DISTINCT FROM (op.selector_receipt->>'cost_exact')::numeric THEN
+            RAISE EXCEPTION 'billing_component_receipt_conflict' USING ERRCODE = 'PBR01';
+        END IF;
+        op.selector_state := 'settled';
+        released := released + op.selector_allowance;
+    END IF;
+    -- Legacy failure rows/defaulted token counts are not proof of a free attempt.
+    -- PR 4 must propagate a server-owned reported receipt through canonical billing.
+    IF answer_event.id IS NOT NULL AND op.answer_state IN ('dispatched','pending')
+       AND answer_event.status='success'
+       AND answer_event.usage_snapshot->>'kind'='reported' THEN
+        IF answer_event.api_key IS DISTINCT FROM op.api_key
+           OR answer_event.organization_id IS DISTINCT FROM op.organization_id
+           OR answer_event.user_id IS DISTINCT FROM op.user_id
+           OR answer_event.team_id IS DISTINCT FROM op.team_id
+           OR answer_event.owner_account_id IS DISTINCT FROM (op.snapshot #>> '{attribution,owner_account_id}')
+           OR answer_event.model IS DISTINCT FROM op.model
+           OR answer_event.spend_exact IS NULL OR answer_event.spend_exact > op.answer_allowance THEN
+            RAISE EXCEPTION 'billing_component_receipt_conflict' USING ERRCODE = 'PBR01';
+        END IF;
+        op.answer_state := 'settled';
+        op.answer_receipt := jsonb_build_object('cost_exact',answer_event.spend_exact::text,'event_id',answer_event.id);
+        released := released + op.answer_allowance;
+    END IF;
+    IF op.expires_at <= NOW() THEN
+        IF op.selector_state='reserved' THEN
+            op.selector_state := 'unattempted'; released := released + op.selector_allowance;
+        ELSIF op.selector_state='dispatched' THEN op.selector_state := 'pending'; END IF;
+        IF op.answer_state='reserved' THEN
+            op.answer_state := 'unattempted'; released := released + op.answer_allowance;
+        ELSIF op.answer_state='dispatched' THEN op.answer_state := 'pending'; END IF;
+    END IF;
+    IF released > 0 THEN PERFORM deltallm_adjust_operation_hold(p_id,-released); END IF;
+    IF op.selector_state IN ('settled','unattempted') AND op.answer_state IN ('settled','unattempted') THEN
+        op.closed_at := NOW();
+        UPDATE deltallm_telemetry_ingestion_capacity SET pending_count=pending_count-1
+            WHERE queue_name='billing_operations';
+    END IF;
+    UPDATE deltallm_billing_operations SET selector_state=op.selector_state,answer_state=op.answer_state,
+        answer_receipt=op.answer_receipt,closed_at=op.closed_at,updated_at=NOW() WHERE operation_id=p_id;
+END;
+$$;
+
+-- Background-only isolation. The spend writer uses the strict function above so
+-- a conflicting event/ledger transaction still rolls back. The exception block is
+-- a subtransaction: no partial hold release can survive a quarantined operation.
+CREATE FUNCTION deltallm_recover_operation_isolated(p_id TEXT) RETURNS TEXT LANGUAGE plpgsql AS $$
+DECLARE
+    failure_code TEXT;
+BEGIN
+    PERFORM 1 FROM deltallm_billing_operations WHERE operation_id=p_id FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'billing_operation_missing' USING ERRCODE = 'P0002'; END IF;
+    BEGIN
+        PERFORM deltallm_recover_operation(p_id);
+        RETURN 'recovered';
+    EXCEPTION
+        WHEN SQLSTATE 'PBR01' THEN failure_code := 'receipt_conflict';
+        WHEN integrity_constraint_violation OR data_exception OR no_data_found THEN
+            failure_code := 'integrity_failure';
+    END;
+    -- Infrastructure failures, deadlocks and cancellation are deliberately NOT
+    -- caught. Only a committed row-specific quarantine leaves the recovery indexes.
+    UPDATE deltallm_billing_operations SET recovery_blocked_at=NOW(),
+        recovery_error_code=failure_code,updated_at=NOW() WHERE operation_id=p_id;
+    RETURN failure_code;
+END;
+$$;
+
+RESET lock_timeout;
+RESET statement_timeout;
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,7 @@ model DeltaLLM_TeamModelSpendCounter {
   model       String
   spend       Float    @default(0)
   spend_exact Decimal? @db.Decimal(38, 18)
+  reserved_spend_exact Decimal @default(0) @db.Decimal(38, 18)
   updated_at  DateTime @updatedAt
 
   @@id([team_id, model])
@@ -92,6 +93,7 @@ model DeltaLLM_VerificationToken {
   soft_budget           Float?
   spend                 Float    @default(0)
   spend_exact           Decimal? @db.Decimal(38, 18)
+  reserved_spend_exact Decimal @default(0) @db.Decimal(38, 18)
   budget_duration       String?
   budget_reset_at       DateTime?
   rpm_limit             Int?
@@ -127,6 +129,7 @@ model DeltaLLM_UserTable {
   soft_budget     Float?
   spend           Float    @default(0)
   spend_exact     Decimal? @db.Decimal(38, 18)
+  reserved_spend_exact Decimal @default(0) @db.Decimal(38, 18)
   budget_duration String?
   budget_reset_at DateTime?
   models          String[]
@@ -156,6 +159,7 @@ model DeltaLLM_TeamTable {
   soft_budget      Float?
   spend            Float    @default(0)
   spend_exact      Decimal? @db.Decimal(38, 18)
+  reserved_spend_exact Decimal @default(0) @db.Decimal(38, 18)
   budget_duration  String?
   budget_reset_at  DateTime?
   model_max_budget Json?
@@ -223,6 +227,7 @@ model DeltaLLM_OrganizationTable {
   model_tpm_limit   Json?
   spend             Float    @default(0)
   spend_exact       Decimal? @db.Decimal(38, 18)
+  reserved_spend_exact Decimal @default(0) @db.Decimal(38, 18)
   budget_duration   String?
   budget_reset_at   DateTime?
   metadata          Json?
@@ -560,6 +565,35 @@ model DeltaLLM_CacheInvalidationOutbox {
   @@index([lease_expires_at], map: "deltallm_cacheinvalidationoutbox_lease_expires_idx")
   @@index([scope_type, scope_id], map: "deltallm_cacheinvalidationoutbox_scope_idx")
   @@map("deltallm_cacheinvalidationoutbox")
+}
+
+model DeltaLLM_BillingOperation {
+  operation_id       String    @id
+  owner_token        String
+  api_key            String
+  user_id            String?
+  team_id            String?
+  organization_id    String?
+  model              String
+  snapshot           Json
+  selector_event_id  String    @unique
+  selector_allowance Decimal   @db.Decimal(38, 18)
+  answer_allowance   Decimal   @db.Decimal(38, 18)
+  selector_state     String    @default("reserved")
+  answer_state       String    @default("reserved")
+  selector_receipt   Json?
+  answer_receipt     Json?
+  closed_at          DateTime? @db.Timestamptz
+  recovery_blocked_at DateTime? @db.Timestamptz
+  recovery_error_code String?
+  expires_at         DateTime  @db.Timestamptz
+  created_at         DateTime  @default(now()) @db.Timestamptz
+  updated_at         DateTime  @default(now()) @db.Timestamptz
+
+  @@index([organization_id, created_at, operation_id], map: "deltallm_billing_operations_org_time_idx")
+  @@index([created_at, operation_id], map: "deltallm_billing_operations_time_idx")
+  @@index([team_id, created_at, operation_id], map: "deltallm_billing_operations_team_time_idx")
+  @@map("deltallm_billing_operations")
 }
 
 model DeltaLLM_SpendIngestionOutbox {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 markers = [
   "integration: exercises a real local infrastructure dependency when available",
+  "postgres: exercises real PostgreSQL constraints, transactions, and locking",
+  "redis: exercises real Redis coordination, Lua, TTL, and recovery",
 ]
 
 [tool.ruff]

--- a/scripts/verify_migration_paths.py
+++ b/scripts/verify_migration_paths.py
@@ -595,6 +595,57 @@ $migration_verify$;
     )
 
 
+def _verify_operation_reservations(prisma: str, database_url: str) -> None:
+    _db_execute(
+        prisma,
+        schema=CURRENT_SCHEMA,
+        database_url=database_url,
+        sql="""
+DO $reservation_verify$
+BEGIN
+  IF to_regclass('public.deltallm_billing_operations') IS NULL
+     OR to_regprocedure('deltallm_adjust_operation_hold(text,numeric)') IS NULL
+     OR to_regprocedure('deltallm_recover_operation(text)') IS NULL
+     OR to_regprocedure('deltallm_recover_operation_isolated(text)') IS NULL THEN
+    RAISE EXCEPTION 'billing operation prerequisite objects are missing';
+  END IF;
+  IF (SELECT count(*) FROM information_schema.columns
+      WHERE table_schema='public' AND column_name='reserved_spend_exact'
+        AND numeric_precision=38 AND numeric_scale=18
+        AND table_name IN ('deltallm_verificationtoken','deltallm_usertable',
+          'deltallm_teamtable','deltallm_organizationtable','deltallm_teammodelspend')) <> 5 THEN
+    RAISE EXCEPTION 'exact billing hold counters are missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM deltallm_telemetry_ingestion_capacity
+      WHERE queue_name='billing_operations' AND pending_count=0) THEN
+    RAISE EXCEPTION 'billing operation capacity seed is invalid';
+  END IF;
+  IF (SELECT count(*) FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='deltallm_billing_operations'
+        AND column_name IN ('recovery_blocked_at','recovery_error_code')) <> 2
+     OR NOT EXISTS (SELECT 1 FROM pg_constraint
+      WHERE conrelid='deltallm_billing_operations'::regclass AND contype='c'
+        AND pg_get_constraintdef(oid) LIKE '%recovery_blocked_at IS NULL%recovery_error_code IS NULL%') THEN
+    RAISE EXCEPTION 'billing recovery quarantine contract is missing';
+  END IF;
+  IF (SELECT count(*) FROM pg_index
+      WHERE indexrelid IN ('deltallm_billing_operations_recovery_idx'::regclass,
+        'deltallm_billing_operations_receipt_idx'::regclass)
+        AND pg_get_expr(indpred,indrelid) LIKE '%recovery_blocked_at IS NULL%') <> 2 THEN
+    RAISE EXCEPTION 'billing recovery indexes must exclude quarantined rows';
+  END IF;
+  IF (SELECT count(*) FROM pg_trigger
+      WHERE tgname IN ('deltallm_key_hold_delete_guard','deltallm_user_hold_delete_guard',
+        'deltallm_team_hold_delete_guard','deltallm_org_hold_delete_guard',
+        'deltallm_model_hold_delete_guard') AND NOT tgisinternal) <> 5 THEN
+    RAISE EXCEPTION 'economic hold deletion guards are missing';
+  END IF;
+END
+$reservation_verify$;
+""",
+    )
+
+
 def verify_migration_paths(*, admin_url: str, base_ref: str, prisma: str) -> None:
     suffix = uuid.uuid4().hex[:12]
     fresh_name = f"deltallm_migration_verify_{suffix}_fresh"
@@ -613,6 +664,7 @@ def verify_migration_paths(*, admin_url: str, base_ref: str, prisma: str) -> Non
         shared_url = database_url_for(admin_url, shared_name)
         _migrate(prisma, schema=CURRENT_SCHEMA, database_url=fresh_url)
         _verify_fresh_database(prisma, fresh_url)
+        _verify_operation_reservations(prisma, fresh_url)
 
         with tempfile.TemporaryDirectory(prefix="deltallm-migration-base-") as temp:
             temp_root = Path(temp)
@@ -629,6 +681,8 @@ def verify_migration_paths(*, admin_url: str, base_ref: str, prisma: str) -> Non
             _migrate(prisma, schema=CURRENT_SCHEMA, database_url=shared_url)
         _verify_upgrade_database(prisma, upgrade_url)
         _verify_shared_migration_database(prisma, shared_url)
+        _verify_operation_reservations(prisma, upgrade_url)
+        _verify_operation_reservations(prisma, shared_url)
     finally:
         primary_error = sys.exc_info()[1]
         cleanup_errors: list[subprocess.CalledProcessError] = []

--- a/src/api/admin/endpoints/spend.py
+++ b/src/api/admin/endpoints/spend.py
@@ -12,9 +12,15 @@ from typing import Any, Literal, TypeVar
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 
-from src.api.admin.endpoints.common import db_or_503, get_auth_scope, log_admin_query_timing, to_json_value
+from src.api.admin.endpoints.common import (
+    db_or_503,
+    get_auth_scope,
+    log_admin_query_timing,
+    to_json_value,
+)
 from src.auth.roles import Permission
 from src.billing.spend_read import SpendReadSource, get_spend_read_source
+from src.db.spend_components import external_request_sql
 from src.middleware.admin import require_any_admin_permission
 from src.providers.resolution import provider_from_model, resolve_provider
 from src.services.spend_reporting_cache import (
@@ -233,7 +239,9 @@ def _grouped_spend_config(
         }
     if group_by == "organization":
         return {
-            "joins": ["LEFT JOIN deltallm_organizationtable o ON o.organization_id = s.organization_id"],
+            "joins": [
+                "LEFT JOIN deltallm_organizationtable o ON o.organization_id = s.organization_id"
+            ],
             "group_expr": "s.organization_id",
             "display_expr": "NULLIF(TRIM(COALESCE(o.organization_name, '')), '')",
             "group_by_exprs": [
@@ -334,7 +342,9 @@ def _resolve_reporting_visibility(
 
 
 def _reporting_v2_enabled(request: Request) -> bool:
-    general_settings = getattr(getattr(request.app.state, "app_config", None), "general_settings", None)
+    general_settings = getattr(
+        getattr(request.app.state, "app_config", None), "general_settings", None
+    )
     return bool(getattr(general_settings, "spend_reporting_v2_enabled", False))
 
 
@@ -347,7 +357,9 @@ def _reporting_context(request: Request, visibility: SpendVisibility) -> dict[st
 
 async def _reporting_cache(request: Request) -> SpendReportingCache:
     redis_client = getattr(request.app.state, "redis", None)
-    general_settings = getattr(getattr(request.app.state, "app_config", None), "general_settings", None)
+    general_settings = getattr(
+        getattr(request.app.state, "app_config", None), "general_settings", None
+    )
     max_concurrent_loads = int(getattr(general_settings, "spend_reporting_max_concurrency", 2))
     global_max_concurrent_loads = int(
         getattr(general_settings, "spend_reporting_global_max_concurrency", 2)
@@ -549,9 +561,7 @@ async def _run_reporting_transaction(
                 load_budget.global_max_concurrent_loads,
             )
             if not admission_rows:
-                raise ReportingRefreshBusy(
-                    "Global reporting query capacity is currently full"
-                )
+                raise ReportingRefreshBusy("Global reporting query capacity is currently full")
             return await operation(tx, deadline, cancellation_grace)
     except ReportingQueryTimedOut:
         raise
@@ -596,6 +606,7 @@ def _summary_reporting_cache_payload(
 ) -> dict[str, Any]:
     return {
         "endpoint": "summary",
+        "component_count_schema": 1,
         "source": source.table,
         "scope": _reporting_scope_cache_payload(visibility),
         "start_date": start_date.isoformat() if start_date else None,
@@ -631,18 +642,20 @@ def _spend_report_cache_payload(
         "scope_type": scope_type,
         "scope_id": scope_id,
         "scope_unassigned": scope_unassigned,
-        "response_schema": 2,
+        "response_schema": 3,
     }
     if group_by == "day":
         payload["interval"] = interval
         return payload
 
-    payload.update({
-        "search": search,
-        "sort_by": sort_by,
-        "limit": limit,
-        "offset": offset,
-    })
+    payload.update(
+        {
+            "search": search,
+            "sort_by": sort_by,
+            "limit": limit,
+            "offset": offset,
+        }
+    )
     if group_by == "provider":
         payload["model_provider_overrides"] = model_provider_overrides
     if group_by == "user":
@@ -705,12 +718,14 @@ async def spend_summary(
     source = get_spend_read_source()
     cache_ttl = reporting_cache_ttl(start_date, end_date)
     force_refresh = _reporting_cache_revalidation_requested(cache_control)
-    cache_key = cache.key(_summary_reporting_cache_payload(
-        source=source,
-        visibility=visibility,
-        start_date=start_date,
-        end_date=end_date,
-    ))
+    cache_key = cache.key(
+        _summary_reporting_cache_payload(
+            source=source,
+            visibility=visibility,
+            start_date=start_date,
+            end_date=end_date,
+        )
+    )
     clauses: list[str] = []
     params: list[Any] = []
 
@@ -741,10 +756,10 @@ async def spend_summary(
                 COALESCE(SUM(total_tokens), 0) AS total_tokens,
                 COALESCE(SUM({source.prompt_tokens_column}), 0) AS prompt_tokens,
                 COALESCE(SUM({source.completion_tokens_column}), 0) AS completion_tokens,
-                COUNT(*) AS total_requests,
+                COUNT(*) FILTER (WHERE {external_request_sql()}) AS total_requests,
                 COUNT(DISTINCT model) FILTER (WHERE NULLIF(TRIM(model), '') IS NOT NULL) AS unique_models,
-                COUNT(*) FILTER (WHERE COALESCE(status, 'success') = 'success') AS successful_requests,
-                COUNT(*) FILTER (WHERE status = 'error') AS failed_requests
+                COUNT(*) FILTER (WHERE {external_request_sql()} AND COALESCE(status, 'success') = 'success') AS successful_requests,
+                COUNT(*) FILTER (WHERE {external_request_sql()} AND status = 'error') AS failed_requests
             FROM {source.table}
             {where_sql}
             """,
@@ -785,7 +800,9 @@ async def spend_summary(
 )
 async def spend_report(
     request: Request,
-    group_by: str = Query(default="day", pattern="^(model|provider|day|user|team|organization|api_key)$"),
+    group_by: str = Query(
+        default="day", pattern="^(model|provider|day|user|team|organization|api_key)$"
+    ),
     interval: Literal["day", "week", "month"] = Query(default="day"),
     start_date: date | None = Query(default=None),
     end_date: date | None = Query(default=None),
@@ -818,38 +835,42 @@ async def spend_report(
     )
     visibility = _resolve_reporting_visibility(request, scope, view)
     if group_by not in visibility.allowed_groupings:
-        raise HTTPException(status_code=403, detail="This usage dimension is outside your reporting scope")
+        raise HTTPException(
+            status_code=403, detail="This usage dimension is outside your reporting scope"
+        )
     if scope_type is not None and scope_type not in visibility.allowed_dimensions:
-        raise HTTPException(status_code=403, detail="This usage filter is outside your reporting scope")
+        raise HTTPException(
+            status_code=403, detail="This usage filter is outside your reporting scope"
+        )
     db = db_or_503(request)
     source = get_spend_read_source()
     user_identity_labels_visible = _user_identity_labels_visible(scope, visibility)
     model_provider_overrides = (
-        _legacy_cache_model_provider_overrides(request)
-        if group_by == "provider"
-        else None
+        _legacy_cache_model_provider_overrides(request) if group_by == "provider" else None
     )
     cache = await _reporting_cache(request)
     cache_ttl = reporting_cache_ttl(start_date, end_date)
     force_refresh = _reporting_cache_revalidation_requested(cache_control)
     normalized_search = search.strip() if search and search.strip() else None
-    cache_key = cache.key(_spend_report_cache_payload(
-        source=source,
-        visibility=visibility,
-        group_by=group_by,
-        interval=interval,
-        start_date=start_date,
-        end_date=end_date,
-        search=normalized_search,
-        sort_by=sort_by,
-        scope_type=scope_type,
-        scope_id=scope_id,
-        scope_unassigned=scope_unassigned,
-        model_provider_overrides=model_provider_overrides,
-        user_identity_labels_visible=user_identity_labels_visible,
-        limit=limit,
-        offset=offset,
-    ))
+    cache_key = cache.key(
+        _spend_report_cache_payload(
+            source=source,
+            visibility=visibility,
+            group_by=group_by,
+            interval=interval,
+            start_date=start_date,
+            end_date=end_date,
+            search=normalized_search,
+            sort_by=sort_by,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            scope_unassigned=scope_unassigned,
+            model_provider_overrides=model_provider_overrides,
+            user_identity_labels_visible=user_identity_labels_visible,
+            limit=limit,
+            offset=offset,
+        )
+    )
     if group_by == "day":
         bucket_expr = {
             "day": "DATE(start_time)",
@@ -891,10 +912,10 @@ async def spend_report(
                 SELECT
                     {bucket_expr} AS group_key,
                     COALESCE(SUM(spend), 0) AS total_spend,
-                    COUNT(*) AS request_count,
+                    COUNT(*) FILTER (WHERE {external_request_sql()}) AS request_count,
                     COALESCE(SUM(total_tokens), 0) AS total_tokens,
-                    COUNT(*) FILTER (WHERE COALESCE(status, 'success') = 'success') AS successful_requests,
-                    COUNT(*) FILTER (WHERE status = 'error') AS failed_requests
+                    COUNT(*) FILTER (WHERE {external_request_sql()} AND COALESCE(status, 'success') = 'success') AS successful_requests,
+                    COUNT(*) FILTER (WHERE {external_request_sql()} AND status = 'error') AS failed_requests
                 FROM {source.table}
                 {where_sql}
                 GROUP BY {bucket_expr}
@@ -995,7 +1016,7 @@ async def spend_report(
                     ({group_expr}) IS NULL AS is_unassigned,
                     {display_expr} AS display_name,
                     COALESCE(SUM(s.spend), 0) AS total_spend,
-                    COUNT(*) AS request_count,
+                    COUNT(*) FILTER (WHERE {external_request_sql(alias="s")}) AS request_count,
                     COALESCE(SUM(s.total_tokens), 0) AS total_tokens,
                     COALESCE(SUM(s.{source.prompt_tokens_column}), 0) AS prompt_tokens,
                     COALESCE(SUM(s.{source.completion_tokens_column}), 0) AS completion_tokens
@@ -1046,11 +1067,7 @@ async def spend_report(
         response = {
             "group_by": group_by,
             "data": [
-                to_json_value({
-                    k: v
-                    for k, v in dict(row).items()
-                    if k != "total_count"
-                })
+                to_json_value({k: v for k, v in dict(row).items() if k != "total_count"})
                 for row in data_rows
             ],
             "pagination": {
@@ -1110,7 +1127,9 @@ async def spend_feature_status(
         required_permission=Permission.SPEND_READ,
     )
     visibility = _resolve_reporting_visibility(request, scope, None)
-    general_settings = getattr(getattr(request.app.state, "app_config", None), "general_settings", None)
+    general_settings = getattr(
+        getattr(request.app.state, "app_config", None), "general_settings", None
+    )
     return {
         "cache_enabled": bool(getattr(general_settings, "cache_enabled", False)),
         "reporting_api_version": 2 if _reporting_v2_enabled(request) else 1,
@@ -1178,9 +1197,7 @@ async def request_logs(
     if cursor:
         cursor_time, cursor_id = _decode_request_log_cursor(cursor)
         params.extend((cursor_time, cursor_id))
-        clauses.append(
-            f"(start_time, id) < (${len(params) - 1}::timestamp, ${len(params)})"
-        )
+        clauses.append(f"(start_time, id) < (${len(params) - 1}::timestamp, ${len(params)})")
     apply_spend_visibility(
         clauses=clauses,
         params=params,
@@ -1238,11 +1255,7 @@ async def request_logs(
                 )
                 total = int((total_rows[0] if total_rows else {}).get("total") or 0)
 
-            has_more = (
-                offset + limit < total
-                if total is not None
-                else len(logs) > limit
-            )
+            has_more = offset + limit < total if total is not None else len(logs) > limit
             page_logs = logs[:limit]
             next_cursor = None
             if has_more and page_logs and not offset_pagination:

--- a/src/billing/operation_reservation.py
+++ b/src/billing/operation_reservation.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal, ROUND_CEILING, localcontext
+from enum import StrEnum
+from typing import Literal, Protocol
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from src.billing.money import canonical_money
+from src.billing.selector_charge import (
+    AcceptedSelectorCharge,
+    FrozenBillingContract,
+    Identifier,
+    Price,
+    SelectorChargeAttribution,
+    SelectorPriceSnapshot,
+    SelectorTokenReceipt,
+    TokenCount,
+)
+from src.models.errors import ServiceUnavailableError
+
+
+class BillingOperationUnavailable(ServiceUnavailableError):
+    error_type = "billing_operation_unavailable"
+    message = "Billing operation is unavailable"
+
+    def __init__(self) -> None:
+        super().__init__(code="billing_operation_unavailable")
+
+
+class ComponentState(StrEnum):
+    RESERVED = "reserved"
+    DISPATCHED = "dispatched"
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    SETTLED = "settled"
+    UNATTEMPTED = "unattempted"
+
+
+class BoundedTokenQuote(FrozenBillingContract):
+    """Server-qualified execution ceilings, never request token estimates.
+
+    The execution owner must enforce all three ceilings. Unknown provider billing
+    dimensions, uncapped retries/continuations or unbounded output cannot use this
+    contract. For heterogeneous candidates quote their maximum applicable rate.
+    """
+
+    pricing: SelectorPriceSnapshot
+    max_input_tokens: TokenCount
+    max_output_tokens: TokenCount
+    max_attempts: int = Field(ge=1, le=128)
+    basis: Identifier
+
+    @property
+    def allowance(self) -> Decimal:
+        price = self.pricing
+        input_rate = max(
+            price.input_cost_per_token, price.input_cost_per_token_cache_hit or Decimal(0)
+        )
+        with localcontext() as context:
+            context.prec = 80
+            per_attempt = (
+                self.max_input_tokens * input_rate
+                + self.max_output_tokens * price.output_cost_per_token
+                + price.cost_per_request
+            )
+            amount = self.max_attempts * per_attempt.quantize(
+                Decimal("1e-18"), rounding=ROUND_CEILING
+            )
+        return canonical_money(amount)
+
+
+class ProviderEnforcedSelectorCeiling(FrozenBillingContract):
+    """Trusted deployment capability, NOT a prompt estimate or a client setting.
+
+    Bootstrap may construct this only from a qualified provider contract that caps
+    all billable input (including server templates) at its context window, honors
+    the selector's 64-token output cap, and has no other billable dimensions.
+    Unknown/custom provider contracts cannot acquire this capability. Reserving the
+    entire context window avoids assuming a characters-to-tokens conversion.
+    """
+
+    deployment_id: Identifier
+    context_window_tokens: int = Field(ge=1, le=2**31 - 1)
+    contract_version: Identifier
+    billing_dimensions: Literal["input_output_cache_read_request"]
+
+
+class OperationReservation(FrozenBillingContract):
+    attribution: SelectorChargeAttribution = Field(repr=False)
+    owner_token: UUID = Field(repr=False)
+    selector: BoundedTokenQuote
+    selector_ceiling: ProviderEnforcedSelectorCeiling
+    answer: BoundedTokenQuote
+    expires_at: AwareDatetime
+    reference_answer_pricing: SelectorPriceSnapshot | None = None
+    measurable_switch_penalty: Price | None = None
+    reference_basis: Literal["uncached_answer_tokens:v1"] = "uncached_answer_tokens:v1"
+
+    @model_validator(mode="after")
+    def bounded_selector(self) -> OperationReservation:
+        if self.selector.max_attempts != 1 or self.selector.max_output_tokens != 64:
+            raise ValueError("selector reservation requires one bounded 64-token attempt")
+        if (
+            self.selector_ceiling.deployment_id != self.attribution.deployment_id
+            or self.selector.max_input_tokens < self.selector_ceiling.context_window_tokens
+        ):
+            raise ValueError("selector quote must cover its qualified provider context ceiling")
+        self.total_allowance
+        return self
+
+    @property
+    def total_allowance(self) -> Decimal:
+        with localcontext() as context:
+            context.prec = 80
+            return canonical_money(self.selector.allowance + self.answer.allowance)
+
+
+class ReservedOperation(FrozenBillingContract):
+    operation: OperationReservation = Field(repr=False)
+    selector_state: ComponentState
+    answer_state: ComponentState
+
+
+class OperationReservationStore(Protocol):
+    async def reserve(
+        self, operation: OperationReservation, *, expires_at: float
+    ) -> ReservedOperation: ...
+
+    async def dispatch(
+        self,
+        operation: OperationReservation,
+        *,
+        component: Literal["selector", "answer"],
+        expires_at: float,
+    ) -> None: ...
+
+    async def unattempted(
+        self,
+        operation: OperationReservation,
+        *,
+        component: Literal["selector", "answer"],
+        expires_at: float,
+    ) -> None: ...
+
+    async def accept_selector(
+        self, operation: OperationReservation, charge: AcceptedSelectorCharge, *, expires_at: float
+    ) -> None: ...
+
+    async def confirm_not_dispatched(
+        self, operation: OperationReservation, *, expires_at: float
+    ) -> None: ...
+
+
+def selector_receipt(
+    operation: OperationReservation, *, usage: SelectorTokenReceipt, started_at: datetime
+) -> AcceptedSelectorCharge:
+    return AcceptedSelectorCharge(
+        attribution=operation.attribution,
+        pricing=operation.selector.pricing,
+        usage=usage,
+        started_at=started_at,
+        finished_at=datetime.now(UTC),
+    )

--- a/src/billing/routing_costs.py
+++ b/src/billing/routing_costs.py
@@ -1,0 +1,103 @@
+from collections import Counter
+from decimal import Decimal, localcontext
+from typing import Literal
+
+from pydantic import Field
+
+from src.billing.money import canonical_money, money_string
+from src.billing.operation_reservation import ComponentState
+from src.billing.selector_charge import FrozenBillingContract, Identifier, Price
+
+
+class RoutingCostObservation(FrozenBillingContract):
+    selector_state: ComponentState | None = None
+    answer_state: ComponentState | None = None
+    answer_model: Identifier | None = None
+    selector_provider_cost: Price | None = None
+    selector_customer_charge: Price | None = None
+    answer_provider_cost: Price | None = None
+    answer_customer_charge: Price | None = None
+    baseline_answer_provider_cost: Price | None = None
+    measurable_penalty: Price | None = None
+
+    @property
+    def net_savings(self) -> Decimal | None:
+        values = (
+            self.baseline_answer_provider_cost,
+            self.answer_provider_cost,
+            self.selector_provider_cost,
+            self.measurable_penalty,
+        )
+        if any(value is None for value in values):
+            return None
+        baseline, answer, selector, penalty = values
+        with localcontext() as context:
+            context.prec = 80
+            return canonical_money(baseline - answer - selector - penalty)
+
+
+class RoutingCostAggregate(FrozenBillingContract):
+    savings_kind: Literal["counterfactual_estimate"] = "counterfactual_estimate"
+    operation_count: int = Field(ge=0)
+    complete_cost_count: int = Field(ge=0)
+    pending_reconciliation_count: int = Field(ge=0)
+    savings_covered_count: int = Field(ge=0)
+    selector_provider_cost_exact: str
+    selector_customer_charge_exact: str
+    answer_provider_cost_exact: str
+    answer_customer_charge_exact: str
+    net_savings_exact: str | None
+    partial: bool
+    answer_distribution: tuple[tuple[str, int], ...]
+
+
+def aggregate_routing_costs(
+    rows: tuple[RoutingCostObservation, ...], *, truncated: bool = False
+) -> RoutingCostAggregate:
+    """Bounded, control-plane aggregation. Null means unknown, not free work.
+
+    A counterfactual baseline and penalty must be explicitly measured/frozen by the
+    future answer owner. No duplicate answer or selector calls estimate savings.
+    """
+    if len(rows) > 1000:
+        raise ValueError("routing cost aggregation requires a bounded page")
+    fields = (
+        "selector_provider_cost",
+        "selector_customer_charge",
+        "answer_provider_cost",
+        "answer_customer_charge",
+    )
+    totals = {field: Decimal(0) for field in fields}
+    complete = covered = 0
+    savings = Decimal(0)
+    distribution: Counter[str] = Counter()
+    with localcontext() as context:
+        context.prec = 80
+        for row in rows:
+            values = row.model_dump()
+            for field in fields:
+                if values[field] is not None:
+                    totals[field] += values[field]
+            complete += all(values[field] is not None for field in fields)
+            if row.net_savings is not None:
+                covered += 1
+                savings += row.net_savings
+            if row.answer_model is not None:
+                distribution[row.answer_model] += 1
+    return RoutingCostAggregate(
+        operation_count=len(rows),
+        complete_cost_count=complete,
+        pending_reconciliation_count=sum(
+            row.selector_state is ComponentState.PENDING
+            or row.answer_state is ComponentState.PENDING
+            for row in rows
+        ),
+        savings_covered_count=covered,
+        selector_provider_cost_exact=money_string(totals["selector_provider_cost"]),
+        selector_customer_charge_exact=money_string(totals["selector_customer_charge"]),
+        answer_provider_cost_exact=money_string(totals["answer_provider_cost"]),
+        answer_customer_charge_exact=money_string(totals["answer_customer_charge"]),
+        net_savings_exact=money_string(savings) if covered else None,
+        partial=truncated or complete != len(rows) or covered != len(rows),
+        answer_distribution=tuple(sorted(distribution.items())),
+    )

--- a/src/billing/selector_charge.py
+++ b/src/billing/selector_charge.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import UTC
+from decimal import Decimal, localcontext
+from typing import Annotated, Literal
+from uuid import UUID, uuid5
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
+
+from src.billing.money import MONEY_MAX_ABS, canonical_money, money_string
+
+SELECTOR_CHARGE_PURPOSE = "selector:v1"
+SELECTOR_CALL_TYPE = "model_router_selector"
+Identifier = Annotated[str, Field(min_length=1, max_length=256)]
+Price = Annotated[
+    Decimal, Field(ge=0, lt=MONEY_MAX_ABS, allow_inf_nan=False, max_digits=38, decimal_places=18)
+]
+TokenCount = Annotated[int, Field(ge=0, le=2**31 - 1)]
+
+
+class FrozenBillingContract(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True, extra="forbid", hide_input_in_errors=True)
+
+
+class SelectorTokenReceipt(FrozenBillingContract):
+    """A reported receipt, never an estimate or an unknown/unattempted placeholder."""
+
+    kind: Literal["reported"] = "reported"
+    prompt_tokens: TokenCount
+    completion_tokens: TokenCount
+    total_tokens: TokenCount
+    cached_input_tokens: TokenCount | None = None
+
+    @model_validator(mode="after")
+    def validate_counts(self) -> SelectorTokenReceipt:
+        if self.total_tokens != self.prompt_tokens + self.completion_tokens:
+            raise ValueError("selector receipt token totals are inconsistent")
+        if self.cached_input_tokens is not None and self.cached_input_tokens > self.prompt_tokens:
+            raise ValueError("selector receipt cached input exceeds input tokens")
+        return self
+
+
+class SelectorPriceSnapshot(FrozenBillingContract):
+    """Explicit token/request pricing only; unsupported price dimensions fail closed upstream."""
+
+    source: Identifier
+    version: Identifier
+    currency: Literal["USD"] = "USD"
+    rounding: Literal["ROUND_HALF_EVEN"] = "ROUND_HALF_EVEN"
+    input_cost_per_token: Price
+    output_cost_per_token: Price
+    input_cost_per_token_cache_hit: Price | None = None
+    cost_per_request: Price
+
+    def cost(self, receipt: SelectorTokenReceipt) -> Decimal:
+        cached_rate = self.input_cost_per_token_cache_hit
+        if cached_rate is not None and cached_rate != self.input_cost_per_token:
+            if receipt.cached_input_tokens is None:
+                raise ValueError("selector receipt is missing required cached-input usage")
+        cached = receipt.cached_input_tokens or 0
+        with localcontext() as context:
+            context.prec = 80
+            amount = (
+                (receipt.prompt_tokens - cached) * self.input_cost_per_token
+                + cached * (cached_rate if cached_rate is not None else self.input_cost_per_token)
+                + receipt.completion_tokens * self.output_cost_per_token
+                + self.cost_per_request
+            )
+        return canonical_money(amount)
+
+
+class SelectorChargeAttribution(FrozenBillingContract):
+    """Resolved server-side attribution; accepting this type does not authorize its IDs."""
+
+    operation_id: UUID = Field(repr=False)
+    api_key: Identifier = Field(repr=False)
+    user_id: Identifier | None = Field(default=None, repr=False)
+    team_id: Identifier | None = Field(default=None, repr=False)
+    organization_id: Identifier | None = Field(default=None, repr=False)
+    owner_account_id: Identifier | None = Field(default=None, repr=False)
+    end_user_id: Identifier | None = Field(default=None, repr=False)
+    model_group: Identifier
+    deployment_id: Identifier
+    deployment_model: Identifier
+    provider: Identifier
+
+    @property
+    def component_event_id(self) -> str:
+        return str(uuid5(self.operation_id, SELECTOR_CHARGE_PURPOSE))
+
+
+class AcceptedSelectorCharge(FrozenBillingContract):
+    """Frozen receipt-to-spend mapping; durability remains owned by spend ingestion."""
+
+    attribution: SelectorChargeAttribution = Field(repr=False)
+    pricing: SelectorPriceSnapshot
+    usage: SelectorTokenReceipt
+    started_at: AwareDatetime
+    finished_at: AwareDatetime
+
+    @model_validator(mode="after")
+    def validate_charge(self) -> AcceptedSelectorCharge:
+        if self.finished_at < self.started_at:
+            raise ValueError("selector receipt finishes before it starts")
+        if (self.finished_at - self.started_at).total_seconds() * 1000 > 2**31 - 1:
+            raise ValueError("selector receipt duration exceeds spend storage bounds")
+        self.pricing.cost(self.usage)
+        return self
+
+    @property
+    def provider_cost(self) -> Decimal:
+        return self.pricing.cost(self.usage)
+
+    @property
+    def customer_charge(self) -> Decimal:
+        # Product decision: pass-through provider cost, no selector markup.
+        return self.provider_cost
+
+    def spend_payload(self) -> dict[str, object]:
+        owner = self.attribution
+        return {
+            "request_id": str(owner.operation_id),
+            "api_key": owner.api_key,
+            "user_id": owner.user_id,
+            "team_id": owner.team_id,
+            "organization_id": owner.organization_id,
+            "owner_account_id": owner.owner_account_id,
+            "owner_snapshot_complete": True,
+            "end_user_id": owner.end_user_id,
+            "model": owner.model_group,
+            "call_type": SELECTOR_CALL_TYPE,
+            "usage": {
+                "prompt_tokens": self.usage.prompt_tokens,
+                "completion_tokens": self.usage.completion_tokens,
+                "total_tokens": self.usage.total_tokens,
+                "prompt_tokens_cached": self.usage.cached_input_tokens,
+            },
+            "cost": money_string(self.customer_charge),
+            "cost_exact": money_string(self.customer_charge),
+            "provider_cost_exact": money_string(self.provider_cost),
+            "cache_hit": False,
+            "start_time": self.started_at.astimezone(UTC),
+            "end_time": self.finished_at.astimezone(UTC),
+            "metadata": {
+                "component_purpose": SELECTOR_CHARGE_PURPOSE,
+                "parent_event_id": str(owner.operation_id),
+                "deployment_id": owner.deployment_id,
+                "deployment_model": owner.deployment_model,
+                "provider": owner.provider,
+                "provider_cost": money_string(self.provider_cost),
+                "selector_pricing": self.pricing.model_dump(mode="json"),
+                "billing": {"billing_unit": "token", "usage_snapshot": self.usage.model_dump()},
+            },
+        }

--- a/src/billing/spend.py
+++ b/src/billing/spend.py
@@ -2,43 +2,19 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from datetime import UTC, datetime
 from typing import Any, Literal, Sequence
 
 from src.billing.ledger import SpendLedgerService
 from src.billing.money import canonical_money, money_string
 from src.billing.spend_events import build_spend_event
+from src.billing.spend_preparation import PreparedSpendEvent, prepare_spend_event
 from src.db.client import is_prisma_transaction_client
 
 logger = logging.getLogger(__name__)
 
 SpendLogOnceResult = Literal["inserted", "duplicate"]
-
-_POSTGRES_INTEGER_FIELDS = (
-    "total_tokens",
-    "input_tokens",
-    "output_tokens",
-    "cached_input_tokens",
-    "cached_output_tokens",
-    "input_audio_tokens",
-    "output_audio_tokens",
-    "input_characters",
-    "output_characters",
-    "image_count",
-    "rerank_units",
-    "latency_ms",
-    "http_status_code",
-)
-
-
-@dataclass(frozen=True, slots=True)
-class PreparedSpendEvent:
-    event_id: str
-    event_type: str
-    row: dict[str, Any]
-    event_entry: dict[str, Any]
 
 
 class SpendTrackingService:
@@ -345,68 +321,7 @@ class SpendTrackingService:
     ) -> PreparedSpendEvent:
         """Normalize and validate one outbox record before a bulk transaction."""
 
-        if event_type not in {"spend", "request_failure"}:
-            raise ValueError(f"unsupported spend outbox event type: {event_type}")
-        usage = payload.get("usage") if event_type == "spend" else None
-        if usage is not None and not isinstance(usage, dict):
-            raise ValueError("spend usage must be an object")
-        metadata = payload.get("metadata")
-        if metadata is not None and not isinstance(metadata, dict):
-            raise ValueError("spend metadata must be an object")
-
-        now = datetime.now(tz=UTC)
-        start_time = payload.get("start_time") or now
-        end_time = payload.get("end_time") or now
-        if not isinstance(start_time, datetime) or not isinstance(end_time, datetime):
-            raise ValueError("spend timestamps must be datetime values")
-        exact_cost = canonical_money(
-            payload.get("cost_exact", payload.get("cost")) if event_type == "spend" else 0
-        )
-        cost = float(exact_cost)
-
-        event_entry = build_spend_event(
-            request_id=str(payload.get("request_id") or ""),
-            api_key=str(payload.get("api_key") or ""),
-            user_id=payload.get("user_id"),
-            team_id=payload.get("team_id"),
-            organization_id=payload.get("organization_id"),
-            end_user_id=payload.get("end_user_id"),
-            model=str(payload.get("model") or ""),
-            call_type=str(payload.get("call_type") or ""),
-            usage=usage,
-            cost=cost,
-            metadata=dict(metadata or {}),
-            cache_hit=bool(payload.get("cache_hit", False)),
-            start_time=start_time,
-            end_time=end_time,
-            status="success" if event_type == "spend" else "error",
-            http_status_code=payload.get("http_status_code"),
-            error_type=payload.get("error_type"),
-            owner_account_id=payload.get("owner_account_id"),
-            owner_snapshot_complete=bool(payload.get("owner_snapshot_complete", True)),
-        )
-        for field in _POSTGRES_INTEGER_FIELDS:
-            value = event_entry.get(field)
-            if value is not None and not -(2**31) <= int(value) <= 2**31 - 1:
-                raise ValueError(f"{field} is outside the PostgreSQL integer range")
-
-        row = dict(event_entry)
-        row["id"] = str(event_id)
-        row["spend_exact"] = money_string(exact_cost)
-        provider_cost = event_entry.get("provider_cost")
-        row["provider_cost_exact"] = (
-            money_string(provider_cost) if provider_cost is not None else None
-        )
-        row["start_time"] = start_time.isoformat()
-        row["end_time"] = end_time.isoformat()
-        # Fail before batching if nested metadata contains non-finite values.
-        json.dumps(row, default=str, allow_nan=False)
-        return PreparedSpendEvent(
-            event_id=str(event_id),
-            event_type=event_type,
-            row=row,
-            event_entry=event_entry,
-        )
+        return prepare_spend_event(event_id=event_id, event_type=event_type, payload=payload)
 
     async def log_prepared_batch_once(
         self,
@@ -519,7 +434,9 @@ class SpendTrackingService:
 
         def _add(target: dict[Any, Decimal], key: Any, amount: Decimal) -> None:
             if key:
-                target[key] = target.get(key, Decimal(0)) + amount
+                with localcontext() as context:
+                    context.prec = 80
+                    target[key] = canonical_money(target.get(key, Decimal(0)) + amount)
 
         for event_id in inserted_ids:
             prepared_event = event_entries[event_id]

--- a/src/billing/spend_ingestion.py
+++ b/src/billing/spend_ingestion.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass
 from datetime import datetime
 import json
 import logging
+import math
 from time import perf_counter
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from src.billing.fallback_gate import (
@@ -16,6 +17,8 @@ from src.billing.fallback_gate import (
     FallbackGateTimedOut,
 )
 from src.billing.money import money_string
+from src.billing.operation_reservation import BillingOperationUnavailable
+from src.billing.selector_charge import AcceptedSelectorCharge
 from src.billing.spend import PreparedSpendEvent, SpendTrackingService, _failure_metadata
 from src.db.client import is_prisma_transaction_client
 from src.db.errors import is_record_specific_database_error
@@ -42,7 +45,11 @@ from src.telemetry.lifecycle import (
     wait_for_startup,
 )
 
+if TYPE_CHECKING:
+    from src.db.billing_operation_recovery import BillingOperationRecovery
+
 logger = logging.getLogger(__name__)
+_SELECTOR_RECEIPT_ACCEPT_TIMEOUT_SECONDS = 2.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,6 +88,14 @@ class SpendIngestionOverloadedError(ServiceUnavailableError):
         super().__init__(message=message, code="spend_ingestion_capacity")
 
 
+class SelectorChargeUnavailableError(ServiceUnavailableError):
+    error_type = "selector_accounting_unavailable"
+    message = "Selector usage accounting is temporarily unavailable"
+
+    def __init__(self) -> None:
+        super().__init__(code="selector_accounting_unavailable")
+
+
 class SpendIngestionService:
     """Durable bounded ingress for synchronous gateway spend events."""
 
@@ -90,10 +105,12 @@ class SpendIngestionService:
         db_client: Any | None,
         writer: SpendTrackingService,
         config: SpendIngestionConfig,
+        operation_recovery: BillingOperationRecovery | None = None,
     ) -> None:
         self.db = db_client
         self.writer = writer
         self.config = config
+        self.operation_recovery = operation_recovery
         self.repository = SpendIngestionRepository(db_client)
         self._running = False
         self._wake = asyncio.Event()
@@ -315,6 +332,34 @@ class SpendIngestionService:
     async def log_spend_once(self, **kwargs: Any) -> Any:
         return await self.writer.log_spend_once(**kwargs)
 
+    async def log_selector_charge(
+        self, charge: AcceptedSelectorCharge, *, expires_at: float
+    ) -> None:
+        """Accept a frozen selector receipt without the legacy best-effort fallback."""
+
+        if type(expires_at) not in (int, float) or not math.isfinite(expires_at):
+            raise ValueError("selector charge deadline must be a finite monotonic instant")
+        now = asyncio.get_running_loop().time()
+        if expires_at <= now or not self.config.enabled or self._closed or self.db is None:
+            increment_spend_ingestion_failure("selector_receipt")
+            raise SelectorChargeUnavailableError()
+        try:
+            async with asyncio.timeout_at(
+                min(expires_at, now + _SELECTOR_RECEIPT_ACCEPT_TIMEOUT_SECONDS)
+            ):
+                await self._enqueue(
+                    "spend",
+                    charge.spend_payload(),
+                    event_id=charge.attribution.component_event_id,
+                )
+        except SpendIngestionOverloadedError:
+            raise
+        except Exception as exc:
+            # In particular, never expose a billing TimeoutError to the selector's
+            # provider-timeout safe-default handler. Cancellation still propagates.
+            increment_spend_ingestion_failure("selector_receipt")
+            raise SelectorChargeUnavailableError() from exc
+
     async def _enqueue(
         self,
         event_type: str,
@@ -326,7 +371,9 @@ class SpendIngestionService:
             raise RuntimeError("spend ingestion database is unavailable")
         accepted_payload = dict(payload)
         if event_type == "spend":
-            accepted_payload["cost_exact"] = money_string(payload.get("cost"))
+            accepted_payload["cost_exact"] = money_string(
+                payload.get("cost_exact", payload.get("cost"))
+            )
             accepted_payload["spend_event_version"] = 2
         # This identifier is owned by the server and is intentionally unrelated
         # to the caller-controlled request ID. It is persisted once and reused
@@ -447,6 +494,14 @@ class SpendIngestionService:
             logger.debug("failed to publish spend ingestion backlog", exc_info=True)
 
     async def _claim_batch(self) -> list[_OutboxRecord]:
+        if self.operation_recovery is not None:
+            try:
+                await self.operation_recovery.recover()
+            except BillingOperationUnavailable:
+                # Durable intents/receipts remain recoverable. A recovery timeout
+                # must not starve the canonical outbox that can settle those holds.
+                increment_spend_ingestion_failure("operation_recovery")
+                logger.warning("billing_operation_recovery_unavailable")
         return await self.repository.claim_batch(
             limit=self.config.batch_size,
             worker_id=self.config.worker_id,
@@ -508,10 +563,18 @@ class SpendIngestionService:
         )
         try:
             async with self._transaction() as tx:
+                if self.operation_recovery is not None:
+                    await self.operation_recovery.lock_for_events(
+                        tx, [record.event_id for record, _ in records]
+                    )
                 batch_writer = self.writer.with_db(tx)
                 _, ledger_counts = await batch_writer.log_prepared_batch_once(
                     [prepared for _, prepared in records]
                 )
+                if self.operation_recovery is not None:
+                    await self.operation_recovery.settle_events(
+                        tx, [record.event_id for record, _ in records]
+                    )
                 completed = await self.repository.with_db(tx).mark_completed(
                     event_ids=[record.event_id for record, _ in records],
                     worker_id=self.config.worker_id,

--- a/src/billing/spend_preparation.py
+++ b/src/billing/spend_preparation.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from src.billing.money import canonical_money, money_string
+from src.billing.spend_events import build_spend_event
+
+# Compatibility boundary for historical outbox payloads. New domain contracts
+# supply exact string amounts; only this mapper accepts the legacy dynamic shape.
+_POSTGRES_INTEGER_FIELDS = (
+    "total_tokens",
+    "input_tokens",
+    "output_tokens",
+    "cached_input_tokens",
+    "cached_output_tokens",
+    "input_audio_tokens",
+    "output_audio_tokens",
+    "input_characters",
+    "output_characters",
+    "image_count",
+    "rerank_units",
+    "latency_ms",
+    "http_status_code",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedSpendEvent:
+    event_id: str
+    event_type: str
+    row: dict[str, Any]
+    event_entry: dict[str, Any]
+
+
+def prepare_spend_event(
+    *, event_id: str, event_type: str, payload: dict[str, Any]
+) -> PreparedSpendEvent:
+    """Validate an accepted outbox event without I/O or current-price lookups."""
+
+    if event_type not in {"spend", "request_failure"}:
+        raise ValueError(f"unsupported spend outbox event type: {event_type}")
+    usage = payload.get("usage") if event_type == "spend" else None
+    if usage is not None and not isinstance(usage, dict):
+        raise ValueError("spend usage must be an object")
+    metadata = payload.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise ValueError("spend metadata must be an object")
+
+    now = datetime.now(tz=UTC)
+    start_time = payload.get("start_time") or now
+    end_time = payload.get("end_time") or now
+    if not isinstance(start_time, datetime) or not isinstance(end_time, datetime):
+        raise ValueError("spend timestamps must be datetime values")
+    exact_cost = canonical_money(
+        payload.get("cost_exact", payload.get("cost")) if event_type == "spend" else 0
+    )
+    cost = float(exact_cost)
+
+    event_entry = build_spend_event(
+        request_id=str(payload.get("request_id") or ""),
+        api_key=str(payload.get("api_key") or ""),
+        user_id=payload.get("user_id"),
+        team_id=payload.get("team_id"),
+        organization_id=payload.get("organization_id"),
+        end_user_id=payload.get("end_user_id"),
+        model=str(payload.get("model") or ""),
+        call_type=str(payload.get("call_type") or ""),
+        usage=usage,
+        cost=cost,
+        metadata=dict(metadata or {}),
+        cache_hit=bool(payload.get("cache_hit", False)),
+        start_time=start_time,
+        end_time=end_time,
+        status="success" if event_type == "spend" else "error",
+        http_status_code=payload.get("http_status_code"),
+        error_type=payload.get("error_type"),
+        owner_account_id=payload.get("owner_account_id"),
+        owner_snapshot_complete=bool(payload.get("owner_snapshot_complete", True)),
+    )
+    for field in _POSTGRES_INTEGER_FIELDS:
+        value = event_entry.get(field)
+        if value is not None and not -(2**31) <= int(value) <= 2**31 - 1:
+            raise ValueError(f"{field} is outside the PostgreSQL integer range")
+
+    row = dict(event_entry)
+    row["id"] = str(event_id)
+    row["spend_exact"] = money_string(exact_cost)
+    provider_cost = payload.get("provider_cost_exact", event_entry.get("provider_cost"))
+    row["provider_cost_exact"] = money_string(provider_cost) if provider_cost is not None else None
+    if provider_cost is not None:
+        # The legacy float is a reporting mirror, never the exact amount source.
+        row["provider_cost"] = float(canonical_money(provider_cost))
+        event_entry["provider_cost"] = row["provider_cost"]
+    row["start_time"] = start_time.isoformat()
+    row["end_time"] = end_time.isoformat()
+    # Fail before batching if nested metadata contains non-finite values.
+    json.dumps(row, default=str, allow_nan=False)
+    return PreparedSpendEvent(
+        event_id=str(event_id),
+        event_type=event_type,
+        row=row,
+        event_entry=event_entry,
+    )

--- a/src/cache/execution_eligibility.py
+++ b/src/cache/execution_eligibility.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ResponseCacheOutcome(StrEnum):
+    UNRESOLVED = "unresolved"
+    HIT = "hit"
+    MISS = "miss"
+    BYPASS = "bypass"
+
+
+@dataclass(frozen=True, slots=True)
+class ResponseCacheEligibility:
+    """Cache-owned evidence, not caller metadata or authorization evidence.
+
+    The future execution edge must also supply completed authenticated preflight.
+    A missing signal is unresolved, never an implicit miss.
+    """
+
+    outcome: ResponseCacheOutcome = ResponseCacheOutcome.UNRESOLVED
+
+    def require_provider_execution(self) -> None:
+        if self.outcome not in (ResponseCacheOutcome.MISS, ResponseCacheOutcome.BYPASS):
+            raise RuntimeError("Response cache has not authorized provider execution")

--- a/src/cache/key_builder.py
+++ b/src/cache/key_builder.py
@@ -33,15 +33,34 @@ class CacheKeyBuilder:
         self.fields = fields or set(DEFAULT_CACHE_KEY_FIELDS)
         self.salt = custom_salt
 
-    def build_key(self, request: ChatCompletionRequest) -> str:
-        return self.build_key_from_payload(request.model_dump(exclude_none=True))
+    def build_key(
+        self, request: ChatCompletionRequest, *, routing_fingerprint: str | None = None
+    ) -> str:
+        return self.build_key_from_payload(
+            request.model_dump(exclude_none=True), routing_fingerprint=routing_fingerprint
+        )
 
-    def build_key_from_payload(self, request_data: dict[str, Any], custom_key: str | None = None) -> str:
+    def build_key_from_payload(
+        self,
+        request_data: dict[str, Any],
+        custom_key: str | None = None,
+        *,
+        routing_fingerprint: str | None = None,
+    ) -> str:
         if custom_key:
-            return f"custom:{custom_key}"
-
-        components = {field: request_data[field] for field in self.fields if field in request_data}
-        normalized = self._normalize(components)
+            components = {"custom_key": custom_key}
+        else:
+            components = {
+                "payload": {
+                    field: request_data[field] for field in self.fields if field in request_data
+                }
+            }
+        # Server-owned dimensions cannot be removed by field configuration, custom keys,
+        # or a similarly named field in caller payload/metadata.
+        normalized = {
+            "request": self._normalize(components),
+            "routing_fingerprint": routing_fingerprint,
+        }
         as_string = json.dumps(normalized, sort_keys=True, separators=(",", ":"))
         if self.salt:
             as_string = f"{self.salt}:{as_string}"

--- a/src/cache/middleware.py
+++ b/src/cache/middleware.py
@@ -41,12 +41,13 @@ from src.telemetry.request_failures import enqueue_request_log_write, maybe_log_
 from src.telemetry.event_identity import get_or_create_billing_event_id
 
 from .backends.base import CacheBackend, CacheEntry
+from .execution_eligibility import ResponseCacheEligibility, ResponseCacheOutcome
 from .key_builder import CacheKeyBuilder
 from .metrics import CacheMetricsProtocol, NoopCacheMetrics
 from .pricing import has_cache_hit_only_pricing, provider_cache_miss_usage
 
 logger = logging.getLogger(__name__)
-_CACHE_SCHEMA_VERSION = "v2"
+_CACHE_SCHEMA_VERSION = "v4"
 
 
 class CacheControl(str, Enum):
@@ -125,6 +126,7 @@ class CacheMiddleware(BaseHTTPMiddleware):
         }
 
     async def dispatch(self, request: Request, call_next):
+        request.state.response_cache_eligibility = ResponseCacheEligibility()
         backend: CacheBackend | None = getattr(request.app.state, "cache_backend", None)
         key_builder: CacheKeyBuilder | None = getattr(request.app.state, "cache_key_builder", None)
         metrics: CacheMetricsProtocol = getattr(
@@ -133,6 +135,9 @@ class CacheMiddleware(BaseHTTPMiddleware):
         streaming_handler = getattr(request.app.state, "streaming_cache_handler", None)
 
         if backend is None or key_builder is None or not self._should_cache(request):
+            request.state.response_cache_eligibility = ResponseCacheEligibility(
+                ResponseCacheOutcome.BYPASS
+            )
             return await call_next(request)
 
         request_data = await self._read_request_data(request)
@@ -164,12 +169,21 @@ class CacheMiddleware(BaseHTTPMiddleware):
             endpoint = request.url.path
 
             if cache_options.control == CacheControl.BYPASS:
+                request.state.response_cache_eligibility = ResponseCacheEligibility(
+                    ResponseCacheOutcome.BYPASS
+                )
                 request.state.cache_hit = False
                 response = await call_next(request)
                 response.headers["x-deltallm-cache-hit"] = "false"
                 return response
 
-            cache_key = key_builder.build_key_from_payload(request_data, cache_options.custom_key)
+            routing_runtime = pin_routing_runtime_generation(request.app.state, request.state)
+            model_group = routing_runtime.router.resolve_model_group(model)
+            cache_key = key_builder.build_key_from_payload(
+                request_data,
+                cache_options.custom_key,
+                routing_fingerprint=routing_runtime.routing_fingerprints.get(model_group),
+            )
             response_mode = "stream" if bool(request_data.get("stream")) else "json"
             cache_key = (
                 f"schema:{_CACHE_SCHEMA_VERSION}:mode:{response_mode}:"
@@ -183,12 +197,18 @@ class CacheMiddleware(BaseHTTPMiddleware):
 
             if bool(request_data.get("stream")) and streaming_handler is not None:
                 if request.url.path != "/v1/chat/completions":
+                    request.state.response_cache_eligibility = ResponseCacheEligibility(
+                        ResponseCacheOutcome.BYPASS
+                    )
                     response = await call_next(request)
                     response.headers["x-deltallm-cache-hit"] = "false"
                     return response
                 if cache_options.control != CacheControl.NO_CACHE:
                     cached = await backend.get(cache_key)
                     if cached is not None and streaming_handler.can_replay(cached):
+                        request.state.response_cache_eligibility = ResponseCacheEligibility(
+                            ResponseCacheOutcome.HIT
+                        )
                         metrics.hit(endpoint=endpoint, model=model)
                         request.state.cache_context.hit = True
                         request.state.cache_hit = True
@@ -214,6 +234,9 @@ class CacheMiddleware(BaseHTTPMiddleware):
                 )
                 request.state.cache_context.hit = False
                 request.state.cache_hit = False
+                request.state.response_cache_eligibility = ResponseCacheEligibility(
+                    ResponseCacheOutcome.MISS
+                )
                 response = await call_next(request)
                 response.headers["x-deltallm-cache-hit"] = "false"
                 return response
@@ -221,6 +244,9 @@ class CacheMiddleware(BaseHTTPMiddleware):
             if cache_options.control != CacheControl.NO_CACHE:
                 cached_entry = await backend.get(cache_key)
                 if cached_entry is not None:
+                    request.state.response_cache_eligibility = ResponseCacheEligibility(
+                        ResponseCacheOutcome.HIT
+                    )
                     metrics.hit(endpoint=endpoint, model=model)
                     request.state.cache_context.hit = True
                     request.state.cache_hit = True
@@ -231,6 +257,9 @@ class CacheMiddleware(BaseHTTPMiddleware):
                 metrics.miss(endpoint=endpoint, model=model)
                 request.state.cache_hit = False
 
+            request.state.response_cache_eligibility = ResponseCacheEligibility(
+                ResponseCacheOutcome.MISS
+            )
             response = await call_next(request)
             request.state.cache_hit = False
             response.headers["x-deltallm-cache-hit"] = "false"

--- a/src/db/billing_operation_recovery.py
+++ b/src/db/billing_operation_recovery.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from enum import StrEnum
+import json
+import logging
+from typing import TYPE_CHECKING, Literal
+
+from src.billing.operation_reservation import BillingOperationUnavailable
+from src.db.billing_operations import BillingOperationRepository
+from src.db.spend_ingestion import SpendIngestionRepository
+from src.metrics.spend_ingestion import increment_spend_ingestion_failure
+
+if TYPE_CHECKING:
+    from prisma import Prisma
+
+
+logger = logging.getLogger(__name__)
+
+
+class RecoveryOutcome(StrEnum):
+    RECOVERED = "recovered"
+    RECEIPT_CONFLICT = "receipt_conflict"
+    INTEGRITY_FAILURE = "integrity_failure"
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryAttempt:
+    operation_id: str | None
+    unavailable: bool = False
+
+
+class BillingOperationRecovery:
+    """Bounded recovery slice driven only by the existing spend worker.
+
+    A retained receipt is forwarded through the canonical spend outbox. Missing
+    receipts become pending reconciliation; recovery never calls a provider.
+    """
+
+    def __init__(
+        self, operations: BillingOperationRepository, *, max_pending_events: int, max_attempts: int
+    ) -> None:
+        self.operations = operations
+        self.max_pending_events = max_pending_events
+        self.max_attempts = max_attempts
+
+    async def recover(self) -> int:
+        # Prioritize one known receipt, then rotate one other open operation. Each
+        # owns a short transaction: a slow final row cannot roll back a whole batch.
+        receipt = await self._recover_one("receipts")
+        opened = await self._recover_one("open", skip_id=receipt.operation_id)
+        if receipt.unavailable or opened.unavailable:
+            # Report after both independent lanes; the spend worker still drains
+            # its outbox. Cancellation is never converted into a lane failure.
+            raise BillingOperationUnavailable()
+        return int(receipt.operation_id is not None) + int(opened.operation_id is not None)
+
+    async def _recover_one(
+        self, lane: Literal["receipts", "open"], *, skip_id: str | None = None
+    ) -> RecoveryAttempt:
+        deadline = asyncio.get_running_loop().time() + 0.25
+        predicate = "selector_state='accepted'" if lane == "receipts" else "closed_at IS NULL"
+        operation_id = None
+        try:
+            async with self.operations._transaction(deadline) as tx:
+                rows = await tx.query_raw(
+                    "SELECT operation_id,selector_event_id,selector_state,selector_receipt "
+                    f"FROM deltallm_billing_operations WHERE {predicate} "
+                    "AND recovery_blocked_at IS NULL "
+                    "AND ($1::text IS NULL OR operation_id<>$1) "
+                    "ORDER BY updated_at,operation_id FOR UPDATE SKIP LOCKED LIMIT 1",
+                    skip_id,
+                )
+                if not rows:
+                    return RecoveryAttempt(None)
+                row = rows[0]
+                operation_id = str(row["operation_id"])
+                # Account and operation-capacity locks precede outbox admission.
+                results = await tx.query_raw(
+                    "SELECT deltallm_recover_operation_isolated($1) AS outcome", operation_id
+                )
+                outcome = RecoveryOutcome(str(results[0]["outcome"]))
+                if outcome is RecoveryOutcome.RECOVERED and row["selector_state"] == "accepted":
+                    receipt = row["selector_receipt"]
+                    payload = json.loads(receipt) if isinstance(receipt, str) else receipt
+                    # Full outbox: retain the authoritative receipt for a later slice.
+                    await SpendIngestionRepository(tx).enqueue(
+                        event_id=str(row["selector_event_id"]),
+                        event_type="spend",
+                        payload=payload,
+                        max_attempts=self.max_attempts,
+                        max_pending_events=self.max_pending_events,
+                    )
+        except BillingOperationUnavailable:
+            return RecoveryAttempt(operation_id, unavailable=True)
+        if outcome is not RecoveryOutcome.RECOVERED:
+            # A committed quarantine is visible without leaking receipt/tenant data.
+            increment_spend_ingestion_failure(f"operation_recovery_{outcome.value}")
+            logger.warning("billing_operation_recovery_blocked", extra={"cause": outcome.value})
+        return RecoveryAttempt(operation_id)
+
+    @staticmethod
+    async def lock_for_events(tx: Prisma, event_ids: list[str]) -> None:
+        if len(event_ids) > 1000:
+            raise ValueError("billing settlement batch must be bounded")
+        await tx.query_raw(
+            "SELECT operation_id FROM deltallm_billing_operations "
+            "WHERE operation_id=ANY($1::text[]) OR selector_event_id=ANY($1::text[]) "
+            "ORDER BY operation_id FOR UPDATE",
+            event_ids,
+        )
+
+    @staticmethod
+    async def settle_events(tx: Prisma, event_ids: list[str]) -> None:
+        await tx.query_raw(
+            "SELECT deltallm_recover_operation(operation_id)::text FROM deltallm_billing_operations "
+            "WHERE operation_id=ANY($1::text[]) OR selector_event_id=ANY($1::text[]) "
+            "ORDER BY operation_id",
+            event_ids,
+        )

--- a/src/db/billing_operations.py
+++ b/src/db/billing_operations.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import timedelta
+import json
+import math
+from decimal import Decimal
+from typing import TYPE_CHECKING, AsyncIterator, Literal
+
+from src.billing.money import money_string
+from src.billing.operation_reservation import (
+    BillingOperationUnavailable,
+    ComponentState,
+    OperationReservation,
+    ReservedOperation,
+)
+from src.billing.selector_charge import AcceptedSelectorCharge
+
+if TYPE_CHECKING:
+    from prisma import Prisma
+
+Component = Literal["selector", "answer"]
+DB_BUDGET_SECONDS = 0.25
+
+
+class BillingOperationRepository:
+    """Reservation/intent extension of spend ingestion; never dispatches providers.
+
+    Production bootstrap does not construct this prerequisite until PR 4. The
+    existing spend owner must drive recovery and settle holds in its writer transaction.
+    """
+
+    def __init__(self, db: Prisma, *, max_pending_operations: int = 100_000) -> None:
+        if not 1 <= max_pending_operations <= 100_000:
+            raise ValueError("invalid billing operation capacity")
+        self.db = db
+        self.max_pending_operations = max_pending_operations
+
+    @asynccontextmanager
+    async def _transaction(self, expires_at: float) -> AsyncIterator[Prisma]:
+        now = asyncio.get_running_loop().time()
+        if not math.isfinite(expires_at) or expires_at <= now:
+            raise BillingOperationUnavailable()
+        remaining = min(expires_at - now, DB_BUDGET_SECONDS)
+        try:
+            async with asyncio.timeout(remaining):
+                async with self.db.tx(
+                    max_wait=timedelta(seconds=remaining), timeout=timedelta(seconds=remaining)
+                ) as tx:
+                    await tx.query_raw(
+                        "SELECT set_config('statement_timeout',$1,true), "
+                        "set_config('lock_timeout',$1,true)",
+                        f"{max(1, int(remaining * 1000))}ms",
+                    )
+                    yield tx
+        except Exception:
+            # Billing errors, including its deadline, must never become selector defaults.
+            raise BillingOperationUnavailable() from None
+
+    async def reserve(
+        self, operation: OperationReservation, *, expires_at: float
+    ) -> ReservedOperation:
+        async with self._transaction(expires_at) as tx:
+            # Match settlement: operation -> canonical account rows -> capacity.
+            # Unique insertion serializes duplicate IDs without a global lock.
+            if not await self._insert(tx, operation):
+                rows = await tx.query_raw(
+                    "SELECT * FROM deltallm_billing_operations WHERE operation_id=$1 FOR UPDATE",
+                    str(operation.attribution.operation_id),
+                )
+                if not rows:
+                    raise BillingOperationUnavailable()
+                return self._existing(rows[0], operation)
+            await tx.execute_raw(
+                "SELECT deltallm_adjust_operation_hold($1,$2::numeric)",
+                str(operation.attribution.operation_id),
+                money_string(operation.total_allowance),
+            )
+            capacity = await tx.query_raw(
+                "UPDATE deltallm_telemetry_ingestion_capacity SET pending_count=pending_count+1 "
+                "WHERE queue_name='billing_operations' AND pending_count<$1 RETURNING pending_count",
+                self.max_pending_operations,
+            )
+            if not capacity:
+                # Roll back insertion and every hold when shared capacity is unavailable.
+                raise BillingOperationUnavailable()
+        return ReservedOperation(
+            operation=operation,
+            selector_state=ComponentState.RESERVED,
+            answer_state=ComponentState.RESERVED,
+        )
+
+    async def _insert(self, tx: Prisma, operation: OperationReservation) -> bool:
+        owner = operation.attribution
+        inserted = await tx.query_raw(
+            "INSERT INTO deltallm_billing_operations "
+            "(operation_id,owner_token,api_key,user_id,team_id,organization_id,model,snapshot,"
+            "selector_event_id,selector_allowance,answer_allowance,expires_at) "
+            "VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10::numeric,$11::numeric,$12::timestamptz) "
+            "ON CONFLICT (operation_id) DO NOTHING RETURNING operation_id",
+            str(owner.operation_id),
+            str(operation.owner_token),
+            owner.api_key,
+            owner.user_id,
+            owner.team_id,
+            owner.organization_id,
+            owner.model_group,
+            operation.model_dump_json(),
+            owner.component_event_id,
+            money_string(operation.selector.allowance),
+            money_string(operation.answer.allowance),
+            operation.expires_at.isoformat(),
+        )
+        return bool(inserted)
+
+    @staticmethod
+    def _existing(row: dict[str, object], operation: OperationReservation) -> ReservedOperation:
+        # Frozen snapshots prevent a replay from changing attribution, price or allowance.
+        if row["snapshot"] != operation.model_dump(mode="json"):
+            raise BillingOperationUnavailable()
+        return ReservedOperation(
+            operation=operation,
+            selector_state=ComponentState(str(row["selector_state"])),
+            answer_state=ComponentState(str(row["answer_state"])),
+        )
+
+    async def dispatch(
+        self, operation: OperationReservation, *, component: Component, expires_at: float
+    ) -> None:
+        state = _column(component, "state")
+        async with self._transaction(expires_at) as tx:
+            rows = await tx.query_raw(
+                f"UPDATE deltallm_billing_operations SET {state}='dispatched',updated_at=NOW() "
+                f"WHERE operation_id=$1 AND owner_token=$2 AND {state}='reserved' "
+                "AND snapshot=$3::jsonb AND expires_at>NOW() RETURNING operation_id",
+                str(operation.attribution.operation_id),
+                str(operation.owner_token),
+                operation.model_dump_json(),
+            )
+            if not rows:
+                # Dispatch is deliberately non-replayable, including an ambiguous prior commit.
+                raise BillingOperationUnavailable()
+
+    async def unattempted(
+        self, operation: OperationReservation, *, component: Component, expires_at: float
+    ) -> None:
+        state, allowance = _column(component, "state"), _column(component, "allowance")
+        async with self._transaction(expires_at) as tx:
+            rows = await tx.query_raw(
+                f"UPDATE deltallm_billing_operations SET {state}='unattempted',updated_at=NOW() "
+                f"WHERE operation_id=$1 AND owner_token=$2 AND snapshot=$3::jsonb AND {state}='reserved' RETURNING {allowance}",
+                str(operation.attribution.operation_id),
+                str(operation.owner_token),
+                operation.model_dump_json(),
+            )
+            if rows and Decimal(str(rows[0][allowance])) > 0:
+                await tx.execute_raw(
+                    "SELECT deltallm_adjust_operation_hold($1,-$2::numeric)",
+                    str(operation.attribution.operation_id),
+                    str(rows[0][allowance]),
+                )
+            if rows:
+                await tx.execute_raw(
+                    "SELECT deltallm_recover_operation($1)", str(operation.attribution.operation_id)
+                )
+
+    async def accept_selector(
+        self, operation: OperationReservation, charge: AcceptedSelectorCharge, *, expires_at: float
+    ) -> None:
+        if (
+            charge.attribution != operation.attribution
+            or charge.pricing != operation.selector.pricing
+        ):
+            raise BillingOperationUnavailable()
+        exceeded = (
+            charge.customer_charge > operation.selector.allowance
+            or charge.usage.prompt_tokens > operation.selector.max_input_tokens
+            or charge.usage.completion_tokens > operation.selector.max_output_tokens
+        )
+        await self._accept_receipt(
+            operation, component="selector", payload=charge.spend_payload(), expires_at=expires_at
+        )
+        if exceeded:
+            # Preserve authoritative usage even if a provider violates its quoted ceiling.
+            # Stop further answer work, without discarding incurred cost or inventing a refund.
+            raise BillingOperationUnavailable()
+
+    async def confirm_not_dispatched(
+        self, operation: OperationReservation, *, expires_at: float
+    ) -> None:
+        """Only a live provider owner with a proved pre-send rejection may use this."""
+        async with self._transaction(expires_at) as tx:
+            rows = await tx.query_raw(
+                "UPDATE deltallm_billing_operations SET selector_state='unattempted',updated_at=NOW() "
+                "WHERE operation_id=$1 AND owner_token=$2 AND snapshot=$3::jsonb AND selector_state='dispatched' "
+                "RETURNING selector_allowance",
+                str(operation.attribution.operation_id),
+                str(operation.owner_token),
+                operation.model_dump_json(),
+            )
+            if rows and operation.selector.allowance > 0:
+                await tx.execute_raw(
+                    "SELECT deltallm_adjust_operation_hold($1,-$2::numeric)",
+                    str(operation.attribution.operation_id),
+                    money_string(operation.selector.allowance),
+                )
+            if rows:
+                await tx.execute_raw(
+                    "SELECT deltallm_recover_operation($1)", str(operation.attribution.operation_id)
+                )
+
+    async def _accept_receipt(
+        self,
+        operation: OperationReservation,
+        *,
+        component: Component,
+        payload: dict[str, object],
+        expires_at: float,
+    ) -> None:
+        state, receipt = _column(component, "state"), _column(component, "receipt")
+        encoded = json.dumps(payload, default=str, sort_keys=True)
+        async with self._transaction(expires_at) as tx:
+            rows = await tx.query_raw(
+                f"UPDATE deltallm_billing_operations SET {state}=CASE WHEN {state}='settled' THEN 'settled' ELSE 'accepted' END,{receipt}=$3::jsonb,updated_at=NOW() "
+                f"WHERE operation_id=$1 AND owner_token=$2 AND snapshot=$4::jsonb AND ({state} IN ('dispatched','pending') "
+                f"OR ({state} IN ('accepted','settled') AND {receipt}=$3::jsonb)) "
+                "RETURNING operation_id",
+                str(operation.attribution.operation_id),
+                str(operation.owner_token),
+                encoded,
+                operation.model_dump_json(),
+            )
+            if not rows:
+                raise BillingOperationUnavailable()
+
+
+def _column(component: Component, field: Literal["state", "allowance", "receipt"]) -> str:
+    columns = {
+        ("selector", "state"): "selector_state",
+        ("selector", "allowance"): "selector_allowance",
+        ("selector", "receipt"): "selector_receipt",
+        ("answer", "state"): "answer_state",
+        ("answer", "allowance"): "answer_allowance",
+        ("answer", "receipt"): "answer_receipt",
+    }
+    return columns[component, field]

--- a/src/db/errors.py
+++ b/src/db/errors.py
@@ -13,6 +13,7 @@ _RECORD_SPECIFIC_PRISMA_CODES = {
     "P2020",
     "P2023",
 }
+_RECORD_SPECIFIC_SQLSTATES = {"PBR01"}  # Frozen billing-component receipt conflict.
 
 
 def is_record_specific_database_error(exc: Exception) -> bool:
@@ -39,7 +40,10 @@ def is_record_specific_database_error(exc: Exception) -> bool:
                 if code and str(key).lower() in {"code", "sqlstate", "pgcode"}
             )
         if any(
-            code in _RECORD_SPECIFIC_PRISMA_CODES or code.startswith(("22", "23")) for code in codes
+            code in _RECORD_SPECIFIC_PRISMA_CODES
+            or code in _RECORD_SPECIFIC_SQLSTATES
+            or code.startswith(("22", "23"))
+            for code in codes
         ):
             return True
         current = current.__cause__ or current.__context__

--- a/src/db/routing_costs.py
+++ b/src/db/routing_costs.py
@@ -1,0 +1,121 @@
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta
+from decimal import Decimal
+import json
+
+from pydantic import ValidationError
+
+from src.billing.routing_costs import RoutingCostObservation
+from src.billing.operation_reservation import ComponentState
+from src.billing.selector_charge import SelectorPriceSnapshot, SelectorTokenReceipt
+from src.billing.spend_read import SPEND_READ_SOURCE
+from src.services.spend_visibility import SpendVisibility, apply_spend_visibility
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingCostQuery:
+    sql: str
+    params: tuple[object, ...]
+    limit: int
+
+
+def routing_cost_query(
+    *,
+    visibility: SpendVisibility,
+    start: datetime,
+    end: datetime,
+    limit: int = 100,
+    before: tuple[datetime, str] | None = None,
+) -> RoutingCostQuery:
+    """Execute through the existing bounded, protected reporting query owner.
+
+    The operation page is bounded before two unique spend-event joins. The returned
+    observations are not a full-history total; aggregate coverage retains that fact.
+    """
+    if (
+        start.tzinfo is None
+        or end.tzinfo is None
+        or not timedelta(0) < end - start <= timedelta(days=31)
+    ):
+        raise ValueError("routing cost reports require an aware range of at most 31 days")
+    if not 1 <= limit <= 1000:
+        raise ValueError("routing cost report limit must be bounded")
+    source = replace(
+        SPEND_READ_SOURCE,
+        table="deltallm_billing_operations",
+        owner_account_column="(snapshot #>> '{attribution,owner_account_id}')",
+    )
+    params: list[object] = [start, end]
+    clauses = ["created_at >= $1::timestamptz", "created_at < $2::timestamptz"]
+    apply_spend_visibility(clauses=clauses, params=params, visibility=visibility, source=source)
+    if before is not None:
+        params.extend(before)
+        clauses.append(
+            f"(created_at,operation_id)<(${len(params) - 1}::timestamptz,${len(params)}::text)"
+        )
+    params.append(limit + 1)
+    sql = f"""
+        WITH page AS MATERIALIZED (
+            SELECT * FROM deltallm_billing_operations WHERE {" AND ".join(clauses)}
+            ORDER BY created_at DESC,operation_id DESC LIMIT ${len(params)}
+        )
+        SELECT o.operation_id,o.created_at,o.selector_state,o.answer_state,a.deployment_model AS answer_model,
+            CASE WHEN o.selector_state='unattempted' THEN '0' ELSE
+                COALESCE(s.provider_cost_exact::text,o.selector_receipt->>'provider_cost_exact') END AS selector_provider_cost,
+            CASE WHEN o.selector_state='unattempted' THEN '0' ELSE
+                COALESCE(s.spend_exact::text,o.selector_receipt->>'cost_exact') END AS selector_customer_charge,
+            CASE WHEN o.answer_state='unattempted' THEN '0'
+                WHEN a.status='success' AND a.usage_snapshot->>'kind'='reported'
+                THEN a.provider_cost_exact::text END AS answer_provider_cost,
+            CASE WHEN o.answer_state='unattempted' THEN '0'
+                WHEN a.status='success' AND a.usage_snapshot->>'kind'='reported'
+                THEN a.spend_exact::text END AS answer_customer_charge,
+            o.snapshot->'reference_answer_pricing' AS reference_answer_pricing,
+            o.snapshot->>'measurable_switch_penalty' AS measurable_penalty,
+            a.input_tokens,a.output_tokens,a.total_tokens,a.status
+        FROM page o LEFT JOIN deltallm_spendlog_events s ON s.id=o.selector_event_id
+        LEFT JOIN deltallm_spendlog_events a ON a.id=o.operation_id
+        ORDER BY o.created_at DESC,o.operation_id DESC
+    """
+    return RoutingCostQuery(sql, tuple(params), limit)
+
+
+def routing_cost_observation(row: dict[str, object]) -> RoutingCostObservation:
+    amounts = {}
+    for name in (
+        "selector_provider_cost",
+        "selector_customer_charge",
+        "answer_provider_cost",
+        "answer_customer_charge",
+        "measurable_penalty",
+    ):
+        value = row.get(name)
+        amounts[name] = None if value is None else Decimal(str(value))
+    return RoutingCostObservation(
+        answer_model=row.get("answer_model"),
+        selector_state=ComponentState(str(row["selector_state"]))
+        if row.get("selector_state") is not None
+        else None,
+        answer_state=ComponentState(str(row["answer_state"]))
+        if row.get("answer_state") is not None
+        else None,
+        baseline_answer_provider_cost=_reference_cost(row),
+        **amounts,
+    )
+
+
+def _reference_cost(row: dict[str, object]) -> Decimal | None:
+    pricing = row.get("reference_answer_pricing")
+    if pricing is None or row.get("status") != "success":
+        return None
+    try:
+        frozen = SelectorPriceSnapshot.model_validate_json(json.dumps(pricing))
+        receipt = SelectorTokenReceipt(
+            prompt_tokens=row.get("input_tokens"),
+            completion_tokens=row.get("output_tokens"),
+            total_tokens=row.get("total_tokens"),
+            cached_input_tokens=0,
+        )
+        return frozen.cost(receipt)
+    except (ValueError, ValidationError):
+        return None

--- a/src/db/spend_components.py
+++ b/src/db/spend_components.py
@@ -1,0 +1,9 @@
+from typing import Literal
+
+
+def external_request_sql(*, alias: Literal["", "s"] = "") -> str:
+    """One definition for external-operation counts in existing admin reports."""
+    if alias not in ("", "s"):
+        raise ValueError("invalid spend table alias")
+    column = f"{alias}.call_type" if alias else "call_type"
+    return f"{column} IS DISTINCT FROM 'model_router_selector'"

--- a/src/metrics/selector.py
+++ b/src/metrics/selector.py
@@ -1,0 +1,102 @@
+from enum import StrEnum
+
+from prometheus_client import Counter, Histogram
+
+from src.metrics.prometheus import get_prometheus_registry
+from src.router.selection.contracts import SelectorCause, SelectorDecision
+
+
+class SelectorTermination(StrEnum):
+    CANCELLED = "cancelled"
+    DEADLINE = "deadline"
+    ACCOUNTING_UNAVAILABLE = "accounting_unavailable"
+    INVARIANT_FAILURE = "invariant_failure"
+
+
+class SelectorEscalation(StrEnum):
+    CAPACITY = "capacity"
+    HEALTH = "health"
+    CONTEXT = "context"
+    PROVIDER_FAILURE = "provider_failure"
+    NO_ELIGIBLE_MEMBER = "no_eligible_member"
+
+
+cleanup_failures = Counter(
+    "deltallm_selector_capacity_cleanup_failures_total",
+    "Selector capacity releases left to lease expiry",
+    registry=get_prometheus_registry(),
+)
+
+
+def observe_selector_cleanup_failure() -> None:
+    cleanup_failures.inc()
+
+
+decisions = Counter(
+    "deltallm_selector_decisions_total",
+    "One decision per selector operation",
+    ["cause", "rank"],
+    registry=get_prometheus_registry(),
+)
+terminations = Counter(
+    "deltallm_selector_terminations_total",
+    "Selector operations without a decision",
+    ["cause"],
+    registry=get_prometheus_registry(),
+)
+latency = Histogram(
+    "deltallm_selector_duration_seconds",
+    "Selector latency including prerequisite work",
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 5),
+    registry=get_prometheus_registry(),
+)
+escalations = Counter(
+    "deltallm_selector_escalations_total",
+    "Upward answer-lane escalations",
+    ["cause", "rank"],
+    registry=get_prometheus_registry(),
+)
+terminal_lanes = Counter(
+    "deltallm_selector_terminal_lane_total",
+    "Terminal answer lane",
+    ["rank"],
+    registry=get_prometheus_registry(),
+)
+ttft_contribution = Histogram(
+    "deltallm_selector_ttft_contribution_seconds",
+    "Selector contribution to streaming TTFT",
+    buckets=(0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 5),
+    registry=get_prometheus_registry(),
+)
+
+
+def observe_selector_decision(decision: SelectorDecision) -> None:
+    if not isinstance(decision.cause, SelectorCause):
+        raise ValueError("invalid selector cause")
+    decisions.labels(cause=decision.cause.value, rank=_rank(decision.minimum_rank)).inc()
+    latency.observe(decision.latency_ms / 1000)
+
+
+def observe_selector_termination(cause: SelectorTermination, *, seconds: float) -> None:
+    if not isinstance(cause, SelectorTermination):
+        raise ValueError("invalid selector termination")
+    terminations.labels(cause=cause.value).inc()
+    latency.observe(max(0, seconds))
+
+
+def observe_selector_escalation(cause: SelectorEscalation, *, rank: int) -> None:
+    if not isinstance(cause, SelectorEscalation):
+        raise ValueError("invalid selector escalation")
+    escalations.labels(cause=cause.value, rank=_rank(rank)).inc()
+
+
+def observe_selector_answer(*, rank: int, selector_seconds: float, streaming: bool) -> None:
+    terminal_lanes.labels(rank=_rank(rank)).inc()
+    if streaming:
+        ttft_contribution.observe(max(0, selector_seconds))
+
+
+def _rank(rank: int) -> str:
+    if type(rank) is not int or not 0 <= rank < 8:
+        raise ValueError("invalid selector rank")
+    return str(rank)

--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -10,6 +10,7 @@ import httpx
 from src.models.errors import FailureClassification, InvalidRequestError, ProxyError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
+from src.providers.token_receipt import ProviderTokenReceipt, anthropic_token_receipt
 from src.providers.base import (
     ProviderAdapter,
     ProviderErrorDetails,
@@ -170,6 +171,9 @@ def _chat_tool_choice_to_anthropic(tool_choice: Any) -> dict[str, Any] | None:
 
 
 class AnthropicAdapter(ProviderAdapter):
+    def reported_token_receipt(self, payload: object) -> ProviderTokenReceipt | None:
+        return anthropic_token_receipt(payload)
+
     provider_name = "anthropic"
 
     def validate_single_result_payload(self, payload: object) -> None:

--- a/src/providers/azure.py
+++ b/src/providers/azure.py
@@ -9,6 +9,7 @@ from src.models.errors import FailureClassification, ProxyError
 from src.models.request_serialization import dump_openai_chat_request
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
+from src.providers.token_receipt import ProviderTokenReceipt, openai_token_receipt
 from src.providers.base import (
     ProviderAdapter,
     ProviderErrorDetails,
@@ -48,6 +49,9 @@ _CONTENT_MESSAGE_MARKERS = ("content management policy", "responsible ai policy"
 
 
 class AzureOpenAIAdapter(ProviderAdapter):
+    def reported_token_receipt(self, payload: object) -> ProviderTokenReceipt | None:
+        return openai_token_receipt(payload)
+
     provider_name = "azure_openai"
 
     def validate_single_result_payload(self, payload: object) -> None:

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -29,6 +29,7 @@ from src.providers.error_body import (
     bound_provider_error_response_body as bound_provider_error_response_body,
     provider_error_body_is_unavailable,
 )
+from src.providers.token_receipt import ProviderTokenReceipt, TokenReceiptObserver
 
 _MAX_CLASSIFICATION_MESSAGE_CHARS = 2048
 _PROVIDER_ERROR_READ_CHUNK_BYTES = 8192
@@ -425,11 +426,17 @@ class ProviderAdapter(ABC):
             raise invalid_provider_response_error() from exc
 
     async def translate_single_success_response(
-        self, response: httpx.Response, model_name: str
+        self,
+        response: httpx.Response,
+        model_name: str,
+        *,
+        receipt_observer: TokenReceiptObserver | None = None,
     ) -> ChatCompletionResponse:
         """Opt-in single-result contract without changing ordinary answer translation."""
         payload = parse_provider_json_response(response)
         try:
+            if receipt_observer is not None:
+                receipt_observer(self.reported_token_receipt(payload))
             self.validate_single_result_payload(payload)
             canonical = await self.translate_response(payload, model_name)
             if len(canonical.choices) != 1:
@@ -439,6 +446,9 @@ class ProviderAdapter(ABC):
             raise
         except Exception as exc:
             raise invalid_provider_response_error() from exc
+
+    def reported_token_receipt(self, payload: object) -> ProviderTokenReceipt | None:
+        return None
 
     def validate_single_result_payload(self, payload: object) -> None:
         """Adapters that collapse results or finish states validate before translation."""

--- a/src/providers/bedrock.py
+++ b/src/providers/bedrock.py
@@ -17,6 +17,7 @@ from src.models.errors import (
 )
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
+from src.providers.token_receipt import ProviderTokenReceipt, native_token_receipt
 from src.providers.base import (
     ProviderAdapter,
     ProviderErrorDetails,
@@ -204,6 +205,17 @@ def _classified_stream_finish_reason(failure: ProxyError) -> str:
 
 
 class BedrockAdapter(ProviderAdapter):
+    def reported_token_receipt(self, payload: object) -> ProviderTokenReceipt | None:
+        return native_token_receipt(
+            payload,
+            usage_key="usage",
+            input_key="inputTokens",
+            output_key="outputTokens",
+            total_key="totalTokens",
+            cache_key="cacheReadInputTokens",
+            unsupported_usage_keys=("cacheWriteInputTokens",),
+        )
+
     provider_name = "bedrock"
     stream_uses_bytes = True
 

--- a/src/providers/chat_hop.py
+++ b/src/providers/chat_hop.py
@@ -15,6 +15,7 @@ from src.models.responses import ChatCompletionResponse
 from src.providers.chat_upstream import ChatUpstream
 from src.providers.error_body import provider_error_body_is_unavailable
 from src.providers.signing import apply_request_signing
+from src.providers.token_receipt import TokenReceiptObserver
 
 logger = logging.getLogger(__name__)
 RESPONSE_CLOSE_GRACE_SECONDS = 0.05
@@ -65,6 +66,7 @@ async def execute_chat_hop(
     timeout: httpx.Timeout,
     observer: HopObserver | None = None,
     bounded: BoundedChatResponse | None = None,
+    receipt_observer: TokenReceiptObserver | None = None,
 ) -> ChatCompletionResponse:
     """Shared single-attempt transport; clients and answer accounting belong to callers."""
     request_url = f"{upstream.api_base}{upstream.endpoint}"
@@ -109,7 +111,7 @@ async def execute_chat_hop(
     try:
         if bounded is not None:
             canonical = await upstream.adapter.translate_single_success_response(
-                response, model_name
+                response, model_name, receipt_observer=receipt_observer
             )
         else:
             canonical = await upstream.adapter.translate_success_response(response, model_name)

--- a/src/providers/gemini.py
+++ b/src/providers/gemini.py
@@ -10,6 +10,7 @@ import httpx
 from src.models.errors import FailureClassification, InvalidRequestError, ProxyError
 from src.models.requests import ChatCompletionRequest
 from src.models.responses import ChatCompletionResponse
+from src.providers.token_receipt import ProviderTokenReceipt, native_token_receipt
 from src.providers.base import (
     ProviderAdapter,
     ProviderErrorDetails,
@@ -126,6 +127,16 @@ def _is_valid_gemini_success_payload(data: Mapping[str, Any]) -> bool:
 
 
 class GeminiAdapter(ProviderAdapter):
+    def reported_token_receipt(self, payload: object) -> ProviderTokenReceipt | None:
+        return native_token_receipt(
+            payload,
+            usage_key="usageMetadata",
+            input_key="promptTokenCount",
+            output_key="candidatesTokenCount",
+            total_key="totalTokenCount",
+            cache_key="cachedContentTokenCount",
+        )
+
     provider_name = "gemini"
 
     def __init__(self, http_client: httpx.AsyncClient) -> None:

--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -18,6 +18,7 @@ from src.providers.base import (
     reject_openai_compatible_failure_response,
 )
 from src.providers.healthcheck import is_provider_healthy
+from src.providers.token_receipt import ProviderTokenReceipt, openai_token_receipt
 from src.providers.openai_compatible import (
     translate_openai_compatible_stream,
     validate_openai_single_result,
@@ -62,6 +63,9 @@ _CONTENT_MESSAGE_MARKERS = (
 
 class OpenAIAdapter(ProviderAdapter):
     provider_name = "openai"
+
+    def reported_token_receipt(self, payload: object) -> ProviderTokenReceipt | None:
+        return openai_token_receipt(payload)
 
     def validate_single_result_payload(self, payload: object) -> None:
         validate_openai_single_result(payload)

--- a/src/providers/request_defaults.py
+++ b/src/providers/request_defaults.py
@@ -1,0 +1,13 @@
+"""The shared projection of configured defaults actually forwarded to providers."""
+
+from collections.abc import Mapping
+
+_UI_ONLY_DEFAULT_KEYS = frozenset({"available_voices"})
+
+
+def provider_request_defaults(model_info: Mapping[str, object]) -> dict[str, object]:
+    # Compatibility boundary for the existing dynamic provider-parameter contract.
+    defaults = model_info.get("default_params")
+    if not isinstance(defaults, dict):
+        return {}
+    return {key: value for key, value in defaults.items() if key not in _UI_ONLY_DEFAULT_KEYS}

--- a/src/providers/token_receipt.py
+++ b/src/providers/token_receipt.py
@@ -1,0 +1,91 @@
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderTokenReceipt:
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    cached_input_tokens: int | None = None
+
+
+TokenReceiptObserver = Callable[[ProviderTokenReceipt | None], None]
+
+
+def token_receipt(
+    *,
+    input_tokens: object,
+    output_tokens: object,
+    total_tokens: object,
+    cached_input_tokens: object = None,
+) -> ProviderTokenReceipt | None:
+    values = (input_tokens, output_tokens, total_tokens)
+    if any(type(value) is not int or not 0 <= value <= 2**31 - 1 for value in values):
+        return None
+    if total_tokens != input_tokens + output_tokens:
+        return None
+    if cached_input_tokens is not None and (
+        type(cached_input_tokens) is not int or not 0 <= cached_input_tokens <= input_tokens
+    ):
+        return None
+    return ProviderTokenReceipt(input_tokens, output_tokens, total_tokens, cached_input_tokens)
+
+
+def openai_token_receipt(payload: object) -> ProviderTokenReceipt | None:
+    if not isinstance(payload, Mapping) or not isinstance(payload.get("usage"), Mapping):
+        return None
+    usage = payload["usage"]
+    details = usage.get("prompt_tokens_details")
+    cached = details.get("cached_tokens") if isinstance(details, Mapping) else None
+    return token_receipt(
+        input_tokens=usage.get("prompt_tokens"),
+        output_tokens=usage.get("completion_tokens"),
+        total_tokens=usage.get("total_tokens"),
+        cached_input_tokens=cached,
+    )
+
+
+def native_token_receipt(
+    payload: object,
+    *,
+    usage_key: str,
+    input_key: str,
+    output_key: str,
+    total_key: str,
+    cache_key: str,
+    unsupported_usage_keys: tuple[str, ...] = (),
+) -> ProviderTokenReceipt | None:
+    if not isinstance(payload, Mapping) or not isinstance(payload.get(usage_key), Mapping):
+        return None
+    usage = payload[usage_key]
+    if any(usage.get(key, 0) != 0 for key in unsupported_usage_keys):
+        return None
+    return token_receipt(
+        input_tokens=usage.get(input_key),
+        output_tokens=usage.get(output_key),
+        total_tokens=usage.get(total_key),
+        cached_input_tokens=usage.get(cache_key),
+    )
+
+
+def anthropic_token_receipt(payload: object) -> ProviderTokenReceipt | None:
+    if not isinstance(payload, Mapping) or not isinstance(payload.get("usage"), Mapping):
+        return None
+    usage = payload["usage"]
+    # Cache creation has a separate pricing dimension not supported by the frozen
+    # token/request price contract. Preserve unknown instead of silently undercharging.
+    if usage.get("cache_creation_input_tokens", 0) != 0:
+        return None
+    cached = usage.get("cache_read_input_tokens")
+    uncached, output = usage.get("input_tokens"), usage.get("output_tokens")
+    cache_count = 0 if cached is None else cached
+    if any(type(value) is not int or value < 0 for value in (uncached, output, cache_count)):
+        return None
+    total_input = uncached + cache_count
+    return token_receipt(
+        input_tokens=total_input,
+        output_tokens=output,
+        total_tokens=total_input + output,
+        cached_input_tokens=cached,
+    )

--- a/src/router/attempt_scripts.py
+++ b/src/router/attempt_scripts.py
@@ -1,0 +1,148 @@
+_ATTEMPT_ADMISSION_SCRIPT = """
+-- router_attempt_admission_v2
+local redis_time = redis.call('TIME')
+local now_ms = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000)
+local capacity_count = tonumber(ARGV[1]) or 0
+local lease_ttl_ms = tonumber(ARGV[2]) or 1000
+local legacy_compat_ttl_ms = tonumber(ARGV[3]) or lease_ttl_ms
+local owner_token = ARGV[4]
+
+local expired = redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', now_ms)
+local current = tonumber(redis.call('GET', KEYS[1]) or '0') or 0
+current = math.max(0, current - expired)
+local owner_count = redis.call('ZCARD', KEYS[2])
+current = math.max(current, owner_count)
+
+local active_ttl_ms = redis.call('PTTL', KEYS[1])
+if current <= 0 then
+  redis.call('DEL', KEYS[1])
+elseif expired > 0 then
+  redis.call('SET', KEYS[1], current)
+  if active_ttl_ms > 0 then
+    redis.call('PEXPIRE', KEYS[1], active_ttl_ms)
+  end
+end
+
+if redis.call('EXISTS', KEYS[3]) == 1 then
+  return {0, 'cooldown', 0}
+end
+
+local healthy = redis.call('HGET', KEYS[4], 'healthy')
+local concurrency = tonumber(ARGV[6 + capacity_count]) or 0
+if tonumber(ARGV[7 + capacity_count * 2]) == 1 then
+  local existing_expiry = redis.call('ZSCORE', KEYS[2], owner_token)
+  if existing_expiry then
+    return {1, 'acquired', current, tonumber(existing_expiry), 0}
+  end
+end
+if concurrency > 0 and current >= concurrency then
+  return {0, 'capacity', 0}
+end
+for index = 1, capacity_count do
+  local usage = tonumber(redis.call('GET', KEYS[5 + index]) or '0')
+  local limit = tonumber(ARGV[4 + index])
+  local consume = tonumber(ARGV[6 + capacity_count + index]) or 0
+  if usage >= limit or usage + consume > limit then
+    return {0, 'capacity', 0}
+  end
+end
+
+local recovery = 0
+if healthy == 'false' then
+  if redis.call('HGET', KEYS[4], 'recovery_required') ~= 'true' then
+    return {0, 'unhealthy', 0}
+  end
+  local claimed = redis.call('SET', KEYS[5], owner_token, 'NX', 'PX', lease_ttl_ms)
+  if not claimed then
+    return {0, 'recovery_in_progress', 0}
+  end
+  recovery = 1
+end
+
+local expires_at_ms = now_ms + lease_ttl_ms
+for index = 1, capacity_count do
+  local consume = tonumber(ARGV[6 + capacity_count + index]) or 0
+  if consume > 0 then
+    redis.call('INCRBY', KEYS[5 + index], consume)
+    redis.call('EXPIRE', KEYS[5 + index], 120)
+  end
+end
+redis.call('ZADD', KEYS[2], expires_at_ms, owner_token)
+local active = current + 1
+redis.call('SET', KEYS[1], active)
+
+local latest = redis.call('ZREVRANGE', KEYS[2], 0, 0, 'WITHSCORES')
+local key_expires_at_ms = expires_at_ms
+if #latest >= 2 then
+  key_expires_at_ms = math.max(key_expires_at_ms, tonumber(latest[2]))
+end
+if current > owner_count then
+  key_expires_at_ms = math.max(key_expires_at_ms, now_ms + legacy_compat_ttl_ms)
+end
+key_expires_at_ms = key_expires_at_ms + tonumber(ARGV[5 + capacity_count])
+redis.call('PEXPIREAT', KEYS[1], key_expires_at_ms)
+redis.call('PEXPIREAT', KEYS[2], key_expires_at_ms)
+return {1, 'acquired', active, expires_at_ms, recovery}
+"""
+
+_ATTEMPT_RELEASE_SCRIPT = """
+-- router_attempt_release_v2
+local removed = redis.call('ZREM', KEYS[2], ARGV[1])
+local current = tonumber(redis.call('GET', KEYS[1]) or '0')
+local owner_count = redis.call('ZCARD', KEYS[2])
+if removed == 1 then
+  current = math.max(0, current - 1)
+end
+current = math.max(current, owner_count)
+
+if current <= 0 then
+  redis.call('DEL', KEYS[1])
+else
+  local active_ttl_ms = redis.call('PTTL', KEYS[1])
+  redis.call('SET', KEYS[1], current)
+  if active_ttl_ms > 0 then
+    redis.call('PEXPIRE', KEYS[1], active_ttl_ms)
+  end
+end
+if owner_count == 0 then
+  redis.call('DEL', KEYS[2])
+end
+if redis.call('GET', KEYS[3]) == ARGV[1] then
+  redis.call('DEL', KEYS[3])
+end
+return current
+"""
+
+_ATTEMPT_ACTIVE_BATCH_SCRIPT = """
+-- router_attempt_active_batch_v1
+local redis_time = redis.call('TIME')
+local now_ms = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000)
+local deployment_count = math.floor(#KEYS / 2)
+local results = {}
+
+for index = 1, deployment_count do
+  local active_key = KEYS[((index - 1) * 2) + 1]
+  local owners_key = KEYS[((index - 1) * 2) + 2]
+  local expired = redis.call('ZREMRANGEBYSCORE', owners_key, '-inf', now_ms)
+  local current = tonumber(redis.call('GET', active_key) or '0') or 0
+  current = math.max(0, current - expired)
+  local owner_count = redis.call('ZCARD', owners_key)
+  current = math.max(current, owner_count)
+
+  if current <= 0 then
+    redis.call('DEL', active_key)
+  elseif expired > 0 then
+    local active_ttl_ms = redis.call('PTTL', active_key)
+    redis.call('SET', active_key, current)
+    if active_ttl_ms > 0 then
+      redis.call('PEXPIRE', active_key, active_ttl_ms)
+    end
+  end
+  if owner_count == 0 then
+    redis.call('DEL', owners_key)
+  end
+  results[index] = current
+end
+
+return results
+"""

--- a/src/router/candidates.py
+++ b/src/router/candidates.py
@@ -36,15 +36,42 @@ class AttemptRejectionReason(str, Enum):
 class AttemptCapacityLimit:
     counter: UsageCounterName
     limit: int
+    consume: int = 0
 
     def __post_init__(self) -> None:
         if self.limit <= 0:
             raise ValueError("attempt capacity limit must be positive")
+        if type(self.consume) is not int or self.consume < 0:
+            raise ValueError("attempt consumption must be a nonnegative integer")
 
 
 @dataclass(frozen=True, slots=True)
 class AttemptCapacity:
     limits: tuple[AttemptCapacityLimit, ...] = ()
+    max_concurrency: int | None = None
+    require_shared: bool = False
+    owner_token: str | None = None
+
+    def __post_init__(self) -> None:
+        if len({item.counter for item in self.limits}) != len(self.limits):
+            raise ValueError("attempt counters must be unique")
+        if self.max_concurrency is not None and (
+            type(self.max_concurrency) is not int or not 1 <= self.max_concurrency <= 2**31 - 1
+        ):
+            raise ValueError("attempt concurrency must be positive")
+        if self.require_shared and any(
+            type(item.limit) is not int
+            or not 1 <= item.limit <= 2**31 - 1
+            or item.consume > 2**31 - 1
+            for item in self.limits
+        ):
+            raise ValueError("shared attempt limits must be bounded integers")
+        if self.owner_token is not None and not 16 <= len(self.owner_token) <= 128:
+            raise ValueError("attempt owner token must be bounded")
+        if (
+            self.max_concurrency or any(item.consume for item in self.limits)
+        ) and not self.require_shared:
+            raise ValueError("reserved provider capacity requires shared coordination")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/router/fallback_identity.py
+++ b/src/router/fallback_identity.py
@@ -1,0 +1,132 @@
+"""Hash configured fallback dependencies without enumerating paths or executing routing."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from graphlib import TopologicalSorter
+from hashlib import sha256
+import json
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.router.failover import FallbackConfig
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackEdges:
+    ordinary: tuple[str, ...]
+    context: tuple[str, ...]
+    content: tuple[str, ...]
+
+    def targets(self) -> tuple[str, ...]:
+        return self.ordinary + self.context + self.content
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    return sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def fingerprint_fallback_dependencies(
+    local_identities: Mapping[str, str], config: FallbackConfig
+) -> Mapping[str, str]:
+    """Precompute one digest per group, with O(V+E) graph work and temporary state.
+
+    Cycles are condensed before hashing, so long chains and diamonds neither recurse
+    nor enumerate paths. A conservative dependency graph includes all three fallback
+    kinds; runtime eligibility, retry limits and traversal remain failover-owned.
+    """
+
+    maps = (config.fallbacks, config.context_window_fallbacks, config.content_policy_fallbacks)
+    nodes = set(local_identities).union(*(mapping.keys() for mapping in maps))
+    nodes.update(target for mapping in maps for targets in mapping.values() for target in targets)
+    edges = {
+        node: FallbackEdges(*(tuple(dict.fromkeys(mapping.get(node, ()))) for mapping in maps))
+        for node in nodes
+    }
+    # Keep target spelling: failover looks plans up by the configured key even
+    # though the planner itself strips input. Normalizing here could hide a change.
+    graph = {node: edge.targets() for node, edge in edges.items()}
+    components, owner = _components(graph)
+    dependencies = {
+        index: {
+            owner[target] for node in members for target in graph[node] if owner[target] != index
+        }
+        for index, members in enumerate(components)
+    }
+    resolved: dict[int, str] = {}
+    for index in TopologicalSorter(dependencies).static_order():
+        resolved[index] = _digest(
+            [
+                {
+                    "group": node,
+                    "local": local_identities.get(node),
+                    "edges": [
+                        [
+                            (target, resolved[owner[target]] if owner[target] != index else None)
+                            for target in targets
+                        ]
+                        for targets in (
+                            edges[node].ordinary,
+                            edges[node].context,
+                            edges[node].content,
+                        )
+                    ],
+                }
+                for node in components[index]
+            ]
+        )
+    return MappingProxyType(
+        {
+            node: "route-response-v1:" + _digest({"root": node, "component": resolved[owner[node]]})
+            for node in local_identities
+        }
+    )
+
+
+def _finish_order(graph: Mapping[str, tuple[str, ...]]) -> list[str]:
+    visited: set[str] = set()
+    finished: list[str] = []
+    for node in graph:
+        if node in visited:
+            continue
+        visited.add(node)
+        stack: list[tuple[str, Iterator[str]]] = [(node, iter(graph[node]))]
+        while stack:
+            current, targets = stack[-1]
+            target = next(targets, None)
+            if target is None:
+                finished.append(current)
+                stack.pop()
+            elif target not in visited:
+                visited.add(target)
+                stack.append((target, iter(graph[target])))
+    return finished
+
+
+def _components(
+    graph: Mapping[str, tuple[str, ...]],
+) -> tuple[list[tuple[str, ...]], dict[str, int]]:
+    reverse: dict[str, list[str]] = {node: [] for node in graph}
+    for node, targets in graph.items():
+        for target in targets:
+            reverse[target].append(node)
+    owner: dict[str, int] = {}
+    components: list[tuple[str, ...]] = []
+    for node in reversed(_finish_order(graph)):
+        if node in owner:
+            continue
+        index = len(components)
+        owner[node] = index
+        pending, members = [node], []
+        while pending:
+            current = pending.pop()
+            members.append(current)
+            for target in reverse[current]:
+                if target not in owner:
+                    owner[target] = index
+                    pending.append(target)
+        components.append(tuple(sorted(members)))
+    return components, owner

--- a/src/router/routing_identity.py
+++ b/src/router/routing_identity.py
@@ -1,0 +1,157 @@
+"""Precompute response-cache routing identity as part of runtime publication."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from hashlib import sha256
+import json
+from typing import TYPE_CHECKING
+
+from src.providers.request_defaults import provider_request_defaults
+from src.providers.resolution import resolve_provider, resolve_upstream_model
+from src.route_policy_contract import (
+    LLMTierSelectorPolicy,
+    SELECTOR_POLICY_SEMANTICS_VERSION,
+)
+from src.router.callable_key_ownership import resolve_enabled_route_group_owners
+from src.router.fallback_identity import fingerprint_fallback_dependencies
+from src.router.selection.policy import build_routing_fingerprint
+
+if TYPE_CHECKING:
+    from src.router.failover import FallbackConfig
+    from src.router.router import Deployment, RouteGroupPolicy, RoutingStrategy
+
+
+def build_runtime_routing_fingerprints(
+    *,
+    groups: Sequence[Mapping[str, object]],
+    policies: Mapping[str, RouteGroupPolicy],
+    deployments: Mapping[str, Sequence[Deployment]],
+    default_strategy: RoutingStrategy,
+    failover_config: FallbackConfig,
+    enable_pre_call_checks: bool = False,
+) -> Mapping[str, str]:
+    """Project validated runtime inputs once; never read mutable state on cache lookup."""
+
+    owners = resolve_enabled_route_group_owners(groups)
+    fingerprints: dict[str, str] = {}
+    for key, members in deployments.items():
+        group = owners.get(key, {})
+        policy = policies.get(key)
+        # File policies already contain current context semantics; historical database
+        # policies carry their own version. No generation or policy revision enters identity.
+        version = group.get("policy_semantics_version")
+        semantics = (
+            int(version) if isinstance(version, (int, str)) else SELECTOR_POLICY_SEMANTICS_VERSION
+        )
+        selector = group.get("selector") if semantics >= SELECTOR_POLICY_SEMANTICS_VERSION else None
+        selector = LLMTierSelectorPolicy.model_validate(selector) if selector is not None else None
+        lanes = _member_lanes(group) if selector is not None else {}
+        strategy = policy.strategy if policy is not None and policy.strategy else default_strategy
+        policy_identity = build_routing_fingerprint(
+            workload_mode=str(group.get("mode") or ""),
+            strategy=strategy.value,
+            semantics_version=semantics,
+            timeout_seconds=policy.timeout_seconds if policy else None,
+            retry_max_attempts=policy.retry_max_attempts if policy else None,
+            retryable_error_classes=policy.retryable_error_classes if policy else None,
+            context=policy.context if policy else None,
+            selector=selector,
+            effective_members=[
+                {
+                    "deployment_id": member.deployment_id,
+                    "enabled": True,
+                    "weight": member.weight,
+                    "priority": member.priority,
+                    "lane": lanes.get(member.deployment_id),
+                }
+                for member in members
+            ],
+        )
+        fingerprints[key] = _digest(
+            {
+                "policy": policy_identity,
+                "deployments": [_deployment_identity(member) for member in members],
+                "pre_call_checks": enable_pre_call_checks,
+                "execution": {
+                    "timeout": float(
+                        policy.timeout_seconds
+                        if policy and policy.timeout_seconds is not None
+                        else failover_config.timeout
+                    ),
+                    "retries": policy.retry_max_attempts
+                    if policy and policy.retry_max_attempts is not None
+                    else failover_config.num_retries,
+                    "retry_after": float(failover_config.retry_after),
+                    "backoff_multiplier": float(failover_config.backoff_multiplier),
+                    "backoff_max": float(failover_config.backoff_max),
+                    "backoff_jitter": failover_config.backoff_jitter,
+                },
+            }
+        )
+    return fingerprint_fallback_dependencies(fingerprints, failover_config)
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    return sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _deployment_identity(deployment: Deployment) -> str:
+    """Project only configuration used by provider execution and candidate ordering.
+
+    Credentials, health incarnation, live capacity/health, and opaque operator
+    metadata are deliberately absent. Only the digest survives publication.
+    """
+
+    params, info = deployment.deltallm_params, deployment.model_info
+    api_base = params.get("api_base")
+    return _digest(
+        {
+            "provider": resolve_provider(params),
+            "model": resolve_upstream_model(params),
+            "api_base": api_base.rstrip("/") if isinstance(api_base, str) else api_base,
+            "connection": {
+                key: params.get(key)
+                for key in (
+                    "api_version",
+                    "region",
+                    "auth_header_name",
+                    "auth_header_format",
+                    "timeout",
+                    "stream_timeout",
+                    "max_tokens",
+                )
+            },
+            "credential_reference": deployment.named_credential_id,
+            "mode": str(info.get("mode") or "chat").strip().lower(),
+            "defaults": provider_request_defaults(info),
+            "context_limits": {
+                key: info.get(key)
+                for key in ("max_tokens", "max_input_tokens", "max_output_tokens")
+            },
+            "tags": sorted(set(deployment.tags)),
+            "input_cost_per_token": info.get(
+                "input_cost_per_token", deployment.input_cost_per_token
+            ),
+            "output_cost_per_token": info.get(
+                "output_cost_per_token", deployment.output_cost_per_token
+            ),
+            "cost_per_request": info.get("cost_per_request"),
+            "rpm": deployment.rpm_limit,
+            "tpm": deployment.tpm_limit,
+        }
+    )
+
+
+def _member_lanes(group: Mapping[str, object]) -> dict[str, str]:
+    members = group.get("members")
+    if not isinstance(members, list):
+        return {}
+    return {
+        str(member["deployment_id"]): member["lane"]
+        for member in members
+        if isinstance(member, Mapping)
+        and isinstance(member.get("deployment_id"), str)
+        and isinstance(member.get("lane"), str)
+    }

--- a/src/router/runtime_generation.py
+++ b/src/router/runtime_generation.py
@@ -11,6 +11,7 @@ from src.router.failover import FallbackConfig, FailoverManager
 from src.router.registry import DeploymentRegistryStore
 from src.router.router import Router, RouterConfig, RoutingStrategy
 from src.router.runtime_authorization import CallableTargetGrantSnapshot
+from src.router.routing_identity import build_runtime_routing_fingerprints
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,6 +33,7 @@ class RoutingRuntimeGeneration:
     router: Router
     failover_manager: FailoverManager
     cooldown_manager: CooldownManager
+    routing_fingerprints: Mapping[str, str]
     source: str = "config_only"
     requires_reconciliation: bool = False
 
@@ -74,6 +76,14 @@ class RoutingRuntimeGeneration:
             router=router,
             failover_manager=failover_manager,
             cooldown_manager=cooldown_manager,
+            routing_fingerprints=build_runtime_routing_fingerprints(
+                groups=route_groups,
+                policies=router_config.route_group_policies,
+                deployments=deployment_registry.snapshot(),
+                default_strategy=strategy,
+                failover_config=failover_config,
+                enable_pre_call_checks=router_config.enable_pre_call_checks,
+            ),
             source=source,
             requires_reconciliation=requires_reconciliation,
         )

--- a/src/router/selection/capacity.py
+++ b/src/router/selection/capacity.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, replace
+import logging
+import math
+import secrets
+from typing import Protocol
+
+from src.models.errors import ServiceUnavailableError
+from src.metrics.selector import observe_selector_cleanup_failure
+from src.router.candidates import AttemptCapacity, AttemptCapacityLimit, AttemptPermit
+from src.router.health_state import DeploymentHealthRef
+from src.router.selection.contracts import (
+    SelectorCause,
+    SelectorHopFailure,
+    SelectorHopOutcome,
+    SelectorInvariantError,
+    SelectorModelHop,
+    SelectorPrompt,
+    UnattemptedSelectorUsage,
+)
+
+logger = logging.getLogger(__name__)
+CAPACITY_CLEANUP_SECONDS = 0.05
+
+
+class SelectorCapacityOwner(Protocol):
+    async def acquire_attempt(
+        self, health_ref: DeploymentHealthRef, capacity: AttemptCapacity, *, lease_ttl_seconds: int
+    ) -> AttemptPermit: ...
+
+    async def release_attempt(self, permit: AttemptPermit) -> int | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SelectorCapacityBounds:
+    health_ref: DeploymentHealthRef
+    rpm: int
+    tpm: int
+    concurrency: int
+    token_allowance: int
+
+    def __post_init__(self) -> None:
+        for value in (self.rpm, self.tpm, self.concurrency, self.token_allowance):
+            if type(value) is not int or not 1 <= value <= 2**31 - 1:
+                raise SelectorInvariantError()
+
+
+class CapacityAdmittedSelectorHop:
+    """Uses canonical router admission, with no local fallback or caller RPM charge.
+
+    RPM and the conservative TPM bound are consumed atomically. They are not refunded
+    for unknown dispatch outcomes; the minute window expires normally. Actual usage
+    belongs to durable billing and must not increment these counters a second time.
+    """
+
+    def __init__(
+        self, *, owner: SelectorCapacityOwner, hop: SelectorModelHop, bounds: SelectorCapacityBounds
+    ) -> None:
+        self._owner, self._hop, self._bounds = owner, hop, bounds
+
+    async def invoke(
+        self, *, deployment_id: str, prompt: SelectorPrompt, expires_at: float
+    ) -> SelectorHopOutcome:
+        bounds = self._bounds
+        if deployment_id != bounds.health_ref.deployment_id or not math.isfinite(expires_at):
+            raise SelectorInvariantError()
+        remaining = expires_at - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            raise TimeoutError()
+        owner_token = secrets.token_urlsafe(24)
+        capacity = AttemptCapacity(
+            limits=(
+                AttemptCapacityLimit("rpm", bounds.rpm, 1),
+                AttemptCapacityLimit("tpm", bounds.tpm, bounds.token_allowance),
+            ),
+            max_concurrency=bounds.concurrency,
+            require_shared=True,
+            owner_token=owner_token,
+        )
+        # The token is known before the await: cleanup can release an ambiguous acquire.
+        permit = AttemptPermit(deployment_id, bounds.health_ref, True, "redis", owner_token)
+        try:
+            async with asyncio.timeout_at(expires_at):
+                try:
+                    acquired = await self._owner.acquire_attempt(
+                        bounds.health_ref,
+                        capacity,
+                        lease_ttl_seconds=max(1, math.ceil(remaining + CAPACITY_CLEANUP_SECONDS)),
+                    )
+                except ServiceUnavailableError:
+                    return _denied(SelectorCause.CAPACITY_UNAVAILABLE)
+                if not acquired.acquired:
+                    permit = acquired
+                    return _denied(SelectorCause.CAPACITY_DENIED)
+                if acquired.backend != "redis" or acquired.owner_token != owner_token:
+                    raise SelectorInvariantError()
+                permit = acquired
+                return await self._hop.invoke(
+                    deployment_id=deployment_id, prompt=prompt, expires_at=expires_at
+                )
+        finally:
+            if permit.acquired:
+                await self._release(permit)
+
+    async def _release(self, permit: AttemptPermit) -> None:
+        try:
+            async with asyncio.timeout(CAPACITY_CLEANUP_SECONDS):
+                released = await self._owner.release_attempt(replace(permit, acquired=True))
+                if released is None:
+                    observe_selector_cleanup_failure()
+                    logger.warning("selector_capacity_cleanup_incomplete")
+        except Exception:
+            # TTL is the bounded recovery path; never expose backend text or affect health.
+            observe_selector_cleanup_failure()
+            logger.warning("selector_capacity_cleanup_incomplete")
+
+
+def _denied(cause: SelectorCause) -> SelectorHopFailure:
+    return SelectorHopFailure(cause=cause, usage=UnattemptedSelectorUsage())

--- a/src/router/selection/contracts.py
+++ b/src/router/selection/contracts.py
@@ -32,6 +32,8 @@ class SelectorCause(StrEnum):
     INVALID_JSON = "invalid_json"
     UNKNOWN_LANE = "unknown_lane"
     OUTPUT_TOO_LARGE = "output_too_large"
+    CAPACITY_DENIED = "capacity_denied"
+    CAPACITY_UNAVAILABLE = "capacity_unavailable"
 
 
 class SelectorPolicyIdentity(FrozenContract):
@@ -80,6 +82,7 @@ class ReportedSelectorUsage(FrozenContract):
     prompt_tokens: int = Field(ge=0, le=MAX_OBSERVED_COUNT)
     completion_tokens: int = Field(ge=0, le=MAX_OBSERVED_COUNT)
     total_tokens: int = Field(ge=0, le=MAX_OBSERVED_COUNT)
+    cached_input_tokens: int | None = Field(default=None, ge=0, le=MAX_OBSERVED_COUNT)
 
 
 class UnknownSelectorUsage(FrozenContract):
@@ -143,6 +146,12 @@ class SelectorModelHop(Protocol):
     ) -> SelectorHopOutcome:
         """Execute one concrete-deployment hop within the supplied monotonic deadline."""
         ...
+
+
+class SelectorAdmission(Protocol):
+    async def admit(self, *, expires_at: float) -> None: ...
+
+    async def finish(self, usage: SelectorUsage, *, expires_at: float) -> None: ...
 
 
 class SelectorInvariantError(RuntimeError):

--- a/src/router/selection/economics.py
+++ b/src/router/selection/economics.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+import logging
+
+from pydantic import ValidationError
+
+from src.billing.operation_reservation import (
+    BillingOperationUnavailable,
+    ComponentState,
+    OperationReservation,
+    OperationReservationStore,
+    selector_receipt,
+)
+from src.billing.selector_charge import AcceptedSelectorCharge, SelectorTokenReceipt
+from src.cache.execution_eligibility import ResponseCacheEligibility
+from src.router.selection.contracts import (
+    ReportedSelectorUsage,
+    SelectorHopOutcome,
+    SelectorInvariantError,
+    SelectorModelHop,
+    SelectorPrompt,
+    SelectorUsage,
+    UnattemptedSelectorUsage,
+)
+
+RECEIPT_CLEANUP_SECONDS = 0.25
+logger = logging.getLogger(__name__)
+
+
+class ReservedSelectorAdmission:
+    """An isolated prerequisite supplied by the future authenticated execution edge.
+
+    Neither this type nor a cache signal authorizes a principal. The edge must have
+    completed canonical authentication, final-model policy and caller admission.
+    The repository verifies the frozen key's durable ownership relationships again.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: OperationReservationStore,
+        operation: OperationReservation,
+        cache: ResponseCacheEligibility,
+    ) -> None:
+        self._store, self._operation, self._cache = store, operation, cache
+
+    async def admit(self, *, expires_at: float) -> None:
+        self._cache.require_provider_execution()
+        result = await self._store.reserve(self._operation, expires_at=expires_at)
+        if result.selector_state is not ComponentState.RESERVED:
+            # A previous process might already have dispatched this exact operation.
+            raise BillingOperationUnavailable()
+
+    async def finish(self, usage: SelectorUsage, *, expires_at: float) -> None:
+        if isinstance(usage, UnattemptedSelectorUsage):
+            await self._store.unattempted(
+                self._operation, component="selector", expires_at=expires_at
+            )
+
+
+class AccountedSelectorHop:
+    """Dispatch intent and receipts are independent of the answer's eventual result."""
+
+    def __init__(
+        self,
+        *,
+        store: OperationReservationStore,
+        operation: OperationReservation,
+        hop: SelectorModelHop,
+    ) -> None:
+        self._store, self._operation, self._hop = store, operation, hop
+
+    async def invoke(
+        self, *, deployment_id: str, prompt: SelectorPrompt, expires_at: float
+    ) -> SelectorHopOutcome:
+        operation = self._operation
+        if deployment_id != operation.attribution.deployment_id:
+            raise SelectorInvariantError()
+        started = datetime.now(UTC)
+        await self._store.dispatch(operation, component="selector", expires_at=expires_at)
+        outcome = await self._hop.invoke(
+            deployment_id=deployment_id, prompt=prompt, expires_at=expires_at
+        )
+        if isinstance(outcome.usage, UnattemptedSelectorUsage):
+            await self._store.confirm_not_dispatched(
+                operation, expires_at=asyncio.get_running_loop().time() + RECEIPT_CLEANUP_SECONDS
+            )
+        if isinstance(outcome.usage, ReportedSelectorUsage):
+            try:
+                usage = SelectorTokenReceipt(
+                    prompt_tokens=outcome.usage.prompt_tokens,
+                    completion_tokens=outcome.usage.completion_tokens,
+                    total_tokens=outcome.usage.total_tokens,
+                    cached_input_tokens=outcome.usage.cached_input_tokens,
+                )
+                charge = selector_receipt(operation, usage=usage, started_at=started)
+            except (ValueError, ValidationError):
+                # Persisted dispatch intent remains uncertain; never invent a zero receipt.
+                raise BillingOperationUnavailable() from None
+            # Receipt durability has a bounded cleanup grace independent of provider time.
+            await self._accept(charge)
+        return outcome
+
+    async def _accept(self, charge: AcceptedSelectorCharge) -> None:
+        deadline = asyncio.get_running_loop().time() + RECEIPT_CLEANUP_SECONDS
+        try:
+            await self._store.accept_selector(self._operation, charge, expires_at=deadline)
+        except asyncio.CancelledError:
+            # One idempotent receipt retry after cancellation, within the SAME cleanup
+            # deadline. There is no detached task and the provider is never replayed.
+            try:
+                await self._store.accept_selector(self._operation, charge, expires_at=deadline)
+            except Exception:
+                logger.warning("selector_receipt_pending_reconciliation")
+            raise

--- a/src/router/selection/prerequisites.py
+++ b/src/router/selection/prerequisites.py
@@ -1,0 +1,42 @@
+from src.billing.operation_reservation import OperationReservation, OperationReservationStore
+from src.cache.execution_eligibility import ResponseCacheEligibility
+from src.router.selection.capacity import (
+    CapacityAdmittedSelectorHop,
+    SelectorCapacityBounds,
+    SelectorCapacityOwner,
+)
+from src.router.selection.contracts import SelectorInvariantError, SelectorModelHop
+from src.router.selection.economics import AccountedSelectorHop, ReservedSelectorAdmission
+from src.router.selection.service import SelectorService
+
+
+def admitted_selector_service(
+    *,
+    provider: SelectorModelHop,
+    capacity_owner: SelectorCapacityOwner,
+    capacity: SelectorCapacityBounds,
+    billing: OperationReservationStore,
+    operation: OperationReservation,
+    cache: ResponseCacheEligibility,
+) -> SelectorService:
+    """The PR 3 execution boundary: dormant until the PR 4 authenticated edge.
+
+    Composition order is budget/cache admission -> shared provider capacity ->
+    durable dispatch intent -> one direct provider hop -> durable receipt -> release.
+    This factory never constructs clients, starts workers or authorizes identities.
+    """
+    if capacity.health_ref.deployment_id != operation.attribution.deployment_id:
+        raise SelectorInvariantError()
+    if (
+        capacity.token_allowance
+        < operation.selector.max_input_tokens + operation.selector.max_output_tokens
+    ):
+        raise SelectorInvariantError()
+    return SelectorService(
+        CapacityAdmittedSelectorHop(
+            owner=capacity_owner,
+            bounds=capacity,
+            hop=AccountedSelectorHop(store=billing, operation=operation, hop=provider),
+        ),
+        admission=ReservedSelectorAdmission(store=billing, operation=operation, cache=cache),
+    )

--- a/src/router/selection/provider.py
+++ b/src/router/selection/provider.py
@@ -19,6 +19,7 @@ from src.providers.chat_upstream import (
     resolve_chat_upstream_from_registry,
 )
 from src.providers.resolution import resolve_upstream_model
+from src.providers.token_receipt import ProviderTokenReceipt
 from src.router.selection.contracts import (
     SELECTOR_OUTPUT_BYTES,
     SELECTOR_OUTPUT_TOKENS,
@@ -29,6 +30,7 @@ from src.router.selection.contracts import (
     SelectorHopSuccess,
     SelectorInvariantError,
     SelectorPrompt,
+    SelectorUsage,
     UnknownSelectorUsage,
     UnattemptedSelectorUsage,
 )
@@ -149,6 +151,18 @@ class SelectorProviderHop:
         if remaining <= 0:
             raise TimeoutError()
         timeout = _bounded_timeout(self._client.timeout, upstream.timeout, remaining)
+        observed: SelectorUsage = UnknownSelectorUsage()
+
+        def observe(receipt: ProviderTokenReceipt | None) -> None:
+            nonlocal observed
+            if receipt is not None:
+                observed = ReportedSelectorUsage(
+                    prompt_tokens=receipt.input_tokens,
+                    completion_tokens=receipt.output_tokens,
+                    total_tokens=receipt.total_tokens,
+                    cached_input_tokens=receipt.cached_input_tokens,
+                )
+
         try:
             canonical = await execute_chat_hop(
                 client=self._client,
@@ -158,12 +172,11 @@ class SelectorProviderHop:
                 model_name=model,
                 timeout=timeout,
                 bounded=BoundedChatResponse(),
+                receipt_observer=observe,
             )
         except ChatHopError as exc:
-            return SelectorHopFailure(
-                cause=SelectorCause(exc.cause.value), usage=UnknownSelectorUsage()
-            )
-        return _selector_result(canonical)
+            return SelectorHopFailure(cause=SelectorCause(exc.cause.value), usage=observed)
+        return _selector_result(canonical, receipt=observed)
 
 
 def _bounded_timeout(
@@ -210,12 +223,18 @@ def _classifier_request(
     )
 
 
-def _selector_result(response: ChatCompletionResponse) -> SelectorHopOutcome:
+def _selector_result(
+    response: ChatCompletionResponse, *, receipt: SelectorUsage | None = None
+) -> SelectorHopOutcome:
     try:
-        usage = ReportedSelectorUsage(
-            prompt_tokens=response.usage.prompt_tokens,
-            completion_tokens=response.usage.completion_tokens,
-            total_tokens=response.usage.total_tokens,
+        usage = (
+            receipt
+            if receipt is not None
+            else ReportedSelectorUsage(
+                prompt_tokens=response.usage.prompt_tokens,
+                completion_tokens=response.usage.completion_tokens,
+                total_tokens=response.usage.total_tokens,
+            )
         )
     except ValidationError:
         return SelectorHopFailure(

--- a/src/router/selection/service.py
+++ b/src/router/selection/service.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 
 import asyncio
 
+from src.billing.operation_reservation import BillingOperationUnavailable
+from src.metrics.selector import (
+    SelectorTermination,
+    observe_selector_decision,
+    observe_selector_termination,
+)
+from src.models.errors import TimeoutError as RequestTimeoutError
+
 from src.models.requests import ChatCompletionRequest
 from src.route_policy_contract import LLMTierSelectorPolicy, SelectorLane
 from src.router.selection.contracts import (
@@ -11,6 +19,8 @@ from src.router.selection.contracts import (
     SelectorModelHop,
     SelectorPolicyIdentity,
     SelectorUsage,
+    SelectorAdmission,
+    SelectorInvariantError,
     UnknownSelectorUsage,
 )
 from src.router.selection.parser import parse_selector_output
@@ -21,8 +31,11 @@ from src.router.selection.request_state import RequestSelectorState
 class SelectorService:
     """Isolated prerequisite: deliberately not constructed by production bootstrap."""
 
-    def __init__(self, hop: SelectorModelHop) -> None:
+    def __init__(
+        self, hop: SelectorModelHop, *, admission: SelectorAdmission | None = None
+    ) -> None:
         self._hop = hop
+        self._admission = admission
 
     async def select_once(
         self,
@@ -52,10 +65,62 @@ class SelectorService:
         policy: LLMTierSelectorPolicy,
         identity: SelectorPolicyIdentity,
     ) -> SelectorDecision:
+        started = asyncio.get_running_loop().time()
+        try:
+            decision = await self._execute(
+                state=state,
+                payload=payload,
+                token_estimate=token_estimate,
+                policy=policy,
+                identity=identity,
+            )
+        except asyncio.CancelledError:
+            observe_selector_termination(
+                SelectorTermination.CANCELLED, seconds=asyncio.get_running_loop().time() - started
+            )
+            raise
+        except RequestTimeoutError:
+            observe_selector_termination(
+                SelectorTermination.DEADLINE, seconds=asyncio.get_running_loop().time() - started
+            )
+            raise
+        except BillingOperationUnavailable:
+            observe_selector_termination(
+                SelectorTermination.ACCOUNTING_UNAVAILABLE,
+                seconds=asyncio.get_running_loop().time() - started,
+            )
+            raise
+        except SelectorInvariantError:
+            observe_selector_termination(
+                SelectorTermination.INVARIANT_FAILURE,
+                seconds=asyncio.get_running_loop().time() - started,
+            )
+            raise
+        observe_selector_decision(decision)
+        return decision
+
+    async def _execute(
+        self,
+        *,
+        state: RequestSelectorState,
+        payload: ChatCompletionRequest,
+        token_estimate: int,
+        policy: LLMTierSelectorPolicy,
+        identity: SelectorPolicyIdentity,
+    ) -> SelectorDecision:
         loop = asyncio.get_running_loop()
         started = loop.time()
         expires_at = min(state.deadline.expires_at, started + policy.timeout_ms / 1000)
         result: SelectorLane | SelectorCause
+        if self._admission is not None:
+            try:
+                async with asyncio.timeout_at(expires_at):
+                    await self._admission.admit(expires_at=expires_at)
+            except TimeoutError:
+                # An ambiguous reservation is not permission to answer in a default
+                # lane. Only provider/selection timeouts may default after admission.
+                state.deadline.require_remaining()
+                raise BillingOperationUnavailable() from None
         try:
             async with asyncio.timeout_at(expires_at):
                 features = project_selector_request(payload, token_estimate=token_estimate)
@@ -87,6 +152,8 @@ class SelectorService:
             state.deadline.require_remaining()
             result = SelectorCause.SELECTOR_TIMEOUT
         state.deadline.require_remaining()
+        if self._admission is not None:
+            await self._admission.finish(state.usage, expires_at=state.deadline.expires_at)
         return _decision(
             result,
             policy=policy,

--- a/src/router/state.py
+++ b/src/router/state.py
@@ -7,6 +7,11 @@ from datetime import UTC, datetime
 from typing import Any, Literal, Mapping, Protocol
 
 from src.models.errors import ServiceUnavailableError
+from src.router.attempt_scripts import (
+    _ATTEMPT_ADMISSION_SCRIPT,
+    _ATTEMPT_RELEASE_SCRIPT,
+    _ATTEMPT_ACTIVE_BATCH_SCRIPT,
+)
 from src.router.candidates import (
     DEFAULT_ATTEMPT_PERMIT_TTL_SECONDS,
     AttemptCapacity,
@@ -41,137 +46,6 @@ _ATTEMPT_LEASE_CLEANUP_GRACE_MS = 1_000
 _ATTEMPT_LEGACY_COMPAT_TTL_SECONDS = 86_400
 _HEALTH_INVALIDATION_CHUNK_REFS = 100
 _MAX_HEALTH_INVALIDATION_REFS = 1_000
-
-_ATTEMPT_ADMISSION_SCRIPT = """
--- router_attempt_admission_v2
-local redis_time = redis.call('TIME')
-local now_ms = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000)
-local capacity_count = tonumber(ARGV[1]) or 0
-local lease_ttl_ms = tonumber(ARGV[2]) or 1000
-local legacy_compat_ttl_ms = tonumber(ARGV[3]) or lease_ttl_ms
-local owner_token = ARGV[4]
-
-local expired = redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', now_ms)
-local current = tonumber(redis.call('GET', KEYS[1]) or '0') or 0
-current = math.max(0, current - expired)
-local owner_count = redis.call('ZCARD', KEYS[2])
-current = math.max(current, owner_count)
-
-local active_ttl_ms = redis.call('PTTL', KEYS[1])
-if current <= 0 then
-  redis.call('DEL', KEYS[1])
-elseif expired > 0 then
-  redis.call('SET', KEYS[1], current)
-  if active_ttl_ms > 0 then
-    redis.call('PEXPIRE', KEYS[1], active_ttl_ms)
-  end
-end
-
-if redis.call('EXISTS', KEYS[3]) == 1 then
-  return {0, 'cooldown', 0}
-end
-
-local healthy = redis.call('HGET', KEYS[4], 'healthy')
-for index = 1, capacity_count do
-  local usage = tonumber(redis.call('GET', KEYS[5 + index]) or '0')
-  local limit = tonumber(ARGV[4 + index])
-  if usage >= limit then
-    return {0, 'capacity', 0}
-  end
-end
-
-local recovery = 0
-if healthy == 'false' then
-  if redis.call('HGET', KEYS[4], 'recovery_required') ~= 'true' then
-    return {0, 'unhealthy', 0}
-  end
-  local claimed = redis.call('SET', KEYS[5], owner_token, 'NX', 'PX', lease_ttl_ms)
-  if not claimed then
-    return {0, 'recovery_in_progress', 0}
-  end
-  recovery = 1
-end
-
-local expires_at_ms = now_ms + lease_ttl_ms
-redis.call('ZADD', KEYS[2], expires_at_ms, owner_token)
-local active = current + 1
-redis.call('SET', KEYS[1], active)
-
-local latest = redis.call('ZREVRANGE', KEYS[2], 0, 0, 'WITHSCORES')
-local key_expires_at_ms = expires_at_ms
-if #latest >= 2 then
-  key_expires_at_ms = math.max(key_expires_at_ms, tonumber(latest[2]))
-end
-if current > owner_count then
-  key_expires_at_ms = math.max(key_expires_at_ms, now_ms + legacy_compat_ttl_ms)
-end
-key_expires_at_ms = key_expires_at_ms + tonumber(ARGV[5 + capacity_count])
-redis.call('PEXPIREAT', KEYS[1], key_expires_at_ms)
-redis.call('PEXPIREAT', KEYS[2], key_expires_at_ms)
-return {1, 'acquired', active, expires_at_ms, recovery}
-"""
-
-_ATTEMPT_RELEASE_SCRIPT = """
--- router_attempt_release_v2
-local removed = redis.call('ZREM', KEYS[2], ARGV[1])
-local current = tonumber(redis.call('GET', KEYS[1]) or '0')
-local owner_count = redis.call('ZCARD', KEYS[2])
-if removed == 1 then
-  current = math.max(0, current - 1)
-end
-current = math.max(current, owner_count)
-
-if current <= 0 then
-  redis.call('DEL', KEYS[1])
-else
-  local active_ttl_ms = redis.call('PTTL', KEYS[1])
-  redis.call('SET', KEYS[1], current)
-  if active_ttl_ms > 0 then
-    redis.call('PEXPIRE', KEYS[1], active_ttl_ms)
-  end
-end
-if owner_count == 0 then
-  redis.call('DEL', KEYS[2])
-end
-if redis.call('GET', KEYS[3]) == ARGV[1] then
-  redis.call('DEL', KEYS[3])
-end
-return current
-"""
-
-_ATTEMPT_ACTIVE_BATCH_SCRIPT = """
--- router_attempt_active_batch_v1
-local redis_time = redis.call('TIME')
-local now_ms = (tonumber(redis_time[1]) * 1000) + math.floor(tonumber(redis_time[2]) / 1000)
-local deployment_count = math.floor(#KEYS / 2)
-local results = {}
-
-for index = 1, deployment_count do
-  local active_key = KEYS[((index - 1) * 2) + 1]
-  local owners_key = KEYS[((index - 1) * 2) + 2]
-  local expired = redis.call('ZREMRANGEBYSCORE', owners_key, '-inf', now_ms)
-  local current = tonumber(redis.call('GET', active_key) or '0') or 0
-  current = math.max(0, current - expired)
-  local owner_count = redis.call('ZCARD', owners_key)
-  current = math.max(current, owner_count)
-
-  if current <= 0 then
-    redis.call('DEL', active_key)
-  elseif expired > 0 then
-    local active_ttl_ms = redis.call('PTTL', active_key)
-    redis.call('SET', active_key, current)
-    if active_ttl_ms > 0 then
-      redis.call('PEXPIRE', active_key, active_ttl_ms)
-    end
-  end
-  if owner_count == 0 then
-    redis.call('DEL', owners_key)
-  end
-  results[index] = current
-end
-
-return results
-"""
 
 
 class DeploymentStateBackend(Protocol):
@@ -469,7 +343,7 @@ class RedisStateBackend:
         deployment_id = resolved_ref.deployment_id
         minute = self._minute_window()
         normalized_ttl_seconds = max(1, int(lease_ttl_seconds))
-        owner_token = secrets.token_urlsafe(18)
+        owner_token = capacity.owner_token or secrets.token_urlsafe(18)
         capacity_keys = [
             self._usage_key(deployment_id, item.counter, minute) for item in capacity.limits
         ]
@@ -488,6 +362,9 @@ class RedisStateBackend:
             owner_token,
             *(item.limit for item in capacity.limits),
             _ATTEMPT_LEASE_CLEANUP_GRACE_MS,
+            capacity.max_concurrency or 0,
+            *(item.consume for item in capacity.limits),
+            int(capacity.require_shared),
         ]
         try:
             raw = await self._redis_call(
@@ -520,6 +397,11 @@ class RedisStateBackend:
                 rejection_reason=AttemptRejectionReason(self._decode_redis_text(raw[1])),
             )
         except Exception as exc:
+            if capacity.require_shared:
+                self._mark_backend_failure(
+                    RuntimeError("provider capacity coordination unavailable")
+                )
+                raise ServiceUnavailableError(message="Provider capacity unavailable") from None
             self._handle_backend_failure(exc)
             return self._acquire_local_attempt(
                 health_ref=resolved_ref,

--- a/src/routers/routing_decision.py
+++ b/src/routers/routing_decision.py
@@ -7,6 +7,7 @@ from typing import Any
 from fastapi import Request
 
 from src.providers.resolution import resolve_provider
+from src.telemetry.selector_decision import ProtectedSelectorDecision
 
 _FAILURE_TARGET_ATTR = "_failure_target"
 
@@ -119,6 +120,14 @@ def route_decision_metadata(request: Request) -> dict[str, Any] | None:
     if not isinstance(decision, dict):
         return None
     return deepcopy(decision)
+
+
+def attach_selector_decision(request: Request, decision: ProtectedSelectorDecision) -> None:
+    """Protected metadata only; public route-decision headers remain unchanged."""
+    current = route_decision_metadata(request) or {}
+    current["selector"] = decision.model_dump(mode="json")
+    request.state.route_decision = current
+    _refresh_request_resolution(request)
 
 
 def set_prompt_provenance(

--- a/src/routers/utils.py
+++ b/src/routers/utils.py
@@ -7,23 +7,16 @@ from typing import Any
 from fastapi import Request
 
 from src.models.errors import BudgetExceededError
+from src.providers.request_defaults import provider_request_defaults
 
 logger = logging.getLogger(__name__)
-
-
-_UI_ONLY_DEFAULT_KEYS = frozenset({"available_voices"})
 
 
 def apply_default_params(
     upstream_payload: dict[str, Any],
     model_info: dict[str, Any],
 ) -> dict[str, Any]:
-    defaults = model_info.get("default_params")
-    if not isinstance(defaults, dict) or not defaults:
-        return upstream_payload
-    for key, value in defaults.items():
-        if key in _UI_ONLY_DEFAULT_KEYS:
-            continue
+    for key, value in provider_request_defaults(model_info).items():
         if key not in upstream_payload:
             upstream_payload[key] = value
     return upstream_payload
@@ -44,6 +37,7 @@ async def enforce_budget_if_configured(
         return
     try:
         from src.billing.budget import BudgetExceeded
+
         await budget_service.check_budgets(
             api_key=getattr(auth_ctx, "api_key", None),
             user_id=getattr(auth_ctx, "user_id", None),

--- a/src/telemetry/selector_decision.py
+++ b/src/telemetry/selector_decision.py
@@ -1,0 +1,31 @@
+from typing import Literal
+
+from pydantic import Field
+
+from src.router.selection.contracts import (
+    FrozenContract,
+    SelectorCause,
+    SelectorDecision,
+    SelectorPolicyIdentity,
+)
+
+
+class ProtectedSelectorDecision(FrozenContract):
+    kind: Literal["llm-tier"] = "llm-tier"
+    lane: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,31}$")
+    minimum_rank: int = Field(ge=0, lt=8)
+    cause: SelectorCause
+    latency_ms: float = Field(ge=0, allow_inf_nan=False)
+    used_default: bool
+    policy_identity: SelectorPolicyIdentity
+
+    @classmethod
+    def from_decision(cls, decision: SelectorDecision) -> "ProtectedSelectorDecision":
+        return cls(
+            lane=decision.lane,
+            minimum_rank=decision.minimum_rank,
+            cause=decision.cause,
+            latency_ms=decision.latency_ms,
+            used_default=decision.used_default,
+            policy_identity=decision.policy_identity,
+        )

--- a/tests/billing_operation_fixtures.py
+++ b/tests/billing_operation_fixtures.py
@@ -1,0 +1,94 @@
+import asyncio
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from src.db.billing_operation_recovery import BillingOperationRecovery
+from src.db.billing_operations import BillingOperationRepository
+from tests import test_billing_operations_postgres as operation_fixtures
+
+selector_billing_db = operation_fixtures.selector_billing_db
+operation_db = operation_fixtures.operation_db
+
+
+@pytest.fixture
+async def review_operation_db(operation_db):
+    db, operation, charge = operation_db
+    try:
+        yield db, operation, charge
+    finally:
+        # Every test-created child shares this disposable, unique key. The underlying
+        # fixtures clear its operation holds/rows and reconcile spend capacity next.
+        await db.execute_raw(
+            "DELETE FROM deltallm_spend_ingestion_outbox WHERE payload_json->>'api_key'=$1",
+            operation.attribution.api_key,
+        )
+
+
+def another_operation(operation, charge):
+    owner = operation.attribution.model_copy(update={"operation_id": uuid4()})
+    return operation.model_copy(update={"attribution": owner}), charge.model_copy(
+        update={"attribution": owner}
+    )
+
+
+def recovery(db):
+    return BillingOperationRecovery(
+        BillingOperationRepository(db), max_pending_events=100000, max_attempts=10
+    )
+
+
+async def expire(db, operation):
+    await db.execute_raw(
+        "UPDATE deltallm_billing_operations SET created_at=NOW()-interval '10 minutes', "
+        "expires_at=NOW()-interval '5 minutes' WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+
+
+async def operation_row(db, operation):
+    rows = await db.query_raw(
+        "SELECT * FROM deltallm_billing_operations WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+    return rows[0]
+
+
+async def capacity(db):
+    rows = await db.query_raw(
+        "SELECT pending_count FROM deltallm_telemetry_ingestion_capacity "
+        "WHERE queue_name='billing_operations'"
+    )
+    return int(rows[0]["pending_count"])
+
+
+async def reserved_totals(db, operation):
+    rows = await db.query_raw(
+        "SELECT reserved_spend_exact::text AS amount FROM deltallm_verificationtoken WHERE token=$1 "
+        "UNION ALL SELECT reserved_spend_exact::text FROM deltallm_usertable WHERE user_id=$2 "
+        "UNION ALL SELECT reserved_spend_exact::text FROM deltallm_teamtable WHERE team_id=$3 "
+        "UNION ALL SELECT reserved_spend_exact::text FROM deltallm_organizationtable WHERE organization_id=$4 "
+        "UNION ALL SELECT reserved_spend_exact::text FROM deltallm_teammodelspend WHERE team_id=$3 AND model=$5",
+        operation.attribution.api_key,
+        operation.attribution.user_id,
+        operation.attribution.team_id,
+        operation.attribution.organization_id,
+        operation.attribution.model_group,
+    )
+    assert len(rows) == 5
+    return [Decimal(row["amount"]) for row in rows]
+
+
+async def wait_for_blocked_transaction(db, blocking_pid):
+    async def observed():
+        while True:
+            rows = await db.query_raw(
+                "SELECT 1 FROM pg_stat_activity WHERE $1::int=ANY(pg_blocking_pids(pid)) LIMIT 1",
+                blocking_pid,
+            )
+            if rows:
+                return
+            await asyncio.sleep(0.001)
+
+    await asyncio.wait_for(observed(), 2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,10 +360,24 @@ class FakeRedis:
             if cooldown_key in self.store:
                 return [0, "cooldown", 0]
             capacity_count = int(argv[0])
+            owner_token = argv[3]
+            shared = len(argv) > 6 + capacity_count * 2 and int(argv[6 + capacity_count * 2]) == 1
+            if shared:
+                for score, member in self.zset_store.get(owners_key, []):
+                    if member == owner_token:
+                        return [1, "acquired", current_active, score, 0]
+            concurrency = int(argv[5 + capacity_count]) if len(argv) > 5 + capacity_count else 0
+            if concurrency and current_active >= concurrency:
+                return [0, "capacity", 0]
             for index in range(capacity_count):
                 current = int(self.store.get(keys[5 + index], 0) or 0)
                 limit = int(argv[4 + index])
-                if current >= limit:
+                consume = (
+                    int(argv[6 + capacity_count + index])
+                    if len(argv) > 6 + capacity_count + index
+                    else 0
+                )
+                if current >= limit or current + consume > limit:
                     return [0, "capacity", 0]
 
             lease_ttl_ms = int(argv[1])
@@ -379,6 +393,16 @@ class FakeRedis:
                 self.ttl_store[recovery_key] = max(1, lease_ttl_ms // 1000)
                 recovery = 1
             expires_at_ms = now_ms + lease_ttl_ms
+            for index in range(capacity_count):
+                consume = (
+                    int(argv[6 + capacity_count + index])
+                    if len(argv) > 6 + capacity_count + index
+                    else 0
+                )
+                if consume:
+                    key = keys[5 + index]
+                    self.store[key] = int(self.store.get(key, 0) or 0) + consume
+                    self.ttl_store[key] = 120
             await self.zadd(owners_key, {owner_token: expires_at_ms})
             active = current_active + 1
             self.store[active_key] = active

--- a/tests/performance/routing_cache_profile.py
+++ b/tests/performance/routing_cache_profile.py
@@ -1,0 +1,168 @@
+"""Constant-arrival cache-path comparison using the repository's ASGI test fixture.
+
+Run this file with PYTHONPATH set to the checkout being measured, using that
+checkout's locked environment. Compare the same file against both revisions.
+This is a local gateway regression profile, not PostgreSQL/Redis or deployment
+capacity certification. Real infrastructure tests remain separate gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections import Counter
+import inspect
+import json
+import logging
+from pathlib import Path
+from time import perf_counter
+
+import httpx
+
+from scripts.measure_gateway_load import (
+    RequestResult,
+    run_constant_arrival,
+    summarize,
+    write_results,
+)
+
+# Match the existing pytest/application bootstrap import order for legacy facades.
+from tests.conftest import test_app as app_fixture
+from src.cache import CacheKeyBuilder, InMemoryBackend, NoopCacheMetrics
+from src.cache import key_builder as key_builder_module
+
+
+def instrument_async_methods(target, counts, durations):
+    def wrap(name, method):
+        async def observed(*args, **kwargs):
+            counts[name] += 1
+            started = perf_counter()
+            try:
+                return await method(*args, **kwargs)
+            finally:
+                durations[name] += perf_counter() - started
+
+        return observed
+
+    for name in dir(type(target)):
+        method = getattr(target, name)
+        if inspect.iscoroutinefunction(method):
+            setattr(target, name, wrap(name, method))
+
+
+def queue_slope(run, seconds):
+    points = [
+        (
+            second,
+            sum(
+                sample.start_offset_seconds <= second < sample.completion_offset_seconds
+                for sample in run.samples
+            ),
+        )
+        for second in range(1, seconds)
+    ]
+    mean_x = sum(x for x, _ in points) / len(points)
+    mean_y = sum(y for _, y in points) / len(points)
+    slope = sum((x - mean_x) * (y - mean_y) for x, y in points) / sum(
+        (x - mean_x) ** 2 for x, _ in points
+    )
+    return {"in_flight_samples": points, "in_flight_slope_per_second": slope}
+
+
+async def measure_case(case, label, output_dir):
+    app = await app_fixture.__wrapped__()
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("src.services.key_service").setLevel(logging.WARNING)
+    record = next(iter(app.state._test_repo.records.values()))
+    record.rpm_limit, record.tpm_limit = 1000, 1_000_000
+    app.state.cache_backend = InMemoryBackend(max_size=256)
+    app.state.cache_key_builder = CacheKeyBuilder(custom_salt="profile-only")
+    app.state.cache_metrics = NoopCacheMetrics()
+    redis_counts, redis_duration = Counter(), Counter()
+    cache_counts, cache_duration = Counter(), Counter()
+    provider_counts, provider_duration = Counter(), Counter()
+    instrument_async_methods(app.state.redis, redis_counts, redis_duration)
+    instrument_async_methods(app.state.cache_backend, cache_counts, cache_duration)
+    instrument_async_methods(app.state.http_client, provider_counts, provider_duration)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+
+        async def send(index, request_id):
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"Authorization": "Bearer sk-test", "x-request-id": request_id},
+                json={
+                    "model": "gpt-4o-mini",
+                    "messages": [
+                        {"role": "user", "content": f"fixed {index if case == 'miss' else 0}"}
+                    ],
+                    "max_tokens": 1,
+                    "stream": False,
+                },
+            )
+            return RequestResult(
+                status_code=response.status_code, bytes_received=len(response.content)
+            )
+
+        await send(-1, "warmup")
+        for counter in (
+            redis_counts,
+            redis_duration,
+            cache_counts,
+            cache_duration,
+            provider_counts,
+            provider_duration,
+        ):
+            counter.clear()
+        run = await run_constant_arrival(
+            rate=10, duration_seconds=20, max_in_flight=16, request=send
+        )
+    report = summarize(run, target_rate=10)
+    report.update(
+        label=label,
+        case=case,
+        environment="ASGI with fake Redis, fixed provider mock, no database",
+        measured_key_builder=key_builder_module.__file__,
+        redis_calls=dict(redis_counts),
+        cache_calls=dict(cache_counts),
+        provider_calls=dict(provider_counts),
+        provider_seconds=dict(provider_duration),
+        **queue_slope(run, 20),
+    )
+    write_results(run, report, output_dir / label / case)
+    print(json.dumps(report), flush=True)
+    assert report["success_count"] == 200 and not report["generator_dropped_count"]
+    assert (
+        cache_counts == {"get": 200, "set": 200} if case == "miss" else cache_counts == {"get": 200}
+    )
+    assert provider_counts == ({"post": 200} if case == "miss" else {})
+    per_request_redis = (
+        {
+            "get": 1,
+            "eval": 6,
+            "hgetall": 1,
+            "mget": 1,
+            "zadd": 2,
+            "incr": 1,
+            "expire": 2,
+            "incrby": 1,
+            "zremrangebyscore": 1,
+            "pexpire": 1,
+        }
+        if case == "miss"
+        else {"get": 1, "eval": 3}
+    )
+    assert redis_counts == {name: count * 200 for name, count in per_request_redis.items()}
+
+
+async def main(args):
+    for case in ("miss", "hit"):
+        await measure_case(case, args.label, args.output_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", required=True, choices=("before", "after"))
+    parser.add_argument("--output-dir", required=True, type=Path)
+    asyncio.run(main(parser.parse_args()))

--- a/tests/performance/selector_prerequisites_profile.py
+++ b/tests/performance/selector_prerequisites_profile.py
@@ -1,0 +1,149 @@
+"""Isolated selector regression profile; fake billing/Redis, deterministic provider.
+
+This measures logical dependency calls, not PostgreSQL durability or network latency.
+Run: python -m tests.performance.selector_prerequisites_profile --output-dir <directory>
+"""
+
+import argparse
+import asyncio
+from collections import Counter
+import json
+import logging
+from pathlib import Path
+
+import httpx
+
+from scripts.measure_gateway_load import (
+    RequestResult,
+    run_constant_arrival,
+    summarize,
+    write_results,
+)
+from tests.conftest import FakeRedis
+from tests.performance.routing_cache_profile import queue_slope
+from tests.router.selection.provider_fixtures import bridge, response_body
+from tests.test_operation_reservation import make_operation
+from src.billing.operation_reservation import ComponentState, ReservedOperation
+from src.cache.execution_eligibility import ResponseCacheEligibility, ResponseCacheOutcome
+from src.models.requests import ChatCompletionRequest
+from src.route_policy_contract import LLMTierSelectorPolicy, SelectorLane
+from src.router.execution import RequestDeadline
+from src.router.health_state import DeploymentHealthRef
+from src.router.selection.capacity import SelectorCapacityBounds
+from src.router.selection.contracts import SelectorPolicyIdentity
+from src.router.selection.prerequisites import admitted_selector_service
+from src.router.selection.request_state import RequestSelectorState
+from src.router.state import RedisStateBackend
+
+
+class ObservedBilling:
+    def __init__(self):
+        self.calls = Counter()
+
+    async def reserve(self, operation, **kwargs):
+        self.calls["reserve"] += 1
+        return ReservedOperation(
+            operation=operation,
+            selector_state=ComponentState.RESERVED,
+            answer_state=ComponentState.RESERVED,
+        )
+
+    async def dispatch(self, operation, **kwargs):
+        self.calls["dispatch"] += 1
+
+    async def accept_selector(self, operation, charge, **kwargs):
+        self.calls["accept"] += 1
+        assert charge.attribution == operation.attribution
+        assert charge.customer_charge == charge.provider_cost
+
+    async def unattempted(self, operation, **kwargs):
+        raise AssertionError("profile unexpectedly defaulted without a provider call")
+
+    async def confirm_not_dispatched(self, operation, **kwargs):
+        raise AssertionError("profile unexpectedly defaulted before dispatch")
+
+
+async def main(output_dir):
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    provider_calls = 0
+
+    async def provider_response(request):
+        nonlocal provider_calls
+        provider_calls += 1
+        await asyncio.sleep(0.001)  # Explicit fixed mock provider latency, not a test workaround.
+        return httpx.Response(200, json=response_body())
+
+    billing = ObservedBilling()
+    redis = FakeRedis()
+    capacity = RedisStateBackend(redis)
+    policy = LLMTierSelectorPolicy(
+        kind="llm-tier",
+        classifier_deployment_id="classifier-concrete",
+        lanes=(
+            SelectorLane(id="economy", rank=0, description="Routine work"),
+            SelectorLane(id="quality", rank=1, description="Complex work"),
+        ),
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(provider_response)) as client:
+        provider = bridge(client)
+
+        async def request(index, request_id):
+            operation = make_operation()
+            operation = operation.model_copy(
+                update={
+                    "attribution": operation.attribution.model_copy(
+                        update={"deployment_id": "classifier-concrete"}
+                    ),
+                    "selector_ceiling": operation.selector_ceiling.model_copy(
+                        update={"deployment_id": "classifier-concrete"}
+                    ),
+                }
+            )
+            service = admitted_selector_service(
+                provider=provider,
+                capacity_owner=capacity,
+                billing=billing,
+                operation=operation,
+                cache=ResponseCacheEligibility(ResponseCacheOutcome.MISS),
+                capacity=SelectorCapacityBounds(
+                    DeploymentHealthRef("classifier-concrete"),
+                    rpm=10000,
+                    tpm=100000000,
+                    concurrency=16,
+                    token_allowance=1064,
+                ),
+            )
+            result = await service.select_once(
+                state=RequestSelectorState(RequestDeadline.after(2)),
+                payload=ChatCompletionRequest(
+                    model="group", messages=[{"role": "user", "content": "Hello"}]
+                ),
+                token_estimate=10,
+                policy=policy,
+                identity=SelectorPolicyIdentity(fingerprint="route-policy-v1:" + "a" * 64),
+            )
+            assert not result.used_default
+            return RequestResult(status_code=200, bytes_received=0)
+
+        run = await run_constant_arrival(
+            rate=10, duration_seconds=20, max_in_flight=16, request=request
+        )
+    report = summarize(run, target_rate=10)
+    report.update(
+        environment="isolated selector; fake billing/Redis; 1ms provider mock",
+        billing_operations=dict(billing.calls),
+        provider_calls=provider_calls,
+        ttft_note="selector contribution only; real streaming integration remains PR 4",
+        **queue_slope(run, 20),
+    )
+    write_results(run, report, output_dir)
+    print(json.dumps(report), flush=True)
+    assert report["success_count"] == 200 and not report["generator_dropped_count"]
+    assert billing.calls == {"reserve": 200, "dispatch": 200, "accept": 200}
+    assert provider_calls == 200
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    asyncio.run(main(parser.parse_args().output_dir))

--- a/tests/router/selection/test_accounted_provider.py
+++ b/tests/router/selection/test_accounted_provider.py
@@ -1,0 +1,40 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import httpx
+
+from src.router.selection.economics import AccountedSelectorHop
+from tests.router.selection.provider_fixtures import PROMPT, bridge, response_body
+from tests.test_operation_reservation import make_operation
+
+
+async def test_malformed_selector_result_preserves_authoritative_paid_usage():
+    operation = make_operation()
+    operation = operation.model_copy(
+        update={
+            "attribution": operation.attribution.model_copy(
+                update={"deployment_id": "classifier-concrete"}
+            ),
+            "selector_ceiling": operation.selector_ceiling.model_copy(
+                update={"deployment_id": "classifier-concrete"}
+            ),
+        }
+    )
+    body = response_body()
+    body["choices"] = []
+    billing = AsyncMock()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json=body))
+    ) as client:
+        hop = AccountedSelectorHop(store=billing, operation=operation, hop=bridge(client))
+        outcome = await hop.invoke(
+            deployment_id="classifier-concrete",
+            prompt=PROMPT,
+            expires_at=asyncio.get_running_loop().time() + 2,
+        )
+    assert outcome.usage.kind == "reported"
+    billing.dispatch.assert_awaited_once()
+    billing.accept_selector.assert_awaited_once()
+    charge = billing.accept_selector.call_args.args[1]
+    assert charge.usage.total_tokens == 18
+    assert charge.customer_charge == charge.provider_cost > 0

--- a/tests/router/selection/test_capacity.py
+++ b/tests/router/selection/test_capacity.py
@@ -1,0 +1,118 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.models.errors import ServiceUnavailableError
+from src.router.candidates import (
+    AttemptPermit,
+    AttemptRejectionReason,
+    AttemptCapacity,
+    AttemptCapacityLimit,
+)
+from src.router.health_state import DeploymentHealthRef
+from src.router.selection.capacity import CapacityAdmittedSelectorHop, SelectorCapacityBounds
+from src.router.selection.contracts import (
+    SelectorCause,
+    SelectorHopSuccess,
+    SelectorPrompt,
+    UnknownSelectorUsage,
+)
+from src.router.state import RedisStateBackend
+
+
+def setup_hop():
+    ref = DeploymentHealthRef("classifier", "generation")
+    owner, provider = AsyncMock(), AsyncMock()
+
+    async def acquire(health_ref, capacity, **kwargs):
+        return AttemptPermit(
+            health_ref.deployment_id, health_ref, True, "redis", capacity.owner_token
+        )
+
+    owner.acquire_attempt.side_effect = acquire
+    provider.invoke.return_value = SelectorHopSuccess(
+        text='{"lane":"economy"}', usage=UnknownSelectorUsage()
+    )
+    hop = CapacityAdmittedSelectorHop(
+        owner=owner,
+        hop=provider,
+        bounds=SelectorCapacityBounds(ref, rpm=10, tpm=1000, concurrency=2, token_allowance=100),
+    )
+    kwargs = dict(
+        deployment_id="classifier",
+        prompt=SelectorPrompt(system="s", user="u"),
+        expires_at=asyncio.get_running_loop().time() + 1,
+    )
+    return hop, owner, provider, kwargs
+
+
+async def test_shared_capacity_has_one_owner_and_consumes_hidden_hop_only():
+    hop, owner, provider, kwargs = setup_hop()
+    await hop.invoke(**kwargs)
+    owner.acquire_attempt.assert_awaited_once()
+    capacity = owner.acquire_attempt.call_args.args[1]
+    assert [(limit.counter, limit.consume) for limit in capacity.limits] == [
+        ("rpm", 1),
+        ("tpm", 100),
+    ]
+    assert capacity.max_concurrency == 2 and capacity.require_shared
+    provider.invoke.assert_awaited_once_with(**kwargs)
+    permit = owner.release_attempt.call_args.args[0]
+    assert permit.owner_token == capacity.owner_token and permit.acquired
+    owner.release_attempt.assert_awaited_once()
+
+
+@pytest.mark.parametrize("failure", ["denied", "unavailable", "cancelled", "deadline", "provider"])
+async def test_capacity_terminal_paths_release_owned_or_ambiguous_permit(failure):
+    hop, owner, provider, kwargs = setup_hop()
+    if failure == "denied":
+        owner.acquire_attempt.side_effect = None
+        owner.acquire_attempt.return_value = AttemptPermit(
+            "classifier",
+            DeploymentHealthRef("classifier"),
+            False,
+            rejection_reason=AttemptRejectionReason.CAPACITY,
+        )
+        assert (await hop.invoke(**kwargs)).cause == SelectorCause.CAPACITY_DENIED
+        owner.release_attempt.assert_not_awaited()
+        provider.invoke.assert_not_awaited()
+        return
+    if failure == "unavailable":
+        owner.acquire_attempt.side_effect = ServiceUnavailableError()
+        assert (await hop.invoke(**kwargs)).cause == SelectorCause.CAPACITY_UNAVAILABLE
+        provider.invoke.assert_not_awaited()
+    else:
+        error = {
+            "cancelled": asyncio.CancelledError,
+            "deadline": TimeoutError,
+            "provider": RuntimeError,
+        }[failure]
+        if failure == "cancelled":
+            owner.acquire_attempt.side_effect = error()
+        else:
+            provider.invoke.side_effect = error()
+        with pytest.raises(error):
+            await hop.invoke(**kwargs)
+    owner.release_attempt.assert_awaited_once()
+    assert owner.release_attempt.call_args.args[0].owner_token
+
+
+async def test_reserved_capacity_never_falls_back_to_process_local_admission():
+    hop, _, provider, kwargs = setup_hop()
+    hop._owner = RedisStateBackend(None, degraded_mode="fail_open")
+    result = await hop.invoke(**kwargs)
+    assert result.cause == SelectorCause.CAPACITY_UNAVAILABLE
+    provider.invoke.assert_not_awaited()
+
+
+@pytest.mark.parametrize("invalid", [True, 1.1, 0, 2**31])
+def test_selector_capacity_rejects_non_integral_or_unbounded_concurrency(invalid):
+    with pytest.raises(ValueError):
+        AttemptCapacity(max_concurrency=invalid, require_shared=True)
+
+
+@pytest.mark.parametrize("invalid", [True, 1.1, 2**31])
+def test_selector_capacity_rejects_non_integral_or_unbounded_counters(invalid):
+    with pytest.raises(ValueError):
+        AttemptCapacity(limits=(AttemptCapacityLimit("rpm", invalid, 1),), require_shared=True)

--- a/tests/router/selection/test_economics.py
+++ b/tests/router/selection/test_economics.py
@@ -1,0 +1,175 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.billing.operation_reservation import (
+    BillingOperationUnavailable,
+    ComponentState,
+    ReservedOperation,
+)
+from src.cache.execution_eligibility import ResponseCacheEligibility, ResponseCacheOutcome
+from src.models.requests import ChatCompletionRequest
+from src.router.candidates import AttemptPermit
+from src.router.execution import RequestDeadline
+from src.router.health_state import DeploymentHealthRef
+from src.router.selection.capacity import SelectorCapacityBounds
+from src.router.selection.contracts import (
+    SelectorHopSuccess,
+    ReportedSelectorUsage,
+    UnknownSelectorUsage,
+)
+from src.router.selection.prerequisites import admitted_selector_service
+from src.router.selection.request_state import RequestSelectorState
+from tests.test_operation_reservation import make_operation
+
+
+def execution(policy, identity, *, cache=ResponseCacheOutcome.MISS):
+    operation = make_operation()
+    policy = policy.model_copy(
+        update={"classifier_deployment_id": operation.attribution.deployment_id}
+    )
+    billing, capacity, provider = AsyncMock(), AsyncMock(), AsyncMock()
+    billing.reserve.return_value = ReservedOperation(
+        operation=operation,
+        selector_state=ComponentState.RESERVED,
+        answer_state=ComponentState.RESERVED,
+    )
+
+    async def acquire(ref, bounds, **kwargs):
+        return AttemptPermit(ref.deployment_id, ref, True, "redis", bounds.owner_token)
+
+    capacity.acquire_attempt.side_effect = acquire
+    provider.invoke.return_value = SelectorHopSuccess(
+        text='{"lane":"economy"}',
+        usage=ReportedSelectorUsage(prompt_tokens=100, completion_tokens=5, total_tokens=105),
+    )
+    service = admitted_selector_service(
+        provider=provider,
+        capacity_owner=capacity,
+        capacity=SelectorCapacityBounds(
+            DeploymentHealthRef(operation.attribution.deployment_id),
+            rpm=100,
+            tpm=10000,
+            concurrency=2,
+            token_allowance=1064,
+        ),
+        billing=billing,
+        operation=operation,
+        cache=ResponseCacheEligibility(cache),
+    )
+    kwargs = dict(
+        state=RequestSelectorState(RequestDeadline.after(2)),
+        payload=ChatCompletionRequest(
+            model="group", messages=[{"role": "user", "content": "Hello"}]
+        ),
+        token_estimate=10,
+        policy=policy,
+        identity=identity,
+    )
+    return service, billing, capacity, provider, operation, kwargs
+
+
+async def test_prerequisites_finalize_exact_receipt_once_before_returning_decision(
+    selector_policy, policy_identity
+):
+    service, billing, capacity, provider, operation, kwargs = execution(
+        selector_policy, policy_identity
+    )
+    first = await service.select_once(**kwargs)
+    assert await service.select_once(**kwargs) is first
+    billing.reserve.assert_awaited_once()
+    billing.dispatch.assert_awaited_once()
+    billing.accept_selector.assert_awaited_once()
+    provider.invoke.assert_awaited_once()
+    capacity.acquire_attempt.assert_awaited_once()
+    capacity.release_attempt.assert_awaited_once()
+    charge = billing.accept_selector.call_args.args[1]
+    assert charge.attribution == operation.attribution
+    assert charge.customer_charge == charge.provider_cost
+    assert charge.usage.total_tokens == 105
+
+
+@pytest.mark.parametrize("cache", [ResponseCacheOutcome.HIT, ResponseCacheOutcome.UNRESOLVED])
+async def test_cached_or_unresolved_requests_cannot_do_any_hidden_work(
+    selector_policy, policy_identity, cache
+):
+    service, billing, capacity, provider, _, kwargs = execution(
+        selector_policy, policy_identity, cache=cache
+    )
+    with pytest.raises(RuntimeError, match="cache"):
+        await service.select_once(**kwargs)
+    billing.reserve.assert_not_awaited()
+    capacity.acquire_attempt.assert_not_awaited()
+    provider.invoke.assert_not_awaited()
+
+
+async def test_recovered_dispatched_operation_never_replays_provider(
+    selector_policy, policy_identity
+):
+    service, billing, capacity, provider, operation, kwargs = execution(
+        selector_policy, policy_identity
+    )
+    billing.reserve.return_value = ReservedOperation(
+        operation=operation,
+        selector_state=ComponentState.PENDING,
+        answer_state=ComponentState.RESERVED,
+    )
+    with pytest.raises(BillingOperationUnavailable):
+        await service.select_once(**kwargs)
+    capacity.acquire_attempt.assert_not_awaited()
+    provider.invoke.assert_not_awaited()
+
+
+async def test_cancellation_during_receipt_acceptance_retries_only_identical_receipt(
+    selector_policy, policy_identity
+):
+    service, billing, capacity, provider, _, kwargs = execution(selector_policy, policy_identity)
+    billing.accept_selector.side_effect = [asyncio.CancelledError(), None]
+    with pytest.raises(asyncio.CancelledError):
+        await service.select_once(**kwargs)
+    assert billing.accept_selector.await_count == 2
+    first, second = billing.accept_selector.call_args_list
+    assert first == second
+    provider.invoke.assert_awaited_once()
+    capacity.release_attempt.assert_awaited_once()
+
+
+async def test_unknown_usage_is_not_finalized_as_zero(selector_policy, policy_identity):
+    service, billing, capacity, provider, _, kwargs = execution(selector_policy, policy_identity)
+    provider.invoke.return_value = SelectorHopSuccess(
+        text='{"lane":"quality"}', usage=UnknownSelectorUsage()
+    )
+    decision = await service.select_once(**kwargs)
+    assert decision.usage.kind == "unknown"
+    billing.dispatch.assert_awaited_once()
+    billing.accept_selector.assert_not_awaited()
+    billing.unattempted.assert_not_awaited()
+    capacity.release_attempt.assert_awaited_once()
+
+
+async def test_accounting_failure_never_becomes_a_safe_lane_default(
+    selector_policy, policy_identity
+):
+    service, billing, _, provider, _, kwargs = execution(selector_policy, policy_identity)
+    billing.reserve.side_effect = BillingOperationUnavailable()
+    with pytest.raises(BillingOperationUnavailable):
+        await service.select_once(**kwargs)
+    provider.invoke.assert_not_awaited()
+
+
+async def test_selector_deadline_during_reservation_never_defaults_without_admission(
+    selector_policy, policy_identity
+):
+    service, billing, capacity, provider, _, kwargs = execution(selector_policy, policy_identity)
+    kwargs["policy"] = kwargs["policy"].model_copy(update={"timeout_ms": 100})
+
+    async def pending_reservation(*args, **kw):
+        await asyncio.Event().wait()
+
+    billing.reserve.side_effect = pending_reservation
+    with pytest.raises(BillingOperationUnavailable):
+        await service.select_once(**kwargs)
+    capacity.acquire_attempt.assert_not_awaited()
+    provider.invoke.assert_not_awaited()
+    billing.unattempted.assert_not_awaited()

--- a/tests/test_billing_operation_locking_postgres.py
+++ b/tests/test_billing_operation_locking_postgres.py
@@ -1,0 +1,170 @@
+import asyncio
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.billing.operation_reservation import BillingOperationUnavailable, ComponentState
+from src.db.billing_operations import BillingOperationRepository
+from tests import billing_operation_fixtures as fixtures
+from tests.test_billing_operations_postgres import deadline, hold
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres]
+selector_billing_db = fixtures.selector_billing_db
+operation_db = fixtures.operation_db
+review_operation_db = fixtures.review_operation_db
+
+
+async def test_waiting_reservation_does_not_block_same_key_settlement(
+    review_operation_db, monkeypatch
+):
+    db, old, charge = review_operation_db
+    before = await fixtures.capacity(db)
+    repository = BillingOperationRepository(db)
+    await repository.reserve(old, expires_at=deadline())
+    await fixtures.expire(db, old)
+    new, _ = fixtures.another_operation(old, charge)
+    inserted = asyncio.Event()
+    original_insert = repository._insert
+
+    async def observe_insert(tx, operation):
+        result = await original_insert(tx, operation)
+        inserted.set()
+        return result
+
+    monkeypatch.setattr(repository, "_insert", observe_insert)
+    task = None
+    try:
+        async with db.tx(timeout=timedelta(seconds=2)) as tx:
+            await tx.query_raw(
+                "SELECT operation_id FROM deltallm_billing_operations WHERE operation_id=$1 FOR UPDATE",
+                str(old.attribution.operation_id),
+            )
+            await tx.query_raw(
+                "SELECT token FROM deltallm_verificationtoken WHERE token=$1 FOR UPDATE",
+                old.attribution.api_key,
+            )
+            task = asyncio.create_task(repository.reserve(new, expires_at=deadline()))
+            await asyncio.wait_for(inserted.wait(), 1)
+            # Old implementation held global capacity and waited for our account
+            # lock here. Reconciliation then waited for its global capacity lock.
+            await tx.execute_raw(
+                "SELECT deltallm_recover_operation($1)", str(old.attribution.operation_id)
+            )
+        assert (await task).selector_state is ComponentState.RESERVED
+    finally:
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+    assert await hold(db, new) == new.total_allowance
+    assert await fixtures.reserved_totals(db, new) == [new.total_allowance] * 5
+    assert (await fixtures.operation_row(db, old))["closed_at"] is not None
+    assert await fixtures.capacity(db) == before + 1
+
+
+async def test_duplicate_reservation_does_not_hold_capacity_while_waiting_for_operation(
+    review_operation_db,
+):
+    db, operation, _ = review_operation_db
+    before = await fixtures.capacity(db)
+    repository = BillingOperationRepository(db)
+    await repository.reserve(operation, expires_at=deadline())
+    await fixtures.expire(db, operation)
+    task = None
+    try:
+        async with db.tx(timeout=timedelta(seconds=2)) as tx:
+            await tx.query_raw(
+                "SELECT operation_id FROM deltallm_billing_operations WHERE operation_id=$1 FOR UPDATE",
+                str(operation.attribution.operation_id),
+            )
+            pid = (await tx.query_raw("SELECT pg_backend_pid() AS pid"))[0]["pid"]
+            task = asyncio.create_task(repository.reserve(operation, expires_at=deadline()))
+            await fixtures.wait_for_blocked_transaction(db, pid)
+            await tx.execute_raw(
+                "SELECT deltallm_recover_operation($1)", str(operation.attribution.operation_id)
+            )
+        assert (await task).selector_state is ComponentState.UNATTEMPTED
+    finally:
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+    assert await hold(db, operation) == 0
+    assert await fixtures.capacity(db) == before
+
+
+async def test_identical_concurrent_reservations_use_one_hold_and_capacity_slot(
+    review_operation_db,
+):
+    db, operation, _ = review_operation_db
+    before = await fixtures.capacity(db)
+    repositories = [BillingOperationRepository(db), BillingOperationRepository(db)]
+    results = await asyncio.gather(
+        *(repositories[index % 2].reserve(operation, expires_at=deadline()) for index in range(8))
+    )
+    assert all(result.selector_state is ComponentState.RESERVED for result in results)
+    assert await hold(db, operation) == operation.total_allowance
+    assert await fixtures.capacity(db) == before + 1
+
+
+async def test_concurrent_conflicting_owner_cannot_reuse_operation(review_operation_db):
+    db, operation, _ = review_operation_db
+    changed = operation.model_copy(update={"owner_token": uuid4()})
+    before = await fixtures.capacity(db)
+    results = await asyncio.gather(
+        BillingOperationRepository(db).reserve(operation, expires_at=deadline()),
+        BillingOperationRepository(db).reserve(changed, expires_at=deadline()),
+        return_exceptions=True,
+    )
+    assert sum(isinstance(result, BillingOperationUnavailable) for result in results) == 1
+    assert sum(not isinstance(result, BaseException) for result in results) == 1
+    assert await fixtures.reserved_totals(db, operation) == [operation.total_allowance] * 5
+    assert await fixtures.capacity(db) == before + 1
+
+
+async def test_full_capacity_rolls_back_new_operation_and_all_holds(review_operation_db):
+    db, first, charge = review_operation_db
+    repository = BillingOperationRepository(db)
+    await repository.reserve(first, expires_at=deadline())
+    used = await fixtures.capacity(db)
+    second, _ = fixtures.another_operation(first, charge)
+    with pytest.raises(BillingOperationUnavailable):
+        await BillingOperationRepository(db, max_pending_operations=used).reserve(
+            second, expires_at=deadline()
+        )
+    assert await hold(db, first) == first.total_allowance
+    assert await fixtures.reserved_totals(db, first) == [first.total_allowance] * 5
+    assert await fixtures.capacity(db) == used
+    assert not await db.query_raw(
+        "SELECT operation_id FROM deltallm_billing_operations WHERE operation_id=$1",
+        str(second.attribution.operation_id),
+    )
+
+
+async def test_recovery_never_holds_spend_capacity_while_waiting_for_account(review_operation_db):
+    db, operation, charge = review_operation_db
+    repository = BillingOperationRepository(db)
+    await repository.reserve(operation, expires_at=deadline())
+    await repository.dispatch(operation, component="selector", expires_at=deadline())
+    await repository.accept_selector(operation, charge, expires_at=deadline())
+    await fixtures.expire(db, operation)
+    task = None
+    try:
+        async with db.tx(timeout=timedelta(seconds=2)) as tx:
+            await tx.query_raw(
+                "SELECT token FROM deltallm_verificationtoken WHERE token=$1 FOR UPDATE",
+                operation.attribution.api_key,
+            )
+            pid = (await tx.query_raw("SELECT pg_backend_pid() AS pid"))[0]["pid"]
+            task = asyncio.create_task(fixtures.recovery(db)._recover_one("receipts"))
+            await fixtures.wait_for_blocked_transaction(db, pid)
+            # Mirrors canonical spend completion after its ledger update. The old
+            # recovery path enqueued first and already owned this capacity row.
+            await tx.execute_raw(
+                "UPDATE deltallm_telemetry_ingestion_capacity SET updated_at=NOW() WHERE queue_name='spend'"
+            )
+        assert not (await task).unavailable
+    finally:
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+    assert await hold(db, operation) == operation.selector.allowance

--- a/tests/test_billing_operation_quarantine_postgres.py
+++ b/tests/test_billing_operation_quarantine_postgres.py
@@ -1,0 +1,225 @@
+import asyncio
+from decimal import Decimal
+import json
+
+import pytest
+from prisma.errors import RawQueryError
+
+from src.billing.spend import SpendTrackingService
+from src.billing.spend_ingestion import SpendIngestionConfig, SpendIngestionService
+from src.db.billing_operation_recovery import BillingOperationRecovery
+from src.db.billing_operations import BillingOperationRepository
+from src.db.errors import is_record_specific_database_error
+from tests import billing_operation_fixtures as fixtures
+from tests.test_billing_operations_postgres import deadline, hold
+from tests.test_selector_charge_db_integration import _scope_totals
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres]
+selector_billing_db = fixtures.selector_billing_db
+operation_db = fixtures.operation_db
+review_operation_db = fixtures.review_operation_db
+
+
+async def accept(db, operation, charge):
+    repository = BillingOperationRepository(db)
+    await repository.reserve(operation, expires_at=deadline())
+    await repository.dispatch(operation, component="selector", expires_at=deadline())
+    await repository.accept_selector(operation, charge, expires_at=deadline())
+
+
+def conflicting_payload(charge):
+    payload = charge.spend_payload()
+    payload["cost_exact"] = str(charge.customer_charge + Decimal("0.01"))
+    return payload
+
+
+async def write_event(db, charge, payload):
+    async with db.tx() as tx:
+        await SpendTrackingService(tx).log_batch_once(
+            [(charge.attribution.component_event_id, "spend", payload)]
+        )
+
+
+async def test_poison_receipt_is_durable_and_neighbors_recover_across_workers(review_operation_db):
+    db, bad, bad_charge = review_operation_db
+    good, good_charge = fixtures.another_operation(bad, bad_charge)
+    abandoned, _ = fixtures.another_operation(bad, bad_charge)
+    await accept(db, bad, bad_charge)
+    await accept(db, good, good_charge)
+    await BillingOperationRepository(db).reserve(abandoned, expires_at=deadline())
+    await fixtures.expire(db, abandoned)
+    # Deliberately inconsistent durable event in this disposable DB only.
+    await write_event(db, bad_charge, conflicting_payload(bad_charge))
+    await db.execute_raw(
+        "UPDATE deltallm_billing_operations SET updated_at=NOW()-interval '1 minute' WHERE operation_id=$1",
+        str(bad.attribution.operation_id),
+    )
+    original = await fixtures.operation_row(db, bad)
+    ledger = await _scope_totals(db, bad.attribution.api_key)
+    first = await fixtures.recovery(db)._recover_one("receipts")
+    assert not first.unavailable
+    blocked = await fixtures.operation_row(db, bad)
+    assert blocked["recovery_error_code"] == "receipt_conflict"
+    assert blocked["recovery_blocked_at"] is not None
+    for field in ("snapshot", "selector_receipt", "selector_state", "answer_state", "closed_at"):
+        assert blocked[field] == original[field]
+    assert (
+        await hold(db, bad)
+        == bad.total_allowance + good.total_allowance + abandoned.total_allowance
+    )
+    assert await _scope_totals(db, bad.attribution.api_key) == ledger
+    await asyncio.gather(fixtures.recovery(db).recover(), fixtures.recovery(db).recover())
+    assert (await fixtures.operation_row(db, abandoned))["closed_at"] is not None
+    service = SpendIngestionService(
+        db_client=db,
+        writer=SpendTrackingService(db),
+        config=SpendIngestionConfig(enabled=True, worker_enabled=False),
+        operation_recovery=fixtures.recovery(db),
+    )
+    records = await service._claim_batch()
+    assert [record.event_id for record in records] == [good.attribution.component_event_id]
+    await service._process_batch(records)
+    await BillingOperationRepository(db).unattempted(
+        good, component="answer", expires_at=deadline()
+    )
+    assert await hold(db, bad) == bad.total_allowance
+    assert await _scope_totals(db, bad.attribution.api_key) == {
+        scope: amount + good_charge.customer_charge for scope, amount in ledger.items()
+    }
+    assert await fixtures.recovery(db).recover() == 0
+    assert (await fixtures.operation_row(db, bad))["recovery_blocked_at"] == blocked[
+        "recovery_blocked_at"
+    ]
+
+
+async def test_strict_writer_rolls_back_conflicting_charge_and_exposes_record_error(
+    review_operation_db,
+):
+    db, operation, charge = review_operation_db
+    await accept(db, operation, charge)
+    original = await _scope_totals(db, operation.attribution.api_key)
+    with pytest.raises(RawQueryError, match="billing_component_receipt_conflict") as error:
+        async with db.tx() as tx:
+            ids = [charge.attribution.component_event_id]
+            await BillingOperationRecovery.lock_for_events(tx, ids)
+            await SpendTrackingService(tx).log_batch_once(
+                [(ids[0], "spend", conflicting_payload(charge))]
+            )
+            await BillingOperationRecovery.settle_events(tx, ids)
+    assert is_record_specific_database_error(error.value)
+    assert await _scope_totals(db, operation.attribution.api_key) == original
+    assert await hold(db, operation) == operation.total_allowance
+    assert not await db.query_raw(
+        "SELECT id FROM deltallm_spendlog_events WHERE id=$1", charge.attribution.component_event_id
+    )
+
+
+async def test_explicit_requeue_of_reconciled_evidence_is_idempotent(review_operation_db):
+    db, operation, charge = review_operation_db
+    await accept(db, operation, charge)
+    # Models a previously investigated quarantine whose authoritative evidence is
+    # now consistent. Requeue changes scheduling only, not the frozen charge/holds.
+    await db.execute_raw(
+        "UPDATE deltallm_billing_operations SET recovery_blocked_at=NOW(), "
+        "recovery_error_code='receipt_conflict' WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+    assert await fixtures.recovery(db).recover() == 0
+    await db.execute_raw(
+        "UPDATE deltallm_billing_operations SET recovery_blocked_at=NULL,recovery_error_code=NULL "
+        "WHERE operation_id=$1 AND recovery_error_code='receipt_conflict'",
+        str(operation.attribution.operation_id),
+    )
+    await fixtures.recovery(db).recover()
+    await fixtures.recovery(db).recover()
+    rows = await db.query_raw(
+        "SELECT event_id FROM deltallm_spend_ingestion_outbox WHERE event_id=$1",
+        charge.attribution.component_event_id,
+    )
+    assert len(rows) == 1
+    assert await hold(db, operation) == operation.total_allowance
+
+
+async def test_integrity_failure_rolls_back_partial_release_and_keeps_capacity(review_operation_db):
+    db, operation, charge = review_operation_db
+    await accept(db, operation, charge)
+    await fixtures.expire(db, operation)
+    await write_event(db, charge, charge.spend_payload())
+    # Deliberately damaged last counter: preceding scope updates must roll back.
+    await db.execute_raw(
+        "UPDATE deltallm_teammodelspend SET reserved_spend_exact=0 WHERE team_id=$1 AND model=$2",
+        operation.attribution.team_id,
+        operation.attribution.model_group,
+    )
+    before = await fixtures.capacity(db)
+    await fixtures.recovery(db).recover()
+    row = await fixtures.operation_row(db, operation)
+    assert row["recovery_error_code"] == "integrity_failure"
+    assert row["selector_state"] == "accepted"
+    assert row["answer_state"] == "reserved"
+    assert row["closed_at"] is None
+    assert await hold(db, operation) == operation.total_allowance
+    assert await fixtures.capacity(db) == before
+
+
+@pytest.mark.parametrize("error", [RuntimeError, asyncio.CancelledError])
+async def test_quarantine_does_not_escape_rolled_back_transaction(review_operation_db, error):
+    db, operation, charge = review_operation_db
+    await accept(db, operation, charge)
+    await write_event(db, charge, conflicting_payload(charge))
+    with pytest.raises(error):
+        async with db.tx() as tx:
+            outcome = await tx.query_raw(
+                "SELECT deltallm_recover_operation_isolated($1) AS outcome",
+                str(operation.attribution.operation_id),
+            )
+            assert outcome[0]["outcome"] == "receipt_conflict"
+            raise error()
+    assert (await fixtures.operation_row(db, operation))["recovery_blocked_at"] is None
+    assert await hold(db, operation) == operation.total_allowance
+
+
+@pytest.mark.parametrize(
+    "assignment",
+    [
+        "recovery_blocked_at=NOW()",
+        "recovery_error_code='receipt_conflict'",
+        "recovery_blocked_at=NOW(),recovery_error_code='private-provider-text'",
+    ],
+)
+async def test_quarantine_status_is_paired_and_allowlisted_in_database(
+    review_operation_db, assignment
+):
+    db, operation, _ = review_operation_db
+    await BillingOperationRepository(db).reserve(operation, expires_at=deadline())
+    with pytest.raises(RawQueryError):
+        await db.execute_raw(
+            f"UPDATE deltallm_billing_operations SET {assignment} WHERE operation_id=$1",
+            str(operation.attribution.operation_id),
+        )
+    assert (await fixtures.operation_row(db, operation))["recovery_blocked_at"] is None
+
+
+async def test_receipt_index_excludes_large_quarantined_history(review_operation_db):
+    db, operation, charge = review_operation_db
+    await accept(db, operation, charge)
+    await db.execute_raw(
+        "INSERT INTO deltallm_billing_operations "
+        "(operation_id,owner_token,api_key,model,snapshot,selector_event_id,"
+        "selector_allowance,answer_allowance,selector_state,selector_receipt,"
+        "recovery_blocked_at,recovery_error_code,expires_at) "
+        "SELECT $1||n::text,'test-owner',$2,'group','{}'::jsonb,$1||'event'||n::text,"
+        "0,0,'accepted','{}'::jsonb,NOW(),'receipt_conflict',NOW()+interval '5 minutes' "
+        "FROM generate_series(1,5000) n",
+        str(operation.owner_token),
+        operation.attribution.api_key,
+    )
+    await db.execute_raw("ANALYZE deltallm_billing_operations")
+    rows = await db.query_raw(
+        "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT operation_id "
+        "FROM deltallm_billing_operations WHERE selector_state='accepted' AND recovery_blocked_at IS NULL "
+        "ORDER BY updated_at,operation_id FOR UPDATE SKIP LOCKED LIMIT 1"
+    )
+    plan = json.dumps(rows)
+    assert "deltallm_billing_operations_receipt_idx" in plan
+    assert "Seq Scan" not in plan

--- a/tests/test_billing_operation_repository.py
+++ b/tests/test_billing_operation_repository.py
@@ -1,0 +1,87 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.billing.operation_reservation import BillingOperationUnavailable, ComponentState
+from src.db.billing_operations import BillingOperationRepository
+from tests.test_operation_reservation import make_operation
+
+
+def transaction_mock(results):
+    tx = MagicMock()
+    tx.query_raw = AsyncMock(side_effect=results)
+    tx.execute_raw = AsyncMock()
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=tx)
+    context.__aexit__ = AsyncMock(return_value=False)
+    return tx, context
+
+
+def deadline():
+    return asyncio.get_running_loop().time() + 2
+
+
+async def test_reservation_locks_operation_then_accounts_then_capacity_with_four_statements():
+    operation = make_operation()
+    tx, context = transaction_mock([[], [{"operation_id": "inserted"}], [{"pending_count": 1}]])
+    db = MagicMock()
+    db.tx.return_value = context
+    result = await BillingOperationRepository(db).reserve(operation, expires_at=deadline())
+    statements = [call.args[0] for call in tx.mock_calls if call[0] in {"query_raw", "execute_raw"}]
+    assert len(statements) == 4
+    assert "set_config('statement_timeout'" in statements[0]
+    assert "INSERT INTO deltallm_billing_operations" in statements[1]
+    assert "ON CONFLICT (operation_id) DO NOTHING RETURNING" in statements[1]
+    assert "deltallm_adjust_operation_hold" in statements[2]
+    assert "pending_count=pending_count+1" in statements[3]
+    assert result.selector_state is ComponentState.RESERVED
+    assert db.tx.call_args.kwargs["timeout"].total_seconds() <= 0.25
+
+
+@pytest.mark.parametrize("changed", [False, True])
+async def test_duplicate_only_reads_frozen_operation_without_touching_holds_or_capacity(changed):
+    operation = make_operation()
+    snapshot = operation.model_dump(mode="json")
+    if changed:
+        snapshot["owner_token"] = "different-owner"
+    tx, context = transaction_mock(
+        [[], [], [{"snapshot": snapshot, "selector_state": "reserved", "answer_state": "reserved"}]]
+    )
+    db = MagicMock()
+    db.tx.return_value = context
+    repository = BillingOperationRepository(db)
+    if changed:
+        with pytest.raises(BillingOperationUnavailable):
+            await repository.reserve(operation, expires_at=deadline())
+    else:
+        assert (await repository.reserve(operation, expires_at=deadline())).operation == operation
+    assert tx.query_raw.await_count == 3
+    assert "FOR UPDATE" in tx.query_raw.call_args.args[0]
+    tx.execute_raw.assert_not_awaited()
+    assert all("ingestion_capacity" not in call.args[0] for call in tx.query_raw.call_args_list)
+
+
+async def test_capacity_exhaustion_aborts_transaction_after_hold_adjustment():
+    tx, context = transaction_mock([[], [{"operation_id": "inserted"}], []])
+    db = MagicMock()
+    db.tx.return_value = context
+    with pytest.raises(BillingOperationUnavailable):
+        await BillingOperationRepository(db).reserve(make_operation(), expires_at=deadline())
+    tx.execute_raw.assert_awaited_once()
+    assert context.__aexit__.call_args.args[0] is BillingOperationUnavailable
+
+
+@pytest.mark.parametrize("error", [asyncio.CancelledError, TimeoutError])
+async def test_reservation_interruption_leaves_transaction_and_never_retries(error):
+    tx, context = transaction_mock([[], error()])
+    db = MagicMock()
+    db.tx.return_value = context
+    expected = (
+        asyncio.CancelledError if error is asyncio.CancelledError else BillingOperationUnavailable
+    )
+    with pytest.raises(expected):
+        await BillingOperationRepository(db).reserve(make_operation(), expires_at=deadline())
+    assert tx.query_raw.await_count == 2
+    assert context.__aexit__.call_args.args[0] is error
+    tx.execute_raw.assert_not_awaited()

--- a/tests/test_billing_operations_postgres.py
+++ b/tests/test_billing_operations_postgres.py
@@ -1,0 +1,348 @@
+import asyncio
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from src.billing.operation_reservation import BillingOperationUnavailable
+from src.billing.spend import SpendTrackingService
+from src.billing.spend_ingestion import SpendIngestionConfig, SpendIngestionService
+from src.db.billing_operations import BillingOperationRepository
+from src.db.billing_operation_recovery import BillingOperationRecovery
+from tests.test_operation_reservation import make_operation
+from tests import test_selector_charge_db_integration as selector_db_fixtures
+
+selector_billing_db = selector_db_fixtures.selector_billing_db
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres]
+
+
+@pytest.fixture
+async def operation_db(selector_billing_db):
+    db, charge = selector_billing_db
+    operation = make_operation().model_copy(
+        update={
+            "attribution": charge.attribution,
+            "expires_at": datetime.now(UTC) + timedelta(seconds=60),
+        }
+    )
+    await db.execute_raw(
+        "INSERT INTO deltallm_teammodelspend(team_id,model,spend,spend_exact,updated_at) "
+        "VALUES ($1,$2,0,0,NOW())",
+        charge.attribution.team_id,
+        charge.attribution.model_group,
+    )
+    try:
+        yield db, operation, charge
+    finally:
+        # Disposable fixture cleanup; production must reconcile rather than clear holds.
+        await db.execute_raw(
+            "UPDATE deltallm_verificationtoken SET reserved_spend_exact=0 WHERE token=$1",
+            charge.attribution.api_key,
+        )
+        await db.execute_raw(
+            "UPDATE deltallm_usertable SET reserved_spend_exact=0 WHERE user_id=$1",
+            charge.attribution.user_id,
+        )
+        await db.execute_raw(
+            "UPDATE deltallm_teamtable SET reserved_spend_exact=0 WHERE team_id=$1",
+            charge.attribution.team_id,
+        )
+        await db.execute_raw(
+            "UPDATE deltallm_organizationtable SET reserved_spend_exact=0 WHERE organization_id=$1",
+            charge.attribution.organization_id,
+        )
+        await db.execute_raw(
+            "UPDATE deltallm_teammodelspend SET reserved_spend_exact=0 WHERE team_id=$1",
+            charge.attribution.team_id,
+        )
+        await db.execute_raw(
+            "DELETE FROM deltallm_billing_operations WHERE api_key=$1", charge.attribution.api_key
+        )
+        await db.execute_raw(
+            "UPDATE deltallm_telemetry_ingestion_capacity SET pending_count="
+            "(SELECT count(*) FROM deltallm_billing_operations WHERE closed_at IS NULL) WHERE queue_name='billing_operations'"
+        )
+
+
+def deadline():
+    return asyncio.get_running_loop().time() + 2
+
+
+async def hold(db, operation):
+    rows = await db.query_raw(
+        "SELECT reserved_spend_exact::text AS amount FROM deltallm_verificationtoken WHERE token=$1",
+        operation.attribution.api_key,
+    )
+    return Decimal(rows[0]["amount"])
+
+
+@pytest.mark.parametrize("scope", ["key", "user", "team", "org", "model"])
+async def test_concurrent_whole_operation_reservations_cannot_bypass_budget(operation_db, scope):
+    db, operation, _ = operation_db
+    targets = {
+        "key": ("deltallm_verificationtoken", "token"),
+        "user": ("deltallm_usertable", "user_id"),
+        "team": ("deltallm_teamtable", "team_id"),
+        "org": ("deltallm_organizationtable", "organization_id"),
+    }
+    amount = str(operation.total_allowance * Decimal("1.5"))
+    if scope == "model":
+        await db.execute_raw(
+            "UPDATE deltallm_teamtable SET model_max_budget=jsonb_build_object($3::text,$1::numeric) WHERE team_id=$2",
+            amount,
+            operation.attribution.team_id,
+            operation.attribution.model_group,
+        )
+    else:
+        table, column = targets[scope]
+        await db.execute_raw(
+            f"UPDATE {table} SET max_budget=$1::numeric::double precision WHERE {column}=$2",
+            amount,
+            operation.attribution.api_key,
+        )
+    repositories = [BillingOperationRepository(db), BillingOperationRepository(db)]
+
+    async def reserve(index):
+        candidate = operation.model_copy(
+            update={
+                "attribution": operation.attribution.model_copy(update={"operation_id": uuid4()}),
+                "owner_token": uuid4(),
+            }
+        )
+        try:
+            await repositories[index % 2].reserve(candidate, expires_at=deadline())
+            return True
+        except BillingOperationUnavailable:
+            return False
+
+    results = await asyncio.gather(*(reserve(index) for index in range(8)))
+    assert sum(results) == 1
+    assert await hold(db, operation) == operation.total_allowance
+
+
+async def test_receipt_recovery_settles_exactly_once_and_releases_unused_answer_allowance(
+    operation_db,
+):
+    db, operation, charge = operation_db
+    repository = BillingOperationRepository(db)
+    await repository.reserve(operation, expires_at=deadline())
+    await repository.reserve(operation, expires_at=deadline())
+    await repository.dispatch(operation, component="selector", expires_at=deadline())
+    await repository.accept_selector(operation, charge, expires_at=deadline())
+    recovery = BillingOperationRecovery(repository, max_pending_events=100000, max_attempts=10)
+    service = SpendIngestionService(
+        db_client=db,
+        writer=SpendTrackingService(db),
+        config=SpendIngestionConfig(enabled=True, worker_enabled=False),
+        operation_recovery=recovery,
+    )
+    records = await service._claim_batch()
+    await service._process_batch(records)
+    await repository.unattempted(operation, component="answer", expires_at=deadline())
+    assert await hold(db, operation) == 0
+    await repository.accept_selector(operation, charge, expires_at=deadline())
+    assert await service._claim_batch() == []
+    rows = await db.query_raw(
+        "SELECT spend_exact::text AS amount FROM deltallm_verificationtoken WHERE token=$1",
+        operation.attribution.api_key,
+    )
+    assert Decimal(rows[0]["amount"]) == charge.customer_charge
+
+
+async def test_process_loss_after_dispatch_retains_unknown_hold_and_forbids_replay(operation_db):
+    db, operation, _ = operation_db
+    repository = BillingOperationRepository(db)
+    await repository.reserve(operation, expires_at=deadline())
+    await repository.dispatch(operation, component="selector", expires_at=deadline())
+    # Move both timestamps while preserving the database lifetime constraint.
+    await db.execute_raw(
+        "UPDATE deltallm_billing_operations SET created_at=NOW()-interval '10 minutes', "
+        "expires_at=NOW()-interval '5 minutes' WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+    recovery = BillingOperationRecovery(
+        BillingOperationRepository(db), max_pending_events=100000, max_attempts=10
+    )
+    await recovery.recover()
+    assert await hold(db, operation) == operation.selector.allowance
+    with pytest.raises(BillingOperationUnavailable):
+        await repository.dispatch(operation, component="selector", expires_at=deadline())
+    rows = await db.query_raw(
+        "SELECT selector_state,answer_state FROM deltallm_billing_operations WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+    assert rows[0] == {"selector_state": "pending", "answer_state": "unattempted"}
+
+
+async def test_changed_tenant_snapshot_cannot_reserve_or_dispatch(operation_db):
+    db, operation, _ = operation_db
+    repository = BillingOperationRepository(db)
+    wrong = operation.model_copy(
+        update={
+            "attribution": operation.attribution.model_copy(update={"organization_id": "other-org"})
+        }
+    )
+    with pytest.raises(BillingOperationUnavailable):
+        await repository.reserve(wrong, expires_at=deadline())
+    assert await hold(db, operation) == 0
+    await repository.reserve(operation, expires_at=deadline())
+    with pytest.raises(BillingOperationUnavailable):
+        await repository.dispatch(
+            operation.model_copy(update={"owner_token": uuid4()}),
+            component="selector",
+            expires_at=deadline(),
+        )
+
+
+@pytest.mark.parametrize("error", [RuntimeError, asyncio.CancelledError])
+async def test_reservation_rollback_does_not_leak_hold_or_capacity(
+    operation_db, monkeypatch, error
+):
+    db, operation, _ = operation_db
+    repository = BillingOperationRepository(db)
+    insert = repository._insert
+
+    async def fail_after_insert(tx, candidate):
+        await insert(tx, candidate)
+        raise error()
+
+    monkeypatch.setattr(repository, "_insert", fail_after_insert)
+    expected = (
+        asyncio.CancelledError if error is asyncio.CancelledError else BillingOperationUnavailable
+    )
+    with pytest.raises(expected):
+        await repository.reserve(operation, expires_at=deadline())
+    assert await hold(db, operation) == 0
+    assert not await db.query_raw(
+        "SELECT operation_id FROM deltallm_billing_operations WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+    monkeypatch.setattr(repository, "_insert", insert)
+    await repository.reserve(operation, expires_at=deadline())
+    assert await hold(db, operation) == operation.total_allowance
+
+
+async def test_pending_answer_can_settle_from_a_late_direct_writer_receipt(operation_db):
+    db, operation, charge = operation_db
+    repository = BillingOperationRepository(db)
+    await repository.reserve(operation, expires_at=deadline())
+    await repository.dispatch(operation, component="selector", expires_at=deadline())
+    await repository.dispatch(operation, component="answer", expires_at=deadline())
+    await db.execute_raw(
+        "UPDATE deltallm_billing_operations SET created_at=NOW()-interval '10 minutes', "
+        "expires_at=NOW()-interval '5 minutes' WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+    recovery = BillingOperationRecovery(repository, max_pending_events=100000, max_attempts=10)
+    await recovery.recover()
+    payload = charge.spend_payload()
+    payload["call_type"] = "chat_completion"
+    async with db.tx() as tx:
+        await SpendTrackingService(tx).log_batch_once(
+            [(str(operation.attribution.operation_id), "spend", payload)]
+        )
+    await recovery.recover()
+    assert await hold(db, operation) == operation.selector.allowance
+    rows = await db.query_raw(
+        "SELECT selector_state,answer_state FROM deltallm_billing_operations WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+    assert rows[0] == {"selector_state": "pending", "answer_state": "settled"}
+
+
+async def test_physical_deletion_cannot_orphan_outstanding_economic_holds(operation_db):
+    from prisma.errors import RawQueryError
+
+    db, operation, _ = operation_db
+    repository = BillingOperationRepository(db)
+    await repository.reserve(operation, expires_at=deadline())
+    with pytest.raises(RawQueryError, match="requires_reconciliation"):
+        await db.execute_raw(
+            "DELETE FROM deltallm_verificationtoken WHERE token=$1", operation.attribution.api_key
+        )
+    assert await hold(db, operation) == operation.total_allowance
+    await repository.unattempted(operation, component="answer", expires_at=deadline())
+    await repository.unattempted(operation, component="selector", expires_at=deadline())
+    assert await hold(db, operation) == 0
+
+
+async def test_changed_receipt_cannot_replace_the_accepted_charge(operation_db):
+    db, operation, charge = operation_db
+    repository = BillingOperationRepository(db)
+    await repository.reserve(operation, expires_at=deadline())
+    await repository.dispatch(operation, component="selector", expires_at=deadline())
+    await repository.accept_selector(operation, charge, expires_at=deadline())
+    changed = charge.model_copy(update={"finished_at": charge.finished_at + timedelta(seconds=1)})
+    with pytest.raises(BillingOperationUnavailable):
+        await repository.accept_selector(operation, changed, expires_at=deadline())
+    mismatched = operation.model_copy(
+        update={
+            "attribution": operation.attribution.model_copy(update={"model_group": "another-group"})
+        }
+    )
+    with pytest.raises(BillingOperationUnavailable):
+        await repository.accept_selector(
+            mismatched,
+            charge.model_copy(update={"attribution": mismatched.attribution}),
+            expires_at=deadline(),
+        )
+
+
+async def test_unknown_answer_failure_is_not_reconciled_as_zero(operation_db):
+    db, operation, _ = operation_db
+    repository = BillingOperationRepository(db)
+    await repository.reserve(operation, expires_at=deadline())
+    await repository.dispatch(operation, component="answer", expires_at=deadline())
+    await repository.unattempted(operation, component="selector", expires_at=deadline())
+    await SpendTrackingService(db).log_request_failure_once(
+        event_id=str(operation.attribution.operation_id),
+        request_id=str(operation.attribution.operation_id),
+        api_key=operation.attribution.api_key,
+        user_id=operation.attribution.user_id,
+        team_id=operation.attribution.team_id,
+        organization_id=operation.attribution.organization_id,
+        end_user_id=None,
+        model=operation.attribution.model_group,
+        call_type="chat_completion",
+        http_status_code=500,
+        error_type="unknown_provider_usage",
+    )
+    await BillingOperationRecovery(repository, max_pending_events=100000, max_attempts=10).recover()
+    assert await hold(db, operation) == operation.answer.allowance
+
+
+async def test_recovery_query_uses_bounded_open_row_index_amid_terminal_history(operation_db):
+    import json
+
+    db, operation, _ = operation_db
+    await BillingOperationRepository(db).reserve(operation, expires_at=deadline())
+    await db.execute_raw(
+        "INSERT INTO deltallm_billing_operations "
+        "(operation_id,owner_token,api_key,model,snapshot,selector_event_id,"
+        "selector_allowance,answer_allowance,selector_state,answer_state,closed_at,expires_at) "
+        "SELECT $1||n::text,'test-owner',$2,'group','{}'::jsonb,$1||'event'||n::text,"
+        "0,0,'unattempted','unattempted',NOW(),NOW()+interval '5 minutes' "
+        "FROM generate_series(1,5000) n",
+        str(operation.owner_token),
+        operation.attribution.api_key,
+    )
+    await db.execute_raw(
+        "INSERT INTO deltallm_billing_operations "
+        "(operation_id,owner_token,api_key,model,snapshot,selector_event_id,"
+        "selector_allowance,answer_allowance,recovery_blocked_at,recovery_error_code,expires_at) "
+        "SELECT $1||'blocked'||n::text,'test-owner',$2,'group','{}'::jsonb,$1||'blocked-event'||n::text,"
+        "0,0,NOW(),'receipt_conflict',NOW()+interval '5 minutes' FROM generate_series(1,5000) n",
+        str(operation.owner_token),
+        operation.attribution.api_key,
+    )
+    await db.execute_raw("ANALYZE deltallm_billing_operations")
+    rows = await db.query_raw(
+        "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT operation_id "
+        "FROM deltallm_billing_operations WHERE closed_at IS NULL AND recovery_blocked_at IS NULL "
+        "ORDER BY updated_at,operation_id FOR UPDATE SKIP LOCKED LIMIT 1"
+    )
+    plan = json.dumps(rows)
+    assert "deltallm_billing_operations_recovery_idx" in plan
+    assert "Seq Scan" not in plan

--- a/tests/test_billing_receipt_errors.py
+++ b/tests/test_billing_receipt_errors.py
@@ -1,0 +1,49 @@
+import pytest
+
+from src.billing.spend_ingestion import SpendIngestionConfig, SpendIngestionService
+from src.db.errors import is_record_specific_database_error
+from src.db.spend_ingestion import SpendOutboxRecord
+from tests.test_spend_ingestion import _OutboxDB, _Writer, _spend_payload
+
+
+class DatabaseFailure(Exception):
+    def __init__(self, code):
+        self.meta = {"code": code}
+
+
+@pytest.mark.parametrize(
+    "code,record_specific", [("PBR01", True), ("40P01", False), ("57014", False), ("08006", False)]
+)
+def test_receipt_conflict_is_isolated_but_infrastructure_failures_are_not(code, record_specific):
+    assert is_record_specific_database_error(DatabaseFailure(code)) is record_specific
+
+
+class ConflictingWriter(_Writer):
+    async def log_prepared_batch_once(self, events):
+        if any(event.event_id == "conflict" for event in events):
+            raise DatabaseFailure("PBR01")
+        return await super().log_prepared_batch_once(events)
+
+
+async def test_conflicting_receipt_does_not_retry_valid_neighbors():
+    db = _OutboxDB()
+    service = SpendIngestionService(
+        db_client=db, writer=ConflictingWriter(), config=SpendIngestionConfig(enabled=True)
+    )
+    await service._process_batch(
+        [
+            SpendOutboxRecord(identity, "spend", _spend_payload(), 1)
+            for identity in ("good-before", "conflict", "good-after")
+        ]
+    )
+    completed = [
+        event_id
+        for query, params in db.executions
+        if "SELECT event_id FROM completed" in query
+        for event_id in params[0]
+    ]
+    retried = [
+        params[0] for query, params in db.executions if "SELECT event_id FROM transitioned" in query
+    ]
+    assert completed == ["good-before", "good-after"]
+    assert retried == ["conflict"]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -510,8 +510,8 @@ async def test_cache_keys_are_versioned_and_separated_by_response_mode(client, t
     assert stream_response.status_code == 200
     keys = list(test_app.state.cache_backend._cache)
     assert len(keys) == 2
-    assert any("schema:v2:mode:json:" in key for key in keys)
-    assert any("schema:v2:mode:stream:" in key for key in keys)
+    assert any("schema:v4:mode:json:" in key for key in keys)
+    assert any("schema:v4:mode:stream:" in key for key in keys)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cache_execution_eligibility.py
+++ b/tests/test_cache_execution_eligibility.py
@@ -1,0 +1,13 @@
+import pytest
+
+from src.cache.execution_eligibility import ResponseCacheEligibility, ResponseCacheOutcome
+
+
+@pytest.mark.parametrize("outcome", list(ResponseCacheOutcome))
+def test_only_explicit_miss_or_bypass_allows_provider_execution(outcome):
+    eligibility = ResponseCacheEligibility(outcome)
+    if outcome in (ResponseCacheOutcome.MISS, ResponseCacheOutcome.BYPASS):
+        eligibility.require_provider_execution()
+    else:
+        with pytest.raises(RuntimeError, match="cache"):
+            eligibility.require_provider_execution()

--- a/tests/test_cache_routing_redis_integration.py
+++ b/tests/test_cache_routing_redis_integration.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+import time
+from uuid import uuid4
+
+import pytest
+
+from redis.asyncio import Redis
+
+from src.cache.backends.base import CacheEntry
+from src.cache.backends.redis import RedisBackend
+from src.cache.key_builder import CacheKeyBuilder
+
+pytestmark = [pytest.mark.integration, pytest.mark.redis]
+
+
+@pytest.mark.skipif(
+    not os.getenv("DELTALLM_TEST_REDIS_URL"),
+    reason="DELTALLM_TEST_REDIS_URL is required for the Redis integration test",
+)
+@pytest.mark.parametrize("legacy_version", ["v2", "v3"])
+async def test_routing_identity_is_stable_across_clients_and_isolates_old_policy_and_version(
+    legacy_version,
+):
+    writer = Redis.from_url(os.environ["DELTALLM_TEST_REDIS_URL"], decode_responses=True)
+    reader = Redis.from_url(os.environ["DELTALLM_TEST_REDIS_URL"], decode_responses=True)
+    write_backend, read_backend = RedisBackend(writer), RedisBackend(reader)
+    salt = uuid4().hex
+    first_builder, second_builder = (
+        CacheKeyBuilder(custom_salt=salt),
+        CacheKeyBuilder(custom_salt=salt),
+    )
+
+    def key(builder, policy, version="v4"):
+        digest = builder.build_key_from_payload({}, "same custom key", routing_fingerprint=policy)
+        return f"scope:key:integration:schema:{version}:mode:json:endpoint:chat:{digest}"
+
+    original = key(first_builder, "policy-a")
+    equivalent = key(second_builder, "policy-a")
+    changed = key(second_builder, "policy-b")
+    legacy = key(first_builder, "policy-a", version=legacy_version)
+    entry = CacheEntry(response={"answer": "cached"}, model="group", cached_at=time.time(), ttl=60)
+    try:
+        await write_backend.set(legacy, entry)
+        assert await read_backend.get(original) is None
+        await write_backend.set(original, entry)
+        assert original == equivalent
+        loaded = await read_backend.get(equivalent)
+        assert loaded is not None and loaded.response == entry.response
+        assert await read_backend.get(changed) is None
+        assert 0 < await reader.pttl(f"cache:{original}") <= 60_000
+    finally:
+        await writer.delete(f"cache:{original}", f"cache:{legacy}")
+        await writer.aclose()
+        await reader.aclose()

--- a/tests/test_migration_verifier.py
+++ b/tests/test_migration_verifier.py
@@ -155,3 +155,28 @@ def test_default_base_ref_fails_without_stable_main_release(
 
     with pytest.raises(RuntimeError, match="no stable release tag reachable from origin/main"):
         verify_migration_paths._default_base_ref()  # noqa: SLF001
+
+
+def test_migration_verifier_checks_exact_reservations_and_deletion_guards(monkeypatch):
+    statements = []
+    monkeypatch.setattr(
+        verify_migration_paths, "_db_execute", lambda *args, sql, **kwargs: statements.append(sql)
+    )
+    verify_migration_paths._verify_operation_reservations(
+        "prisma", "postgresql://localhost/upgrade"
+    )
+    assert len(statements) == 1
+    for invariant in (
+        "reserved_spend_exact",
+        "numeric_precision=38",
+        "numeric_scale=18",
+        "deltallm_recover_operation",
+        "deltallm_recover_operation_isolated",
+        "recovery_blocked_at",
+        "recovery_error_code",
+        "pg_get_constraintdef",
+        "pg_get_expr",
+        "deltallm_key_hold_delete_guard",
+        "pending_count=0",
+    ):
+        assert invariant in statements[0]

--- a/tests/test_operation_recovery.py
+++ b/tests/test_operation_recovery.py
@@ -1,0 +1,110 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.billing.operation_reservation import BillingOperationUnavailable
+from src.billing.spend_ingestion import SpendIngestionConfig, SpendIngestionService
+from src.db.billing_operation_recovery import BillingOperationRecovery
+from src.db.billing_operations import BillingOperationRepository
+from src.db.spend_ingestion import SpendIngestionRepository
+from tests.test_billing_operation_repository import transaction_mock
+from tests.test_spend_ingestion import _OutboxDB, _Writer
+
+
+async def test_recovery_unavailable_does_not_starve_durable_spend_delivery():
+    recovery = AsyncMock()
+    recovery.recover.side_effect = BillingOperationUnavailable()
+    service = SpendIngestionService(
+        db_client=_OutboxDB(),
+        writer=_Writer(),
+        operation_recovery=recovery,
+        config=SpendIngestionConfig(enabled=True, worker_enabled=False),
+    )
+    service.repository.claim_batch = AsyncMock(return_value=[])
+    assert await service._claim_batch() == []
+    service.repository.claim_batch.assert_awaited_once()
+    recovery.recover.assert_awaited_once_with()
+
+
+def recovery_with_transactions(*contexts):
+    db = MagicMock()
+    db.tx.side_effect = contexts
+    return BillingOperationRecovery(
+        BillingOperationRepository(db), max_pending_events=1000, max_attempts=10
+    )
+
+
+def receipt_row():
+    return {
+        "operation_id": "private-operation",
+        "selector_event_id": "private-child",
+        "selector_state": "accepted",
+        "selector_receipt": {"api_key": "private-key", "cost_exact": "0.01"},
+    }
+
+
+async def test_recovery_reconciles_accounts_before_outbox_admission(monkeypatch):
+    first, context = transaction_mock([[], [receipt_row()], [{"outcome": "recovered"}]])
+    second, empty = transaction_mock([[], []])
+
+    async def enqueue(**kwargs):
+        assert "deltallm_recover_operation_isolated" in first.query_raw.call_args.args[0]
+        assert kwargs["event_id"] == "private-child"
+
+    enqueued = AsyncMock(side_effect=enqueue)
+    monkeypatch.setattr(SpendIngestionRepository, "enqueue", enqueued)
+    assert await recovery_with_transactions(context, empty).recover() == 1
+    enqueued.assert_awaited_once()
+    assert second.query_raw.call_args.args[1] == "private-operation"
+    assert "recovery_blocked_at IS NULL" in second.query_raw.call_args.args[0]
+
+
+@pytest.mark.parametrize("outcome", ["receipt_conflict", "integrity_failure"])
+async def test_quarantine_skips_enqueue_and_reports_only_committed_allowlisted_cause(
+    monkeypatch, caplog, outcome
+):
+    _, context = transaction_mock([[], [receipt_row()], [{"outcome": outcome}]])
+    second, empty = transaction_mock([[], []])
+    enqueue = AsyncMock()
+    monkeypatch.setattr(SpendIngestionRepository, "enqueue", enqueue)
+    metric = MagicMock()
+    monkeypatch.setattr(
+        "src.db.billing_operation_recovery.increment_spend_ingestion_failure", metric
+    )
+    assert await recovery_with_transactions(context, empty).recover() == 1
+    enqueue.assert_not_awaited()
+    metric.assert_called_once_with(f"operation_recovery_{outcome}")
+    assert caplog.records[-1].cause == outcome
+    assert "private" not in caplog.text
+    assert second.query_raw.await_count == 2
+
+
+@pytest.mark.parametrize("failure_at", ["select", "reconcile", "commit"])
+async def test_transient_failure_still_attempts_other_lane_without_retrying_row(
+    monkeypatch, caplog, failure_at
+):
+    results = [[], [receipt_row()], [{"outcome": "receipt_conflict"}]]
+    if failure_at != "commit":
+        results[1 if failure_at == "select" else 2] = RuntimeError("private-backend-text")
+    _, context = transaction_mock(results)
+    if failure_at == "commit":
+        context.__aexit__.side_effect = RuntimeError("private-backend-text")
+    second, empty = transaction_mock([[], []])
+    with pytest.raises(BillingOperationUnavailable):
+        await recovery_with_transactions(context, empty).recover()
+    assert second.query_raw.await_count == 2
+    assert second.query_raw.call_args.args[1] == (
+        None if failure_at == "select" else "private-operation"
+    )
+    assert "billing_operation_recovery_blocked" not in caplog.text
+    assert "private" not in caplog.text
+
+
+async def test_cancellation_rolls_back_and_does_not_start_the_other_lane():
+    _, context = transaction_mock([[], [receipt_row()], asyncio.CancelledError()])
+    recovery = recovery_with_transactions(context)
+    with pytest.raises(asyncio.CancelledError):
+        await recovery.recover()
+    assert recovery.operations.db.tx.call_count == 1
+    assert context.__aexit__.call_args.args[0] is asyncio.CancelledError

--- a/tests/test_operation_reservation.py
+++ b/tests/test_operation_reservation.py
@@ -1,0 +1,105 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, localcontext
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.billing.operation_reservation import (
+    BoundedTokenQuote,
+    OperationReservation,
+    ProviderEnforcedSelectorCeiling,
+)
+from tests.test_selector_charge import make_selector_charge
+
+
+def make_operation():
+    charge = make_selector_charge()
+    selector = BoundedTokenQuote(
+        pricing=charge.pricing,
+        max_input_tokens=1000,
+        max_output_tokens=64,
+        max_attempts=1,
+        basis="provider-input-context-ceiling:v1",
+    )
+    answer = BoundedTokenQuote(
+        pricing=charge.pricing,
+        max_input_tokens=32000,
+        max_output_tokens=4000,
+        max_attempts=4,
+        basis="bounded-answer-plan:v1",
+    )
+    return OperationReservation(
+        attribution=charge.attribution,
+        owner_token=uuid4(),
+        selector=selector,
+        selector_ceiling=ProviderEnforcedSelectorCeiling(
+            deployment_id=charge.attribution.deployment_id,
+            context_window_tokens=1000,
+            contract_version="qualified-mock-context:v1",
+            billing_dimensions="input_output_cache_read_request",
+        ),
+        answer=answer,
+        expires_at=datetime.now(UTC) + timedelta(seconds=5),
+    )
+
+
+def test_exact_operation_allowance_covers_selector_and_all_answer_attempts():
+    operation = make_operation()
+    expected = operation.selector.allowance + operation.answer.allowance
+    with localcontext() as context:
+        context.prec = 5
+        assert operation.total_allowance == expected
+    assert operation.total_allowance > operation.answer.allowance
+    assert operation.attribution.component_event_id != str(operation.attribution.operation_id)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("max_attempts", 0),
+        ("max_attempts", 129),
+        ("max_input_tokens", -1),
+        ("max_output_tokens", 2**31),
+        ("max_input_tokens", 1.1),
+    ],
+)
+def test_unbounded_or_invalid_quotes_fail_closed(field, value):
+    values = make_operation().selector.model_dump()
+    values[field] = value
+    with pytest.raises(ValidationError):
+        BoundedTokenQuote(**values)
+
+
+def test_selector_is_one_attempt_with_a_fixed_output_ceiling():
+    operation = make_operation()
+    values = operation.model_dump()
+    values["selector"]["max_attempts"] = 2
+    with pytest.raises(ValidationError, match="one bounded"):
+        OperationReservation(**values)
+
+
+def test_quote_reserves_the_maximum_cached_or_uncached_rate():
+    operation = make_operation()
+    pricing = operation.selector.pricing.model_copy(
+        update={"input_cost_per_token_cache_hit": Decimal("0.01")}
+    )
+    quote = operation.selector.model_copy(update={"pricing": pricing})
+    assert quote.allowance >= Decimal(10)
+
+
+@pytest.mark.parametrize(
+    "change", ["missing", "underquoted", "wrong_target", "unsupported_billing"]
+)
+def test_selector_requires_a_matching_qualified_provider_ceiling(change):
+    values = make_operation().model_dump()
+    if change == "missing":
+        del values["selector_ceiling"]
+    elif change == "underquoted":
+        values["selector"]["max_input_tokens"] = 999
+    elif change == "wrong_target":
+        values["selector_ceiling"]["deployment_id"] = "other"
+    else:
+        values["selector_ceiling"]["billing_dimensions"] = "cache_creation"
+    with pytest.raises(ValidationError):
+        OperationReservation(**values)

--- a/tests/test_provider_token_receipt.py
+++ b/tests/test_provider_token_receipt.py
@@ -1,0 +1,86 @@
+import pytest
+
+from src.providers.token_receipt import anthropic_token_receipt, openai_token_receipt
+from src.providers.bedrock import BedrockAdapter
+
+
+def test_openai_receipt_preserves_reported_cached_input_without_exposing_public_fields():
+    receipt = openai_token_receipt(
+        {
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 5,
+                "total_tokens": 105,
+                "prompt_tokens_details": {"cached_tokens": 60},
+            }
+        }
+    )
+    assert receipt.cached_input_tokens == 60
+    assert receipt.total_tokens == 105
+
+
+def test_missing_cache_details_are_unknown_not_reported_zero():
+    receipt = openai_token_receipt(
+        {"usage": {"prompt_tokens": 100, "completion_tokens": 5, "total_tokens": 105}}
+    )
+    assert receipt.cached_input_tokens is None
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"prompt_tokens": True, "completion_tokens": 0, "total_tokens": 1},
+        {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 12},
+        {
+            "prompt_tokens": 10,
+            "completion_tokens": 1,
+            "total_tokens": 11,
+            "prompt_tokens_details": {"cached_tokens": 11},
+        },
+    ],
+)
+def test_invalid_billing_counts_are_unknown(values):
+    assert openai_token_receipt({"usage": values}) is None
+
+
+def test_anthropic_includes_cache_reads_but_rejects_unsupported_cache_creation_pricing():
+    payload = {"usage": {"input_tokens": 10, "output_tokens": 5, "cache_read_input_tokens": 20}}
+    receipt = anthropic_token_receipt(payload)
+    assert (
+        receipt.input_tokens == 30
+        and receipt.total_tokens == 35
+        and receipt.cached_input_tokens == 20
+    )
+    payload["usage"]["cache_creation_input_tokens"] = 5
+    assert anthropic_token_receipt(payload) is None
+
+
+def test_malformed_false_cache_receipt_is_not_reported_as_zero():
+    assert (
+        anthropic_token_receipt(
+            {
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "cache_read_input_tokens": False,
+                }
+            }
+        )
+        is None
+    )
+
+
+def test_bedrock_rejects_unpriced_cache_creation_receipt():
+    assert (
+        BedrockAdapter(None).reported_token_receipt(
+            {
+                "usage": {
+                    "inputTokens": 10,
+                    "outputTokens": 5,
+                    "totalTokens": 15,
+                    "cacheWriteInputTokens": 10,
+                }
+            }
+        )
+        is None
+    )

--- a/tests/test_routing_cache_identity.py
+++ b/tests/test_routing_cache_identity.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.cache import CacheKeyBuilder, InMemoryBackend, NoopCacheMetrics, StreamingCacheHandler
+from src.callbacks import CallbackManager, CustomLogger
+from src.router import (
+    FallbackConfig,
+    FailoverManager,
+    Router,
+    RouterConfig,
+    RoutingStrategy,
+    build_deployment_registry,
+    build_route_group_policies,
+)
+from src.router.registry import DeploymentRegistryStore
+from src.router.routing_identity import build_runtime_routing_fingerprints
+from src.router.runtime_generation import RoutingRuntimeGeneration
+from src.router.selection.policy import build_routing_fingerprint
+
+
+def _group():
+    return {
+        "key": "gpt-4o-mini",
+        "mode": "chat",
+        "policy_semantics_version": 3,
+        "policy_version": 1,
+        "members": [{"deployment_id": "gpt-4o-mini-0"}],
+    }
+
+
+def _fingerprints(groups, *, default_strategy=RoutingStrategy.SIMPLE_SHUFFLE):
+    registry = build_deployment_registry(
+        {
+            "gpt-4o-mini": [
+                {
+                    "deltallm_params": {"model": "openai/small"},
+                    "model_info": {"mode": "chat", "weight": 3},
+                }
+            ]
+        },
+        route_groups=groups,
+    )
+    return build_runtime_routing_fingerprints(
+        groups=groups,
+        policies=build_route_group_policies(groups),
+        deployments=registry,
+        default_strategy=default_strategy,
+        failover_config=FallbackConfig(),
+    )
+
+
+def test_runtime_identity_reuses_canonical_fingerprint_and_effective_member_weights(monkeypatch):
+    group = _group()
+    expected = build_routing_fingerprint(
+        workload_mode="chat",
+        strategy="simple-shuffle",
+        semantics_version=3,
+        effective_members=[
+            {"deployment_id": "gpt-4o-mini-0", "enabled": True, "weight": 3, "priority": 0}
+        ],
+    )
+    observed = []
+
+    def fingerprint(**kwargs):
+        result = build_routing_fingerprint(**kwargs)
+        observed.append(result)
+        return result
+
+    monkeypatch.setattr("src.router.routing_identity.build_routing_fingerprint", fingerprint)
+    identities = _fingerprints([group])
+    assert observed == [expected]
+    assert identities["gpt-4o-mini"].startswith("route-response-v1:")
+    with pytest.raises(TypeError):
+        identities["gpt-4o-mini"] = "mutated"
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        {"policy_version": 9},
+        {"revision": 99, "generation_id": "new", "source": "redis"},
+        {"metadata": {"operator_note": "opaque"}},
+        {"strategy": "simple-shuffle"},
+        {"members": [{"deployment_id": "gpt-4o-mini-0", "weight": 3, "priority": 0}]},
+    ],
+)
+def test_equivalent_effective_policy_reuses_identity(update):
+    assert _fingerprints([_group()]) == _fingerprints([{**_group(), **update}])
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        {"strategy": "least-busy"},
+        {"timeouts": {"global_ms": 4000}},
+        {"retry": {"max_attempts": 3}},
+        {"retry": {"retryable_error_classes": ["timeout"]}},
+        {"members": [{"deployment_id": "gpt-4o-mini-0", "weight": 5}]},
+        {"members": [{"deployment_id": "gpt-4o-mini-0", "priority": 2}]},
+        {"members": [{"deployment_id": "gpt-4o-mini-0", "enabled": False}]},
+        {"context": {"mode": "smallest-sufficient", "unknown_capacity": "exclude"}},
+    ],
+)
+def test_effective_policy_change_invalidates_identity(update):
+    assert _fingerprints([_group()]) != _fingerprints([{**_group(), **update}])
+
+
+def test_inherited_strategy_and_disabled_group_ownership_affect_identity():
+    group = _group()
+    assert _fingerprints([group]) != _fingerprints(
+        [group], default_strategy=RoutingStrategy.LEAST_BUSY
+    )
+    assert _fingerprints([{**group, "enabled": False}]) == _fingerprints([])
+
+
+def test_version_aware_selector_and_lane_fingerprint_without_activation():
+    group = _group()
+    group["selector"] = {
+        "kind": "llm-tier",
+        "classifier_deployment_id": "gpt-4o-mini-0",
+        "lanes": [
+            {"id": "economy", "rank": 0, "description": "Routine"},
+            {"id": "quality", "rank": 1, "description": "Complex"},
+        ],
+    }
+    group["members"][0]["lane"] = "economy"
+    changed = deepcopy(group)
+    changed["members"][0]["lane"] = "quality"
+    assert _fingerprints([group]) != _fingerprints([changed])
+    changed = deepcopy(group)
+    changed["selector"]["timeout_ms"] = 1000
+    assert _fingerprints([group]) != _fingerprints([changed])
+    historical = {**group, "policy_semantics_version": 1}
+    assert _fingerprints([historical]) == _fingerprints(
+        [{**historical, "selector": {"opaque": True}, "members": _group()["members"]}]
+    )
+    # Current file configuration has no stored database semantics version.
+    file_group = {key: value for key, value in group.items() if key != "policy_semantics_version"}
+    assert _fingerprints([file_group]) == _fingerprints([group])
+
+
+@pytest.mark.parametrize("custom_key", [None, "private custom key"])
+def test_routing_dimension_cannot_be_removed_by_custom_key_or_field_configuration(custom_key):
+    builder = CacheKeyBuilder(fields={"messages"}, custom_salt="salt")
+    payload = {"messages": [], "routing_fingerprint": "caller-controlled"}
+    first = builder.build_key_from_payload(payload, custom_key, routing_fingerprint="policy-a")
+    second = builder.build_key_from_payload(payload, custom_key, routing_fingerprint="policy-b")
+    assert first != second
+    assert len(first) == 64 and "private" not in first and "policy-a" not in first
+    assert first == builder.build_key_from_payload(
+        {**payload, "routing_fingerprint": "changed"}, custom_key, routing_fingerprint="policy-a"
+    )
+    assert first != CacheKeyBuilder(
+        fields={"messages"}, custom_salt="other"
+    ).build_key_from_payload(payload, custom_key, routing_fingerprint="policy-a")
+
+
+def _publish(test_app, groups, *, aliases=None, failover_config=None):
+    old = test_app.state.routing_runtime_generation_store.require_snapshot()
+    failover_config = failover_config or old.failover_config
+    registry = DeploymentRegistryStore(
+        build_deployment_registry(test_app.state.model_registry, route_groups=groups)
+    )
+    config = RouterConfig(
+        route_group_policies=build_route_group_policies(groups), model_group_alias=aliases or {}
+    )
+    router = Router(old.strategy, old.router.state, config, registry)
+    manager = FailoverManager(
+        config=failover_config,
+        candidate_planner=router,
+        state_backend=old.router.state,
+        cooldown_manager=old.cooldown_manager,
+    )
+    new = RoutingRuntimeGeneration.create(
+        revision=old.revision + 1,
+        app_config=old.app_config,
+        model_registry=test_app.state.model_registry,
+        route_groups=groups,
+        callable_target_catalog=dict(old.callable_target_catalog),
+        authorization_snapshot=old.authorization_snapshot,
+        deployment_registry=registry,
+        strategy=old.strategy,
+        router_config=config,
+        failover_config=failover_config,
+        salt_key=old.salt_key,
+        router=router,
+        failover_manager=manager,
+        cooldown_manager=old.cooldown_manager,
+    )
+    test_app.state.routing_runtime_generation_store.replace(new)
+    return new
+
+
+def _enable_cache(test_app):
+    # These scenarios exercise up to four independently admitted outer requests.
+    # Keep rate admission enabled; give this test key enough capacity for the scenario.
+    next(iter(test_app.state._test_repo.records.values())).rpm_limit = 10
+    backend = InMemoryBackend(max_size=100)
+    test_app.state.cache_backend = backend
+    test_app.state.cache_key_builder = CacheKeyBuilder(custom_salt="routing-cache-test")
+    test_app.state.cache_metrics = NoopCacheMetrics()
+    test_app.state.streaming_cache_handler = StreamingCacheHandler(backend)
+    return backend
+
+
+@pytest.mark.parametrize("endpoint", ["/v1/chat/completions", "/v1/responses", "/v1/completions"])
+@pytest.mark.parametrize("custom", [False, True])
+async def test_http_cache_policy_publish_equivalent_reload_and_rollback(
+    client, test_app, endpoint, custom
+):
+    backend = _enable_cache(test_app)
+    _publish(test_app, [_group()])
+    body = {"model": "gpt-4o-mini"}
+    if endpoint == "/v1/responses":
+        body["input"] = "cached request"
+    elif endpoint == "/v1/completions":
+        body["prompt"] = "cached request"
+    else:
+        body["messages"] = [{"role": "user", "content": "cached request"}]
+    if custom:
+        body["metadata"] = {"cache_key": "same private key"}
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+
+    async def send(expected):
+        response = await client.post(endpoint, json=body, headers=headers)
+        assert response.status_code == 200, response.text
+        assert response.headers["x-deltallm-cache-hit"] == expected
+        return response
+
+    await send("false")
+    _publish(test_app, [{**_group(), "policy_version": 2}])
+    await send("true")
+    _publish(test_app, [{**_group(), "strategy": "least-busy"}])
+    await send("false")
+    _publish(test_app, [_group()])
+    await send("true")
+    assert test_app.state.http_client.post_calls == 2
+    assert len(backend._cache) == 2
+
+
+async def test_streaming_cache_respects_policy_identity_and_reuses_equivalent_generations(
+    client, test_app
+):
+    _enable_cache(test_app)
+    _publish(test_app, [_group()])
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {
+        "model": "gpt-4o-mini",
+        "stream": True,
+        "messages": [{"role": "user", "content": "stream identity"}],
+        "metadata": {"cache_key": "same"},
+    }
+    for group, expected in [
+        (_group(), "false"),
+        (_group(), "true"),
+        ({**_group(), "strategy": "least-busy"}, "false"),
+    ]:
+        _publish(test_app, [group])
+        response = await client.post("/v1/chat/completions", json=body, headers=headers)
+        assert response.status_code == 200, response.text
+        assert response.headers["x-deltallm-cache-hit"] == expected
+        assert "[DONE]" in response.text
+    assert test_app.state.http_client.stream_calls == 2
+
+
+@pytest.mark.parametrize("version", ["v2", "v3"])
+async def test_prior_namespace_is_not_read(client, test_app, version):
+    backend = _enable_cache(test_app)
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "version"}]}
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    await client.post("/v1/chat/completions", json=body, headers=headers)
+    key, entry = next(iter(backend._cache.items()))
+    assert "schema:v4:" in key
+    backend._cache[key.replace("schema:v4:", f"schema:{version}:")] = entry
+    del backend._cache[key]
+    response = await client.post("/v1/chat/completions", json=body, headers=headers)
+    assert response.status_code == 200
+    assert response.headers["x-deltallm-cache-hit"] == "false"
+    assert test_app.state.http_client.post_calls == 2
+
+
+class _PublishDuringPreflight(CustomLogger):
+    def __init__(self, test_app):
+        self.test_app = test_app
+
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        _publish(self.test_app, [{**_group(), "strategy": "least-busy"}])
+        return data
+
+
+async def test_cache_identity_remains_pinned_across_preflight_reload(client, test_app):
+    _enable_cache(test_app)
+    initial = _publish(test_app, [_group()])
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "pinned"}]}
+    await client.post("/v1/chat/completions", json=body, headers=headers)
+    callbacks = CallbackManager()
+    callbacks.register_callback(_PublishDuringPreflight(test_app), callback_type="success")
+    test_app.state.callback_manager = callbacks
+    response = await client.post("/v1/chat/completions", json=body, headers=headers)
+    assert response.status_code == 200
+    assert response.headers["x-deltallm-cache-hit"] == "true"
+    assert test_app.state.routing_runtime_generation_store.require_snapshot() is not initial
+    assert test_app.state.http_client.post_calls == 1
+
+
+async def test_cache_hit_never_constructs_or_invokes_selector(client, test_app, monkeypatch):
+    _enable_cache(test_app)
+    selector = AsyncMock(side_effect=AssertionError("selector must remain unreachable"))
+    monkeypatch.setattr("src.router.selection.service.SelectorService.select_once", selector)
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "no selector"}]}
+    for expected in ("false", "true"):
+        response = await client.post("/v1/chat/completions", json=body, headers=headers)
+        assert response.status_code == 200
+        assert response.headers["x-deltallm-cache-hit"] == expected
+    selector.assert_not_called()
+
+
+async def test_alias_retargeting_uses_the_new_effective_routing_identity(client, test_app):
+    _enable_cache(test_app)
+    groups = [
+        {**_group(), "key": "route-a"},
+        {**_group(), "key": "route-b", "strategy": "least-busy"},
+    ]
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "alias"}],
+        "metadata": {"cache_key": "same"},
+    }
+    for target, expected in [("route-a", "false"), ("route-b", "false"), ("route-a", "true")]:
+        _publish(test_app, groups, aliases={"gpt-4o-mini": target})
+        response = await client.post("/v1/chat/completions", json=body, headers=headers)
+        assert response.status_code == 200, response.text
+        assert response.headers["x-deltallm-cache-hit"] == expected
+    assert test_app.state.http_client.post_calls == 2
+
+
+def test_unrelated_group_changes_leave_primary_identity_unchanged():
+    other = {**_group(), "key": "unrelated"}
+    original = _fingerprints([_group(), other])
+    changed = _fingerprints([_group(), {**other, "strategy": "least-busy"}])
+    assert original["gpt-4o-mini"] == changed["gpt-4o-mini"]
+    assert original["unrelated"] != changed["unrelated"]
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["router/routing_identity.py", "router/fallback_identity.py", "providers/request_defaults.py"],
+)
+def test_fingerprint_projection_is_small_request_free_and_dependency_free(module):
+    path = Path(__file__).parents[1] / "src" / module
+    source = path.read_text()
+    assert len(source.splitlines()) < 500
+    for node in ast.walk(ast.parse(source)):
+        assert not isinstance(node, (ast.AsyncFunctionDef, ast.Await))
+        if isinstance(node, ast.FunctionDef):
+            assert node.end_lineno - node.lineno < 80
+        if isinstance(node, ast.Name):
+            assert node.id not in {"Any", "Request", "getattr", "hasattr", "setattr"}
+        if isinstance(node, ast.ImportFrom):
+            assert not (node.module or "").startswith(
+                ("fastapi", "src.db", "redis", "prisma", "httpx", "src.bootstrap")
+            )

--- a/tests/test_routing_cache_invalidation.py
+++ b/tests/test_routing_cache_invalidation.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+
+import httpx
+import pytest
+
+from src.router import FallbackConfig
+from src.services.callable_targets import build_callable_target_catalog
+from tests.test_routing_cache_identity import _enable_cache, _group, _publish
+
+
+def _request_body(endpoint, custom):
+    body = {"model": "gpt-4o-mini"}
+    if endpoint == "/v1/responses":
+        body["input"] = "routing identity regression"
+    elif endpoint == "/v1/completions":
+        body["prompt"] = "routing identity regression"
+    else:
+        body["messages"] = [{"role": "user", "content": "routing identity regression"}]
+    if custom:
+        body["metadata"] = {"cache_key": "same caller key"}
+    return body
+
+
+def _label_provider_answers(test_app, monkeypatch, *, primary_error=None):
+    original = test_app.state.http_client.post
+
+    async def post(url, headers, json, timeout):
+        if primary_error is not None and json["model"] == "gpt-4o-mini":
+            status, code = primary_error
+            test_app.state.http_client.post_calls += 1
+            return httpx.Response(
+                status,
+                json={"error": {"message": "Primary unavailable", "code": code}},
+                request=httpx.Request("POST", url),
+            )
+        response = await original(url, headers, json, timeout)
+        result = response.json()
+        result["choices"][0]["message"]["content"] = "answered by " + json["model"]
+        return httpx.Response(200, json=result)
+
+    monkeypatch.setattr(test_app.state.http_client, "post", post)
+
+
+@pytest.mark.parametrize("endpoint", ["/v1/chat/completions", "/v1/responses", "/v1/completions"])
+@pytest.mark.parametrize("custom", [False, True])
+async def test_deployment_retarget_invalidates_cache_and_rollback_reuses_it(
+    client, test_app, monkeypatch, endpoint, custom
+):
+    _enable_cache(test_app)
+    _label_provider_answers(test_app, monkeypatch)
+    body = _request_body(endpoint, custom)
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    fingerprints = []
+    for model, expected in [
+        ("gpt-4o-mini", "false"),
+        ("gpt-4o-mini", "true"),
+        ("new-answer-model", "false"),
+        ("gpt-4o-mini", "true"),
+    ]:
+        registry = deepcopy(test_app.state.model_registry)
+        registry["gpt-4o-mini"][0]["deltallm_params"]["model"] = "openai/" + model
+        test_app.state.model_registry = registry
+        generation = _publish(test_app, [_group()])
+        fingerprints.append(generation.routing_fingerprints["gpt-4o-mini"])
+        response = await client.post(endpoint, headers=headers, json=body)
+        assert response.status_code == 200, response.text
+        assert response.headers["x-deltallm-cache-hit"] == expected
+        assert "answered by " + model in response.text
+    assert fingerprints[0] == fingerprints[1] == fingerprints[3] != fingerprints[2]
+    assert test_app.state.http_client.post_calls == 2
+
+
+@pytest.mark.parametrize("custom", [False, True])
+@pytest.mark.parametrize(
+    ("kind", "status", "code"),
+    [
+        ("fallbacks", 503, "server_error"),
+        ("context_window_fallbacks", 400, "context_length_exceeded"),
+        ("content_policy_fallbacks", 400, "content_filter"),
+    ],
+)
+async def test_reachable_fallback_member_change_invalidates_primary_cache(
+    client, test_app, monkeypatch, custom, kind, status, code
+):
+    _enable_cache(test_app)
+    _label_provider_answers(test_app, monkeypatch, primary_error=(status, code))
+    fallback = "text-embedding-3-small"
+    registry = deepcopy(test_app.state.model_registry)
+    registry[fallback] = [
+        {
+            "deltallm_params": {"model": "openai/" + model, "api_key": "test-provider-key"},
+            "model_info": {"mode": "chat"},
+        }
+        for model in ("old-fallback", "new-fallback")
+    ]
+    test_app.state.model_registry = registry
+    store = test_app.state.routing_runtime_generation_store
+    store.replace(
+        replace(
+            store.require_snapshot(),
+            callable_target_catalog=build_callable_target_catalog(registry),
+        )
+    )
+    config = FallbackConfig(**{kind: {"gpt-4o-mini": [fallback]}})
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    fingerprints = []
+    for index, expected in [(0, "false"), (0, "true"), (1, "false"), (0, "true")]:
+        group = {
+            "key": fallback,
+            "mode": "chat",
+            "policy_semantics_version": 3,
+            "members": [{"deployment_id": f"{fallback}-{index}"}],
+        }
+        generation = _publish(test_app, [_group(), group], failover_config=config)
+        fingerprints.append(generation.routing_fingerprints["gpt-4o-mini"])
+        response = await client.post(
+            "/v1/chat/completions",
+            headers=headers,
+            json=_request_body("/v1/chat/completions", custom),
+        )
+        assert response.status_code == 200, response.text
+        assert response.headers["x-deltallm-cache-hit"] == expected
+        assert "answered by " + ("old-fallback" if index == 0 else "new-fallback") in response.text
+    assert fingerprints[0] == fingerprints[1] == fingerprints[3] != fingerprints[2]
+    assert test_app.state.http_client.post_calls == 4
+
+
+@pytest.mark.parametrize("stream", [False, True])
+async def test_stream_and_embedding_deployment_changes_invalidate_cache(client, test_app, stream):
+    _enable_cache(test_app)
+    model = "gpt-4o-mini" if stream else "text-embedding-3-small"
+    endpoint = "/v1/chat/completions" if stream else "/v1/embeddings"
+    body = {"model": model, "metadata": {"cache_key": "same"}}
+    if stream:
+        body.update(stream=True, messages=[{"role": "user", "content": "stream identity"}])
+    else:
+        body["input"] = "embedding identity"
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    for upstream, expected in [(model, "false"), ("replacement", "false"), (model, "true")]:
+        registry = deepcopy(test_app.state.model_registry)
+        registry[model][0]["deltallm_params"]["model"] = "openai/" + upstream
+        test_app.state.model_registry = registry
+        _publish(test_app, [])
+        response = await client.post(endpoint, json=body, headers=headers)
+        assert response.status_code == 200, response.text
+        assert response.headers["x-deltallm-cache-hit"] == expected
+        if stream:
+            assert "[DONE]" in response.text
+    assert (
+        test_app.state.http_client.stream_calls if stream else test_app.state.http_client.post_calls
+    ) == 2
+
+
+async def test_admin_registry_rebuild_recomputes_deployment_cache_identity(
+    client, test_app, monkeypatch
+):
+    from src.api.admin.endpoints.models import _rebuild_runtime_registry
+
+    _enable_cache(test_app)
+    _label_provider_answers(test_app, monkeypatch)
+    _publish(test_app, [])
+    headers = {"Authorization": f"Bearer {test_app.state._test_key}"}
+    body = _request_body("/v1/chat/completions", False)
+    first = await client.post("/v1/chat/completions", json=body, headers=headers)
+    assert first.status_code == 200 and first.headers["x-deltallm-cache-hit"] == "false"
+    registry = deepcopy(test_app.state.model_registry)
+    registry["gpt-4o-mini"][0]["deltallm_params"]["model"] = "openai/new-admin-model"
+    test_app.state.model_registry = registry
+    _rebuild_runtime_registry(test_app)
+    second = await client.post("/v1/chat/completions", json=body, headers=headers)
+    assert second.status_code == 200 and second.headers["x-deltallm-cache-hit"] == "false"
+    assert "answered by new-admin-model" in second.text
+    assert test_app.state.http_client.post_calls == 2

--- a/tests/test_routing_costs.py
+++ b/tests/test_routing_costs.py
@@ -1,0 +1,133 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from src.billing.routing_costs import RoutingCostObservation, aggregate_routing_costs
+from src.db.routing_costs import routing_cost_query, routing_cost_observation
+from src.services.spend_visibility import SpendVisibility
+
+
+def cost(**updates):
+    return RoutingCostObservation(
+        **{
+            "answer_model": "small",
+            "selector_provider_cost": Decimal(".01"),
+            "selector_customer_charge": Decimal(".01"),
+            "answer_provider_cost": Decimal(".10"),
+            "answer_customer_charge": Decimal(".15"),
+            "baseline_answer_provider_cost": Decimal(".20"),
+            "measurable_penalty": Decimal(".02"),
+            **updates,
+        }
+    )
+
+
+def test_net_savings_are_exact_net_of_selector_and_penalty_not_customer_markup():
+    report = aggregate_routing_costs((cost(), cost()))
+    assert report.net_savings_exact == "0.140000000000000000"
+    assert report.selector_customer_charge_exact == "0.020000000000000000"
+    assert report.answer_customer_charge_exact == "0.300000000000000000"
+    assert report.operation_count == report.savings_covered_count == 2
+    assert report.answer_distribution == (("small", 2),)
+    assert not report.partial
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "baseline_answer_provider_cost",
+        "selector_provider_cost",
+        "answer_provider_cost",
+        "measurable_penalty",
+    ],
+)
+def test_missing_evidence_produces_unknown_savings_not_invented_zero(field):
+    report = aggregate_routing_costs((cost(**{field: None}),))
+    assert report.net_savings_exact is None
+    assert report.savings_covered_count == 0
+    assert report.partial
+
+
+def test_negative_savings_are_not_clamped_and_truncation_is_visible():
+    report = aggregate_routing_costs(
+        (cost(baseline_answer_provider_cost=Decimal(0)),), truncated=True
+    )
+    assert report.net_savings_exact == "-0.130000000000000000"
+    assert report.partial
+
+
+@pytest.mark.parametrize(
+    "visibility,expected",
+    [
+        (SpendVisibility(False, organization_ids=("org-a",)), "organization_id"),
+        (SpendVisibility(False, team_ids=("team-a",)), "team_id"),
+        (
+            SpendVisibility(False, owner_account_id="owner-a", self_organization_ids=("org-a",)),
+            "owner_account_id",
+        ),
+        (SpendVisibility(False), "1 = 0"),
+    ],
+)
+def test_cost_page_uses_canonical_visibility_before_bounded_unique_event_joins(
+    visibility, expected
+):
+    end = datetime.now(UTC)
+    query = routing_cost_query(
+        visibility=visibility, start=end - timedelta(days=1), end=end, limit=50
+    )
+    assert expected in query.sql
+    assert query.params[-1] == 51
+    assert "WITH page AS MATERIALIZED" in query.sql
+    assert query.sql.index("LIMIT") < query.sql.index("LEFT JOIN")
+    assert "org-a" not in query.sql and "owner-a" not in query.sql
+    assert "s.id=o.selector_event_id" in query.sql
+    assert "a.id=o.operation_id" in query.sql
+
+
+def test_cost_aggregation_is_bounded():
+    with pytest.raises(ValueError, match="bounded"):
+        aggregate_routing_costs((cost(),) * 1001)
+
+
+def test_savings_baseline_uses_only_frozen_server_pricing_with_reported_answer_tokens():
+    from tests.test_operation_reservation import make_operation
+    from src.billing.selector_charge import SelectorTokenReceipt
+
+    price = make_operation().selector.pricing
+    row = dict(
+        reference_answer_pricing=price.model_dump(mode="json"),
+        input_tokens=100,
+        output_tokens=5,
+        total_tokens=105,
+        status="success",
+        baseline_answer_provider_cost="999",
+        answer_model="small",
+    )
+    observation = routing_cost_observation(row)
+    assert observation.baseline_answer_provider_cost == price.cost(
+        SelectorTokenReceipt(
+            prompt_tokens=100, completion_tokens=5, total_tokens=105, cached_input_tokens=0
+        )
+    )
+    assert observation.net_savings is None
+    row["total_tokens"] = None
+    assert routing_cost_observation(row).baseline_answer_provider_cost is None
+    row["total_tokens"], row["status"] = 105, "failure"
+    assert routing_cost_observation(row).baseline_answer_provider_cost is None
+
+
+def test_pending_reconciliation_is_visible_separately_from_zero_cost():
+    from src.billing.operation_reservation import ComponentState
+
+    report = aggregate_routing_costs(
+        (
+            cost(
+                selector_state=ComponentState.PENDING,
+                selector_provider_cost=None,
+                selector_customer_charge=None,
+            ),
+        )
+    )
+    assert report.pending_reconciliation_count == 1
+    assert report.partial and report.net_savings_exact is None

--- a/tests/test_routing_identity_dependencies.py
+++ b/tests/test_routing_identity_dependencies.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from src.providers.request_defaults import provider_request_defaults
+from src.router import Deployment, FallbackConfig, RoutingStrategy
+from src.router.fallback_identity import fingerprint_fallback_dependencies
+from src.router.routing_identity import build_runtime_routing_fingerprints
+from src.routers.utils import apply_default_params
+
+
+def _deployment(*, params=None, info=None):
+    return Deployment(
+        deployment_id="stable-deployment",
+        model_name="public-group",
+        deltallm_params={"model": "openai/model-a", "api_key": "secret-a", **(params or {})},
+        model_info=info or {},
+    )
+
+
+def _identity(deployment, *, config=FallbackConfig(), pre_call_checks=False):
+    return build_runtime_routing_fingerprints(
+        groups=[],
+        policies={},
+        deployments={"public-group": [deployment]},
+        default_strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        failover_config=config,
+        enable_pre_call_checks=pre_call_checks,
+    )["public-group"]
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"model": "openai/model-b"},
+        {"provider": "vllm"},
+        {"api_base": "https://new-provider.example/v1"},
+        {"api_version": "new-version"},
+        {"region": "another-region"},
+        {"auth_header_name": "X-Provider-Token"},
+        {"auth_header_format": "Token {api_key}"},
+        {"timeout": 3},
+        {"stream_timeout": 2},
+        {"max_tokens": 42},
+    ],
+)
+def test_response_affecting_provider_configuration_invalidates(params):
+    assert _identity(_deployment(params=params)) != _identity(_deployment())
+
+
+@pytest.mark.parametrize(
+    "info",
+    [
+        {"mode": "embedding"},
+        {"max_tokens": 8192},
+        {"max_input_tokens": 4096},
+        {"max_output_tokens": 1024},
+        {"input_cost_per_token": 0.1},
+        {"output_cost_per_token": 0.2},
+        {"cost_per_request": 0.3},
+        {"default_params": {"seed": 1}},
+        {"default_params": {"response_format": {"type": "json_object"}}},
+    ],
+)
+def test_execution_defaults_and_context_metadata_invalidate(info):
+    assert _identity(_deployment(info=info)) != _identity(_deployment())
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"tags": ["another-region"]},
+        {"rpm_limit": 100},
+        {"tpm_limit": 1000},
+        {"input_cost_per_token": 0.1},
+        {"output_cost_per_token": 0.2},
+        {"named_credential_id": "another-provider-account"},
+    ],
+)
+def test_effective_candidate_configuration_invalidates(changes):
+    assert _identity(replace(_deployment(), **changes)) != _identity(_deployment())
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        FallbackConfig(timeout=5),
+        FallbackConfig(num_retries=1),
+        FallbackConfig(retry_after=1),
+        FallbackConfig(backoff_multiplier=3),
+        FallbackConfig(backoff_max=1),
+        FallbackConfig(backoff_jitter=False),
+    ],
+)
+def test_inherited_execution_configuration_invalidates(config):
+    assert _identity(_deployment(), config=config) != _identity(_deployment())
+
+
+def test_pre_call_eligibility_changes_invalidate():
+    assert _identity(_deployment(), pre_call_checks=True) != _identity(_deployment())
+
+
+def test_credentials_reloads_and_opaque_metadata_are_not_response_identity(monkeypatch):
+    captured = []
+    from src.router import routing_identity
+
+    original = routing_identity._digest
+
+    def digest(value):
+        captured.append(value)
+        return original(value)
+
+    monkeypatch.setattr(routing_identity, "_digest", digest)
+    changed = _deployment(
+        params={
+            "api_key": "secret-b",
+            "aws_secret_access_key": "secret-c",
+            "operator_note": "note",
+        },
+        info={"metadata": {"note": "opaque"}, "default_params": {"available_voices": ["voice"]}},
+    )
+    changed = replace(changed, health_incarnation="new-health-generation")
+    assert _identity(changed) == _identity(_deployment())
+    for secret in ("secret-a", "secret-b", "secret-c", "new-health-generation", "opaque"):
+        assert secret not in repr(captured)
+
+
+def test_equivalent_defaults_provider_prefixes_and_tag_sets_reuse_identity():
+    original = replace(
+        _deployment(info={"default_params": {"seed": 1, "stop": ["a", "b"]}}), tags=["us", "eu"]
+    )
+    equivalent = replace(
+        _deployment(
+            params={"provider": "openai", "model": "model-a"},
+            info={"mode": "chat", "default_params": {"stop": ["a", "b"], "seed": 1}},
+        ),
+        tags=["eu", "us", "us"],
+    )
+    assert _identity(original) == _identity(equivalent)
+    reversed_stops = replace(
+        equivalent, model_info={"default_params": {"seed": 1, "stop": ["b", "a"]}}
+    )
+    assert _identity(original) != _identity(reversed_stops)
+    assert _identity(_deployment(params={"api_base": "https://provider.example/v1/"})) == _identity(
+        _deployment(params={"api_base": "https://provider.example/v1"})
+    )
+
+
+def test_provider_defaults_have_one_projection_and_preserve_caller_values():
+    info = {"default_params": {"seed": 1, "nested": {"test": True}, "available_voices": ["voice"]}}
+    expected = {"seed": 1, "nested": {"test": True}}
+    assert provider_request_defaults(info) == apply_default_params({}, info) == expected
+    caller = {"seed": 2}
+    assert apply_default_params(caller, info) is caller
+    assert caller == {**expected, "seed": 2}
+
+
+@pytest.mark.parametrize(
+    "kind", ["fallbacks", "context_window_fallbacks", "content_policy_fallbacks"]
+)
+def test_fallback_retarget_order_removal_and_transitive_changes(kind):
+    local = {key: key for key in ("a", "b", "c", "d", "unrelated")}
+    config = FallbackConfig(**{kind: {"a": ["b"], "b": ["c"]}})
+    original = fingerprint_fallback_dependencies(local, config)
+    modified = fingerprint_fallback_dependencies({**local, "c": "changed"}, config)
+    assert original["a"] != modified["a"] and original["b"] != modified["b"]
+    assert original["unrelated"] == modified["unrelated"]
+    for targets in ([], ["d"], ["b", "d"], ["d", "b"]):
+        changed = fingerprint_fallback_dependencies(
+            local, FallbackConfig(**{kind: {"a": targets, "b": ["c"]}})
+        )
+        assert changed["a"] != original["a"]
+    first = fingerprint_fallback_dependencies(local, FallbackConfig(**{kind: {"a": ["b", "d"]}}))
+    second = fingerprint_fallback_dependencies(local, FallbackConfig(**{kind: {"a": ["d", "b"]}}))
+    assert first["a"] != second["a"]
+
+
+def test_fallback_edge_kind_and_missing_target_creation_change_identity():
+    local = {"a": "a"}
+    results = [
+        fingerprint_fallback_dependencies(local, FallbackConfig(**{kind: {"a": ["missing"]}}))["a"]
+        for kind in ("fallbacks", "context_window_fallbacks", "content_policy_fallbacks")
+    ]
+    assert len(set(results)) == 3
+    config = FallbackConfig(fallbacks={"a": ["missing"]})
+    assert (
+        results[0]
+        != fingerprint_fallback_dependencies({**local, "missing": "created"}, config)["a"]
+    )
+
+
+def test_fallback_graph_is_stable_across_snapshot_order_and_cycles():
+    local = {key: key for key in ("a", "b", "c", "unrelated")}
+    config = FallbackConfig(fallbacks={"a": ["b"], "b": ["a", "c"], "c": ["c"]})
+    original = fingerprint_fallback_dependencies(local, config)
+    reordered = FallbackConfig(fallbacks={"c": ["c"], "b": ["a", "c"], "a": ["b", "b"]})
+    assert original == fingerprint_fallback_dependencies(
+        dict(reversed(list(local.items()))), reordered
+    )
+    changed = fingerprint_fallback_dependencies({**local, "c": "replacement"}, config)
+    assert all(original[key] != changed[key] for key in ("a", "b", "c"))
+    assert original["unrelated"] == changed["unrelated"]
+    assert fingerprint_fallback_dependencies({}, FallbackConfig()) == {}
+    with pytest.raises(TypeError):
+        original["a"] = "mutated"
+
+
+def test_configured_fallback_key_spelling_is_not_silently_normalized():
+    local = {"a": "a", "b": "b"}
+    original = fingerprint_fallback_dependencies(local, FallbackConfig(fallbacks={"a": ["b"]}))
+    changed = fingerprint_fallback_dependencies(local, FallbackConfig(fallbacks={"a": [" b "]}))
+    assert original["a"] != changed["a"]
+
+
+@pytest.mark.parametrize("cycle", [False, True])
+def test_large_shared_fallback_graph_has_linear_hash_work_without_recursion(monkeypatch, cycle):
+    from src.router import fallback_identity
+
+    original = fallback_identity._digest
+    calls = 0
+
+    def digest(value):
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(fallback_identity, "_digest", digest)
+    local = {str(index): str(index) for index in range(2000)}
+    edges = {
+        str(index): [str(index + step) for step in (1, 2) if index + step < 2000]
+        for index in range(2000)
+    }
+    if cycle:
+        edges["1999"] = ["0"]
+    identities = fingerprint_fallback_dependencies(local, FallbackConfig(fallbacks=edges))
+    assert len(identities) == 2000
+    assert calls == (2001 if cycle else 4000)

--- a/tests/test_selector_capacity_redis.py
+++ b/tests/test_selector_capacity_redis.py
@@ -1,0 +1,136 @@
+import asyncio
+import os
+from uuid import uuid4
+
+import pytest
+from redis.asyncio import Redis
+
+from src.router.candidates import AttemptCapacity, AttemptCapacityLimit
+from src.router.state import RedisStateBackend
+
+pytestmark = [pytest.mark.integration, pytest.mark.redis]
+
+
+@pytest.fixture
+async def capacity_redis():
+    url = os.getenv("DELTALLM_TEST_REDIS_URL")
+    if not url:
+        if os.getenv("CI"):
+            pytest.fail("CI must provision Redis for selector capacity tests")
+        pytest.skip("DELTALLM_TEST_REDIS_URL is required")
+    first, second = (
+        Redis.from_url(url, decode_responses=True),
+        Redis.from_url(url, decode_responses=True),
+    )
+    identity = "selector-capacity-" + uuid4().hex
+    try:
+        yield first, second, identity
+    finally:
+        keys = [key async for key in first.scan_iter(match=f"*{identity}*", count=100)]
+        if keys:
+            await first.delete(*keys)
+        await first.aclose()
+        await second.aclose()
+
+
+async def test_atomic_consumption_and_owner_release_across_clients(capacity_redis):
+    first, second, identity = capacity_redis
+    owners = [RedisStateBackend(first), RedisStateBackend(second)]
+    capacity = AttemptCapacity(
+        limits=(AttemptCapacityLimit("rpm", 5, 1), AttemptCapacityLimit("tpm", 500, 100)),
+        max_concurrency=2,
+        require_shared=True,
+    )
+    permits = await asyncio.gather(
+        *(owners[index % 2].acquire_attempt(identity, capacity) for index in range(16))
+    )
+    acquired = [permit for permit in permits if permit.acquired]
+    assert len(acquired) == 2
+    usage = await owners[0].get_usage(identity)
+    assert usage["rpm"] == 2 and usage["tpm"] == 200
+    await asyncio.gather(*(owners[1].release_attempt(permit) for permit in acquired))
+    await asyncio.gather(*(owners[0].release_attempt(permit) for permit in acquired))
+    assert await owners[1].get_active_requests(identity) == 0
+    usage = await owners[1].get_usage(identity)
+    assert usage["rpm"] == 2 and usage["tpm"] == 200
+
+
+async def test_live_owner_replay_does_not_consume_twice_and_expiry_recovers(capacity_redis):
+    first, second, identity = capacity_redis
+    a, b = RedisStateBackend(first), RedisStateBackend(second)
+    capacity = AttemptCapacity(
+        limits=(AttemptCapacityLimit("rpm", 10, 1), AttemptCapacityLimit("tpm", 1000, 100)),
+        max_concurrency=1,
+        require_shared=True,
+        owner_token=uuid4().hex,
+    )
+    permit = await a.acquire_attempt(identity, capacity, lease_ttl_seconds=1)
+    replay = await b.acquire_attempt(identity, capacity, lease_ttl_seconds=1)
+    assert replay.owner_token == permit.owner_token
+    assert (await b.get_usage(identity))["rpm"] == 1
+    # Advance the owner's Redis timestamp directly, with no arbitrary wall-clock sleep.
+    await first.zadd(a.keyspace.attempt_owners(identity), {permit.owner_token: 0})
+    new = await b.acquire_attempt(
+        identity,
+        AttemptCapacity(
+            limits=capacity.limits, max_concurrency=1, require_shared=True, owner_token=uuid4().hex
+        ),
+        lease_ttl_seconds=1,
+    )
+    assert new.acquired
+    await a.release_attempt(permit)
+    assert await b.get_active_requests(identity) == 1
+    await b.release_attempt(new)
+
+
+async def test_server_clock_lease_expiry_and_client_reconnect_preserve_owner_isolation(
+    capacity_redis,
+):
+    first, second, identity = capacity_redis
+    a, b = RedisStateBackend(first), RedisStateBackend(second)
+    bounds = AttemptCapacity(
+        limits=(AttemptCapacityLimit("rpm", 100, 1),),
+        max_concurrency=1,
+        require_shared=True,
+    )
+    old = await a.acquire_attempt(identity, bounds, lease_ttl_seconds=1)
+    assert old.acquired
+    seconds, micros = await first.time()
+    # This wait exercises the declared Redis TTL, not a timing workaround.
+    remaining = (old.expires_at_ms - seconds * 1000 - micros / 1000) / 1000
+    await asyncio.sleep(max(0, remaining) + 0.01)
+    await second.connection_pool.disconnect()
+    fresh = await b.acquire_attempt(identity, bounds, lease_ttl_seconds=1)
+    assert fresh.acquired and fresh.owner_token != old.owner_token
+    await a.release_attempt(old)
+    assert await b.get_active_requests(identity) == 1
+    await b.release_attempt(fresh)
+
+
+async def test_transport_outage_fails_closed_and_reconnect_reuses_shared_state(
+    capacity_redis, monkeypatch
+):
+    from redis.exceptions import ConnectionError
+    from src.models.errors import ServiceUnavailableError
+
+    first, second, identity = capacity_redis
+    a, b = RedisStateBackend(first, degraded_mode="fail_open"), RedisStateBackend(second)
+    bounds = AttemptCapacity(
+        limits=(AttemptCapacityLimit("rpm", 10, 1),), max_concurrency=1, require_shared=True
+    )
+    held = await b.acquire_attempt(identity, bounds)
+    original = first.eval
+
+    async def unavailable(*args, **kwargs):
+        raise ConnectionError("test-only transport interruption")
+
+    monkeypatch.setattr(first, "eval", unavailable)
+    with pytest.raises(ServiceUnavailableError):
+        await a.acquire_attempt(identity, bounds)
+    monkeypatch.setattr(first, "eval", original)
+    await first.connection_pool.disconnect()
+    assert not (await a.acquire_attempt(identity, bounds)).acquired
+    await b.release_attempt(held)
+    recovered = await a.acquire_attempt(identity, bounds)
+    assert recovered.acquired
+    await a.release_attempt(recovered)

--- a/tests/test_selector_charge.py
+++ b/tests/test_selector_charge.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, localcontext
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.billing.selector_charge import (
+    AcceptedSelectorCharge,
+    SelectorChargeAttribution,
+    SelectorPriceSnapshot,
+    SelectorTokenReceipt,
+)
+from src.billing.spend import SpendTrackingService
+from src.billing.spend_ingestion import (
+    SelectorChargeUnavailableError,
+    SpendIngestionConfig,
+    SpendIngestionOverloadedError,
+    SpendIngestionService,
+)
+from src.db.spend_ingestion import SpendEnqueueResult
+
+
+def make_selector_charge(**price_overrides: object) -> AcceptedSelectorCharge:
+    now = datetime.now(UTC)
+    return AcceptedSelectorCharge(
+        attribution=SelectorChargeAttribution(
+            operation_id=uuid4(),
+            api_key="verified-key-hash",
+            user_id="verified-user",
+            team_id="verified-team",
+            organization_id="verified-org",
+            owner_account_id="verified-owner",
+            model_group="customer-model-group",
+            deployment_id="concrete-selector",
+            deployment_model="small-model",
+            provider="openai",
+        ),
+        pricing=SelectorPriceSnapshot(
+            **{
+                "source": "deployment-pricing",
+                "version": "revision-7",
+                "input_cost_per_token": Decimal("0.000000150000000001"),
+                "output_cost_per_token": Decimal("0.000000600000000003"),
+                "cost_per_request": Decimal("0.000000000000000005"),
+                **price_overrides,
+            }
+        ),
+        usage=SelectorTokenReceipt(prompt_tokens=100, completion_tokens=5, total_tokens=105),
+        started_at=now,
+        finished_at=now + timedelta(milliseconds=30),
+    )
+
+
+def test_selector_customer_pays_exact_provider_cost_without_markup() -> None:
+    charge = make_selector_charge()
+    with localcontext() as context:
+        context.prec = 5  # Ambient application Decimal precision cannot change billing.
+        assert charge.customer_charge == Decimal("0.000018000000000120")
+        assert charge.provider_cost == charge.customer_charge
+    row = (
+        SpendTrackingService(None)
+        .prepare_batch_event(
+            event_id=charge.attribution.component_event_id,
+            event_type="spend",
+            payload=charge.spend_payload(),
+        )
+        .row
+    )
+    assert row["spend_exact"] == row["provider_cost_exact"] == "0.000018000000000120"
+    assert (
+        row["model"] == "customer-model-group"
+    )  # The caller's model budget, not hidden deployment.
+    assert row["deployment_model"] == "small-model"
+    assert row["call_type"] == "model_router_selector"
+    assert row["metadata"]["component_purpose"] == "selector:v1"
+    assert row["metadata"]["parent_event_id"] == str(charge.attribution.operation_id)
+    assert row["id"] != row["request_id"]
+
+
+def test_selector_receipt_replay_freezes_identity_attribution_prices_and_currency() -> None:
+    charge = make_selector_charge()
+    replay = AcceptedSelectorCharge.model_validate_json(charge.model_dump_json())
+    assert replay == charge
+    assert replay.attribution.component_event_id == charge.attribution.component_event_id
+    assert replay.customer_charge == charge.customer_charge
+    assert replay.spend_payload() == charge.spend_payload()
+    assert (
+        make_selector_charge().attribution.component_event_id
+        != charge.attribution.component_event_id
+    )
+    assert replay.pricing.currency == "USD"
+    assert replay.pricing.rounding == "ROUND_HALF_EVEN"
+    with pytest.raises(ValidationError):
+        replay.pricing.input_cost_per_token = Decimal(0)
+    with pytest.raises(ValidationError):
+        replay.attribution.team_id = "other-team"
+
+
+@pytest.mark.parametrize("kind", ["unknown", "not_attempted"])
+def test_unknown_or_unattempted_usage_cannot_become_a_billable_receipt(kind: str) -> None:
+    with pytest.raises(ValidationError):
+        SelectorTokenReceipt(kind=kind, prompt_tokens=0, completion_tokens=0, total_tokens=0)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"total_tokens": 106},
+        {"prompt_tokens": -1},
+        {"completion_tokens": True},
+        {"cached_input_tokens": 101},
+        {"prompt_tokens": 2**31},
+        {"prompt_tokens": 100.0},
+    ],
+)
+def test_selector_receipt_rejects_inconsistent_or_unrepresentable_usage(
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        SelectorTokenReceipt(
+            **{"prompt_tokens": 100, "completion_tokens": 5, "total_tokens": 105, **overrides}
+        )
+
+
+@pytest.mark.parametrize(
+    "rate",
+    [
+        0.1,
+        "0.1",
+        Decimal("-1"),
+        Decimal("NaN"),
+        Decimal("Infinity"),
+        Decimal("1e20"),
+        Decimal("1e-19"),
+    ],
+)
+def test_pricing_rejects_float_missing_precision_and_invalid_money(rate: object) -> None:
+    with pytest.raises(ValidationError):
+        make_selector_charge(input_cost_per_token=rate)
+
+
+def test_selector_does_not_charge_full_input_rate_when_cache_discount_usage_is_missing() -> None:
+    with pytest.raises(ValidationError, match="missing required cached-input usage"):
+        make_selector_charge(input_cost_per_token_cache_hit=Decimal("0.00000001"))
+    charge = make_selector_charge()
+    pricing = SelectorPriceSnapshot.model_validate(
+        {**charge.pricing.model_dump(), "input_cost_per_token_cache_hit": Decimal("0.00000001")}
+    )
+    usage = SelectorTokenReceipt(
+        prompt_tokens=100, completion_tokens=5, total_tokens=105, cached_input_tokens=80
+    )
+    assert pricing.cost(usage) == Decimal("0.000006800000000040")
+
+
+def test_zero_price_requires_explicit_rates_and_valid_receipt() -> None:
+    charge = make_selector_charge(
+        input_cost_per_token=Decimal(0),
+        output_cost_per_token=Decimal(0),
+        cost_per_request=Decimal(0),
+    )
+    assert charge.customer_charge == 0
+    data = charge.pricing.model_dump()
+    del data["output_cost_per_token"]
+    with pytest.raises(ValidationError):
+        SelectorPriceSnapshot.model_validate(data)
+
+
+def test_selector_charge_rejects_naive_reversed_timestamps_and_cost_overflow() -> None:
+    charge = make_selector_charge()
+    for update in (
+        {"started_at": datetime(2026, 9, 8)},
+        {"finished_at": charge.started_at - timedelta(seconds=1)},
+    ):
+        with pytest.raises(ValidationError):
+            AcceptedSelectorCharge.model_validate({**charge.model_dump(), **update})
+    with pytest.raises(ValidationError, match="NUMERIC"):
+        make_selector_charge(input_cost_per_token=Decimal("99999999999999999999"))
+
+
+def test_provider_exact_amount_survives_legacy_mirror_float_roundtrip() -> None:
+    charge = make_selector_charge()
+    payload = charge.spend_payload()
+    payload["cost_exact"] = "9007199254740992.000000000000000001"
+    payload["provider_cost_exact"] = "9007199254740992.000000000000000003"
+    prepared = SpendTrackingService(None).prepare_batch_event(
+        event_id="event", event_type="spend", payload=payload
+    )
+    assert prepared.row["spend_exact"] == payload["cost_exact"]
+    assert prepared.row["provider_cost_exact"] == payload["provider_cost_exact"]
+    assert prepared.row["spend"] == prepared.row["provider_cost"] == 9007199254740992.0
+
+
+def test_legacy_provider_cost_payload_still_works() -> None:
+    payload = make_selector_charge().spend_payload()
+    del payload["provider_cost_exact"]
+    payload["metadata"]["provider_cost"] = 0.1
+    row = (
+        SpendTrackingService(None)
+        .prepare_batch_event(event_id="event", event_type="spend", payload=payload)
+        .row
+    )
+    assert row["provider_cost_exact"] == "0.100000000000000000"
+
+
+@pytest.mark.asyncio
+async def test_selector_ingress_uses_existing_outbox_and_stable_child_event() -> None:
+    service = SpendIngestionService(
+        db_client=object(),
+        writer=SpendTrackingService(None),
+        config=SpendIngestionConfig(enabled=True),
+    )
+    service.repository.enqueue = AsyncMock(
+        return_value=SpendEnqueueResult(status="accepted", pending_count=1)
+    )
+    charge = make_selector_charge()
+    await service.log_selector_charge(charge, expires_at=asyncio.get_running_loop().time() + 1)
+    await service.log_selector_charge(
+        AcceptedSelectorCharge.model_validate_json(charge.model_dump_json()),
+        expires_at=asyncio.get_running_loop().time() + 1,
+    )
+    assert service.repository.enqueue.await_count == 2
+    first, second = service.repository.enqueue.await_args_list
+    assert first == second
+    assert first.kwargs["event_id"] == charge.attribution.component_event_id
+    payload = first.kwargs["payload"]
+    assert payload["cost_exact"] == payload["provider_cost_exact"] == "0.000018000000000120"
+    assert payload["start_time"].endswith("+00:00")
+    assert "verified-key-hash" not in repr(charge)
+    assert not any(
+        term in json.dumps(payload)
+        for term in ("messages", "prompt_text", "api_base", "authorization")
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["disabled", "closed", "missing_db"])
+async def test_selector_ingress_never_falls_back_to_non_durable_billing(state: str) -> None:
+    service = SpendIngestionService(
+        db_client=None if state == "missing_db" else object(),
+        writer=SpendTrackingService(None),
+        config=SpendIngestionConfig(enabled=state != "disabled"),
+    )
+    service._closed = state == "closed"
+    with pytest.raises(SelectorChargeUnavailableError):
+        await service.log_selector_charge(
+            make_selector_charge(), expires_at=asyncio.get_running_loop().time() + 1
+        )
+
+
+def test_exact_charge_contract_is_small_typed_and_has_no_io_or_edge_dependencies() -> None:
+    root = Path(__file__).parents[1]
+    source = (root / "src/billing/selector_charge.py").read_text()
+    assert len(source.splitlines()) < 500
+    for node in ast.walk(ast.parse(source)):
+        assert not isinstance(node, ast.AsyncFunctionDef)
+        if isinstance(node, ast.FunctionDef):
+            assert node.end_lineno - node.lineno < 80
+        if isinstance(node, ast.Name):
+            assert node.id not in {"Any", "Request", "getattr", "hasattr"}
+        if isinstance(node, ast.ImportFrom):
+            assert not (node.module or "").startswith(
+                ("src.db", "fastapi", "redis", "httpx", "src.api", "src.router")
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("expires_at", [0.0, float("nan"), float("inf"), True])
+async def test_invalid_or_expired_selector_charge_deadline_does_not_enqueue(expires_at) -> None:
+    service = SpendIngestionService(
+        db_client=object(),
+        writer=SpendTrackingService(None),
+        config=SpendIngestionConfig(enabled=True),
+    )
+    service.repository.enqueue = AsyncMock()
+    with pytest.raises((ValueError, SelectorChargeUnavailableError)):
+        await service.log_selector_charge(make_selector_charge(), expires_at=expires_at)
+    service.repository.enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_selector_receipt_timeout_and_cancellation_propagate_without_detached_work(
+    cancel,
+) -> None:
+    service = SpendIngestionService(
+        db_client=object(),
+        writer=SpendTrackingService(None),
+        config=SpendIngestionConfig(enabled=True),
+    )
+    started, closed = asyncio.Event(), asyncio.Event()
+
+    async def blocked_enqueue(**kwargs):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            closed.set()
+
+    service.repository.enqueue = AsyncMock(side_effect=blocked_enqueue)
+    task = asyncio.create_task(
+        service.log_selector_charge(
+            make_selector_charge(),
+            expires_at=asyncio.get_running_loop().time() + (1 if cancel else 0.01),
+        )
+    )
+    try:
+        await started.wait()
+        if cancel:
+            task.cancel()
+        with pytest.raises(asyncio.CancelledError if cancel else SelectorChargeUnavailableError):
+            await task
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+    assert closed.is_set()
+    assert service.repository.enqueue.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_selector_receipt_capacity_rejection_propagates() -> None:
+    service = SpendIngestionService(
+        db_client=object(),
+        writer=SpendTrackingService(None),
+        config=SpendIngestionConfig(enabled=True, overload_policy="fail_closed"),
+    )
+    service.repository.enqueue = AsyncMock(
+        return_value=SpendEnqueueResult(status="full", pending_count=100_000)
+    )
+    with pytest.raises(SpendIngestionOverloadedError):
+        await service.log_selector_charge(
+            make_selector_charge(), expires_at=asyncio.get_running_loop().time() + 1
+        )
+    assert service.repository.enqueue.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_exact_ledger_batch_addition_is_independent_of_ambient_decimal_precision() -> None:
+    db = SimpleNamespace(
+        query_raw=AsyncMock(return_value=[{"id": "first"}, {"id": "second"}]),
+        execute_raw=AsyncMock(return_value=1),
+    )
+    writer = SpendTrackingService(db)
+    first = make_selector_charge().spend_payload()
+    second = dict(first)
+    first["cost_exact"] = "9007199254740992.000000000000000001"
+    second["cost_exact"] = "0.000000000000000002"
+    with localcontext() as context:
+        context.prec = 5
+        await writer.log_batch_once([("first", "spend", first), ("second", "spend", second)])
+    key_update = next(
+        call
+        for call in db.execute_raw.await_args_list
+        if "UPDATE deltallm_verificationtoken" in call.args[0]
+    )
+    assert key_update.args[2] == ["9007199254740992.000000000000000003"]
+
+
+def test_selector_charging_is_not_invoked_by_production_request_paths() -> None:
+    for path in (Path(__file__).parents[1] / "src").rglob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                assert node.func.attr != "log_selector_charge", path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error", [TimeoutError("database detail"), RuntimeError("private database detail")]
+)
+async def test_selector_receipt_dependency_failure_is_not_a_selector_safe_default(error) -> None:
+    service = SpendIngestionService(
+        db_client=object(),
+        writer=SpendTrackingService(None),
+        config=SpendIngestionConfig(enabled=True),
+    )
+    service.repository.enqueue = AsyncMock(side_effect=error)
+    with pytest.raises(SelectorChargeUnavailableError) as raised:
+        await service.log_selector_charge(
+            make_selector_charge(), expires_at=asyncio.get_running_loop().time() + 1
+        )
+    assert not isinstance(raised.value, TimeoutError)
+    assert raised.value.status_code == 503
+    assert "database detail" not in str(raised.value)
+
+
+def test_legacy_spend_preparation_is_one_bounded_io_free_mapping_seam() -> None:
+    root = Path(__file__).parents[1] / "src/billing"
+    source = (root / "spend_preparation.py").read_text()
+    assert len(source.splitlines()) < 200
+    for node in ast.walk(ast.parse(source)):
+        assert not isinstance(node, ast.AsyncFunctionDef)
+        if isinstance(node, ast.FunctionDef):
+            assert node.end_lineno - node.lineno < 80
+        if isinstance(node, ast.ImportFrom):
+            assert not (node.module or "").startswith(("src.db", "fastapi", "redis", "httpx"))
+    # The only dynamic boundary is the pre-existing historical outbox shape;
+    # keep it contained here instead of growing another mapper in the writer.
+    mapper = next(
+        node
+        for node in ast.walk(ast.parse((root / "spend.py").read_text()))
+        if isinstance(node, ast.FunctionDef) and node.name == "prepare_batch_event"
+    )
+    assert len(mapper.body) == 2  # docstring and delegation
+    assert isinstance(mapper.body[1], ast.Return)

--- a/tests/test_selector_charge_db_integration.py
+++ b/tests/test_selector_charge_db_integration.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from src.billing.spend import SpendTrackingService
+from src.billing.spend_ingestion import SpendIngestionConfig, SpendIngestionService
+from src.db.spend_ingestion import SpendIngestionRepository
+from tests.test_selector_charge import make_selector_charge
+from tests.test_telemetry_ingestion_db_integration import _connect_prisma
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres]
+
+
+@pytest.fixture
+async def selector_billing_db():
+    db = await _connect_prisma()
+    identity = str(uuid4())
+    charge = make_selector_charge()
+    charge = charge.model_copy(
+        update={
+            "attribution": charge.attribution.model_copy(
+                update={
+                    "api_key": identity,
+                    "user_id": identity,
+                    "team_id": identity,
+                    "organization_id": identity,
+                    "owner_account_id": None,
+                }
+            )
+        }
+    )
+    try:
+        await db.execute_raw(
+            """
+            WITH org AS (
+                INSERT INTO deltallm_organizationtable (id, organization_id)
+                VALUES ($1, $1) RETURNING organization_id
+            ), team AS (
+                INSERT INTO deltallm_teamtable (team_id, organization_id, models)
+                SELECT $1, organization_id, ARRAY[]::text[] FROM org RETURNING team_id
+            ), principal AS (
+                INSERT INTO deltallm_usertable (user_id, team_id, models)
+                SELECT $1, team_id, ARRAY[]::text[] FROM team RETURNING user_id, team_id
+            )
+            INSERT INTO deltallm_verificationtoken (id, token, user_id, team_id, models)
+            SELECT $1, $1, user_id, team_id, ARRAY[]::text[] FROM principal
+            """,
+            identity,
+        )
+        yield db, charge
+    finally:
+        async with db.tx() as tx:
+            await tx.execute_raw(
+                "DELETE FROM deltallm_spend_ingestion_outbox WHERE event_id = $1",
+                charge.attribution.component_event_id,
+            )
+            await tx.execute_raw(
+                "DELETE FROM deltallm_spendlog_events WHERE api_key = $1", identity
+            )
+            await tx.execute_raw("DELETE FROM deltallm_teammodelspend WHERE team_id = $1", identity)
+            await tx.execute_raw(
+                "DELETE FROM deltallm_verificationtoken WHERE token = $1", identity
+            )
+            await tx.execute_raw("DELETE FROM deltallm_usertable WHERE user_id = $1", identity)
+            await tx.execute_raw("DELETE FROM deltallm_teamtable WHERE team_id = $1", identity)
+            await tx.execute_raw(
+                "DELETE FROM deltallm_organizationtable WHERE organization_id = $1", identity
+            )
+        await SpendIngestionRepository(db).reconcile_capacity()
+        await db.disconnect()
+
+
+async def _scope_totals(db, identity):
+    rows = await db.query_raw(
+        """
+        SELECT 'key' AS scope, spend_exact::text AS spend FROM deltallm_verificationtoken WHERE token = $1
+        UNION ALL SELECT 'user', spend_exact::text FROM deltallm_usertable WHERE user_id = $1
+        UNION ALL SELECT 'team', spend_exact::text FROM deltallm_teamtable WHERE team_id = $1
+        UNION ALL SELECT 'org', spend_exact::text FROM deltallm_organizationtable WHERE organization_id = $1
+        UNION ALL SELECT 'model', spend_exact::text FROM deltallm_teammodelspend WHERE team_id = $1
+        """,
+        identity,
+    )
+    return {row["scope"]: Decimal(row["spend"] or "0") for row in rows}
+
+
+def _ingestion(db):
+    return SpendIngestionService(
+        db_client=db,
+        writer=SpendTrackingService(db),
+        config=SpendIngestionConfig(enabled=True, worker_enabled=False),
+    )
+
+
+@pytest.mark.asyncio
+async def test_selector_receipt_survives_ingress_restart_and_answer_failure(selector_billing_db):
+    db, charge = selector_billing_db
+    ingress = _ingestion(db)
+    await ingress.log_selector_charge(charge, expires_at=asyncio.get_running_loop().time() + 2)
+    await ingress.log_selector_charge(charge, expires_at=asyncio.get_running_loop().time() + 2)
+    # A fresh owner/process consumes the durable receipt, not in-memory state.
+    recovered = _ingestion(db)
+    records = await recovered._claim_batch()
+    assert [record.event_id for record in records] == [charge.attribution.component_event_id]
+    await recovered._process_batch(records)
+    await recovered.log_selector_charge(charge, expires_at=asyncio.get_running_loop().time() + 2)
+    assert await recovered._claim_batch() == []
+    assert await _scope_totals(db, charge.attribution.api_key) == {
+        scope: charge.customer_charge for scope in ("key", "user", "team", "org", "model")
+    }
+    await SpendTrackingService(db).log_request_failure_once(
+        event_id=str(charge.attribution.operation_id),
+        request_id=str(charge.attribution.operation_id),
+        api_key=charge.attribution.api_key,
+        user_id=charge.attribution.user_id,
+        team_id=charge.attribution.team_id,
+        organization_id=charge.attribution.organization_id,
+        end_user_id=None,
+        model=charge.attribution.model_group,
+        call_type="chat_completion",
+        http_status_code=500,
+        error_type="answer_failed",
+    )
+    rows = await db.query_raw(
+        "SELECT id, spend_exact::text AS spend, provider_cost_exact::text AS provider_cost FROM deltallm_spendlog_events WHERE api_key = $1",
+        charge.attribution.api_key,
+    )
+    assert len(rows) == 2
+    selector = next(row for row in rows if row["id"] == charge.attribution.component_event_id)
+    assert (
+        Decimal(selector["spend"]) == Decimal(selector["provider_cost"]) == charge.customer_charge
+    )
+    assert (await _scope_totals(db, charge.attribution.api_key))["key"] == charge.customer_charge
+
+
+@pytest.mark.asyncio
+async def test_concurrent_selector_receipt_delivery_has_one_economic_effect(selector_billing_db):
+    db, charge = selector_billing_db
+
+    async def deliver():
+        async with db.tx(timeout=timedelta(seconds=10)) as tx:
+            return await SpendTrackingService(tx).log_batch_once(
+                [(charge.attribution.component_event_id, "spend", charge.spend_payload())]
+            )
+
+    results = await asyncio.gather(*(deliver() for _ in range(8)))
+    assert sum(bool(inserted) for inserted, _ in results) == 1
+    assert await _scope_totals(db, charge.attribution.api_key) == {
+        scope: charge.customer_charge for scope in ("key", "user", "team", "org", "model")
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [RuntimeError, asyncio.CancelledError])
+async def test_selector_transaction_rollback_then_replay_is_exact(selector_billing_db, error):
+    db, charge = selector_billing_db
+    event = (charge.attribution.component_event_id, "spend", charge.spend_payload())
+    with pytest.raises(error):
+        async with db.tx() as tx:
+            await SpendTrackingService(tx).log_batch_once([event])
+            raise error()
+    assert (
+        await db.query_raw("SELECT id FROM deltallm_spendlog_events WHERE id = $1", event[0]) == []
+    )
+    assert all(
+        value == 0 for value in (await _scope_totals(db, charge.attribution.api_key)).values()
+    )
+    async with db.tx() as tx:
+        inserted, _ = await SpendTrackingService(tx).log_batch_once([event])
+    assert inserted == {event[0]}
+    assert await _scope_totals(db, charge.attribution.api_key) == {
+        scope: charge.customer_charge for scope in ("key", "user", "team", "org", "model")
+    }

--- a/tests/test_selector_observability.py
+++ b/tests/test_selector_observability.py
@@ -1,0 +1,50 @@
+from unittest.mock import Mock
+
+import pytest
+
+from src.metrics import selector
+from src.router.selection.contracts import (
+    SelectorCause,
+    SelectorDecision,
+    SelectorPolicyIdentity,
+    UnknownSelectorUsage,
+)
+from src.telemetry.selector_decision import ProtectedSelectorDecision
+
+
+def decision():
+    return SelectorDecision(
+        lane="economy",
+        minimum_rank=0,
+        cause=SelectorCause.CLASSIFIED,
+        latency_ms=12.0,
+        policy_identity=SelectorPolicyIdentity(fingerprint="route-policy-v1:" + "a" * 64),
+        usage=UnknownSelectorUsage(),
+    )
+
+
+def test_labels_are_fixed_enum_causes_and_bounded_ranks_only(monkeypatch):
+    metric = Mock()
+    monkeypatch.setattr(selector, "decisions", metric)
+    selector.observe_selector_decision(decision())
+    metric.labels.assert_called_once_with(cause="classified", rank="0")
+    with pytest.raises(ValueError):
+        selector.observe_selector_termination("secret/provider/url", seconds=1)
+    with pytest.raises(ValueError):
+        selector.observe_selector_answer(rank=100000, selector_seconds=1, streaming=True)
+
+
+def test_protected_decision_is_allowlisted_and_has_no_content_usage_or_topology():
+    payload = ProtectedSelectorDecision.from_decision(decision()).model_dump(mode="json")
+    assert set(payload) == {
+        "kind",
+        "lane",
+        "minimum_rank",
+        "cause",
+        "latency_ms",
+        "used_default",
+        "policy_identity",
+    }
+    assert payload["lane"] == "economy"
+    assert not payload["used_default"]
+    assert "usage" not in payload and "deployment_id" not in payload

--- a/tests/test_selector_prerequisite_structure.py
+++ b/tests/test_selector_prerequisite_structure.py
@@ -1,0 +1,48 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+MODULES = (
+    "billing/operation_reservation.py",
+    "billing/routing_costs.py",
+    "cache/execution_eligibility.py",
+    "db/billing_operations.py",
+    "db/billing_operation_recovery.py",
+    "db/routing_costs.py",
+    "db/spend_components.py",
+    "metrics/selector.py",
+    "providers/token_receipt.py",
+    "router/selection/capacity.py",
+    "router/selection/economics.py",
+    "router/selection/prerequisites.py",
+    "telemetry/selector_decision.py",
+)
+
+
+@pytest.mark.parametrize("module", MODULES)
+def test_new_prerequisite_boundaries_are_small_typed_and_request_free(module):
+    source = (ROOT / "src" / module).read_text()
+    assert len(source.splitlines()) < 500
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            assert node.end_lineno - node.lineno < 80, (module, node.name)
+        if isinstance(node, ast.Name):
+            assert node.id not in {"Any", "Request", "getattr", "hasattr", "setattr"}, module
+        if isinstance(node, ast.ImportFrom):
+            assert not (node.module or "").startswith(("fastapi", "src.api", "src.bootstrap")), (
+                module
+            )
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert node.func.attr not in {"create_task", "create_pool", "AsyncClient", "Client"}, (
+                module
+            )
+
+
+def test_response_cache_gate_is_mandatory_in_admitted_execution_factory():
+    source = (ROOT / "src/router/selection/prerequisites.py").read_text()
+    assert "cache: ResponseCacheEligibility" in source
+    assert "ReservedSelectorAdmission" in source
+    source = (ROOT / "src/router/selection/economics.py").read_text()
+    assert source.index("require_provider_execution()") < source.index("self._store.reserve(")

--- a/tests/test_ui_route_groups.py
+++ b/tests/test_ui_route_groups.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 from typing import Any
 from urllib.parse import quote
 
+from fastapi import FastAPI
 import pytest
 
 from src.db.callable_targets import CallableTargetBindingRecord
@@ -26,6 +27,7 @@ from src.router.policy_validation import (
     PolicyMemberInventoryItem,
     merge_policy_members,
 )
+from src.router.registry import DeploymentRegistryStore
 from src.router.runtime_generation import rebuild_routing_runtime_generation
 from src.router.selection.policy import (
     RouteSelectorActivationUnsupportedError,
@@ -104,9 +106,37 @@ def _publish_test_model_registry(test_app: Any) -> None:
             model_registry=model_registry,
             route_groups=list(current.route_groups),
             callable_target_catalog=build_callable_target_catalog(model_registry),
-            deployment_registry=build_deployment_registry(model_registry),
+            deployment_registry=DeploymentRegistryStore(build_deployment_registry(model_registry)),
         )
     )
+
+
+def test_published_model_registry_shares_one_deployment_store(test_app: FastAPI) -> None:
+    store = test_app.state.routing_runtime_generation_store
+    previous = store.require_snapshot()
+    test_app.state.model_registry = {
+        "selector-test": [
+            {
+                "deployment_id": "dep-selector",
+                "deltallm_params": {"model": "openai/gpt-4o-mini"},
+                "model_info": {"mode": "chat"},
+            }
+        ]
+    }
+
+    _publish_test_model_registry(test_app)
+
+    published = store.require_snapshot()
+    assert published is not previous
+    assert published.deployment_registry is published.router.deployment_registry
+    assert published.deployment_registry is not previous.deployment_registry
+    assert [
+        deployment.deployment_id
+        for deployment in published.deployment_registry.snapshot()["selector-test"]
+    ] == ["dep-selector"]
+    assert "selector-test" in published.routing_fingerprints
+    assert "selector-test" not in previous.deployment_registry
+    assert "selector-test" not in previous.routing_fingerprints
 
 
 class _FakeRouteGroupRepository:


### PR DESCRIPTION
## Summary

PR 3 of the model-group router implementation, targeting `feature/issue-304-model-router`, not `main`.

Part of #304. This PR does not close the issue.

Adds the economic, provider-capacity, response-cache, and observability prerequisites for the selector. Customers pay the selector's actual provider cost as a separate, exactly-once component; public response usage remains answer-only. The publication/runtime activation guard stays closed. Production request-path integration and activation belong to PR 4. No shadow mode is introduced.

### Implementation checklist

- [x] Bound the direct selector provider hop with shared RPM/TPM/concurrency admission, ownership-aware lease cleanup, deadlines, and cancellation handling. Local capacity failures do not penalize provider health.
- [x] Reserve a conservative selector-plus-answer allowance atomically across applicable key, user, team, organization, and team-model budget scopes before provider dispatch.
- [x] Persist stable operation identity, frozen attribution/pricing, dispatch state, and accepted usage receipts. Use exact monetary values and stable selector child event IDs for idempotent customer charges.
- [x] Capture valid provider usage before strict selector-output validation. Unknown usage remains pending, not zero; recovery never replays a provider request.
- [x] Extend the existing spend/recovery lifecycle with bounded SQL and no new clients, pools, or background-task owner.
- [x] Fix reservation/settlement lock ordering: operation, ordered account rows, billing-operation capacity, then spend/outbox capacity. Fresh reservation uses four application SQL statements including timeout setup; isolated reserve/dispatch/accept uses eight.
- [x] Isolate poison recovery receipts with transactionally persisted quarantine state while preserving strict canonical spend reconciliation. Attempt both recovery lanes and keep infrastructure failures visible.
- [x] Add cache v4 routing identity from immutable effective policy, members, provider defaults, and transitive fallback dependencies. Require typed whole-response cache miss/bypass evidence; reject hits and unresolved outcomes.
- [x] Add bounded metrics, redacted decision metadata, tenant-scoped component costs, reconciliation coverage, model distribution, and explicitly counterfactual savings estimates. Include selector cost without inflating request counts.
- [x] Add the additive Prisma migration, fresh/upgrade/shared-feature verifier checks, regression tests, performance harnesses, and protected recovery runbook.
- [x] Enable CI for PRs targeting the feature branch and supply the real-Redis test URL to the existing test job.
- [x] Keep selector activation disabled and remove the temporary implementation plans.

## Validation

Latest local affected-suite run on this code: **453 passed, 55 skipped, 2,399 warnings in 8.53 seconds**. All 55 skips require PostgreSQL. These skips are not passing database evidence.

Exact test command:

```bash
.venv/bin/python -u -m pytest \
  tests/test_billing_operation_repository.py \
  tests/test_operation_recovery.py \
  tests/test_billing_receipt_errors.py \
  tests/test_operation_reservation.py \
  tests/test_spend_ingestion.py \
  tests/test_billing.py \
  tests/test_billing_cost.py \
  tests/test_billing_tier_pricing.py \
  tests/test_selector_charge.py \
  tests/test_selector_observability.py \
  tests/test_routing_costs.py \
  tests/test_migration_verifier.py \
  tests/test_selector_prerequisite_structure.py \
  tests/router/selection \
  tests/test_billing_operations_postgres.py \
  tests/test_billing_operation_locking_postgres.py \
  tests/test_billing_operation_quarantine_postgres.py \
  tests/test_selector_charge_db_integration.py \
  tests/test_telemetry_ingestion_admin.py \
  tests/test_telemetry_ingestion_db_integration.py \
  tests/test_spend_visibility.py \
  tests/test_spend_reporting_cache.py \
  tests/test_spend_reporting_readiness.py \
  -q --tb=short --disable-warnings -rs -o faulthandler_timeout=45
```

Additional completed checks:

- `.venv/bin/ruff check` and `.venv/bin/ruff format --check`, each with all 69 touched Python paths explicitly supplied: passed during PR preparation.
- `.venv/bin/prisma generate --schema=./prisma/schema.prisma` with this worktree's `.venv/bin` on `PATH`: passed during implementation verification (Prisma Client Python 0.15.0).
- `git diff --check` and `git diff --cached --check`: passed before committing.
- The existing Python 3.14/Pydantic-v1 compatibility warning remains.
- Fixed-mock cache and isolated-selector measurements, raw-artifact locations, and earlier broader verification are documented in `docs/project/model-router-design.md`. They do not certify real PostgreSQL/Redis contention, production latency, or streaming TTFT.

### Required before merge

Opened for review and CI; **not declared merge-ready**.

- [ ] Required feature-branch CI checks pass on this commit, including the full affected application suite.
- [ ] Run real PostgreSQL reservation/settlement, duplicate-admission, both lock-contention schedules, cancellation, reconciliation, and poison-receipt quarantine tests without dependency skips.
- [ ] Pass fresh, last-supported-release upgrade, and shared-feature migration verification against disposable PostgreSQL databases.
- [ ] Run affected real-Redis concurrency, TTL, outage/recovery, and Lua tests without dependency skips.
- [ ] Qualify bounded SQL work, partial-index query plans, and recovery throughput with representative database cardinality and contention.

### Required before PR 4 activation

- [ ] Complete the remaining documented latency, storage/retention, and deployment-capacity qualification gates. No production qualification is inferred from fake-based results.
- [ ] Integrate production request/answer lifecycle boundaries and preserve the compatible accounting/recovery owner before lifting the activation guard.

## Product and documentation impact

- [x] Public API, errors, streaming, authentication, and tenant scope reviewed; response usage remains answer-only and no new public topology details are exposed.
- [x] Settings/defaults/secrets/reload behavior reviewed; no new activation setting or per-request infrastructure client is introduced.
- [x] Schema, migration sequencing, and rollback design documented; real migration execution remains an open gate above.
- [x] Provider usage semantics and frozen pricing reviewed; unsupported or ambiguous receipts remain unknown/pending.
- [x] Admin reporting request counts and cost scope reviewed; UI workflow/state/screenshots are not applicable because this PR changes no UI source.
- [x] Bounded metrics, recovery quarantine, and operator runbook documented; production capacity qualification remains open.
- [x] `docs/project/model-router-design.md` updated with ownership, failure modes, migration, performance evidence, review corrections, and remaining gates.
- [x] Prisma client regenerated locally; generated output is not committed. No new public endpoint is added.

## Rollout and rollback

Apply migration `20260908100000_billing_operation_reservations` through the existing coordinated migration workflow before application rollout. It is additive, with bounded DDL lock/statement timeouts and no inference-path history backfill. Now that this migration is shared, further database changes require a new migration.

Keep selector publication/runtime activation closed throughout PR 3. Cache v4 intentionally invalidates incompatible whole-response entries while preserving stable identity for equivalent effective routing snapshots.

Monitor capacity rejection, accounting/dependency failure, pending operations, committed recovery quarantines, recovery throughput, and journal/index growth. Quarantined operations retain their receipts, economic holds, and pending-capacity allocation; investigate them through the protected billing workflow.

Roll back application activation, not the economic journal or evidence. Retain a compatible spend/recovery owner until accepted/pending operations are reconciled. Do not replay providers, fabricate zero usage, clear unknown holds, or delete financial records to recover capacity.
