### PR TITLE
feat(router): activate real-time model-group selectors (PR 4)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -60,12 +60,19 @@ router_settings:
   #         weight: 3
   #       - deployment_id: embeddings-secondary
   #         weight: 1
-  # Model-router contract example (issue #304). This remains commented because selector
-  # runtime activation is intentionally rejected until the complete PR 4 execution path lands.
+  # Optional real-time model router (issue #304). Before enabling, declare each member's
+  # model_info.chat_capabilities and positive context capacity. The classifier also needs
+  # explicit provider token prices and positive RPM/TPM limits; see docs/configuration/models.md.
+  # Requires general_settings.spend_ingestion_mode: outbox and its enabled healthy worker.
+  # Selector cost is charged to customers; budgets remain soft checks, not spending holds.
+  # Batch and deterministic selector simulation remain unsupported.
   # route_groups:
   #   - key: support-chat
   #     mode: chat
   #     strategy: least-busy
+  #     context:
+  #       mode: smallest-sufficient
+  #       unknown_capacity: exclude
   #     selector:
   #       kind: llm-tier
   #       classifier_deployment_id: support-mini
@@ -111,7 +118,7 @@ general_settings:
   gateway_preflight_lease_ttl_seconds: 30
   # The outbox mode durably accepts one small event on the request path and
   # applies idempotent spend/ledger updates in a bounded background worker.
-  spend_ingestion_mode: legacy
+  spend_ingestion_mode: legacy # Use outbox before activating a model-router selector.
   spend_ingestion_batch_size: 100
   spend_ingestion_flush_interval_ms: 100
   spend_ingestion_lease_seconds: 30

--- a/deploy/kubernetes/helm/values.yaml
+++ b/deploy/kubernetes/helm/values.yaml
@@ -198,6 +198,9 @@ runtime:
       urlKey: REDIS_URL
 
 config:
+  # Selector-enabled chat members require model_info.chat_capabilities and context limits.
+  # Classifiers additionally require explicit provider prices and positive RPM/TPM limits.
+  # Activate only with spend_ingestion_mode: outbox and its enabled worker; see router docs.
   model_list: []
   router_settings:
     routing_strategy: simple-shuffle

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4620,7 +4620,7 @@
             "anyOf": [
               {
                 "items": {
-                  "$ref": "#/components/schemas/RoutePolicyMember"
+                  "$ref": "#/components/schemas/RoutePolicyMemberResponse"
                 },
                 "type": "array"
               },
@@ -4764,6 +4764,64 @@
           "deployment_id"
         ],
         "title": "RoutePolicyMember",
+        "type": "object"
+      },
+      "RoutePolicyMemberResponse": {
+        "additionalProperties": false,
+        "description": "Read compatibility for historical selector-free deployment identifiers.\n\nWrites continue through the strict selector/legacy semantic validators. Do not\napply a new selector-only length limit to a valid legacy response projection.",
+        "properties": {
+          "deployment_id": {
+            "minLength": 1,
+            "title": "Deployment Id",
+            "type": "string"
+          },
+          "enabled": {
+            "default": true,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "lane": {
+            "anyOf": [
+              {
+                "maxLength": 32,
+                "pattern": "^[a-z][a-z0-9_-]{0,31}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lane"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          }
+        },
+        "required": [
+          "deployment_id"
+        ],
+        "title": "RoutePolicyMemberResponse",
         "type": "object"
       },
       "RoutePolicyMutationResponse": {

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -85,6 +85,44 @@ field use their deployment ID as a compatibility incarnation. If an operator man
 later recreates an otherwise identical config-only deployment with the same ID, set a new opaque
 `routing_state_incarnation`; do not change it for metadata-only edits.
 
+## Model-router Capability and Price Metadata
+
+Selector-enabled Route Groups require explicit operator-qualified `model_info.chat_capabilities`
+on every enabled member. An empty object declares the plain text-chat floor. Optional features
+default to `false`; DeltaLLM does not guess capabilities from model names. Set only features the
+specific provider/deployment can honor. Unknown keys and non-boolean flags are rejected.
+
+```yaml
+model_info:
+  mode: chat
+  max_tokens: 32768             # Illustrative; use the deployment's actual context capacity.
+  chat_capabilities:
+    tools: true
+    json_object: true
+    json_schema: true
+    image: false
+    audio: false
+    file: false
+    streaming: true
+    multiple_choices: false
+  rpm_limit: 100                # Required positive limits for the classifier.
+  tpm_limit: 1000000
+  input_cost_per_token: 0.000001 # Illustrative provider prices, not customer tier prices.
+  output_cost_per_token: 0.000002
+```
+
+Context capacity must include a known positive `max_tokens` or `max_input_tokens`. The classifier
+supports input/output token prices, optional `input_cost_per_token_cache_hit`, and optional
+`cost_per_request`. Unsupported nonzero real-time billing dimensions fail qualification; separate
+Batch token rates do not affect this real-time call. Configure zero prices explicitly only when
+the provider call is truly free. Customers pay the frozen selector provider cost without markup.
+
+File configuration and the admin model API accept this metadata. Existing model-form saves preserve
+these fields; configure the flags through the API or file until guided editing is delivered.
+Changes affecting an active selector are revalidated, and updated
+capabilities participate in response-cache identity. See [model-router activation](router.md#model-router-policy-contract)
+for required outbox, context policy, capacity, data handling and soft-budget settings.
+
 ## Custom Upstream Auth Headers
 
 These `deltallm_params` fields are available for the OpenAI-compatible providers that support custom upstream auth headers:

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -233,12 +233,87 @@ the submitted member list as authoritative. Use `"selector": null` to disable se
 removes the selector and all member lanes without discarding the member list, enabled flags,
 weights, priorities, or server-owned member metadata.
 
-In the contract-only delivery stage (PRs 1–3 of issue #304), the API can validate and save a selector
-draft, but publish, rollback activation, deterministic simulation, database runtime loading, and
-file-config runtime loading reject it explicitly. PR 4 is the activation boundary. There is no
-shadow mode and no background classification of production requests.
+Publishing a qualified selector policy activates it for real-time Chat Completions and Responses,
+including streaming. File-configured groups use the same qualification at runtime load. There is
+no shadow mode or background classification of production requests. New operations pin one complete
+routing generation; in-flight operations finish against their original policy and credentials.
 
-The complete design, bounds, compatibility behavior, activation gate, rollout, and rollback order
+Before activation:
+
+- Use a supported concrete chat deployment as the enabled, same-group classifier. Every enabled
+  answer member must declare positive context capacity and explicit
+  [`model_info.chat_capabilities`](models.md#model-router-capability-and-price-metadata).
+- Set group `context.unknown_capacity: exclude`. The classifier needs explicit input/output token
+  prices (zero is allowed when genuinely free) and positive `rpm_limit` and `tpm_limit` metadata.
+- Enable `general_settings.spend_ingestion_mode: outbox` and
+  `spend_ingestion_worker_enabled: true`, with healthy PostgreSQL and shared Redis admission.
+  Missing accounting readiness fails activation/admission; it never becomes a free default call.
+
+For example, add this block alongside the `selector` and `members` in a policy:
+
+```yaml
+context:
+  mode: smallest-sufficient
+  unknown_capacity: exclude
+  safety_margin_tokens: 256
+```
+
+The execution order is normalized prompt/hook/guardrail processing, authentication and caller
+admission, whole-response cache lookup, deterministic member filtering, bounded selector admission
+and classification, then normal answer placement/retry/failover. A cache hit skips classification
+and selector accounting entirely. The selector sees a bounded projection of the final prompt,
+recent context and structural features, not credentials, unrestricted metadata, tool schemas or
+attachment contents. That prompt content goes to the configured classifier's provider: qualify its
+data-handling policy and required routing tags before publishing.
+
+Classification makes at most one provider attempt per external operation. Provider/parse/timeout
+or capacity failures select the configured safe lane; authentication, accounting and parent-deadline
+failures do not. The selected minimum rank is reused across retries, stream setup, MCP continuations
+and later selector-bearing fallback groups, even if lane names differ. A first selector reached
+through fallback runs only when needed. Normal strategy/context ordering applies independently
+within eligible lanes, with upward-only escalation. Selector-free fallback members retain their
+existing equivalence contract. Client disconnect cancels and joins selector work before streaming
+headers are sent. A disconnect terminates locally with `client_disconnected` (499), without opening
+the answer stream. Selector and answer share the original deadline; receipt/lease cleanup has a
+small bounded grace period and never replays a provider call.
+
+Customers pay the selector's actual provider cost, with no selector markup. Its linked, idempotent
+spend component is attributed to the caller even if the answer later fails or disconnects. Public
+OpenAI-compatible `usage` remains answer-only. Reported receipts use frozen exact pricing; unknown
+dispatch usage remains pending reconciliation, not zero. Compare savings as avoided answer spend
+minus selector spend; include cache/model-switch effects when evaluating.
+
+Budgets remain **soft admission checks**, not strict spending reservations. The selector's
+conservative estimate uses configured classifier input capacity plus its 64-token output bound;
+concurrently admitted requests may overshoot. Actual reported usage is still charged, including
+above that estimate. Ordinary traffic gains no new reservation calls. The classifier consumes
+shared provider RPM/TPM/concurrency capacity, while caller RPM is charged once. TPM admission uses
+the conservative context allowance, so configure enough TPM for the intended selector throughput.
+If a team-model budget is configured, its maintained spend counter must exist. Missing counter
+data fails selector admission as accounting unavailable; repair/reconcile it through the existing
+billing owner before retrying. Admission never rebuilds counters by scanning spend history.
+
+Use the existing policy validate/draft/publish/history/rollback API endpoints. Invalid activation
+does not archive the working policy; active member/model changes are requalified transactionally.
+Publish `{"selector": null}` to disable selection, or roll back to a selector-free revision. Rolling
+back to a selector-bearing revision revalidates and reactivates it. Canary through a separately
+authorized group. Before rolling back binaries to pre-PR-4 versions, remove active selectors and
+drain in-flight operations; disposable runtime-cache envelopes use a new version and reload from
+the durable policy source. Equivalent policy reloads keep response-cache identity, while selector,
+lane, capability or fallback-dependency changes invalidate it naturally.
+
+Batch items whose group or configured fallback topology contains a selector return
+`batch_model_router_selector_unsupported` until PR 6. Non-chat workloads reject selector policies.
+Deterministic policy simulation does not run selectors; guided editing and explicit offline
+evaluation are PR 5 work. Streaming with managed MCP tools retains its existing unsupported error.
+
+Monitor bounded selector decision/default/termination counters, duration, terminal rank and
+escalation counters, and selector contribution to streaming TTFT. Detailed lane and policy identity
+stay in protected routing telemetry, not public selector headers. Investigate high defaults by
+checking classifier capacity, provider health, context/capability metadata and strict lane output;
+investigate missing spend through the durable pending-reconciliation state, not synthetic zeroes.
+
+The complete design, bounds, compatibility behavior, rollout, and rollback order
 are documented in [Route-Group Model Router Design](../project/model-router-design.md).
 
 ## Fallback Configuration

--- a/docs/project/model-router-design.md
+++ b/docs/project/model-router-design.md
@@ -4,10 +4,11 @@ Status: accepted design for [issue #304](https://github.com/deltawi/deltallm/iss
 The implementation is split into six reviewable PRs. PRs 1–3 define prerequisites and must not
 activate a selector. PR 4 is the first activation boundary.
 
-Current PR 3 status: prerequisite code is implemented locally; real PostgreSQL/Redis,
-migration and production-capacity qualification are still open. The
-[current completion record](#pr-3-completion-decision--2026-09-08) supersedes the older
-partial-implementation checkpoints below. This is not a merge-readiness sign-off.
+PRs 1–3 are integrated into the feature branch, not `main`. PR 4 implements the
+real-time activation boundary locally, including the user-approved soft-budget
+contract. Its [completion record](#pr-4-completion-record-2026-09-09) supersedes the
+historical partial checkpoints below; the [PR 3 record](#pr-3-completion-decision-2026-09-08)
+remains implementation history, not the current verification status.
 
 ## Goal and non-goals
 
@@ -150,23 +151,21 @@ validates the submitted document only; it does not implicitly inherit a stored d
 `members` may be omitted but cannot be null. Invalid authored fields return HTTP 400, including
 typed request validation, without echoing submitted values. Incompatible effective policy state
 returns HTTP 409. Selector/context null tombstones and legacy selector-free normalization remain
-supported. Publish/rollback preserve the explicit unsupported-selector activation error.
+supported. Publish/rollback report a stable activation error if the complete selector
+runtime or its required deployment metadata cannot be qualified.
 
-Runtime Route-Group snapshots carry explicit proof that the selector activation gate ran. The
-database repository and validated file configuration are the only authorities that can mint an
-`inactive` snapshot before PR 4. Redis is an optimization, not an authority: its bounded 4 MiB
-`deltallm:<environment>:v2:route-group-runtime:r<revision>` entries are produced by the shared Redis
-key builder and use a strict versioned envelope containing the schema version and selector-gate
-state. Missing, legacy, malformed, oversized, or incompatible envelopes are cache misses and reload
-PostgreSQL. Selector, policy JSON, or lane fields are incompatible with this inactive projection
-and therefore also cause a cache miss. Only the durable loader can raise an activation error;
-that error never falls back to file configuration. Owned mode, strategy, timeout, retry, and context
-values are validated before a cache hit. Opaque nested extensions and valid historical numeric
-strings retain their meaning. Invalid groups reject the entire envelope. Read and write failures
-emit redacted structured logs and a fixed-reason `deltallm_route_group_cache_failures_total`
-counter; repair failure does not fail a valid durable read. Cache schema v2 remains compatible for
-valid entries. The previous cache namespace is left
-to expire naturally; PR 4 must bump the envelope and namespace when the activation state changes.
+Runtime Route-Group snapshots carry explicit validation provenance. PR 4 advances the
+bounded 4 MiB cache envelope and shared-key-builder namespace to v3 with `validated-v3`
+provenance. Database and validated file configuration remain authoritative. Canonical
+selector/lane data now survives L1/L2 round trips; runtime generation construction
+independently qualifies deployment capabilities, context, pricing and capacity before
+swapping the snapshot. Missing, old `inactive`, malformed, oversized or incompatible
+envelopes are observable misses and reload PostgreSQL. Loader validation failures never
+fall back to file configuration. Owned mode, strategy, timeout, retry, context and
+selector fields are validated before a cache hit; opaque historical fields keep their
+versioned meaning. Invalid groups reject the entire envelope. Cache failures retain the
+fixed-reason `deltallm_route_group_cache_failures_total` counter and redacted logs;
+repair failure does not fail a valid durable read. Old namespaces expire naturally.
 
 ## Request order after activation
 
@@ -1099,6 +1098,15 @@ scope bypasses reservation.** PR 4 must qualify the common admission boundary fo
 traffic sharing a protected scope before claiming hard-budget support. It must not just
 open the selector gate and treat this prerequisite as proof of whole-gateway hard caps.
 
+**PR 4 decision, 2026-09-09:** the user chose non-strict budgets. Do not extend atomic
+reservation admission to selector-free traffic. Concurrent requests may exceed a budget;
+there is no measured frequency or guaranteed overshoot bound. This supersedes the
+requirement to qualify whole-gateway hard-budget admission, not durable billing: incurred
+selector and answer usage still has one economic effect, and unknown usage remains pending
+for reconciliation. The PR 3 migration is shared and remains immutable. These paragraphs
+describe the reservation prerequisite, not a claim that production uses it or enforces
+hard shared budgets.
+
 ### Dependency, storage and rollout budgets
 
 - Existing selector-free requests: zero added SQL, Redis or provider awaits. All new
@@ -1391,3 +1399,470 @@ qualification. Raw runs and every comparison are preserved.
 The temporary ignored kickoff plan has been deleted as requested. This permanent record
 retains implementation decisions and the outstanding verification gates; no commit,
 push, merge, production activation or remote issue mutation was performed in this turn.
+
+## PR 4 — candidate-planning integration (historical first checkpoint)
+
+The first implementation slice adds immutable lane/rank information to
+`RouteCandidatePlan`. Publication, file-load and runtime activation guards remain closed;
+this slice alone does not make any production request invoke a selector. The remaining
+real-time execution, capability qualification, billing, streaming and Batch rejection
+work must land before activation. No shadow mode is introduced.
+
+### Ownership and compatibility
+
+`src/router/group_policy.py` now owns the existing strategy enum, group policy and runtime
+policy projection; `src/router/router.py` preserves their import facade. The group policy
+is frozen. `SelectorLaneRouting` holds frozen canonical selector/member contracts, using
+the existing assignment validator rather than a new configuration source. Historical
+pre-selector semantics ignore opaque selector fields as before. Selector-free members
+are not subjected to stricter selector validation.
+
+The router owns hard eligibility and one batched state read. The focused
+`src/router/selection/planning.py` owner applies the existing strategy and context ordering
+independently within each permitted lane. Health, cooldown, tags, workload compatibility,
+context capacity and configured pre-call checks run before the decision is applied.
+Missing/unhealthy/full lanes can escalate upward, never below the chosen minimum rank.
+A later selector-enabled group reuses the rank even when its lane names differ; a group
+with no sufficient rank has no executable candidates. Selector-free groups retain their
+existing equivalence contract and ordering.
+
+The existing `RequestSelectorState` remains the sole operation decision owner. The new
+internal request-context bridge cannot replace an attached owner, is separate from caller
+metadata, and does not start or join provider work. Before selection, a plan exposes hard
+eligibility by lane but has **no executable deployments**. Once the decision exists,
+pre-decision selector plans are invalidated; ordinary cached plans remain reusable.
+Explicit/context-demand invalidation discards candidate ordering without discarding the
+decision. Cancellation, failure and deadline expiry cannot return a previously cached
+executable selector plan. This is request-local state, not a new Redis or process cache.
+
+The previously oversized planning method is split at the eligibility/ordering boundary.
+Structure tests ratchet both methods below 80 lines and the router module below 800, and
+prohibit selector execution in planning. No clients, workers, queues, SQL, Redis commands,
+schema changes, public fields, headers or UI settings are added in this slice. The existing
+provider-execution activation guard is retained, including its structural regression.
+
+### Verification scope
+
+Tests cover all supported lane counts (2–8) and every rank, per-lane ordering for all nine
+existing strategy values, safe-default ranking, hard-filter precedence, no downgrade when
+the selected lane is unavailable, differently named fallback lanes, decision retention
+through re-planning, immutable projections, caller-metadata isolation, and terminal-state
+rejection. The cache fingerprint fixture now has a valid nonempty two-lane membership;
+its member-change, timeout-change, historical-semantics and equivalent-snapshot assertions
+are preserved.
+
+Dependency regression tests assert one health/cooldown batch per fresh plan; active,
+usage and latency state is loaded once only when required by the strategy/pre-call policy.
+All lanes share that snapshot, with no additional SQL/Redis/provider round trips. Cached
+plans perform no additional state reads. Selector-free ordering is compared with the
+previous strategy invocation under the same random state, not merely an unordered set.
+
+Full PR 4 acceptance remains open: these tests do not yet prove HTTP selector execution,
+lazy fallback execution, MCP continuation wiring, stream disconnect cancellation, actual
+answer-attempt accounting, capability/data-placement qualification or production activation.
+
+### Local verification — 2026-09-09
+
+Base: local feature integration `37929ea740704653730df1740bb0f236402bd51e`.
+Worktree: `.worktrees/issue-304-pr4-realtime-routing`. The Python 3.11 environment was
+installed from the frozen lock with dev/docs extras and its Prisma client generated.
+
+- `uv run --frozen --no-sync pytest -q -m hermetic --tb=short --durations=5`:
+  **3,179 passed** (final run, including all 89 additional cases).
+- `.venv/bin/pytest -q -m app --tb=short --durations=10`:
+  **1,156 passed**, 22 existing deprecation warnings, 328.39 seconds.
+- `.venv/bin/pytest -q -m postgres --tb=short --durations=10`, with `DATABASE_URL`
+  targeting the feature's isolated migrated PostgreSQL 15 database:
+  **235 passed**, 4 deprecation warnings, 69.82 seconds.
+- `.venv/bin/pytest -q -m redis --tb=short --durations=10`, with both Redis test
+  variables pointing to the isolated Redis 7 instance: **46 passed**, 2 deprecation
+  warnings, 8.38 seconds. Both owned containers were stopped afterward; no data deleted.
+- Full `--collect-only -qq --dependency-lane-report`: **4,675 tests**, partitioned into
+  3,179 hermetic / 1,156 app / 235 postgres / 46 redis / 59 Helm. No classifier, fixture
+  lane or CI selection changes. The unaffected Helm lane and UI gates were not rerun.
+- `.venv/bin/ruff check src/router tests/router/selection tests/test_routing_cache_identity.py`
+  passed; `.venv/bin/ruff format --check` on all 14 changed Python files passed.
+- `.venv/bin/python scripts/docs/export_openapi.py --check`: current, 227 paths /
+  295 operations. `git diff --check` passed. No migration or generated-artifact changes.
+
+The new failover test also exercises the real `FailoverManager` with zero, one and two
+retries, followed by upward escalation, while invalidating plans between attempts.
+Its mock explicitly requests retry-or-next behavior without health damage; local
+fail-fast errors must not be treated as provider-retry failures. A zero configured
+backoff cap makes this a deterministic ordering/ownership test, not a wall-clock test.
+No production retry behavior or deadline was relaxed.
+
+The unchanged `tests/performance/routing_cache_profile.py` harness ran sequentially
+against the clean base worktree and this implementation:
+`.venv/bin/python -m tests.performance.routing_cache_profile --label before|after
+--output-dir /private/tmp/deltallm-pr4-planning.5jEuge`.
+The raw JSONL samples and summaries are retained in that directory. Each profile
+offered 10 RPS for 20 seconds, received **200/200 successes**, dropped no requests,
+and recorded zero sampled in-flight slope. This is ASGI with fake Redis and a fixed
+local provider mock, not a database, streaming TTFT or release-capacity certificate.
+
+| Profile | Before p50 / p95 / p99 (ms) | After p50 / p95 / p99 (ms) |
+| --- | --- | --- |
+| Cache miss | 6.819 / 9.263 / 11.279 | 5.468 / 10.725 / 17.549 |
+| Cache hit | 4.390 / 6.666 / 12.173 | 1.716 / 3.406 / 3.960 |
+
+Redis/cache/provider call counts are identical before and after: misses make one
+provider POST and one response-cache get/set; hits make zero provider calls and one
+cache get. Existing Redis method counts match the harness's exact assertions. The
+after-miss run had a 225.506 ms maximum, 121.565 ms maximum scheduling lag, and maximum
+in-flight of three (one in the other profiles). The miss-tail increase is recorded,
+not dismissed as proved host noise or presented as latency parity. Longer controlled
+performance qualification remains required before PR 4 activation.
+
+### PR 4 execution composition and soft admission (2026-09-09)
+
+The implementation extends the existing billing-operation journal with a typed
+`SoftSelectorOperation`. This is not a weakened `OperationReservation` or an
+invented provider-enforced quote. It acquires no spending holds and does not own
+answer accounting. The journal's answer component is `unattempted` because that
+component is not dispatched through this journal; the existing answer spend owner
+continues to record the answer. This does not describe the answer as free.
+
+Before the selector dispatches, one bounded transactional ownership/budget snapshot
+checks the verified key, user, team, organization and team-model scope with a
+conservative configured-context allowance. Concurrent admissions may overshoot.
+When a team-model budget is configured, its maintained spend counter must exist;
+missing counter data returns accounting unavailable before provider dispatch. No
+append-only spend-history scan or rollup repair runs in this new admission path.
+Actual reported selector usage is accepted even above the estimate. A stable child
+event and frozen provider-price snapshot carry its exact pass-through customer
+charge; unknown usage stays pending. There is no provider replay for reconciliation.
+The existing spend worker recovers journal receipts into its existing outbox and
+settles them in the same ledger transaction. Ordinary answer events do not gain
+operation-journal settlement queries, and selector-free requests acquire no holds.
+No shared migration, new client/pool, new queue or new worker is introduced.
+
+The authenticated Chat/Responses edge binds a single operation only when the pinned
+fallback topology can reach a selector. It supplies the final normalized request,
+whole-response-cache eligibility, verified attribution and original execution
+deadline. Initial hard-rejected groups do not justify a paid classification.
+Failover owns attempts and retries, but defers selector groups until execution
+reaches them. All subsequent groups and MCP model phases reuse the decision's
+minimum rank; payload/context replanning does not reset the decision or deadline.
+The edge owns and joins both the selector task and its blocking disconnect monitor;
+neither is detached. A real ASGI disconnect cancels the provider and unwinds the
+middleware with a local `499 client_disconnected` error before SSE headers. Receipt
+and permit cleanup remain owned by the existing selector prerequisites.
+
+Activation requires explicit `model_info.chat_capabilities` for every enabled
+member, known positive context metadata and `context.unknown_capacity: exclude`.
+The common floor is text chat. Operators must explicitly qualify tools, JSON
+object/schema output, image/audio/file input, multiple choices and streaming; undeclared optional
+features are not inferred from provider/model names. The classifier also requires
+explicit input/output provider prices and positive canonical RPM/TPM limits.
+Its concurrency ceiling is conservatively its RPM ceiling, on the same shared
+deployment lease owner. Unsupported billing dimensions reject qualification.
+Classifier tags use the same static tag filter as answer candidates.
+
+Publication readiness and metadata qualification run within the locked policy
+transaction. File/database runtime generations independently compile qualified,
+immutable selector projections before publication. Disposable route-group cache
+envelopes/keyspaces advance to v3 with `validated-v3` provenance; older inactive
+envelopes are misses. Simulation remains explicit unsupported until PR 5's offline
+evaluation work. Batch rejects both direct selectors and selector-bearing fallback
+topologies with `batch_model_router_selector_unsupported` until PR 6.
+
+The completion record below covers the expanded execution scope; the earlier
+candidate-only counts are retained as historical evidence, not added to final totals.
+
+## PR 4 completion record — 2026-09-09
+
+The complete real-time implementation is local on `issue-304-pr4-realtime-routing`,
+based on feature integration `37929ea740704653730df1740bb0f236402bd51e`. This record
+supersedes the incomplete PR 4 checkpoint above and the old dormant-only activation
+restrictions. No commit, push, PR, remote issue edit or merge to `main` is part of
+this implementation turn. Production defaults do not configure a selector.
+
+### Issue #304 delivery checklist
+
+- [x] Immutable lane-aware `RouteCandidatePlan`; no classifier execution in planning.
+- [x] Authoritative membership, workload, capability, tags, health, capacity and
+  context checks precede decision application; authorization precedes paid selection.
+- [x] Selected rank followed by upward-only escalation, including differently named
+  lanes in later groups; no lower-rank candidate after a quality decision.
+- [x] All existing strategies and context ordering apply within each eligible lane.
+- [x] Existing retries, classified/ordinary/local-context fallbacks, cycle/attempt
+  limits, one decision, MCP continuation and pinned-generation semantics are retained.
+- [x] Chat Completions and Responses work in streaming and non-streaming modes.
+- [x] Classification and durable known receipt precede stream headers/body; actual
+  ASGI disconnect cancels and joins the classifier, without opening an answer stream.
+- [x] Policy qualification, soft budget admission, exact durable billing, shared
+  provider capacity, cache eligibility, bounded telemetry and execution are composed.
+- [x] Atomic publish activates a qualified selector; removal and versioned rollback
+  disable/revalidate it. Invalid metadata changes cannot archive the working policy.
+- [x] Batch explicitly rejects direct and fallback-reachable selectors with
+  `batch_model_router_selector_unsupported`, pending PR 6.
+- [x] Selector-free groups and response-cache hits perform no classifier work;
+  ordinary requests retain their dependency counts and answer usage contract.
+
+The issue's legacy long deployment-ID P2 is also fixed: response DTOs preserve valid
+selector-free identifiers over 256 characters, while selector-enabled writes retain
+their strict bound. The HTTP regression covers validation and draft persistence.
+Guided editing, explicit evaluation and analytics UI remain PR 5; per-item Batch
+classification remains PR 6. Neither is an unfinished PR 4 item. There is no shadow mode.
+
+Main regression owners are `tests/router/selection/test_{planning,lane_bounds,
+planned_failover,planning_dependencies,realtime,realtime_fallbacks,realtime_lifecycle,
+realtime_admission,disconnect,execution_contracts}.py`,
+`tests/db/test_selector_activation.py`, `tests/bootstrap/test_selector.py`,
+`tests/test_soft_selector_operations_postgres.py`, and
+`tests/test_ui_route_policy_legacy_identifiers.py`. Tests include accounting outage,
+capacity/tag/context denial, unsupported features outside the bounded prompt projection,
+one selector across MCP tool phases, policy reload during classification, both provider-
+classified fallback kinds, local context fallback without primary dispatch, stale L2
+cache provenance, and one terminal metric even when a deployment belongs to several groups.
+
+### Ownership, resource and dependency budgets
+
+The user-approved soft budget decision supersedes strict cross-traffic reservation
+qualification. It does not waive durable charges, attribution or fail-closed accounting.
+The new admission query joins five unique scope/counter identities, never scans spend
+history, and returns at most one row. A configured team-model budget with a missing
+counter is unavailable, not zero. The real query-plan regression seeds 10,001 counters,
+uses `deltallm_teammodelspend_pkey` for exactly one row/loop, and has no event-table scan.
+Its focused sample measured 0.089 ms execution / 0.494 ms planning; the other identity
+tables in that fixture are small, so this is not an all-tenant production-scale profile.
+
+One reported selector adds four application statements for fresh admission, two for
+dispatch intent and two for receipt acceptance, including transaction timeout setup
+but excluding begin/commit protocol. These three transactions borrow the existing
+telemetry database pool. Each has a 250 ms ceiling subordinate to the execution deadline;
+receipt cleanup has a shared 250 ms grace and permit cleanup 50 ms with owner-token TTL
+recovery. One request owns at most two joined selector/disconnect tasks, no detached
+work, and at most one classifier provider call. Billing denial returns unavailable;
+provider/format/context/capacity failure uses the safe lane without answer cooldown.
+
+Selector provider acquisition/release adds two canonical Redis EVALs. Eligible-lane
+planning shares the existing batched health/capacity snapshot across every lane. After a
+decision, replanning reads the canonical snapshot again rather than sharing mutable
+state across operations. The integrated mock profile measures the resulting full-path
+delta: per request, `eval +2`, `hgetall +2`, `mget +1`, `zadd +1`, with all other fake
+Redis method counts unchanged. These include fake implementation internals, not wire
+command counts. Baseline operations make zero selector billing calls; selector operations
+make exactly one reserve/dispatch/accept. Ordinary answer outbox batches do not acquire
+new operation-journal settlement queries. Existing spend recovery remains off requests.
+
+There are no new pools, clients, workers, queues, indexes or migrations. Selector work
+borrows the existing provider/telemetry/Redis owners; increased request work does not
+increase their configured connection ceilings. With the current production chart's
+12 API replicas, one process per pod and one rolling-surge pod, the existing database
+allocation is `(12 + 1) * (20 + 5) = 325` connections, including 65 telemetry connections;
+the existing upstream HTTP ceiling is `13 * 500 = 6,500`. Enabling two split workers
+plus their one surge adds 75 database / 1,500 upstream connections, not a second selector
+allocation. Migration/admin headroom and external provider/server limits still need an
+operator-approved deployment budget; these sums are ceilings, not throughput claims.
+The existing shared Redis client remains unchanged; this PR does not certify or redesign
+its deployment-wide pool policy. Provider RPM/TPM and lease state are deployment-scoped
+in shared Redis, not multiplied per API replica. Selector admission uses one RPM and
+`classifier context allowance + 64` TPM units; the concurrency ceiling is its configured
+RPM limit. Account for classifier and answer traffic on the same physical deployment.
+
+The existing 100,000-pending-operation journal bound, canonical retention policy,
+idempotent recovery, storage/index amplification and rollout runbook above remain in
+force. Soft operations hold zero spending allowance and leave answer accounting with
+the existing answer owner; they do not mislabel unknown selector usage as free. No
+production-scale storage or 50-RPS release certificate is claimed by local completion.
+
+### Final correctness and compatibility verification
+
+Python 3.11.13 uses the frozen lock and generated Prisma 0.15 client. Full collection
+is **4,774 tests**, assigned exclusively to 3,212 hermetic / 1,195 app / 262 postgres /
+46 redis / 59 Helm. All five lanes pass with no skipped tests. JUnit and collection
+artifacts are retained at `/private/tmp/deltallm-pr4-final.18iuAt/` on the implementation
+host; this temporary path is evidence, not a durable repository artifact store.
+
+```sh
+.venv/bin/pytest --collect-only -qq --dependency-lane-report
+.venv/bin/pytest -q -m hermetic
+.venv/bin/pytest -q -m app
+DATABASE_URL="$PR4_TEST_DATABASE_URL" .venv/bin/pytest -q -m postgres
+REDIS_URL="$PR4_TEST_REDIS_URL" DELTALLM_TEST_REDIS_URL="$PR4_TEST_REDIS_URL" .venv/bin/pytest -q -m redis
+.venv/bin/pytest -q -m helm
+git ls-files -m -o --exclude-standard -z -- '*.py' | xargs -0 .venv/bin/ruff check
+git ls-files -m -o --exclude-standard -z -- '*.py' | xargs -0 .venv/bin/ruff format --check
+.venv/bin/python scripts/docs/export_openapi.py --check
+.venv/bin/mkdocs build --strict --site-dir /tmp/deltallm-pr4-docs-site
+git diff --check
+```
+
+Use isolated migrated PostgreSQL 15 and Redis 7, not production URLs. Hermetic tests
+include an existing loopback webhook test: sandbox-only execution skipped it; the final
+socket-enabled run passed all 3,212 in 16.36 seconds. The app lane passed in 482.83 seconds
+with 22 existing deprecation warnings; PostgreSQL passed all 262 in 92.72 seconds with
+four existing deprecation warnings. Schema and all shared migrations are unchanged;
+the feature/main alignment already qualified fresh, last-release and shared-feature
+migration paths. PR 4 runs against that same migrated schema. No CI/lane selection
+or test-discovery rules were weakened or changed.
+
+UI verification uses actual Node 22.23.2: **206 unit tests pass**, type-check/production
+build passes, touched-file ESLint passes. Full lint remains the clean feature base's
+**118 errors / 4 warnings**, with identical normalized findings and no new errors.
+The complete generated `ui/dist` is byte-for-byte identical to the clean base: no
+initial-bundle or route-chunk growth. OpenAPI is synchronized at 227 paths / 295
+operations. No provider credentials or live third-party calls were used.
+
+### Constant-arrival and TTFT evidence
+
+Raw JSONL and summaries are in `/private/tmp/deltallm-pr4-final.18iuAt/{cache,
+cache-repeat,realtime}`. Every case offers 10 RPS for 20 seconds, completes 200/200
+successfully with zero generator drops and zero sampled in-flight slope. The existing
+cache harness runs unchanged in the clean feature-base and PR 4 checkouts. The repeat
+reverses execution order (after, then before) and preserves the initial results.
+
+| Cache case | Before p50 / p95 / p99 ms | After p50 / p95 / p99 ms |
+| --- | --- | --- |
+| Initial miss | 10.398 / 18.016 / 21.547 | 10.530 / 16.514 / 27.063 |
+| Initial hit | 5.775 / 9.940 / 16.645 | 5.877 / 7.702 / 8.943 |
+| Repeat miss | 10.675 / 17.793 / 22.339 | 12.017 / 19.863 / 24.021 |
+| Repeat hit | 6.225 / 9.133 / 10.523 | 5.265 / 7.658 / 11.136 |
+
+All cache/Redis/provider count assertions match the base exactly: a miss has one
+cache get/set and one provider post; a hit has one get and no provider post. Miss tail
+latency is higher, not demonstrated parity: initial/repeat PR 4 maxima were 329.166 /
+312.172 ms with 223.542 / 205.932 ms maximum scheduling lag and four observed in-flight
+requests (one in baseline cache cases). These short in-process samples do not attribute
+the stalls to a specific cause or certify a deployment SLO.
+
+The new `tests.performance.realtime_selector_profile` compares the complete admitted
+Chat path with/without selection, using fixed 1 ms provider hops, fake billing and
+fake Redis. TTFT is measured at the first ASGI body, not a buffered client's read.
+
+| Integrated path | p50 / p95 / p99 ms | Stream TTFT p50 / p95 / p99 ms |
+| --- | --- | --- |
+| Baseline non-streaming | 12.587 / 17.900 / 46.752 | — |
+| Selector non-streaming | 19.155 / 27.616 / 32.606 | — |
+| Baseline streaming | 14.352 / 20.697 / 24.267 | 10.752 / 16.662 / 19.579 |
+| Selector streaming | 20.898 / 27.217 / 33.198 | 17.317 / 24.469 / 30.761 |
+
+Median selection overhead was 6.568 ms non-streaming and 6.565 ms for streaming TTFT,
+including the mock selector provider time. Each selector case made 200 selector and
+200 answer calls, and 200 reserve/dispatch/accept operations; both baseline cases made
+200 answer calls and zero selector/billing operations. Total selector provider time
+was 249.923 ms non-streaming / 297.959 ms streaming; answer provider totals were
+252.480 / 248.601 ms. All integrated cases observed maximum in-flight one except the
+baseline non-streaming case (four, 347.995 ms maximum latency). SQL/real-Redis wire
+latency, real-provider quality, net savings and deployment saturation are not measured
+by this harness; real-service correctness is covered separately by the full lanes.
+
+Reproduce with the same locked environment in each checkout:
+
+```sh
+.venv/bin/python -m tests.performance.routing_cache_profile --label before --output-dir /tmp/pr4/cache
+.venv/bin/python -m tests.performance.routing_cache_profile --label after --output-dir /tmp/pr4/cache
+.venv/bin/python -m tests.performance.realtime_selector_profile --output-dir /tmp/pr4/realtime
+```
+
+### PR 4 review corrections — 2026-09-09
+
+Four reproduced review findings are corrected locally without changing the soft
+budget decision, public answer-only usage, settings, schema, UI or deployment
+contracts:
+
+- Streaming MCP requests fail with the existing 400 message after canonical
+  transformed-payload preflight and before binding/admitting a selector. Both Chat
+  and Responses reject tools supplied directly or introduced by a hook with zero
+  selector reserve, dispatch, receipt or provider calls. Failure logging uses the
+  existing preflight error owner, before any deployment is chosen.
+- Initial local-context fallback planning shares the original request deadline.
+  Only the existing batched planning await is deadline-bounded: deferred selector
+  work retains its own bounded receipt/permit cleanup, without an enclosing timeout
+  that could cancel cleanup a second time. Event-barrier tests on Chat and Responses
+  prove cancellation/join and 408 while planning is stalled, before any paid call.
+- A typed prepared-write result keeps the canonical validation projection separate
+  from the stored document. Direct publication qualifies the projection and persists
+  the preserved document, matching draft publication and rollback. PostgreSQL tests
+  prove nested opaque member metadata survives direct publish, draft, removal and
+  rollback; new client-authored unknown fields still fail without a revision change.
+- Activation uses the existing canonical member merge to qualify effective enabled
+  members. Group-disabled and policy-disabled members need not have activation
+  metadata; disabled inventory can lack a lane or concrete model. The classifier
+  must remain enabled and both active lanes populated. PostgreSQL tests cover
+  publication, draft, rollback and active-group edits, plus atomic rejection of
+  re-enabling an unqualified member without changing policy history or revision.
+
+No SQL, Redis, provider call, retry, task owner or pool is added. Ordinary routing
+still performs no selector work; the existing local-fallback batch planner now has
+the same deadline bound as other selector-reachable planning. Publication remains
+inside the existing group-locked transaction and runtime revision lifecycle. No
+migration is needed; the earlier fresh/upgrade and UI/Helm evidence still applies
+to these unchanged surfaces.
+
+#### Review-fix verification
+
+The four HTTP MCP variants, two blocked-planner variants and three failing
+PostgreSQL publication variants reproduced the findings before the fixes. Fourteen
+new regressions are collected automatically: three hermetic, six app and five
+PostgreSQL. Focused routing/publication/HTTP tests passed **399**; the selector
+activation PostgreSQL module passed **15**. All five full lanes then passed:
+
+| Lane | Passed | Runtime |
+| --- | ---: | ---: |
+| Hermetic | 3,215 | 16.79 s |
+| App | 1,201 | 644.98 s |
+| PostgreSQL | 267 | 101.62 s |
+| Redis | 46 | 9.49 s |
+| Helm | 59 | 7.61 s |
+| Total, mutually exclusive | 4,788 | — |
+
+No failures or skips; app/PostgreSQL/Redis retain 22/4/2 existing deprecation
+warnings. Ruff lint and format checks pass for all **82** changed/new Python files.
+OpenAPI remains current at 227 paths / 295 operations; strict MkDocs and
+`git diff --check` pass. No test-classifier or shared-fixture contract was weakened.
+The isolated PostgreSQL/Redis containers were stopped afterward, retaining data.
+UI sources/build inputs and schema/migrations did not change in this follow-up;
+their earlier verification is not represented as a new run.
+
+Raw collection, JUnit and logs: `/private/tmp/deltallm-pr4-review-fixes.O7zXhG`.
+Reproduction commands use the existing frozen-lock `.venv`; set the two task-local
+test URLs to isolated services (Docker may assign new ports after restart):
+
+```sh
+.venv/bin/pytest -q tests/router/selection tests/services/test_route_policy_publication.py tests/db/test_route_policy_repository.py tests/test_ui_route_groups.py
+DATABASE_URL="$PR4_TEST_DATABASE_URL" .venv/bin/pytest -q tests/db/test_selector_activation.py
+.venv/bin/pytest --collect-only -qq --dependency-lane-report
+.venv/bin/pytest -q -m hermetic --durations=10
+.venv/bin/pytest -q -m app --durations=10
+DATABASE_URL="$PR4_TEST_DATABASE_URL" .venv/bin/pytest -q -m postgres --durations=10
+REDIS_URL="$PR4_TEST_REDIS_URL" DELTALLM_TEST_REDIS_URL="$PR4_TEST_REDIS_URL" .venv/bin/pytest -q -m redis --durations=10
+.venv/bin/pytest -q -m helm --durations=10
+git ls-files -m -o --exclude-standard -z -- '*.py' | xargs -0 .venv/bin/ruff check
+git ls-files -m -o --exclude-standard -z -- '*.py' | xargs -0 .venv/bin/ruff format --check
+.venv/bin/python scripts/docs/export_openapi.py --check
+.venv/bin/mkdocs build --strict --site-dir /tmp/pr4-review-docs
+git diff --check
+```
+
+The unchanged cache harness was repeated sequentially on the clean feature base
+and final PR 4 worktree, with no test suites running (`cache-isolated/`). All four
+cases completed 200/200 at 10 RPS for 20 seconds, zero generator drops and zero
+sampled in-flight slope. Redis/cache/provider call dictionaries match exactly:
+misses have one cache get/set and one provider call; hits have one get and no
+provider call. The normal path adds no selector economic work.
+
+| Isolated cache case | Before p50 / p95 / p99 ms | After p50 / p95 / p99 ms |
+| --- | --- | --- |
+| Miss | 6.199 / 12.124 / 15.479 | 6.241 / 13.045 / 34.259 |
+| Hit | 3.115 / 6.021 / 8.165 | 2.585 / 6.064 / 10.571 |
+
+Tail latency is not proven equivalent: the isolated after-miss maximum was
+242.487 ms with 137.569 ms maximum scheduling lag and three in flight, versus one
+in flight in the other cases. An earlier comparison overlapping the app suite is
+retained in `cache/`: its after-miss run failed the 200-success assertion with
+196 successes/four 429s, 705.018 ms maximum scheduling lag and nine in flight.
+Do not silently discard that failed run or attribute its stall to a specific cause.
+
+The integrated real-time profile (`realtime/`) also repeated all four cases:
+200/200 successes each, zero generator drops, 200 answer calls each, and exactly
+200 reserve/dispatch/receipt operations only in each selector case (zero in both
+baselines). Every sampled in-flight slope was non-positive. Stream TTFT p50/p95/p99
+was 10.605/14.771/20.937 ms baseline and 17.033/25.325/31.080 ms with selection.
+This run overlapped the application suite: its baseline non-streaming p95/p99 was
+202.215/257.600 ms, so it is call-count evidence, not a clean latency-overhead
+comparison. Both profiles remain local fake-dependency regression checks, not a
+production performance or real-model savings certificate. Use the same harness
+commands from the preceding section with the review artifact directory.

--- a/src/api/admin/endpoints/models.py
+++ b/src/api/admin/endpoints/models.py
@@ -325,6 +325,18 @@ def _normalize_model_info_or_400(
     existing_model_info: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     normalized = dict(model_info)
+    if normalized.get("chat_capabilities") is not None:
+        from src.chat_capabilities import ChatRoutingCapabilities
+
+        try:
+            normalized["chat_capabilities"] = ChatRoutingCapabilities.model_validate(
+                normalized["chat_capabilities"]
+            ).model_dump()
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="model_info.chat_capabilities must declare supported chat features with boolean values",
+            ) from exc
     if "access_groups" in normalized:
         try:
             normalized["access_groups"] = normalize_access_group_list(

--- a/src/api/admin/route_group_contracts.py
+++ b/src/api/admin/route_group_contracts.py
@@ -142,6 +142,16 @@ class RoutePolicyRetryDocument(BaseModel):
     retryable_error_classes: list[str] | None = None
 
 
+class RoutePolicyMemberResponse(RoutePolicyMember):
+    """Read compatibility for historical selector-free deployment identifiers.
+
+    Writes continue through the strict selector/legacy semantic validators. Do not
+    apply a new selector-only length limit to a valid legacy response projection.
+    """
+
+    deployment_id: str = Field(min_length=1)
+
+
 class RoutePolicyDocumentResponse(BaseModel):
     """Normalized latest policy projection; unknown future fields remain readable."""
 
@@ -149,7 +159,7 @@ class RoutePolicyDocumentResponse(BaseModel):
 
     mode: str | None = None
     strategy: str | None = None
-    members: list[RoutePolicyMember] | None = None
+    members: list[RoutePolicyMemberResponse] | None = None
     timeouts: RoutePolicyTimeoutsDocument | None = None
     retry: RoutePolicyRetryDocument | None = None
     context: RoutePolicyContextDocument | None = None

--- a/src/batch/chat_worker_execution.py
+++ b/src/batch/chat_worker_execution.py
@@ -56,6 +56,7 @@ from src.router.execution import (
     get_failover_attempt_context,
 )
 from src.router.health_policy import affects_deployment_health
+from src.router.selection.reachability import require_batch_selector_support
 from src.routers.routing_decision import route_failover_kwargs
 
 logger = logging.getLogger(__name__)
@@ -122,6 +123,7 @@ class ChatWorkerExecutionMixin:
         )
         app_router = routing_generation.router
         model_group = app_router.resolve_model_group(chat_request.model)
+        require_batch_selector_support(model_group, routing_generation.selector_reachable_groups)
         await self._raise_if_model_group_deferred(model_group)
 
         primary_deployment = await require_initial_deployment(

--- a/src/batch/worker_types.py
+++ b/src/batch/worker_types.py
@@ -7,6 +7,9 @@ from src.batch.embedding_microbatch import _ExecutionSignature
 from src.models.requests import ChatCompletionRequest, EmbeddingRequest
 from src.router.runtime_authorization import CallableTargetGrantSnapshot
 from src.router.runtime_generation import RoutingRuntimeGenerationStore
+from src.router.router import Router
+from src.router.failover import FailoverManager
+from src.router.selection.reachability import selector_reachable_groups
 
 
 BATCH_ARTIFACT_VALIDATION_FAILED_PROVIDER_ERROR = "artifact_validation_failed"
@@ -26,6 +29,7 @@ class BatchRoutingRuntime(Protocol):
     router: Any
     failover_manager: Any
     authorization_snapshot: CallableTargetGrantSnapshot | None
+    selector_reachable_groups: frozenset[str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,6 +41,7 @@ class _LegacyBatchRoutingRuntime:
     router: Any
     failover_manager: Any
     authorization_snapshot: CallableTargetGrantSnapshot | None
+    selector_reachable_groups: frozenset[str] = frozenset()
 
 
 def capture_batch_routing_runtime(app_state: Any) -> BatchRoutingRuntime:
@@ -63,6 +68,18 @@ def capture_batch_routing_runtime(app_state: Any) -> BatchRoutingRuntime:
         router=router,
         failover_manager=failover_manager,
         authorization_snapshot=authorization_snapshot,
+        selector_reachable_groups=(
+            selector_reachable_groups(
+                [
+                    key
+                    for key, policy in router.config.route_group_policies.items()
+                    if policy.selector is not None
+                ],
+                failover_manager.config,
+            )
+            if isinstance(router, Router) and isinstance(failover_manager, FailoverManager)
+            else frozenset()
+        ),
     )
 
 

--- a/src/billing/operation_reservation.py
+++ b/src/billing/operation_reservation.py
@@ -55,21 +55,34 @@ class BoundedTokenQuote(FrozenBillingContract):
 
     @property
     def allowance(self) -> Decimal:
-        price = self.pricing
-        input_rate = max(
-            price.input_cost_per_token, price.input_cost_per_token_cache_hit or Decimal(0)
+        return token_price_allowance(
+            self.pricing,
+            input_tokens=self.max_input_tokens,
+            output_tokens=self.max_output_tokens,
+            attempts=self.max_attempts,
         )
-        with localcontext() as context:
-            context.prec = 80
-            per_attempt = (
-                self.max_input_tokens * input_rate
-                + self.max_output_tokens * price.output_cost_per_token
-                + price.cost_per_request
-            )
-            amount = self.max_attempts * per_attempt.quantize(
-                Decimal("1e-18"), rounding=ROUND_CEILING
-            )
-        return canonical_money(amount)
+
+
+def token_price_allowance(
+    price: SelectorPriceSnapshot, *, input_tokens: int, output_tokens: int, attempts: int = 1
+) -> Decimal:
+    """Exact estimate arithmetic only, not evidence of provider-enforced ceilings."""
+    if (
+        any(type(value) is not int or value < 0 for value in (input_tokens, output_tokens))
+        or type(attempts) is not int
+        or not 1 <= attempts <= 128
+    ):
+        raise ValueError("invalid token-price allowance bounds")
+    input_rate = max(price.input_cost_per_token, price.input_cost_per_token_cache_hit or Decimal(0))
+    with localcontext() as context:
+        context.prec = 80
+        per_attempt = (
+            input_tokens * input_rate
+            + output_tokens * price.output_cost_per_token
+            + price.cost_per_request
+        )
+        amount = attempts * per_attempt.quantize(Decimal("1e-18"), rounding=ROUND_CEILING)
+    return canonical_money(amount)
 
 
 class ProviderEnforcedSelectorCeiling(FrozenBillingContract):
@@ -118,20 +131,46 @@ class OperationReservation(FrozenBillingContract):
             return canonical_money(self.selector.allowance + self.answer.allowance)
 
 
+class SoftSelectorOperation(FrozenBillingContract):
+    """Durable selector component without spending holds or an answer reservation.
+
+    Answer charges retain their canonical spend owner. The admission allowance is
+    a conservative check, not a promise that concurrent spending cannot overshoot.
+    """
+
+    budget_mode: Literal["soft_selector:v1"] = "soft_selector:v1"
+    attribution: SelectorChargeAttribution = Field(repr=False)
+    owner_token: UUID = Field(repr=False)
+    pricing: SelectorPriceSnapshot
+    admission_allowance: Price
+    expires_at: AwareDatetime
+
+
+BillingOperation = OperationReservation | SoftSelectorOperation
+
+
+def operation_selector_pricing(operation: BillingOperation) -> SelectorPriceSnapshot:
+    return (
+        operation.pricing
+        if isinstance(operation, SoftSelectorOperation)
+        else operation.selector.pricing
+    )
+
+
 class ReservedOperation(FrozenBillingContract):
-    operation: OperationReservation = Field(repr=False)
+    operation: BillingOperation = Field(repr=False)
     selector_state: ComponentState
     answer_state: ComponentState
 
 
 class OperationReservationStore(Protocol):
     async def reserve(
-        self, operation: OperationReservation, *, expires_at: float
+        self, operation: BillingOperation, *, expires_at: float
     ) -> ReservedOperation: ...
 
     async def dispatch(
         self,
-        operation: OperationReservation,
+        operation: BillingOperation,
         *,
         component: Literal["selector", "answer"],
         expires_at: float,
@@ -139,27 +178,27 @@ class OperationReservationStore(Protocol):
 
     async def unattempted(
         self,
-        operation: OperationReservation,
+        operation: BillingOperation,
         *,
         component: Literal["selector", "answer"],
         expires_at: float,
     ) -> None: ...
 
     async def accept_selector(
-        self, operation: OperationReservation, charge: AcceptedSelectorCharge, *, expires_at: float
+        self, operation: BillingOperation, charge: AcceptedSelectorCharge, *, expires_at: float
     ) -> None: ...
 
     async def confirm_not_dispatched(
-        self, operation: OperationReservation, *, expires_at: float
+        self, operation: BillingOperation, *, expires_at: float
     ) -> None: ...
 
 
 def selector_receipt(
-    operation: OperationReservation, *, usage: SelectorTokenReceipt, started_at: datetime
+    operation: BillingOperation, *, usage: SelectorTokenReceipt, started_at: datetime
 ) -> AcceptedSelectorCharge:
     return AcceptedSelectorCharge(
         attribution=operation.attribution,
-        pricing=operation.selector.pricing,
+        pricing=operation_selector_pricing(operation),
         usage=usage,
         started_at=started_at,
         finished_at=datetime.now(UTC),

--- a/src/billing/spend_ingestion.py
+++ b/src/billing/spend_ingestion.py
@@ -555,6 +555,15 @@ class SpendIngestionService:
         records: list[tuple[_OutboxRecord, PreparedSpendEvent]],
     ) -> dict[str, int]:
         claim_token = _shared_claim_token([record for record, _ in records])
+        operation_events = [
+            record.event_id
+            for record, prepared in records
+            if self.operation_recovery is not None
+            and (
+                not self.operation_recovery.selector_events_only
+                or prepared.row.get("call_type") == "model_router_selector"
+            )
+        ]
         heartbeat = asyncio.create_task(
             self._lease_heartbeat(
                 event_ids=[record.event_id for record, _ in records],
@@ -563,18 +572,14 @@ class SpendIngestionService:
         )
         try:
             async with self._transaction() as tx:
-                if self.operation_recovery is not None:
-                    await self.operation_recovery.lock_for_events(
-                        tx, [record.event_id for record, _ in records]
-                    )
+                if self.operation_recovery is not None and operation_events:
+                    await self.operation_recovery.lock_for_events(tx, operation_events)
                 batch_writer = self.writer.with_db(tx)
                 _, ledger_counts = await batch_writer.log_prepared_batch_once(
                     [prepared for _, prepared in records]
                 )
-                if self.operation_recovery is not None:
-                    await self.operation_recovery.settle_events(
-                        tx, [record.event_id for record, _ in records]
-                    )
+                if self.operation_recovery is not None and operation_events:
+                    await self.operation_recovery.settle_events(tx, operation_events)
                 completed = await self.repository.with_db(tx).mark_completed(
                     event_ids=[record.event_id for record, _ in records],
                     worker_id=self.config.worker_id,

--- a/src/bootstrap/runtime_services.py
+++ b/src/bootstrap/runtime_services.py
@@ -7,6 +7,7 @@ import socket
 from typing import Any
 
 from src.bootstrap.status import BootstrapStatus
+from src.bootstrap.selector import configure_selector_execution
 from src.billing import (
     AlertConfig,
     AlertService,
@@ -474,6 +475,7 @@ async def init_runtime_services(app: Any, cfg: Any) -> RuntimeServicesRuntime:
             worker_id=f"{socket.gethostname()}:{os.getpid()}:spend",
         ),
     )
+    configure_selector_execution(app.state, spend_ingestion_service)
     await spend_ingestion_service.start()
     app.state.spend_tracking_service = spend_ingestion_service
     app.state.budget_service = BudgetEnforcementService(

--- a/src/bootstrap/selector.py
+++ b/src/bootstrap/selector.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from starlette.datastructures import State
+from src.billing.operation_reservation import BillingOperationUnavailable
+
+from src.billing.spend_ingestion import SpendIngestionService
+from src.db.billing_operation_recovery import BillingOperationRecovery
+from src.db.billing_operations import BillingOperationRepository
+from src.router.runtime_generation import require_routing_runtime_generation
+from src.router.selection.runtime import SelectorExecutionFactory
+
+
+def configure_selector_execution(state: State, spend: SpendIngestionService) -> None:
+    """Extend the existing spend lifecycle; no extra client, pool, queue or worker."""
+    state.selector_execution_factory = None
+    state.routing_runtime_generation_store.set_selector_activation_check(_unavailable)
+    if not spend.config.enabled or not spend.config.worker_enabled:
+        if require_routing_runtime_generation(state).selectors:
+            raise RuntimeError("selector activation requires durable spend outbox and its worker")
+        return
+    operations = BillingOperationRepository(spend.db)
+    spend.operation_recovery = BillingOperationRecovery(
+        operations,
+        max_pending_events=spend.config.max_pending_events,
+        max_attempts=spend.config.max_attempts,
+        selector_events_only=True,
+    )
+    state.selector_execution_factory = SelectorExecutionFactory(
+        client=state.http_client,
+        adapters=state.provider_error_mapper_registry,
+        billing=operations,
+        default_openai_base_url=state.settings.openai_base_url,
+        accounting_ready=lambda: (
+            spend.config.enabled and spend.config.worker_enabled and spend.worker_health.ready
+        ),
+    )
+    state.route_group_repository.selector_activation_check = (
+        state.selector_execution_factory.require_ready
+    )
+    state.routing_runtime_generation_store.set_selector_activation_check(
+        state.selector_execution_factory.require_ready
+    )
+
+
+def _unavailable() -> None:
+    raise BillingOperationUnavailable()

--- a/src/chat/mcp_execution.py
+++ b/src/chat/mcp_execution.py
@@ -13,6 +13,8 @@ from src.models.responses import UserAPIKeyAuth
 from src.rate_limit_policy import estimate_tokens
 from src.router import Deployment, FailoverManager
 from src.router.context_policy import RequestTokenDemand, set_request_token_demand
+from src.router.execution import RequestDeadline
+from src.router.selection.operation import refresh_selector_payload
 
 
 ChatDeploymentCall = Callable[
@@ -30,6 +32,7 @@ class MCPModelRouting:
     timeout_seconds: float | None = None
     retry_max_attempts: int | None = None
     retryable_error_classes: tuple[str, ...] | None = None
+    request_deadline: RequestDeadline | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,7 +67,9 @@ class MCPChatExecutionService:
         routing: MCPModelRouting,
         on_attempt: DeploymentAttemptObserver | None = None,
     ) -> MCPChatExecutionResult:
-        deadline = self.failover_manager.create_request_deadline(routing.timeout_seconds)
+        deadline = routing.request_deadline or self.failover_manager.create_request_deadline(
+            routing.timeout_seconds
+        )
         served_deployment: Deployment | None = None
         phase_primary = routing.primary_deployment
         fallback_used = False
@@ -73,10 +78,12 @@ class MCPChatExecutionService:
             phase_payload: ChatCompletionRequest,
         ) -> tuple[dict[str, Any], float]:
             nonlocal fallback_used, phase_primary, served_deployment
+            token_estimate = estimate_tokens(dump_request_for_preflight(phase_payload))
+            refresh_selector_payload(routing.routing_context, phase_payload, token_estimate)
             set_request_token_demand(
                 routing.routing_context,
                 RequestTokenDemand(
-                    input_tokens=estimate_tokens(dump_request_for_preflight(phase_payload)),
+                    input_tokens=token_estimate,
                     requested_output_tokens=phase_payload.max_tokens,
                 ),
             )

--- a/src/chat_capabilities.py
+++ b/src/chat_capabilities.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ChatRoutingCapabilities(BaseModel):
+    """Operator-qualified model capabilities, not inferred from a model name.
+
+    Text chat is the common floor. Optional features default to unsupported. This
+    declaration is required for selector members before their policy can activate.
+    """
+
+    model_config = ConfigDict(frozen=True, strict=True, extra="forbid")
+
+    tools: bool = False
+    json_object: bool = False
+    json_schema: bool = False
+    image: bool = False
+    audio: bool = False
+    file: bool = False
+    streaming: bool = False
+    multiple_choices: bool = False

--- a/src/config.py
+++ b/src/config.py
@@ -22,6 +22,7 @@ from pydantic import (
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from src.auth.roles import TeamRole, validate_team_role
+from src.chat_capabilities import ChatRoutingCapabilities
 from src.governance.access_groups import normalize_access_group_list
 from src.batch.create.defaults import (
     DEFAULT_CREATE_SESSION_CLEANUP_INTERVAL_SECONDS,
@@ -146,6 +147,7 @@ class DeltaLLMParams(BaseModel):
 
 class ModelInfo(BaseModel):
     mode: ModelMode = "chat"
+    chat_capabilities: ChatRoutingCapabilities | None = None
     weight: int = 1
     priority: int = 0
     tags: list[str] = Field(default_factory=list)

--- a/src/db/billing_operation_recovery.py
+++ b/src/db/billing_operation_recovery.py
@@ -39,11 +39,17 @@ class BillingOperationRecovery:
     """
 
     def __init__(
-        self, operations: BillingOperationRepository, *, max_pending_events: int, max_attempts: int
+        self,
+        operations: BillingOperationRepository,
+        *,
+        max_pending_events: int,
+        max_attempts: int,
+        selector_events_only: bool = False,
     ) -> None:
         self.operations = operations
         self.max_pending_events = max_pending_events
         self.max_attempts = max_attempts
+        self.selector_events_only = selector_events_only
 
     async def recover(self) -> int:
         # Prioritize one known receipt, then rotate one other open operation. Each

--- a/src/db/billing_operations.py
+++ b/src/db/billing_operations.py
@@ -11,11 +11,15 @@ from typing import TYPE_CHECKING, AsyncIterator, Literal
 from src.billing.money import money_string
 from src.billing.operation_reservation import (
     BillingOperationUnavailable,
+    BillingOperation,
     ComponentState,
     OperationReservation,
     ReservedOperation,
+    SoftSelectorOperation,
+    operation_selector_pricing,
 )
 from src.billing.selector_charge import AcceptedSelectorCharge
+from src.db.soft_selector_admission import check_soft_selector_admission
 
 if TYPE_CHECKING:
     from prisma import Prisma
@@ -27,8 +31,8 @@ DB_BUDGET_SECONDS = 0.25
 class BillingOperationRepository:
     """Reservation/intent extension of spend ingestion; never dispatches providers.
 
-    Production bootstrap does not construct this prerequisite until PR 4. The
-    existing spend owner must drive recovery and settle holds in its writer transaction.
+    The existing spend owner drives recovery and settlement in its writer
+    transaction. Soft selector operations use this journal without spending holds.
     """
 
     def __init__(self, db: Prisma, *, max_pending_operations: int = 100_000) -> None:
@@ -58,9 +62,7 @@ class BillingOperationRepository:
             # Billing errors, including its deadline, must never become selector defaults.
             raise BillingOperationUnavailable() from None
 
-    async def reserve(
-        self, operation: OperationReservation, *, expires_at: float
-    ) -> ReservedOperation:
+    async def reserve(self, operation: BillingOperation, *, expires_at: float) -> ReservedOperation:
         async with self._transaction(expires_at) as tx:
             # Match settlement: operation -> canonical account rows -> capacity.
             # Unique insertion serializes duplicate IDs without a global lock.
@@ -72,11 +74,14 @@ class BillingOperationRepository:
                 if not rows:
                     raise BillingOperationUnavailable()
                 return self._existing(rows[0], operation)
-            await tx.execute_raw(
-                "SELECT deltallm_adjust_operation_hold($1,$2::numeric)",
-                str(operation.attribution.operation_id),
-                money_string(operation.total_allowance),
-            )
+            if isinstance(operation, SoftSelectorOperation):
+                await check_soft_selector_admission(tx, operation)
+            else:
+                await tx.execute_raw(
+                    "SELECT deltallm_adjust_operation_hold($1,$2::numeric)",
+                    str(operation.attribution.operation_id),
+                    money_string(operation.total_allowance),
+                )
             capacity = await tx.query_raw(
                 "UPDATE deltallm_telemetry_ingestion_capacity SET pending_count=pending_count+1 "
                 "WHERE queue_name='billing_operations' AND pending_count<$1 RETURNING pending_count",
@@ -88,16 +93,21 @@ class BillingOperationRepository:
         return ReservedOperation(
             operation=operation,
             selector_state=ComponentState.RESERVED,
-            answer_state=ComponentState.RESERVED,
+            answer_state=(
+                ComponentState.UNATTEMPTED
+                if isinstance(operation, SoftSelectorOperation)
+                else ComponentState.RESERVED
+            ),
         )
 
-    async def _insert(self, tx: Prisma, operation: OperationReservation) -> bool:
+    async def _insert(self, tx: Prisma, operation: BillingOperation) -> bool:
         owner = operation.attribution
+        soft = isinstance(operation, SoftSelectorOperation)
         inserted = await tx.query_raw(
             "INSERT INTO deltallm_billing_operations "
             "(operation_id,owner_token,api_key,user_id,team_id,organization_id,model,snapshot,"
-            "selector_event_id,selector_allowance,answer_allowance,expires_at) "
-            "VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10::numeric,$11::numeric,$12::timestamptz) "
+            "selector_event_id,selector_allowance,answer_allowance,expires_at,answer_state) "
+            "VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10::numeric,$11::numeric,$12::timestamptz,$13) "
             "ON CONFLICT (operation_id) DO NOTHING RETURNING operation_id",
             str(owner.operation_id),
             str(operation.owner_token),
@@ -108,14 +118,15 @@ class BillingOperationRepository:
             owner.model_group,
             operation.model_dump_json(),
             owner.component_event_id,
-            money_string(operation.selector.allowance),
-            money_string(operation.answer.allowance),
+            "0" if soft else money_string(operation.selector.allowance),
+            "0" if soft else money_string(operation.answer.allowance),
             operation.expires_at.isoformat(),
+            "unattempted" if soft else "reserved",
         )
         return bool(inserted)
 
     @staticmethod
-    def _existing(row: dict[str, object], operation: OperationReservation) -> ReservedOperation:
+    def _existing(row: dict[str, object], operation: BillingOperation) -> ReservedOperation:
         # Frozen snapshots prevent a replay from changing attribution, price or allowance.
         if row["snapshot"] != operation.model_dump(mode="json"):
             raise BillingOperationUnavailable()
@@ -126,7 +137,7 @@ class BillingOperationRepository:
         )
 
     async def dispatch(
-        self, operation: OperationReservation, *, component: Component, expires_at: float
+        self, operation: BillingOperation, *, component: Component, expires_at: float
     ) -> None:
         state = _column(component, "state")
         async with self._transaction(expires_at) as tx:
@@ -143,7 +154,7 @@ class BillingOperationRepository:
                 raise BillingOperationUnavailable()
 
     async def unattempted(
-        self, operation: OperationReservation, *, component: Component, expires_at: float
+        self, operation: BillingOperation, *, component: Component, expires_at: float
     ) -> None:
         state, allowance = _column(component, "state"), _column(component, "allowance")
         async with self._transaction(expires_at) as tx:
@@ -166,14 +177,14 @@ class BillingOperationRepository:
                 )
 
     async def accept_selector(
-        self, operation: OperationReservation, charge: AcceptedSelectorCharge, *, expires_at: float
+        self, operation: BillingOperation, charge: AcceptedSelectorCharge, *, expires_at: float
     ) -> None:
         if (
             charge.attribution != operation.attribution
-            or charge.pricing != operation.selector.pricing
+            or charge.pricing != operation_selector_pricing(operation)
         ):
             raise BillingOperationUnavailable()
-        exceeded = (
+        exceeded = isinstance(operation, OperationReservation) and (
             charge.customer_charge > operation.selector.allowance
             or charge.usage.prompt_tokens > operation.selector.max_input_tokens
             or charge.usage.completion_tokens > operation.selector.max_output_tokens
@@ -187,7 +198,7 @@ class BillingOperationRepository:
             raise BillingOperationUnavailable()
 
     async def confirm_not_dispatched(
-        self, operation: OperationReservation, *, expires_at: float
+        self, operation: BillingOperation, *, expires_at: float
     ) -> None:
         """Only a live provider owner with a proved pre-send rejection may use this."""
         async with self._transaction(expires_at) as tx:
@@ -199,7 +210,11 @@ class BillingOperationRepository:
                 str(operation.owner_token),
                 operation.model_dump_json(),
             )
-            if rows and operation.selector.allowance > 0:
+            if (
+                rows
+                and isinstance(operation, OperationReservation)
+                and operation.selector.allowance > 0
+            ):
                 await tx.execute_raw(
                     "SELECT deltallm_adjust_operation_hold($1,-$2::numeric)",
                     str(operation.attribution.operation_id),
@@ -212,7 +227,7 @@ class BillingOperationRepository:
 
     async def _accept_receipt(
         self,
-        operation: OperationReservation,
+        operation: BillingOperation,
         *,
         component: Component,
         payload: dict[str, object],

--- a/src/db/route_groups.py
+++ b/src/db/route_groups.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -133,17 +134,32 @@ class RouteGroupRuntimeSnapshot:
 
 
 class RouteGroupRepository(RoutePolicyLifecycleMixin):
-    def __init__(self, prisma_client: Any | None = None, *, use_transactions: bool = True) -> None:
+    def __init__(
+        self,
+        prisma_client: Any | None = None,
+        *,
+        use_transactions: bool = True,
+        selector_activation_check: Callable[[], None] | None = None,
+    ) -> None:
         self.prisma = prisma_client
         self._use_transactions = use_transactions
+        self.selector_activation_check = selector_activation_check
 
     def with_db(self, prisma_client: Any) -> RouteGroupRepository:
-        repository = RouteGroupRepository(prisma_client, use_transactions=False)
+        repository = RouteGroupRepository(
+            prisma_client,
+            use_transactions=False,
+            selector_activation_check=self.selector_activation_check,
+        )
         repository._identity = self._identity
         return repository
 
     def for_identity(self, identity: RouteGroupIdentity) -> RouteGroupRepository:
-        repository = RouteGroupRepository(self.prisma, use_transactions=self._use_transactions)
+        repository = RouteGroupRepository(
+            self.prisma,
+            use_transactions=self._use_transactions,
+            selector_activation_check=self.selector_activation_check,
+        )
         repository._identity = identity
         return repository
 
@@ -661,7 +677,7 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
             return RouteGroupRuntimeSnapshot(
                 revision=0,
                 groups=[],
-                selector_activation_state=RouteSelectorActivationState.INACTIVE,
+                selector_activation_state=RouteSelectorActivationState.VALIDATED,
             )
 
         groups = await self.prisma.query_raw(
@@ -720,7 +736,7 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
             return RouteGroupRuntimeSnapshot(
                 revision=0,
                 groups=[],
-                selector_activation_state=RouteSelectorActivationState.INACTIVE,
+                selector_activation_state=RouteSelectorActivationState.VALIDATED,
             )
 
         revision = int(groups[0].get("runtime_revision") or 0)
@@ -782,6 +798,11 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
                     "timeouts": timeouts if isinstance(timeouts, dict) else None,
                     "retry": retry if isinstance(retry, dict) else None,
                     "context": context if isinstance(context, dict) else None,
+                    **(
+                        {"selector": policy_json["selector"]}
+                        if semantics_version >= 3 and policy_json.get("selector") is not None
+                        else {}
+                    ),
                     "default_prompt": _extract_default_prompt(metadata),
                     "access_groups": metadata.get("access_groups")
                     if isinstance(metadata, dict)
@@ -794,7 +815,7 @@ class RouteGroupRepository(RoutePolicyLifecycleMixin):
             revision=revision,
             groups=runtime_groups,
             database_initialized=database_initialized,
-            selector_activation_state=RouteSelectorActivationState.INACTIVE,
+            selector_activation_state=RouteSelectorActivationState.VALIDATED,
         )
 
     async def _bump_runtime_revision(self) -> int:

--- a/src/db/route_policy_lifecycle.py
+++ b/src/db/route_policy_lifecycle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -18,6 +19,7 @@ from src.router.policy_validation import (
 from src.router.route_group_validation import validate_route_group_member_modes
 from src.router.selection.policy import (
     SELECTOR_POLICY_SEMANTICS_VERSION,
+    RouteSelectorActivationUnsupportedError,
     ensure_selector_activation_supported,
 )
 
@@ -57,6 +59,15 @@ class RoutePolicyValidationContext:
 class StoredRoutePolicyDocument:
     policy_json: dict[str, Any]
     semantics_version: int
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedRoutePolicyWrite:
+    """Keep opaque storage fields separate from the canonical validation projection."""
+
+    document: dict[str, Any]
+    normalized: dict[str, Any]
+    warnings: tuple[str, ...]
 
 
 def parse_policy_json(value: Any) -> dict[str, Any]:
@@ -99,6 +110,24 @@ def to_policy_record(row: dict[str, Any]) -> RoutePolicyRecord:
 
 class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
     prisma: Any | None
+    selector_activation_check: Callable[[], None] | None
+
+    def _require_selector_publication(
+        self, document: dict[str, Any], context: RoutePolicyValidationContext
+    ) -> None:
+        if document.get("selector") is None:
+            return
+        from src.router.selection.activation import validate_selector_activation_inventory
+
+        if self.selector_activation_check is None:
+            raise RouteSelectorActivationUnsupportedError(
+                "selector activation requires durable spend outbox and its worker"
+            )
+        self.selector_activation_check()
+        try:
+            validate_selector_activation_inventory(document, context.inventory)
+        except ValueError as exc:
+            raise RouteSelectorActivationUnsupportedError(str(exc)) from exc
 
     async def get_published_policy(self, group_key: str) -> RoutePolicyRecord | None:
         if self.prisma is None:
@@ -148,22 +177,23 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
             return None
         context = await self._load_policy_validation_context(group_id)
         current = await self._latest_policy_document(group_id, status="published")
-        effective, warnings = self._prepare_policy_write(
+        prepared = self._prepare_policy_write(
             policy_json,
             current=current,
             context=context,
         )
         ensure_selector_activation_supported(
-            effective,
+            prepared.normalized,
             semantics_version=CURRENT_POLICY_SEMANTICS_VERSION,
         )
+        self._require_selector_publication(prepared.normalized, context)
         policy = await self._replace_published_policy(
             group_id,
-            effective,
+            prepared.document,
             semantics_version=CURRENT_POLICY_SEMANTICS_VERSION,
             published_by=published_by,
         )
-        return RoutePolicyWriteResult(policy, warnings) if policy is not None else None
+        return RoutePolicyWriteResult(policy, prepared.warnings) if policy is not None else None
 
     async def save_draft_policy(
         self,
@@ -203,7 +233,7 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
             )
         else:
             current = await self._latest_policy_document(group_id, status="published")
-        effective, warnings = self._prepare_policy_write(
+        prepared = self._prepare_policy_write(
             policy_json,
             current=current,
             context=context,
@@ -211,18 +241,18 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
         if drafts:
             policy = await self._update_draft(
                 str(drafts[0]["route_policy_id"]),
-                effective,
+                prepared.document,
                 semantics_version=CURRENT_POLICY_SEMANTICS_VERSION,
             )
         else:
             policy = await self._insert_policy(
                 group_id,
                 "draft",
-                effective,
+                prepared.document,
                 semantics_version=CURRENT_POLICY_SEMANTICS_VERSION,
                 published_by=None,
             )
-        return RoutePolicyWriteResult(policy, warnings) if policy is not None else None
+        return RoutePolicyWriteResult(policy, prepared.warnings) if policy is not None else None
 
     def _prepare_policy_write(
         self,
@@ -230,7 +260,7 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
         *,
         current: StoredRoutePolicyDocument | None,
         context: RoutePolicyValidationContext,
-    ) -> tuple[dict[str, Any], tuple[str, ...]]:
+    ) -> PreparedRoutePolicyWrite:
         if not isinstance(policy_json, dict):
             raise ValueError("policy payload must be an object")
         current_semantics = (
@@ -253,7 +283,7 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
             existing_semantics_version=current_semantics,
         )
         try:
-            self._validate_policy_document(
+            projection, _ = self._validate_policy_document(
                 effective,
                 context=context,
                 semantics_version=CURRENT_POLICY_SEMANTICS_VERSION,
@@ -263,7 +293,7 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
             raise RoutePolicyStateConflictError(
                 f"policy is incompatible with current route-group members: {exc}"
             ) from exc
-        return effective, tuple(warnings)
+        return PreparedRoutePolicyWrite(effective, projection, tuple(warnings))
 
     async def publish_latest_draft(
         self,
@@ -322,6 +352,8 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
             normalized,
             semantics_version=int(drafts[0].get("semantics_version") or 1),
         )
+        if int(drafts[0].get("semantics_version") or 1) >= SELECTOR_POLICY_SEMANTICS_VERSION:
+            self._require_selector_publication(normalized, context)
         await self._archive_published(group_id)
         rows = await self.prisma.query_raw(
             """
@@ -399,6 +431,8 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
             normalized,
             semantics_version=semantics_version,
         )
+        if semantics_version >= SELECTOR_POLICY_SEMANTICS_VERSION:
+            self._require_selector_publication(normalized, context)
         return await self._replace_published_policy(
             group_id,
             source_document,
@@ -484,6 +518,9 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
                 g.mode AS group_mode,
                 m.deployment_id,
                 m.enabled,
+                d.model_info,
+                d.deltallm_params->>'model' AS provider_model,
+                d.deltallm_params->>'provider' AS provider_name,
                 CASE
                     WHEN d.deployment_id IS NULL THEN NULL
                     ELSE COALESCE(d.model_info->>'mode', 'chat')
@@ -505,6 +542,9 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
                 workload_mode=(
                     str(row["deployment_mode"]) if row.get("deployment_mode") is not None else None
                 ),
+                model_info=parse_policy_json(row.get("model_info")),
+                provider_model=row.get("provider_model"),
+                provider_name=row.get("provider_name"),
             )
             for row in rows
             if str(row.get("deployment_id") or "")
@@ -574,12 +614,18 @@ class RoutePolicyLifecycleMixin(RouteGroupIdentityMixin):
             return
         try:
             context = await self._load_policy_validation_context(group_id)
-            self._validate_policy_document(
+            normalized, _ = self._validate_policy_document(
                 parse_policy_json(rows[0].get("policy_json")),
                 context=context,
                 semantics_version=int(rows[0].get("semantics_version") or 1),
                 stored_document=True,
             )
+            if int(rows[0].get("semantics_version") or 1) >= SELECTOR_POLICY_SEMANTICS_VERSION:
+                from src.router.selection.activation import validate_selector_activation_inventory
+
+                # Existing active policies must remain qualified during member/model
+                # edits. This reuses the already locked transaction, not readiness.
+                validate_selector_activation_inventory(normalized, context.inventory)
         except ValueError as exc:
             raise RoutePolicyStateConflictError(
                 f"route-group change would invalidate the published policy: {exc}"

--- a/src/db/soft_selector_admission.py
+++ b/src/db/soft_selector_admission.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.billing.money import money_string
+from src.billing.operation_reservation import BillingOperationUnavailable, SoftSelectorOperation
+
+if TYPE_CHECKING:
+    from prisma import Prisma
+
+
+async def check_soft_selector_admission(tx: Prisma, operation: SoftSelectorOperation) -> None:
+    """One bounded ownership/budget snapshot; no account locks or spending holds.
+
+    This is the operation journal's soft counterpart to adjust_operation_hold.
+    Missing scopes/counters fail closed. A concurrently admitted operation may
+    overshoot; missing rollups are never repaired by scanning history inline.
+    """
+    owner = operation.attribution
+    rows = await tx.query_raw(
+        """
+        SELECT k.token FROM deltallm_verificationtoken k
+        LEFT JOIN deltallm_usertable u ON u.user_id=$2
+        LEFT JOIN deltallm_teamtable t ON t.team_id=$3
+        LEFT JOIN deltallm_organizationtable o ON o.organization_id=$4
+        LEFT JOIN deltallm_teammodelspend m ON m.team_id=$3 AND m.model=$6
+        WHERE k.token=$1
+          AND k.user_id IS NOT DISTINCT FROM $2::text
+          AND k.team_id IS NOT DISTINCT FROM $3::text
+          AND k.owner_account_id IS NOT DISTINCT FROM $5::text
+          AND t.organization_id IS NOT DISTINCT FROM $4::text
+          AND ($2::text IS NULL OR (u.user_id IS NOT NULL AND u.blocked IS NOT TRUE))
+          AND ($3::text IS NULL OR (t.team_id IS NOT NULL AND t.blocked IS NOT TRUE))
+          AND ($4::text IS NULL OR (o.organization_id IS NOT NULL AND o.lifecycle_state='active'))
+          AND (k.expires IS NULL OR k.expires>CURRENT_TIMESTAMP)
+          AND NOT COALESCE(COALESCE(k.spend_exact,k.spend::numeric,0)+$7::numeric>k.max_budget::numeric,false)
+          AND NOT COALESCE(COALESCE(u.spend_exact,u.spend::numeric,0)+$7::numeric>u.max_budget::numeric,false)
+          AND NOT COALESCE(COALESCE(t.spend_exact,t.spend::numeric,0)+$7::numeric>t.max_budget::numeric,false)
+          AND NOT COALESCE(COALESCE(o.spend_exact,o.spend::numeric,0)+$7::numeric>o.max_budget::numeric,false)
+          AND (t.model_max_budget->>$6 IS NULL OR COALESCE(m.spend_exact,m.spend::numeric)
+                +$7::numeric<=(t.model_max_budget->>$6)::numeric)
+        """,
+        owner.api_key,
+        owner.user_id,
+        owner.team_id,
+        owner.organization_id,
+        owner.owner_account_id,
+        owner.model_group,
+        money_string(operation.admission_allowance),
+    )
+    if not rows:
+        raise BillingOperationUnavailable()

--- a/src/router/candidates.py
+++ b/src/router/candidates.py
@@ -88,6 +88,15 @@ class AttemptPermit:
 
 
 @dataclass(frozen=True, slots=True)
+class RouteCandidateLane:
+    """A policy lane after hard eligibility; lower lanes are empty after selection."""
+
+    lane: str
+    rank: int
+    deployments: tuple[Deployment, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class RouteCandidatePlan:
     """Request-scoped, policy-ordered deployments eligible for failover attempts."""
 
@@ -99,6 +108,8 @@ class RouteCandidatePlan:
     filtered_count: int
     rejection_reason: str | None = None
     context_eligible_count: int | None = None
+    lanes: tuple[RouteCandidateLane, ...] = ()
+    minimum_rank: int | None = None
 
 
 class RouteCandidatePlanner(Protocol):

--- a/src/router/execution.py
+++ b/src/router/execution.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 import inspect
 from dataclasses import dataclass, field
-from typing import Awaitable, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Awaitable, Callable, Generic, TypeVar
 
 from src.models.errors import TimeoutError
-from src.router.router import Deployment
+
+if TYPE_CHECKING:
+    from src.router.router import Deployment
 
 
 T = TypeVar("T")

--- a/src/router/failover.py
+++ b/src/router/failover.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import partial
 from types import MappingProxyType
-from typing import Any, Awaitable, Callable, Protocol
+from typing import Any, Awaitable, Callable
 
 import httpx
 
@@ -44,52 +44,27 @@ from src.router.execution import (
 )
 from src.router.failure_policy import routing_failure_action
 from src.router.health_policy import affects_deployment_health
+from src.router.group_execution import (
+    DeferredRouteGroup,
+    group_preparation_deadline,
+    prepare_group,
+    prepared_deployments,
+)
 from src.router.router import Deployment
 from src.router.state import DeploymentStateBackend
+from src.router.initial_selection import (
+    InitialDeploymentRouter as InitialDeploymentRouter,
+    InitialDeploymentSelection as InitialDeploymentSelection,
+    InitialDeploymentSource as InitialDeploymentSource,
+    get_initial_deployment_selection as get_initial_deployment_selection,
+    require_initial_deployment as require_initial_deployment,
+    select_initial_deployment as select_initial_deployment,
+)
 
 logger = logging.getLogger(__name__)
 _ATTEMPT_PERMIT_CLEANUP_MARGIN_SECONDS = 30
-_INITIAL_DEPLOYMENT_SELECTION_CONTEXT_KEY = "_deltallm_initial_deployment_selection"
 
 TimeoutForDeployment = Callable[[Deployment], float | int | None]
-
-
-class InitialDeploymentRouter(Protocol):
-    async def select_deployment(
-        self,
-        model_group: str,
-        request_context: dict[str, Any],
-    ) -> Deployment | None: ...
-
-    def require_deployment(
-        self,
-        model_group: str,
-        deployment: Deployment | None,
-        *,
-        request_context: dict[str, Any] | None = None,
-    ) -> Deployment: ...
-
-
-class InitialDeploymentSource(StrEnum):
-    PRIMARY = "primary"
-    CONTEXT_FALLBACK = "context_fallback"
-    NONE = "none"
-
-
-@dataclass(frozen=True, slots=True)
-class InitialDeploymentSelection:
-    model_group: str
-    deployment: Deployment | None
-    source: InitialDeploymentSource
-    primary_rejection_reason: str | None
-    terminal_reason: str | None
-
-
-def get_initial_deployment_selection(
-    request_context: dict[str, Any],
-) -> InitialDeploymentSelection | None:
-    value = request_context.get(_INITIAL_DEPLOYMENT_SELECTION_CONTEXT_KEY)
-    return value if isinstance(value, InitialDeploymentSelection) else None
 
 
 def _freeze_fallback_map(
@@ -220,7 +195,7 @@ class _ClassifiedFallbackAvailability(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class _ClassifiedFallbackPlan:
-    deployments: tuple[Deployment, ...]
+    deployments: tuple[Deployment | DeferredRouteGroup, ...]
     availability: _ClassifiedFallbackAvailability
 
 
@@ -475,6 +450,7 @@ class FailoverManager:
     ) -> Any:
         routing_context = routing_context if routing_context is not None else {}
         deadline = request_deadline or self.create_request_deadline(timeout_seconds)
+        await prepare_group(routing_context, model_group)
         chain = await deadline.wait_for(
             self._build_fallback_chain(
                 primary_deployment,
@@ -491,7 +467,9 @@ class FailoverManager:
         attempt_history = _attempt_history
         retries_used = 0
 
-        for chain_index, deployment in enumerate(chain):
+        async for chain_index, deployment in prepared_deployments(
+            chain, planner=self.candidate_planner, context=routing_context
+        ):
             if deployment.deployment_id in visited_ids:
                 continue
             visited_ids.add(deployment.deployment_id)
@@ -716,19 +694,29 @@ class FailoverManager:
         decision = routing_context.get("route_decision")
         if not isinstance(decision, dict) or decision.get("reason") != "context_capacity_exceeded":
             return None
-        plan = await self._get_classified_fallbacks(
+        planning = self._get_classified_fallbacks(
             ErrorClassification.CONTEXT_WINDOW,
             model_group,
             routing_context,
             excluded_ids=set(),
         )
+        deadline = group_preparation_deadline(routing_context)
+        # Bound the batched planner, not deferred selector receipt/permit cleanup.
+        plan = await deadline.wait_for(planning) if deadline is not None else await planning
         if not plan.deployments:
             self._record_context_fallback_unavailability(
                 routing_context,
                 plan.availability,
             )
             return None
-        selected = plan.deployments[0]
+        selected = None
+        async for _, deployment in prepared_deployments(
+            plan.deployments, planner=self.candidate_planner, context=routing_context
+        ):
+            selected = deployment
+            break
+        if selected is None:
+            return None
         decision["primary_rejection_reason"] = "context_capacity_exceeded"
         decision["selected_deployment_id"] = selected.deployment_id
         decision["reason"] = "context_fallback_selected"
@@ -746,6 +734,7 @@ class FailoverManager:
         retry_max_attempts: int | None = None,
         retryable_error_classes: list[str] | set[str] | None = None,
         routing_context: dict[str, Any] | None = None,
+        request_deadline: RequestDeadline | None = None,
     ) -> ManagedFailoverResult[Any]:
         return await self.execute_with_failover(
             primary_deployment=primary_deployment,
@@ -757,6 +746,7 @@ class FailoverManager:
             retry_max_attempts=retry_max_attempts,
             retryable_error_classes=retryable_error_classes,
             routing_context=routing_context,
+            request_deadline=request_deadline,
             _manage_attempt_lifecycle=True,
         )
 
@@ -789,11 +779,14 @@ class FailoverManager:
             fallback_groups,
             routing_context,
         )
-        chain: list[Deployment] = []
+        chain: list[Deployment | DeferredRouteGroup] = []
         seen = set(excluded_ids)
         for group in fallback_groups:
             plan = plans.get(group)
             if plan is None:
+                continue
+            if plan.lanes:
+                chain.append(DeferredRouteGroup(group))
                 continue
             for dep in plan.deployments:
                 if dep.deployment_id not in seen:
@@ -837,7 +830,7 @@ class FailoverManager:
 
     async def _try_classified_fallbacks(
         self,
-        chain: list[Deployment],
+        chain: list[Deployment | DeferredRouteGroup],
         model_group: str,
         execute: Callable[[Deployment], Awaitable[Any]],
         from_deployment_id: str,
@@ -853,7 +846,9 @@ class FailoverManager:
         timeout_for_deployment: TimeoutForDeployment | None = None,
         defer_success: bool = False,
     ) -> tuple[Any, Deployment, AttemptPermit] | None:
-        for deployment in chain:
+        async for _, deployment in prepared_deployments(
+            chain, planner=self.candidate_planner, context=routing_context
+        ):
             if deployment.deployment_id in visited_ids:
                 continue
             visited_ids.add(deployment.deployment_id)
@@ -1154,11 +1149,11 @@ class FailoverManager:
         primary_deployment: Deployment,
         model_group: str,
         routing_context: dict[str, Any],
-    ) -> list[Deployment]:
+    ) -> list[Deployment | DeferredRouteGroup]:
         fallback_groups = self.config.fallbacks.get(model_group, [])
         groups = [model_group, *fallback_groups]
         plans = await self.candidate_planner.plan_deployments(groups, routing_context)
-        chain: list[Deployment] = []
+        chain: list[Deployment | DeferredRouteGroup] = []
         seen: set[str] = set()
 
         def add(deployments: list[Deployment]) -> None:
@@ -1198,17 +1193,28 @@ class FailoverManager:
                 )
             if not context_plan.deployments:
                 raise context_capacity_error(model_group)
-            context_ids = {deployment.deployment_id for deployment in context_plan.deployments}
+            context_ids = {
+                deployment.deployment_id
+                for deployment in context_plan.deployments
+                if not isinstance(deployment, DeferredRouteGroup)
+            }
             if primary_deployment.deployment_id in context_ids:
                 add([primary_deployment])
-            add(list(context_plan.deployments))
+            for entry in context_plan.deployments:
+                if isinstance(entry, DeferredRouteGroup):
+                    chain.append(entry)
+                else:
+                    add([entry])
         elif primary_deployment.deployment_id in eligible_ids:
             add([primary_deployment])
 
         for group in groups:
             plan = plans.get(group)
             if plan is not None:
-                add(list(plan.deployments))
+                if plan.lanes and group != model_group:
+                    chain.append(DeferredRouteGroup(group))
+                else:
+                    add(list(plan.deployments))
 
         if (
             not chain
@@ -1218,70 +1224,3 @@ class FailoverManager:
             raise context_capacity_error(model_group)
 
         return chain
-
-
-async def select_initial_deployment(
-    *,
-    router: InitialDeploymentRouter,
-    failover_manager: FailoverManager,
-    model_group: str,
-    request_context: dict[str, Any],
-) -> InitialDeploymentSelection:
-    """Select a primary or an eligible classified context fallback."""
-
-    selected = await router.select_deployment(model_group, request_context)
-    decision = request_context.get("route_decision")
-    primary_rejection_reason = (
-        str(decision.get("reason"))
-        if selected is None and isinstance(decision, dict) and decision.get("reason") is not None
-        else None
-    )
-    source = (
-        InitialDeploymentSource.PRIMARY if selected is not None else InitialDeploymentSource.NONE
-    )
-    if selected is None:
-        selected = await failover_manager.select_context_fallback_for_local_rejection(
-            model_group,
-            request_context,
-        )
-        if selected is not None:
-            source = InitialDeploymentSource.CONTEXT_FALLBACK
-    decision = request_context.get("route_decision")
-    selection = InitialDeploymentSelection(
-        model_group=model_group,
-        deployment=selected,
-        source=source,
-        primary_rejection_reason=primary_rejection_reason,
-        terminal_reason=(
-            str(decision.get("reason"))
-            if isinstance(decision, dict) and decision.get("reason") is not None
-            else None
-        ),
-    )
-    if selection.source is InitialDeploymentSource.CONTEXT_FALLBACK:
-        request_context[_INITIAL_DEPLOYMENT_SELECTION_CONTEXT_KEY] = selection
-    else:
-        request_context.pop(_INITIAL_DEPLOYMENT_SELECTION_CONTEXT_KEY, None)
-    return selection
-
-
-async def require_initial_deployment(
-    *,
-    router: InitialDeploymentRouter,
-    failover_manager: FailoverManager,
-    model_group: str,
-    request_context: dict[str, Any],
-) -> Deployment:
-    """Select an initial deployment, then apply the router's standard errors."""
-
-    selection = await select_initial_deployment(
-        router=router,
-        failover_manager=failover_manager,
-        model_group=model_group,
-        request_context=request_context,
-    )
-    return router.require_deployment(
-        model_group=model_group,
-        deployment=selection.deployment,
-        request_context=request_context,
-    )

--- a/src/router/group_execution.py
+++ b/src/router/group_execution.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from src.router.candidates import RouteCandidatePlanner
+from src.router.execution import RequestDeadline
+from src.router.selection.contracts import SelectorInvariantError
+
+if TYPE_CHECKING:
+    from src.router.router import Deployment
+
+_PREPARATION_KEY = "_deltallm_group_preparation"
+
+
+class GroupPreparation(Protocol):
+    @property
+    def deadline(self) -> RequestDeadline: ...
+
+    async def prepare(self, model_group: str) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class DeferredRouteGroup:
+    model_group: str
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparationBinding:
+    owner: GroupPreparation
+
+
+def set_group_preparation(context: dict[str, object], owner: GroupPreparation) -> None:
+    binding = context.get(_PREPARATION_KEY)
+    if binding is not None and (
+        not isinstance(binding, _PreparationBinding) or binding.owner is not owner
+    ):
+        raise SelectorInvariantError()
+    context[_PREPARATION_KEY] = _PreparationBinding(owner)
+
+
+async def prepare_group(context: dict[str, object], group: str) -> None:
+    binding = context.get(_PREPARATION_KEY)
+    if binding is not None:
+        if not isinstance(binding, _PreparationBinding):
+            raise SelectorInvariantError()
+        # This is a server-only root context field, never caller metadata.
+        await binding.owner.prepare(group)
+
+
+def group_preparation_deadline(context: dict[str, object]) -> RequestDeadline | None:
+    binding = context.get(_PREPARATION_KEY)
+    if binding is None:
+        return None
+    if not isinstance(binding, _PreparationBinding):
+        raise SelectorInvariantError()
+    return binding.owner.deadline
+
+
+async def prepared_deployments(
+    chain: Sequence[Deployment | DeferredRouteGroup],
+    *,
+    planner: RouteCandidatePlanner,
+    context: dict[str, object],
+) -> AsyncIterator[tuple[int, Deployment]]:
+    """Resolve deferred groups only as execution reaches them, without recursion.
+
+    Failover retains attempt, retry and visited-deployment ownership. The planner
+    stays pure with respect to providers; only the injected application owner may
+    prepare a decision. Selector-free chains perform no additional dependency work.
+    """
+    seen_groups: set[str] = set()
+    index = 0
+    for entry in chain:
+        if isinstance(entry, DeferredRouteGroup):
+            if entry.model_group in seen_groups:
+                continue
+            seen_groups.add(entry.model_group)
+            await prepare_group(context, entry.model_group)
+            deadline = group_preparation_deadline(context)
+            planning = planner.plan_deployments([entry.model_group], context)
+            plans = await deadline.wait_for(planning) if deadline is not None else await planning
+            plan = plans.get(entry.model_group)
+            if plan is not None:
+                if plan.minimum_rank is None:
+                    if any(lane.deployments for lane in plan.lanes):
+                        raise SelectorInvariantError()
+                    continue
+                for deployment in plan.deployments:
+                    yield index, deployment
+                    index += 1
+        else:
+            yield index, entry
+            index += 1

--- a/src/router/group_policy.py
+++ b/src/router/group_policy.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+
+from src.route_group_config import ModelMode, validate_context_routing_workload_mode
+from src.router.context_policy import ContextRoutingPolicy, parse_context_routing_policy
+from src.router.route_group_validation import normalize_route_group_mode
+from src.router.selection.lanes import SelectorLaneRouting, parse_selector_lane_routing
+
+
+class RoutingStrategy(str, Enum):
+    SIMPLE_SHUFFLE = "simple-shuffle"
+    LEAST_BUSY = "least-busy"
+    LATENCY_BASED = "latency-based-routing"
+    COST_BASED = "cost-based-routing"
+    USAGE_BASED = "usage-based-routing"
+    TAG_BASED = "tag-based-routing"
+    PRIORITY_BASED = "priority-based-routing"
+    WEIGHTED = "weighted"
+    RATE_LIMIT_AWARE = "rate-limit-aware"
+
+
+@dataclass(frozen=True, slots=True)
+class RouteGroupPolicy:
+    workload_mode: ModelMode | None = None
+    strategy: RoutingStrategy | None = None
+    policy_version: int | None = None
+    timeout_seconds: float | None = None
+    retry_max_attempts: int | None = None
+    retryable_error_classes: frozenset[str] | None = None
+    context: ContextRoutingPolicy | None = None
+    selector: SelectorLaneRouting | None = None
+
+    def failover_overrides(self) -> dict[str, object]:
+        overrides: dict[str, object] = {}
+        if self.timeout_seconds is not None:
+            overrides["timeout_seconds"] = float(self.timeout_seconds)
+        if self.retry_max_attempts is not None:
+            overrides["retry_max_attempts"] = int(self.retry_max_attempts)
+        if self.retryable_error_classes:
+            overrides["retryable_error_classes"] = sorted(self.retryable_error_classes)
+        return overrides
+
+
+def build_route_group_policies(
+    route_groups: Sequence[Mapping[str, object]] | None,
+) -> dict[str, RouteGroupPolicy]:
+    policies: dict[str, RouteGroupPolicy] = {}
+    for group in route_groups or ():
+        key = str(group.get("key") or "").strip()
+        if not key or not bool(group.get("enabled", True)):
+            continue
+
+        strategy_name = group.get("strategy")
+        strategy: RoutingStrategy | None = None
+        if isinstance(strategy_name, str) and strategy_name in RoutingStrategy._value2member_map_:
+            strategy = RoutingStrategy(strategy_name)
+
+        policy_version = group.get("policy_version")
+        context = parse_context_routing_policy(group.get("context"))
+        if context is not None:
+            validate_context_routing_workload_mode(group.get("mode"))
+        policies[key] = RouteGroupPolicy(
+            workload_mode=normalize_route_group_mode(group.get("mode")),
+            strategy=strategy,
+            policy_version=int(policy_version) if policy_version is not None else None,
+            timeout_seconds=_extract_timeout_seconds(group.get("timeouts")),
+            retry_max_attempts=_extract_retry_max_attempts(group.get("retry")),
+            retryable_error_classes=_extract_retryable_error_classes(group.get("retry")),
+            context=context,
+            selector=parse_selector_lane_routing(group),
+        )
+    return policies
+
+
+def _extract_timeout_seconds(timeouts: object) -> float | None:
+    if not isinstance(timeouts, dict):
+        return None
+    global_seconds = timeouts.get("global_seconds")
+    if global_seconds is not None:
+        try:
+            parsed = float(global_seconds)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+
+    global_ms = timeouts.get("global_ms")
+    if global_ms is None:
+        return None
+    try:
+        parsed_ms = float(global_ms)
+    except (TypeError, ValueError):
+        return None
+    return (parsed_ms / 1000.0) if parsed_ms > 0 else None
+
+
+def _extract_retry_max_attempts(retry: object) -> int | None:
+    if not isinstance(retry, dict):
+        return None
+    value = retry.get("max_attempts")
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _extract_retryable_error_classes(retry: object) -> frozenset[str] | None:
+    if not isinstance(retry, dict):
+        return None
+    classes = retry.get("retryable_error_classes")
+    if not isinstance(classes, list):
+        return None
+    normalized = {str(item).strip() for item in classes if str(item).strip()}
+    return frozenset(normalized) if normalized else None

--- a/src/router/initial_selection.py
+++ b/src/router/initial_selection.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+
+from src.router.group_execution import group_preparation_deadline, prepare_group
+
+if TYPE_CHECKING:
+    from src.router.failover import FailoverManager
+    from src.router.router import Deployment
+
+_INITIAL_DEPLOYMENT_SELECTION_CONTEXT_KEY = "_deltallm_initial_deployment_selection"
+
+
+class InitialDeploymentRouter(Protocol):
+    async def select_deployment(
+        self,
+        model_group: str,
+        request_context: dict[str, object],
+    ) -> Deployment | None: ...
+
+    def require_deployment(
+        self,
+        model_group: str,
+        deployment: Deployment | None,
+        *,
+        request_context: dict[str, object] | None = None,
+    ) -> Deployment: ...
+
+
+class InitialDeploymentSource(StrEnum):
+    PRIMARY = "primary"
+    CONTEXT_FALLBACK = "context_fallback"
+    NONE = "none"
+
+
+@dataclass(frozen=True, slots=True)
+class InitialDeploymentSelection:
+    model_group: str
+    deployment: Deployment | None
+    source: InitialDeploymentSource
+    primary_rejection_reason: str | None
+    terminal_reason: str | None
+
+
+def get_initial_deployment_selection(
+    request_context: dict[str, object],
+) -> InitialDeploymentSelection | None:
+    value = request_context.get(_INITIAL_DEPLOYMENT_SELECTION_CONTEXT_KEY)
+    return value if isinstance(value, InitialDeploymentSelection) else None
+
+
+async def select_initial_deployment(
+    *,
+    router: InitialDeploymentRouter,
+    failover_manager: FailoverManager,
+    model_group: str,
+    request_context: dict[str, object],
+) -> InitialDeploymentSelection:
+    """Select a primary or an eligible classified context fallback."""
+
+    await prepare_group(request_context, model_group)
+    deadline = group_preparation_deadline(request_context)
+    selection = router.select_deployment(model_group, request_context)
+    selected = await deadline.wait_for(selection) if deadline is not None else await selection
+    decision = request_context.get("route_decision")
+    primary_rejection_reason = (
+        str(decision.get("reason"))
+        if selected is None and isinstance(decision, dict) and decision.get("reason") is not None
+        else None
+    )
+    source = (
+        InitialDeploymentSource.PRIMARY if selected is not None else InitialDeploymentSource.NONE
+    )
+    if selected is None:
+        selected = await failover_manager.select_context_fallback_for_local_rejection(
+            model_group,
+            request_context,
+        )
+        if selected is not None:
+            source = InitialDeploymentSource.CONTEXT_FALLBACK
+    decision = request_context.get("route_decision")
+    selection = InitialDeploymentSelection(
+        model_group=model_group,
+        deployment=selected,
+        source=source,
+        primary_rejection_reason=primary_rejection_reason,
+        terminal_reason=(
+            str(decision.get("reason"))
+            if isinstance(decision, dict) and decision.get("reason") is not None
+            else None
+        ),
+    )
+    if selection.source is InitialDeploymentSource.CONTEXT_FALLBACK:
+        request_context[_INITIAL_DEPLOYMENT_SELECTION_CONTEXT_KEY] = selection
+    else:
+        request_context.pop(_INITIAL_DEPLOYMENT_SELECTION_CONTEXT_KEY, None)
+    return selection
+
+
+async def require_initial_deployment(
+    *,
+    router: InitialDeploymentRouter,
+    failover_manager: FailoverManager,
+    model_group: str,
+    request_context: dict[str, object],
+) -> Deployment:
+    """Select an initial deployment, then apply the router's standard errors."""
+
+    selection = await select_initial_deployment(
+        router=router,
+        failover_manager=failover_manager,
+        model_group=model_group,
+        request_context=request_context,
+    )
+    return router.require_deployment(
+        model_group=model_group,
+        deployment=selection.deployment,
+        request_context=request_context,
+    )

--- a/src/router/policy_validation.py
+++ b/src/router/policy_validation.py
@@ -52,6 +52,9 @@ class PolicyMemberInventoryItem:
     deployment_id: str
     enabled: bool = True
     workload_mode: str | None = None
+    model_info: Mapping[str, object] | None = None
+    provider_model: str | None = None
+    provider_name: str | None = None
 
 
 class _SelectorWriteIntent(StrEnum):

--- a/src/router/redis_keys.py
+++ b/src/router/redis_keys.py
@@ -72,7 +72,7 @@ class RouteGroupRuntimeRedisKeyspace:
 
     environment: str = "dev"
     application: str = "deltallm"
-    schema_version: int = 2
+    schema_version: int = 3
 
     def snapshot(self, revision: int) -> str:
         normalized_revision = int(revision)

--- a/src/router/router.py
+++ b/src/router/router.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field, replace
-from enum import Enum
 import logging
 from collections.abc import Mapping
 from typing import Any, Sequence, cast
 
-from src.route_group_config import ModelMode, validate_context_routing_workload_mode
+from src.route_group_config import ModelMode
 from src.metrics import increment_router_context_decision
 from src.models.errors import (
     ModelNotFoundError,
@@ -31,29 +30,37 @@ from src.router.health_state import (
     build_deployment_health_ref,
 )
 from src.router.context_policy import (
-    ContextRoutingPolicy,
     context_capacity_error,
     context_rejection_reason,
     context_routing_metrics_enabled,
     filter_context_candidates,
     get_request_context_routing_policy,
     get_request_token_demand,
-    order_context_candidates,
-    parse_context_routing_policy,
     set_request_context_routing_policy,
 )
 from src.router.registry import DeploymentRegistryStore
+from src.router.group_policy import (
+    RouteGroupPolicy as RouteGroupPolicy,
+    RoutingStrategy as RoutingStrategy,
+    build_route_group_policies as build_route_group_policies,
+)
 from src.router.route_group_validation import (
     normalize_route_group_mode,
     validate_route_group_member_modes,
 )
 from src.router.state import DeploymentStateBackend
+from src.router.selection.planning import order_candidates, selector_context_policy
+from src.router.selection.eligibility import capability_allows
+from src.router.static_filters import required_request_tags, tags_allow_deployment
+from src.router.selection.contracts import SelectorDecision
+from src.router.selection.request_context import refresh_selector_candidate_plans
 from src.router.strategies import (
     CostBasedStrategy,
     LatencyBasedStrategy,
     LeastBusyStrategy,
     PriorityBasedStrategy,
     RateLimitAwareStrategy,
+    RoutingStrategyImpl,
     SimpleShuffleStrategy,
     StrategyStateSnapshot,
     UsageBasedStrategy,
@@ -63,18 +70,6 @@ from src.router.strategies import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class RoutingStrategy(str, Enum):
-    SIMPLE_SHUFFLE = "simple-shuffle"
-    LEAST_BUSY = "least-busy"
-    LATENCY_BASED = "latency-based-routing"
-    COST_BASED = "cost-based-routing"
-    USAGE_BASED = "usage-based-routing"
-    TAG_BASED = "tag-based-routing"
-    PRIORITY_BASED = "priority-based-routing"
-    WEIGHTED = "weighted"
-    RATE_LIMIT_AWARE = "rate-limit-aware"
 
 
 @dataclass
@@ -96,6 +91,7 @@ class Deployment:
     rerank_units_pm_limit: int | None = None
     health_incarnation: str | None = None
     named_credential_id: str | None = None
+    route_group_key: str | None = None
     health_ref: DeploymentHealthRef = field(init=False)
 
     def __post_init__(self) -> None:
@@ -118,32 +114,11 @@ class RouterConfig:
     route_group_policies: dict[str, "RouteGroupPolicy"] = field(default_factory=dict)
 
 
-@dataclass
-class RouteGroupPolicy:
-    workload_mode: ModelMode | None = None
-    strategy: RoutingStrategy | None = None
-    policy_version: int | None = None
-    timeout_seconds: float | None = None
-    retry_max_attempts: int | None = None
-    retryable_error_classes: frozenset[str] | None = None
-    context: ContextRoutingPolicy | None = None
-
-    def failover_overrides(self) -> dict[str, Any]:
-        overrides: dict[str, Any] = {}
-        if self.timeout_seconds is not None:
-            overrides["timeout_seconds"] = float(self.timeout_seconds)
-        if self.retry_max_attempts is not None:
-            overrides["retry_max_attempts"] = int(self.retry_max_attempts)
-        if self.retryable_error_classes:
-            overrides["retryable_error_classes"] = sorted(self.retryable_error_classes)
-        return overrides
-
-
 @dataclass(frozen=True, slots=True)
 class _CandidatePlanInput:
     model_group: str
     strategy: RoutingStrategy
-    strategy_impl: Any
+    strategy_impl: RoutingStrategyImpl
     candidates: tuple[Deployment, ...]
 
 
@@ -221,6 +196,7 @@ class Router:
         groups = list(
             dict.fromkeys(str(group).strip() for group in model_groups if str(group).strip())
         )
+        selector_decision = refresh_selector_candidate_plans(request_context)
         cached = candidate_plan_cache(request_context)
         missing_groups = [group for group in groups if group not in cached]
         if not missing_groups:
@@ -265,45 +241,67 @@ class Router:
 
         for group in pending:
             healthy = self._filter_healthy(group.candidates, health, cooldowns)
-            policy = self.config.route_group_policies.get(group.model_group)
-            context_policy = get_request_context_routing_policy(request_context)
-            if context_policy is None and policy is not None:
-                context_policy = policy.context
-            demand = get_request_token_demand(request_context)
-            configured = self._apply_filters(list(group.candidates), request_context)
-            context_eligible, configured_context_evaluations = filter_context_candidates(
-                configured, demand, context_policy
-            )
-            filtered = self._apply_filters(healthy, request_context)
-            filtered, _ = filter_context_candidates(filtered, demand, context_policy)
-            if self.config.enable_pre_call_checks:
-                filtered = self._apply_pre_call_checks(filtered, state_snapshot.usage or {})
-            ordered = await group.strategy_impl.order(
-                filtered,
-                request_context,
-                state_snapshot,
-            )
-            ordered = order_context_candidates(list(ordered), demand, context_policy)
-            cached[group.model_group] = RouteCandidatePlan(
-                model_group=group.model_group,
-                strategy=group.strategy.value,
-                deployments=tuple(ordered),
-                candidate_count=len(group.candidates),
-                healthy_count=len(healthy),
-                filtered_count=len(filtered),
-                rejection_reason=(
-                    context_rejection_reason(configured_context_evaluations)
-                    if not filtered
-                    else None
-                ),
-                context_eligible_count=(
-                    len(context_eligible)
-                    if context_policy is not None and demand is not None
-                    else None
-                ),
+            cached[group.model_group] = await self._plan_eligible_group(
+                group, healthy, request_context, state_snapshot, selector_decision
             )
 
         return {group: cached[group] for group in groups}
+
+    async def _plan_eligible_group(
+        self,
+        group: _CandidatePlanInput,
+        healthy: list[Deployment],
+        request_context: dict[str, object],
+        state_snapshot: StrategyStateSnapshot,
+        selector_decision: SelectorDecision | None,
+    ) -> RouteCandidatePlan:
+        policy = self.config.route_group_policies.get(group.model_group)
+        context_policy = get_request_context_routing_policy(request_context)
+        if context_policy is None and policy is not None:
+            context_policy = policy.context
+        if policy is not None and policy.selector is not None:
+            context_policy = selector_context_policy(context_policy, policy.context)
+        demand = get_request_token_demand(request_context)
+        configured = self._apply_filters(list(group.candidates), request_context)
+        context_eligible, configured_context_evaluations = filter_context_candidates(
+            configured, demand, context_policy
+        )
+        filtered = self._apply_filters(healthy, request_context)
+        filtered, _ = filter_context_candidates(filtered, demand, context_policy)
+        if policy is not None and policy.selector is not None:
+            filtered = [
+                dep for dep in filtered if capability_allows(request_context, dep.deployment_id)
+            ]
+        if self.config.enable_pre_call_checks:
+            filtered = self._apply_pre_call_checks(filtered, state_snapshot.usage or {})
+        ordered = await order_candidates(
+            eligible=filtered,
+            strategy=group.strategy_impl,
+            context=request_context,
+            snapshot=state_snapshot,
+            demand=demand,
+            context_policy=context_policy,
+            selector=policy.selector if policy is not None else None,
+            decision=selector_decision,
+        )
+        return RouteCandidatePlan(
+            model_group=group.model_group,
+            strategy=group.strategy.value,
+            deployments=ordered.deployments,
+            candidate_count=len(group.candidates),
+            healthy_count=len(healthy),
+            filtered_count=len(filtered),
+            rejection_reason=(
+                context_rejection_reason(configured_context_evaluations)
+                if not filtered
+                else ordered.rejection_reason
+            ),
+            context_eligible_count=(
+                len(context_eligible) if context_policy is not None and demand is not None else None
+            ),
+            lanes=ordered.lanes,
+            minimum_rank=ordered.minimum_rank,
+        )
 
     @staticmethod
     def _workload_mode_mismatch(
@@ -424,22 +422,13 @@ class Router:
         if not deployments:
             return []
 
-        metadata = request_context.get("metadata")
-        request_tags = metadata.get("tags") if isinstance(metadata, dict) else None
-        normalized_tags = (
-            [tag.strip() for tag in request_tags if isinstance(tag, str) and tag.strip()]
-            if isinstance(request_tags, list)
-            else []
-        )
+        normalized_tags = required_request_tags(request_context.get("metadata"))
         request_mode = str(request_context.get(ROUTING_MODE_CONTEXT_KEY) or "").strip().lower()
 
         return [
             deployment
             for deployment in deployments
-            if (
-                not normalized_tags
-                or (deployment.tags and all(tag in deployment.tags for tag in normalized_tags))
-            )
+            if tags_allow_deployment(deployment.tags, normalized_tags)
             and self._supports_request_mode(deployment, request_mode)
         ]
 
@@ -501,7 +490,7 @@ class Router:
 
     def _resolve_strategy_for_group(
         self, model_group: str
-    ) -> tuple[RoutingStrategy, Any, RouteGroupPolicy | None]:
+    ) -> tuple[RoutingStrategy, RoutingStrategyImpl, RouteGroupPolicy | None]:
         policy = self.config.route_group_policies.get(model_group)
         strategy = (
             policy.strategy if policy is not None and policy.strategy is not None else self.strategy
@@ -647,6 +636,7 @@ def build_deployment_registry_with_route_groups(
             grouped_deployments.append(
                 replace(
                     base,
+                    route_group_key=group_key,
                     weight=int(override_weight) if override_weight is not None else base.weight,
                     priority=int(override_priority)
                     if override_priority is not None
@@ -660,85 +650,6 @@ def build_deployment_registry_with_route_groups(
         registry[group_key] = grouped_deployments
 
     return registry
-
-
-def build_route_group_policies(
-    route_groups: list[dict[str, Any]] | None,
-) -> dict[str, RouteGroupPolicy]:
-    policies: dict[str, RouteGroupPolicy] = {}
-    if not route_groups:
-        return policies
-
-    for group in route_groups:
-        key = str(group.get("key") or "").strip()
-        if not key or not bool(group.get("enabled", True)):
-            continue
-
-        strategy_name = group.get("strategy")
-        strategy: RoutingStrategy | None = None
-        if isinstance(strategy_name, str) and strategy_name in RoutingStrategy._value2member_map_:
-            strategy = RoutingStrategy(strategy_name)
-
-        policy_version = group.get("policy_version")
-        timeouts = group.get("timeouts")
-        retry = group.get("retry")
-        context = parse_context_routing_policy(group.get("context"))
-        if context is not None:
-            validate_context_routing_workload_mode(group.get("mode"))
-        policies[key] = RouteGroupPolicy(
-            workload_mode=normalize_route_group_mode(group.get("mode")),
-            strategy=strategy,
-            policy_version=int(policy_version) if policy_version is not None else None,
-            timeout_seconds=_extract_timeout_seconds(timeouts),
-            retry_max_attempts=_extract_retry_max_attempts(retry),
-            retryable_error_classes=_extract_retryable_error_classes(retry),
-            context=context,
-        )
-    return policies
-
-
-def _extract_timeout_seconds(timeouts: Any) -> float | None:
-    if not isinstance(timeouts, dict):
-        return None
-    global_seconds = timeouts.get("global_seconds")
-    if global_seconds is not None:
-        try:
-            parsed = float(global_seconds)
-        except (TypeError, ValueError):
-            return None
-        return parsed if parsed > 0 else None
-
-    global_ms = timeouts.get("global_ms")
-    if global_ms is None:
-        return None
-    try:
-        parsed_ms = float(global_ms)
-    except (TypeError, ValueError):
-        return None
-    return (parsed_ms / 1000.0) if parsed_ms > 0 else None
-
-
-def _extract_retry_max_attempts(retry: Any) -> int | None:
-    if not isinstance(retry, dict):
-        return None
-    value = retry.get("max_attempts")
-    if value is None:
-        return None
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return None
-    return parsed if parsed >= 0 else None
-
-
-def _extract_retryable_error_classes(retry: Any) -> frozenset[str] | None:
-    if not isinstance(retry, dict):
-        return None
-    classes = retry.get("retryable_error_classes")
-    if not isinstance(classes, list):
-        return None
-    normalized = {str(item).strip() for item in classes if str(item).strip()}
-    return frozenset(normalized) if normalized else None
 
 
 def _deployment_from_entry(model_name: str, entry: dict[str, Any], index: int) -> Deployment:

--- a/src/router/routing_identity.py
+++ b/src/router/routing_identity.py
@@ -8,6 +8,7 @@ import json
 from typing import TYPE_CHECKING
 
 from src.providers.request_defaults import provider_request_defaults
+from src.chat_capabilities import ChatRoutingCapabilities
 from src.providers.resolution import resolve_provider, resolve_upstream_model
 from src.route_policy_contract import (
     LLMTierSelectorPolicy,
@@ -125,6 +126,15 @@ def _deployment_identity(deployment: Deployment) -> str:
             },
             "credential_reference": deployment.named_credential_id,
             "mode": str(info.get("mode") or "chat").strip().lower(),
+            **(
+                {
+                    "chat_capabilities": ChatRoutingCapabilities.model_validate(
+                        info["chat_capabilities"]
+                    ).model_dump(mode="json")
+                }
+                if info.get("chat_capabilities") is not None
+                else {}
+            ),
             "defaults": provider_request_defaults(info),
             "context_limits": {
                 key: info.get(key)

--- a/src/router/runtime_generation.py
+++ b/src/router/runtime_generation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
+from collections.abc import Callable
 from types import MappingProxyType
 from typing import Any, Mapping
 from uuid import uuid4
@@ -12,6 +13,8 @@ from src.router.registry import DeploymentRegistryStore
 from src.router.router import Router, RouterConfig, RoutingStrategy
 from src.router.runtime_authorization import CallableTargetGrantSnapshot
 from src.router.routing_identity import build_runtime_routing_fingerprints
+from src.router.selection.qualification import QualifiedSelector, qualify_selector_groups
+from src.router.selection.reachability import selector_reachable_groups
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,6 +39,8 @@ class RoutingRuntimeGeneration:
     routing_fingerprints: Mapping[str, str]
     source: str = "config_only"
     requires_reconciliation: bool = False
+    selectors: Mapping[str, QualifiedSelector] = field(default_factory=lambda: MappingProxyType({}))
+    selector_reachable_groups: frozenset[str] = frozenset()
 
     @classmethod
     def create(
@@ -58,7 +63,12 @@ class RoutingRuntimeGeneration:
         source: str = "config_only",
         requires_reconciliation: bool = False,
     ) -> RoutingRuntimeGeneration:
+        selectors = qualify_selector_groups(
+            router_config.route_group_policies, deployment_registry.snapshot()
+        )
         return cls(
+            selectors=selectors,
+            selector_reachable_groups=selector_reachable_groups(selectors, failover_config),
             generation_id=uuid4().hex,
             revision=revision,
             app_config=app_config,
@@ -101,6 +111,11 @@ class RoutingRuntimeGenerationStore:
 
     def __init__(self, generation: RoutingRuntimeGeneration | None = None) -> None:
         self._current = generation
+        self._selector_activation_check: Callable[[], None] | None = None
+
+    def set_selector_activation_check(self, check: Callable[[], None]) -> None:
+        """Bootstrap installs the local readiness guard before serving requests."""
+        self._selector_activation_check = check
 
     def snapshot(self) -> RoutingRuntimeGeneration | None:
         return self._current
@@ -112,6 +127,8 @@ class RoutingRuntimeGenerationStore:
         return generation
 
     def replace(self, generation: RoutingRuntimeGeneration) -> None:
+        if self._selector_activation_check is not None and generation.selectors:
+            self._selector_activation_check()
         self._current = generation
 
 

--- a/src/router/selection/activation.py
+++ b/src/router/selection/activation.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol
+
+from src.chat_capabilities import ChatRoutingCapabilities
+from src.route_policy_contract import LLMTierSelectorPolicy, RoutePolicyMember
+from src.router.policy_validation import merge_policy_members
+from src.router.selection.policy import SELECTOR_POLICY_SEMANTICS_VERSION
+from src.router.selection.qualification import (
+    selector_price_snapshot,
+    selector_context_capacity,
+    selector_capacity_limits,
+)
+from src.router.selection.target_validation import qualify_chat_target
+
+
+class ActivationInventoryMember(Protocol):
+    enabled: bool
+    model_info: Mapping[str, object] | None
+    provider_model: str | None
+    provider_name: str | None
+
+
+def validate_selector_activation_inventory(
+    document: Mapping[str, object],
+    inventory: Mapping[str, ActivationInventoryMember],
+) -> None:
+    """Qualify a validated policy projection against locked effective membership."""
+    if document.get("selector") is None:
+        return
+    selector = LLMTierSelectorPolicy.model_validate(document["selector"])
+    effective_members = merge_policy_members(
+        [{"deployment_id": key, "enabled": item.enabled} for key, item in inventory.items()],
+        document.get("members"),
+        semantics_version=SELECTOR_POLICY_SEMANTICS_VERSION,
+    )
+    for raw in effective_members:
+        member = RoutePolicyMember.model_validate(raw)
+        if not member.enabled:
+            continue
+        loaded = inventory.get(member.deployment_id)
+        info = loaded.model_info if loaded is not None else None
+        if info is None or info.get("chat_capabilities") is None:
+            raise ValueError("selector members require explicit model_info.chat_capabilities")
+        qualify_chat_target({"model": loaded.provider_model, "provider": loaded.provider_name})
+        ChatRoutingCapabilities.model_validate(info["chat_capabilities"])
+        selector_context_capacity(info)
+        if member.deployment_id == selector.classifier_deployment_id:
+            selector_price_snapshot(info)
+            selector_capacity_limits(info)

--- a/src/router/selection/answer_observation.py
+++ b/src/router/selection/answer_observation.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from src.metrics.selector import (
+    SelectorEscalation,
+    observe_selector_answer,
+    observe_selector_escalation,
+)
+from src.router.selection.contracts import SelectorDecision
+from src.router.selection.qualification import QualifiedSelector
+
+
+class SelectorAnswerObservation:
+    """One terminal observation per external operation, not per MCP/provider hop."""
+
+    def __init__(self, selectors: Mapping[str, QualifiedSelector]) -> None:
+        self._selectors = selectors
+        self.decision: SelectorDecision | None = None
+        self._lowest_attempt: int | None = None
+        self._finished = False
+
+    def _rank(self, group: str, deployment_id: str) -> int | None:
+        qualified = self._selectors.get(group)
+        if qualified is None:
+            return None
+        lane = next(
+            (m.lane for m in qualified.routing.members if m.deployment_id == deployment_id), None
+        )
+        return next((item.rank for item in qualified.routing.policy.lanes if item.id == lane), None)
+
+    def attempted(self, group: str, deployment_id: str) -> None:
+        rank = self._rank(group, deployment_id)
+        if rank is not None:
+            self._lowest_attempt = (
+                rank if self._lowest_attempt is None else min(rank, self._lowest_attempt)
+            )
+
+    def answered(self, group: str, deployment_id: str, *, streaming: bool) -> None:
+        decision = self.decision
+        rank = self._rank(group, deployment_id)
+        if self._finished or decision is None or rank is None:
+            return
+        self._finished = True
+        observe_selector_answer(
+            rank=rank, selector_seconds=decision.latency_ms / 1000, streaming=streaming
+        )
+        if rank > decision.minimum_rank:
+            cause = (
+                SelectorEscalation.PROVIDER_FAILURE
+                if self._lowest_attempt is not None and self._lowest_attempt < rank
+                else SelectorEscalation.NO_ELIGIBLE_MEMBER
+            )
+            observe_selector_escalation(cause, rank=rank)

--- a/src/router/selection/contracts.py
+++ b/src/router/selection/contracts.py
@@ -34,6 +34,7 @@ class SelectorCause(StrEnum):
     OUTPUT_TOO_LARGE = "output_too_large"
     CAPACITY_DENIED = "capacity_denied"
     CAPACITY_UNAVAILABLE = "capacity_unavailable"
+    POLICY_DENIED = "policy_denied"
 
 
 class SelectorPolicyIdentity(FrozenContract):

--- a/src/router/selection/economics.py
+++ b/src/router/selection/economics.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from src.billing.operation_reservation import (
     BillingOperationUnavailable,
     ComponentState,
-    OperationReservation,
+    BillingOperation,
     OperationReservationStore,
     selector_receipt,
 )
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class ReservedSelectorAdmission:
-    """An isolated prerequisite supplied by the future authenticated execution edge.
+    """Admission supplied by the authenticated execution edge.
 
     Neither this type nor a cache signal authorizes a principal. The edge must have
     completed canonical authentication, final-model policy and caller admission.
@@ -41,7 +41,7 @@ class ReservedSelectorAdmission:
         self,
         *,
         store: OperationReservationStore,
-        operation: OperationReservation,
+        operation: BillingOperation,
         cache: ResponseCacheEligibility,
     ) -> None:
         self._store, self._operation, self._cache = store, operation, cache
@@ -67,7 +67,7 @@ class AccountedSelectorHop:
         self,
         *,
         store: OperationReservationStore,
-        operation: OperationReservation,
+        operation: BillingOperation,
         hop: SelectorModelHop,
     ) -> None:
         self._store, self._operation, self._hop = store, operation, hop

--- a/src/router/selection/eligibility.py
+++ b/src/router/selection/eligibility.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from src.models.requests import ChatCompletionRequest
+from src.chat_capabilities import ChatRoutingCapabilities
+from src.router.candidates import invalidate_candidate_plan_cache
+
+_ELIGIBILITY_KEY = "_deltallm_selector_capability_eligibility"
+
+
+@dataclass(frozen=True, slots=True)
+class SelectorCapabilityEligibility:
+    deployment_ids: frozenset[str]
+    qualified_ids: frozenset[str]
+
+
+def set_selector_capability_eligibility(
+    context: dict[str, object],
+    payload: ChatCompletionRequest,
+    capabilities: Mapping[str, ChatRoutingCapabilities],
+    *,
+    requirements: frozenset[str] | None = None,
+) -> None:
+    required = chat_requirements(payload) if requirements is None else requirements
+    eligible = {
+        deployment_id
+        for deployment_id, capability in capabilities.items()
+        if required.issubset(key for key, supported in capability.model_dump().items() if supported)
+    }
+    previous = context.get(_ELIGIBILITY_KEY)
+    qualified_ids = frozenset(capabilities)
+    if isinstance(previous, SelectorCapabilityEligibility):
+        eligible.update(previous.deployment_ids - qualified_ids)
+        qualified_ids |= previous.qualified_ids
+    context[_ELIGIBILITY_KEY] = SelectorCapabilityEligibility(frozenset(eligible), qualified_ids)
+    invalidate_candidate_plan_cache(context)
+
+
+def clear_selector_capability_eligibility(context: dict[str, object]) -> None:
+    context.pop(_ELIGIBILITY_KEY, None)
+    invalidate_candidate_plan_cache(context)
+
+
+def capability_allows(context: dict[str, object], deployment_id: str) -> bool:
+    eligibility = context.get(_ELIGIBILITY_KEY)
+    # The planner can still be used independently, but activation's application
+    # owner always supplies the qualified requirements before executable planning.
+    return eligibility is None or (
+        isinstance(eligibility, SelectorCapabilityEligibility)
+        and (
+            deployment_id not in eligibility.qualified_ids
+            or deployment_id in eligibility.deployment_ids
+        )
+    )
+
+
+def chat_requirements(payload: ChatCompletionRequest) -> frozenset[str]:
+    """Inspect the normalized request, not the intentionally truncated selector prompt.
+
+    One linear pass over an already admitted body, no content copies or I/O. The
+    execution owner reuses this immutable result across groups until payload changes.
+    """
+    required: set[str] = set()
+    if payload.stream:
+        required.add("streaming")
+    if payload.tools:
+        required.add("tools")
+    if payload.n is not None and payload.n > 1:
+        required.add("multiple_choices")
+    if payload.response_format is not None and payload.response_format.type != "text":
+        required.add(payload.response_format.type)
+    modalities = {
+        "image_url": "image",
+        "input_image": "image",
+        "input_audio": "audio",
+        "audio": "audio",
+        "file": "file",
+        "input_file": "file",
+    }
+    for message in payload.messages:
+        if message.role == "tool" or message.tool_calls:
+            required.add("tools")
+        if isinstance(message.content, list):
+            for block in message.content:
+                kind = block.get("type")
+                if kind not in ("text", "input_text"):
+                    required.add(
+                        modalities.get(kind, "unknown") if isinstance(kind, str) else "unknown"
+                    )
+    return frozenset(required)

--- a/src/router/selection/lanes.py
+++ b/src/router/selection/lanes.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from src.route_policy_contract import (
+    LLMTierSelectorPolicy,
+    RoutePolicyMember,
+    SELECTOR_POLICY_SEMANTICS_VERSION,
+    validate_selector_assignments,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SelectorLaneRouting:
+    """Immutable projection of the canonical authored policy, not a second config."""
+
+    policy: LLMTierSelectorPolicy
+    members: tuple[RoutePolicyMember, ...]
+
+    def __post_init__(self) -> None:
+        validate_selector_assignments(self.policy, self.members, group_mode="chat")
+
+
+def parse_selector_lane_routing(group: Mapping[str, object]) -> SelectorLaneRouting | None:
+    selector = group.get("selector")
+    if selector is None:
+        return None
+    version = group.get("policy_semantics_version")
+    semantics = (
+        int(version) if isinstance(version, (int, str)) else SELECTOR_POLICY_SEMANTICS_VERSION
+    )
+    if semantics < SELECTOR_POLICY_SEMANTICS_VERSION:
+        # Historical opaque fields must not acquire current selector semantics.
+        return None
+    if group.get("mode") != "chat":
+        raise ValueError("selector requires route group mode 'chat'")
+    members = group.get("members")
+    if not isinstance(members, (list, tuple)):
+        raise ValueError("selector requires route group members")
+    return SelectorLaneRouting(
+        policy=LLMTierSelectorPolicy.model_validate(selector),
+        members=tuple(RoutePolicyMember.model_validate(member) for member in members),
+    )

--- a/src/router/selection/operation.py
+++ b/src/router/selection/operation.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+from src.billing.operation_reservation import SoftSelectorOperation
+from src.billing.selector_charge import FrozenBillingContract, Identifier, SelectorChargeAttribution
+from src.cache.execution_eligibility import ResponseCacheEligibility
+from src.models.requests import ChatCompletionRequest
+from src.router.selection.capacity import SelectorCapacityOwner
+from src.router.selection.contracts import SelectorDecision
+from src.router.selection.qualification import QualifiedSelector
+from src.router.selection.request_state import RequestSelectorState
+from src.router.selection.runtime import SelectorExecutionFactory
+from src.router.execution import RequestDeadline
+from src.router.candidates import RouteCandidatePlanner
+from src.router.group_execution import set_group_preparation
+from src.router.selection.eligibility import (
+    chat_requirements,
+    clear_selector_capability_eligibility,
+    set_selector_capability_eligibility,
+)
+from src.router.selection.contracts import SelectorInvariantError
+from src.router.selection.request_state import SelectorState
+from src.router.static_filters import required_request_tags, tags_allow_deployment
+from src.router.selection.answer_observation import SelectorAnswerObservation
+
+_OPERATION_KEY = "_deltallm_selector_operation"
+
+
+class SelectorPrincipal(FrozenBillingContract):
+    api_key: Identifier
+    user_id: Identifier | None = None
+    team_id: Identifier | None = None
+    organization_id: Identifier | None = None
+    owner_account_id: Identifier | None = None
+
+
+class SelectorOperation:
+    """One application-level decision, prepared lazily by the execution owner."""
+
+    def __init__(
+        self,
+        *,
+        state: RequestSelectorState,
+        selectors: Mapping[str, QualifiedSelector],
+        factory: SelectorExecutionFactory,
+        principal: SelectorPrincipal,
+        operation_id: UUID,
+        model: str,
+        payload: ChatCompletionRequest,
+        token_estimate: int,
+        cache: ResponseCacheEligibility,
+        capacity_owner: SelectorCapacityOwner,
+        authorize: Callable[[str], None],
+        observe: Callable[[SelectorDecision], None],
+        run_connected: Callable[[Awaitable[SelectorDecision]], Awaitable[SelectorDecision]],
+        context: dict[str, object],
+        planner: RouteCandidatePlanner,
+    ) -> None:
+        self.state, self._selectors, self._factory = state, selectors, factory
+        self._principal, self._id, self._model = principal, operation_id, model
+        self._payload, self._tokens, self._cache = payload, token_estimate, cache
+        self._capacity, self._authorize, self._observe = capacity_owner, authorize, observe
+        self._run_connected = run_connected
+        self._context = context
+        self._planner = planner
+        self.answer_observation = SelectorAnswerObservation(selectors)
+        self._prepared_groups: set[str] = set()
+        self.refresh_payload(payload, token_estimate)
+
+    def refresh_payload(self, payload: ChatCompletionRequest, token_estimate: int) -> None:
+        if self.state.state is SelectorState.RUNNING:
+            raise SelectorInvariantError()
+        self._payload, self._tokens = payload, token_estimate
+        self._requirements = chat_requirements(payload)
+        self._prepared_groups.clear()
+        clear_selector_capability_eligibility(self._context)
+
+    @property
+    def deadline(self) -> RequestDeadline:
+        return self.state.deadline
+
+    async def prepare(self, model_group: str) -> None:
+        qualified = self._selectors.get(model_group)
+        if qualified is None:
+            return
+        self._authorize(model_group)
+        if model_group not in self._prepared_groups:
+            set_selector_capability_eligibility(
+                self._context,
+                self._payload,
+                qualified.capabilities,
+                requirements=self._requirements,
+            )
+            self._prepared_groups.add(model_group)
+        previous = self.state.decision_for_planning()
+        if previous is not None:
+            return
+        plans = await self.deadline.wait_for(
+            self._planner.plan_deployments([model_group], self._context)
+        )
+        plan = plans.get(model_group)
+        if plan is None or not any(lane.deployments for lane in plan.lanes):
+            # Hard-rejected groups do not justify a paid classification. Execution
+            # may proceed to a configured, eligible context fallback instead.
+            return
+        operation = SoftSelectorOperation(
+            attribution=SelectorChargeAttribution(
+                operation_id=self._id,
+                **self._principal.model_dump(),
+                model_group=self._model,
+                deployment_id=qualified.target.deployment_id,
+                deployment_model=qualified.deployment_model,
+                provider=qualified.provider,
+            ),
+            owner_token=uuid4(),
+            pricing=qualified.pricing,
+            admission_allowance=qualified.admission_allowance,
+            expires_at=datetime.now(UTC)
+            + timedelta(seconds=min(840, self.state.deadline.require_remaining())),
+        )
+        service = self._factory.build(
+            qualified,
+            operation=operation,
+            cache=self._cache,
+            capacity_owner=self._capacity,
+            classifier_allowed=tags_allow_deployment(
+                qualified.classifier_tags, required_request_tags(self._context.get("metadata"))
+            ),
+        )
+        decision = await self._run_connected(
+            service.select_once(
+                state=self.state,
+                payload=self._payload,
+                token_estimate=self._tokens,
+                policy=qualified.routing.policy,
+                identity=qualified.identity,
+            )
+        )
+        self.answer_observation.decision = decision
+        self._observe(decision)
+
+
+def bind_selector_preparation(context: dict[str, object], operation: SelectorOperation) -> None:
+    if _OPERATION_KEY in context and context[_OPERATION_KEY] is not operation:
+        raise SelectorInvariantError()
+    context[_OPERATION_KEY] = operation
+    set_group_preparation(context, operation)
+
+
+def selector_answer_observation(context: dict[str, object]) -> SelectorAnswerObservation | None:
+    operation = context.get(_OPERATION_KEY)
+    if operation is None:
+        return None
+    if not isinstance(operation, SelectorOperation):
+        raise SelectorInvariantError()
+    return operation.answer_observation
+
+
+def refresh_selector_payload(
+    context: dict[str, object], payload: ChatCompletionRequest, token_estimate: int
+) -> None:
+    operation = context.get(_OPERATION_KEY)
+    if operation is not None:
+        if not isinstance(operation, SelectorOperation):
+            raise SelectorInvariantError()
+        operation.refresh_payload(payload, token_estimate)

--- a/src/router/selection/planning.py
+++ b/src/router/selection/planning.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, cast
+
+from src.router.candidates import RouteCandidateLane
+from src.router.context_policy import (
+    ContextRoutingPolicy,
+    RequestTokenDemand,
+    order_context_candidates,
+)
+from src.router.selection.contracts import SelectorDecision, SelectorInvariantError
+from src.router.selection.lanes import SelectorLaneRouting
+from src.router.strategies import RoutingStrategyImpl, StrategyStateSnapshot
+
+if TYPE_CHECKING:
+    from src.router.router import Deployment
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateOrdering:
+    deployments: tuple[Deployment, ...]
+    lanes: tuple[RouteCandidateLane, ...] = ()
+    minimum_rank: int | None = None
+    rejection_reason: str | None = None
+
+
+def selector_context_policy(
+    inherited: ContextRoutingPolicy | None, own: ContextRoutingPolicy | None
+) -> ContextRoutingPolicy | None:
+    """A selector fallback cannot weaken either group's deterministic fit limits."""
+    if inherited is None or own is None:
+        return own or inherited
+    return replace(
+        inherited,
+        unknown_capacity="exclude",
+        default_output_tokens=max(inherited.default_output_tokens, own.default_output_tokens),
+        safety_margin_tokens=max(inherited.safety_margin_tokens, own.safety_margin_tokens),
+    )
+
+
+async def order_candidates(
+    *,
+    eligible: list[Deployment],
+    strategy: RoutingStrategyImpl,
+    context: dict[str, object],
+    snapshot: StrategyStateSnapshot,
+    demand: RequestTokenDemand | None,
+    context_policy: ContextRoutingPolicy | None,
+    selector: SelectorLaneRouting | None,
+    decision: SelectorDecision | None,
+) -> CandidateOrdering:
+    """Order only hard-filtered candidates; this boundary never executes a classifier.
+
+    Stateful strategies use the router's one batched snapshot for every lane, so
+    partitioning adds no SQL/Redis/provider work. Without a selector the original
+    strategy-then-context order is unchanged, including random-choice semantics.
+    """
+    if selector is None:
+        ordered = await strategy.order(eligible, context, snapshot)
+        return CandidateOrdering(
+            tuple(
+                order_context_candidates(cast("list[Deployment]", ordered), demand, context_policy)
+            )
+        )
+
+    members = {member.deployment_id: member for member in selector.members}
+    partition: dict[str, list[Deployment]] = {lane.id: [] for lane in selector.policy.lanes}
+    for deployment in eligible:
+        member = members.get(deployment.deployment_id)
+        if member is None:
+            raise SelectorInvariantError()
+        if member.enabled:
+            if member.lane not in partition:
+                raise SelectorInvariantError()
+            partition[member.lane].append(deployment)
+
+    minimum_rank = decision.minimum_rank if decision is not None else None
+    lanes: list[RouteCandidateLane] = []
+    for lane in selector.policy.lanes:
+        candidates = partition[lane.id]
+        if minimum_rank is not None:
+            candidates = candidates if lane.rank >= minimum_rank else []
+            if candidates:
+                ordered = await strategy.order(candidates, context, snapshot)
+                candidates = order_context_candidates(
+                    cast("list[Deployment]", ordered), demand, context_policy
+                )
+        lanes.append(RouteCandidateLane(lane.id, lane.rank, tuple(candidates)))
+    if decision is None:
+        # A pending plan carries eligibility, never executable answer candidates.
+        return CandidateOrdering((), tuple(lanes), rejection_reason="selector_decision_required")
+    deployments = tuple(deployment for lane in lanes for deployment in lane.deployments)
+    return CandidateOrdering(
+        deployments,
+        tuple(lanes),
+        minimum_rank,
+        None if deployments else "no_eligible_selector_lane",
+    )

--- a/src/router/selection/policy.py
+++ b/src/router/selection/policy.py
@@ -25,6 +25,7 @@ class RouteSelectorActivationState(StrEnum):
 
     UNCHECKED = "unchecked"
     INACTIVE = "inactive"
+    VALIDATED = "validated-v3"
 
 
 def ensure_selector_activation_supported(
@@ -32,16 +33,23 @@ def ensure_selector_activation_supported(
     *,
     semantics_version: int,
 ) -> None:
-    """Keep selector policies inert until the complete execution path lands in PR 4."""
+    """Validate executable semantics; inventory and readiness are checked by owners."""
 
     if (
         semantics_version >= SELECTOR_POLICY_SEMANTICS_VERSION
         and policy_json.get("selector") is not None
     ):
-        raise RouteSelectorActivationUnsupportedError(
-            "LLM route-policy selectors cannot be activated until selector execution support "
-            "is available"
-        )
+        try:
+            LLMTierSelectorPolicy.model_validate(policy_json["selector"])
+        except ValueError:
+            raise RouteSelectorActivationUnsupportedError(
+                "invalid executable selector policy"
+            ) from None
+        context = parse_context_routing_policy(policy_json.get("context"))
+        if context is None or context.unknown_capacity != "exclude":
+            raise RouteSelectorActivationUnsupportedError(
+                "selector requires context routing with unknown_capacity=exclude"
+            )
 
 
 def build_routing_fingerprint(

--- a/src/router/selection/provider.py
+++ b/src/router/selection/provider.py
@@ -95,7 +95,7 @@ class ConcreteSelectorTarget:
 
 
 class SelectorProviderHop:
-    """Unwired bridge to the canonical direct hop; it never owns clients or routing."""
+    """Bridge to the canonical direct hop; it never owns clients or routing."""
 
     def __init__(
         self,

--- a/src/router/selection/qualification.py
+++ b/src/router/selection/qualification.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from hashlib import sha256
+import json
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+from src.billing.operation_reservation import token_price_allowance
+from src.billing.selector_charge import SelectorPriceSnapshot
+from src.chat_capabilities import ChatRoutingCapabilities
+from src.providers.resolution import resolve_provider, resolve_upstream_model
+from src.router.selection.capacity import SelectorCapacityBounds
+from src.router.selection.contracts import SelectorPolicyIdentity
+from src.router.selection.lanes import SelectorLaneRouting
+from src.router.selection.policy import build_routing_fingerprint
+from src.router.selection.provider import ConcreteSelectorTarget
+from src.router.selection.target_validation import qualify_chat_target
+
+if TYPE_CHECKING:
+    from src.router.group_policy import RouteGroupPolicy
+    from src.router.router import Deployment
+
+
+@dataclass(frozen=True, slots=True)
+class QualifiedSelector:
+    routing: SelectorLaneRouting
+    identity: SelectorPolicyIdentity
+    target: ConcreteSelectorTarget
+    pricing: SelectorPriceSnapshot
+    capacity: SelectorCapacityBounds
+    admission_allowance: Decimal
+    provider: str
+    deployment_model: str
+    capabilities: Mapping[str, ChatRoutingCapabilities]
+    classifier_tags: frozenset[str]
+
+
+def qualify_selector_groups(
+    policies: Mapping[str, RouteGroupPolicy],
+    deployments: Mapping[str, tuple[Deployment, ...]],
+) -> Mapping[str, QualifiedSelector]:
+    """Compile once per pinned generation, never on a request or Redis cache hit."""
+    return MappingProxyType(
+        {
+            key: _qualify(policy, deployments.get(key, ()))
+            for key, policy in policies.items()
+            if policy.selector is not None
+        }
+    )
+
+
+def _qualify(policy: RouteGroupPolicy, deployments: tuple[Deployment, ...]) -> QualifiedSelector:
+    routing = policy.selector
+    if routing is None:
+        raise ValueError("selector qualification requires a selector")
+    if policy.context is None or policy.context.unknown_capacity != "exclude":
+        raise ValueError("selector requires context routing with unknown_capacity=exclude")
+    enabled = {member.deployment_id for member in routing.members if member.enabled}
+    inventory = {dep.deployment_id: dep for dep in deployments if dep.deployment_id in enabled}
+    if inventory.keys() != enabled:
+        raise ValueError("selector members require concrete enabled deployments")
+    capabilities = MappingProxyType({key: _capabilities(dep) for key, dep in inventory.items()})
+    classifier = inventory[routing.policy.classifier_deployment_id]
+    pricing = selector_price_snapshot(classifier.model_info)
+    input_bound = selector_context_capacity(classifier.model_info)
+    rpm, tpm = selector_capacity_limits(classifier.model_info)
+    capacity = SelectorCapacityBounds(
+        health_ref=classifier.health_ref,
+        rpm=rpm,
+        tpm=tpm,
+        concurrency=rpm,
+        token_allowance=input_bound + 64,
+    )
+    return QualifiedSelector(
+        routing=routing,
+        identity=SelectorPolicyIdentity(
+            policy_version=policy.policy_version,
+            fingerprint=build_routing_fingerprint(
+                workload_mode="chat",
+                strategy=policy.strategy.value if policy.strategy else None,
+                semantics_version=3,
+                timeout_seconds=policy.timeout_seconds,
+                retry_max_attempts=policy.retry_max_attempts,
+                retryable_error_classes=policy.retryable_error_classes,
+                context=policy.context,
+                selector=routing.policy,
+                effective_members=[member.model_dump() for member in routing.members],
+            ),
+        ),
+        target=ConcreteSelectorTarget.from_config(
+            classifier.deployment_id, classifier.deltallm_params
+        ),
+        pricing=pricing,
+        capacity=capacity,
+        admission_allowance=token_price_allowance(
+            pricing, input_tokens=input_bound, output_tokens=64
+        ),
+        provider=resolve_provider(classifier.deltallm_params),
+        deployment_model=resolve_upstream_model(classifier.deltallm_params),
+        capabilities=capabilities,
+        classifier_tags=frozenset(classifier.tags),
+    )
+
+
+def selector_context_capacity(info: Mapping[str, object]) -> int:
+    limits = [info.get(key) for key in ("max_input_tokens", "max_tokens")]
+    known = [value for value in limits if type(value) is int and 1 <= value < 2**31 - 64]
+    if not known:
+        raise ValueError("selector members require known positive context capacity")
+    return min(known)
+
+
+def selector_capacity_limits(info: Mapping[str, object]) -> tuple[int, int]:
+    rpm, tpm = info.get("rpm_limit"), info.get("tpm_limit")
+    if (
+        type(rpm) is not int
+        or type(tpm) is not int
+        or not 1 <= rpm <= 2**31 - 1
+        or not 1 <= tpm <= 2**31 - 1
+    ):
+        raise ValueError("selector classifier requires positive RPM and TPM limits")
+    return rpm, tpm
+
+
+def _capabilities(deployment: Deployment) -> ChatRoutingCapabilities:
+    qualify_chat_target(deployment.deltallm_params)
+    selector_context_capacity(deployment.model_info)
+    value = deployment.model_info.get("chat_capabilities")
+    if value is None:
+        raise ValueError("selector members require explicit model_info.chat_capabilities")
+    return ChatRoutingCapabilities.model_validate(value)
+
+
+def selector_price_snapshot(info: Mapping[str, object]) -> SelectorPriceSnapshot:
+    fields = {
+        "input_cost_per_token",
+        "output_cost_per_token",
+        "input_cost_per_token_cache_hit",
+        "cost_per_request",
+    }
+    for key, value in info.items():
+        if (
+            "cost_per_" in key
+            and key not in fields
+            and key not in {"batch_input_cost_per_token", "batch_output_cost_per_token"}
+            and value not in (None, 0)
+        ):
+            raise ValueError("selector has unsupported provider billing dimensions")
+    if any(info.get(key) is None for key in ("input_cost_per_token", "output_cost_per_token")):
+        raise ValueError("selector requires explicit input and output provider prices")
+    try:
+        prices = {key: Decimal(str(info[key])) for key in fields if info.get(key) is not None}
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        raise ValueError("selector requires finite non-negative provider prices") from exc
+    prices.setdefault("cost_per_request", Decimal(0))
+    version = sha256(
+        json.dumps({key: str(value) for key, value in prices.items()}, sort_keys=True).encode()
+    ).hexdigest()
+    return SelectorPriceSnapshot(source="deployment:model_info", version=version, **prices)

--- a/src/router/selection/reachability.py
+++ b/src/router/selection/reachability.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+from typing import TYPE_CHECKING
+
+from src.models.errors import InvalidRequestError
+
+if TYPE_CHECKING:
+    from src.router.failover import FallbackConfig
+
+
+def selector_reachable_groups(selectors: Collection[str], config: FallbackConfig) -> frozenset[str]:
+    """Reverse reachability in O(V+E), compiled once; cycles never enumerate paths."""
+    parents: dict[str, set[str]] = {}
+    for mapping in (
+        config.fallbacks,
+        config.context_window_fallbacks,
+        config.content_policy_fallbacks,
+    ):
+        for source, targets in mapping.items():
+            for target in targets:
+                parents.setdefault(target, set()).add(source)
+    seen = set(selectors)
+    pending = list(selectors)
+    while pending:
+        for parent in parents.get(pending.pop(), ()):
+            if parent not in seen:
+                seen.add(parent)
+                pending.append(parent)
+    return frozenset(seen)
+
+
+def require_batch_selector_support(group: str, reachable_groups: frozenset[str]) -> None:
+    if group in reachable_groups:
+        raise InvalidRequestError(
+            message="Batch requests do not yet support model-router selectors or selector fallback targets",
+            code="batch_model_router_selector_unsupported",
+        )

--- a/src/router/selection/request_context.py
+++ b/src/router/selection/request_context.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from src.router.candidates import candidate_plan_cache, invalidate_candidate_plan_cache
+from src.router.selection.contracts import SelectorDecision, SelectorInvariantError
+from src.router.selection.request_state import RequestSelectorState
+
+_SELECTOR_STATE_KEY = "_deltallm_selector_state"
+
+
+def set_request_selector_state(context: dict[str, object], state: RequestSelectorState) -> None:
+    """The execution edge attaches one owner, outside caller-controlled metadata."""
+    existing = context.get(_SELECTOR_STATE_KEY)
+    if existing is state:
+        return
+    if existing is not None:
+        raise SelectorInvariantError()
+    context[_SELECTOR_STATE_KEY] = state
+    invalidate_candidate_plan_cache(context)
+
+
+def refresh_selector_candidate_plans(context: dict[str, object]) -> SelectorDecision | None:
+    """Discard pre-decision lane plans, but never discard or rerun the decision."""
+    state = context.get(_SELECTOR_STATE_KEY)
+    if state is None:
+        return None
+    if not isinstance(state, RequestSelectorState):
+        raise SelectorInvariantError()
+    decision = state.decision_for_planning()
+    minimum_rank = decision.minimum_rank if decision is not None else None
+    cached = candidate_plan_cache(context)
+    stale = [
+        group for group, plan in cached.items() if plan.lanes and plan.minimum_rank != minimum_rank
+    ]
+    for group in stale:
+        del cached[group]
+    return decision

--- a/src/router/selection/request_state.py
+++ b/src/router/selection/request_state.py
@@ -59,6 +59,13 @@ class RequestSelectorState:
     def usage(self) -> SelectorUsage:
         return self._usage
 
+    def decision_for_planning(self) -> SelectorDecision | None:
+        """Read the single operation decision without starting or joining provider work."""
+        if self._state in (SelectorState.NEW, SelectorState.RUNNING):
+            self._deadline.require_remaining()
+            return None
+        return self._terminal_result()
+
     def observe_usage(self, usage: SelectorUsage) -> None:
         if self._state is not SelectorState.RUNNING:
             raise SelectorInvariantError()

--- a/src/router/selection/runtime.py
+++ b/src/router/selection/runtime.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import httpx
+from collections.abc import Callable
+
+from src.billing.operation_reservation import (
+    BillingOperationUnavailable,
+    OperationReservationStore,
+    SoftSelectorOperation,
+)
+from src.cache.execution_eligibility import ResponseCacheEligibility
+from src.providers.chat_upstream import ChatAdapterLookup
+from src.router.selection.capacity import CapacityAdmittedSelectorHop, SelectorCapacityOwner
+from src.router.selection.economics import AccountedSelectorHop, ReservedSelectorAdmission
+from src.router.selection.provider import SelectorProviderHop
+from src.router.selection.qualification import QualifiedSelector
+from src.router.selection.service import SelectorService
+from src.router.selection.contracts import (
+    SelectorModelHop,
+    SelectorHopFailure,
+    SelectorCause,
+    SelectorPrompt,
+    UnattemptedSelectorUsage,
+    SelectorHopOutcome,
+)
+from src.rate_limit_policy import estimate_tokens
+
+
+class SelectorExecutionFactory:
+    """Bootstrap-owned dependencies; every operation uses its pinned capacity owner."""
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        adapters: ChatAdapterLookup,
+        billing: OperationReservationStore,
+        default_openai_base_url: str,
+        accounting_ready: Callable[[], bool],
+    ) -> None:
+        self._client, self._adapters = client, adapters
+        self._billing, self._default_base = billing, default_openai_base_url
+        self._accounting_ready = accounting_ready
+
+    def build(
+        self,
+        qualified: QualifiedSelector,
+        *,
+        operation: SoftSelectorOperation,
+        cache: ResponseCacheEligibility,
+        capacity_owner: SelectorCapacityOwner,
+        classifier_allowed: bool = True,
+    ) -> SelectorService:
+        self.require_ready()
+        provider = SelectorProviderHop(
+            client=self._client,
+            adapters=self._adapters,
+            target=qualified.target,
+            default_openai_base_url=self._default_base,
+        )
+        hop: SelectorModelHop = CapacityAdmittedSelectorHop(
+            owner=capacity_owner,
+            bounds=qualified.capacity,
+            hop=AccountedSelectorHop(store=self._billing, operation=operation, hop=provider),
+        )
+        if not classifier_allowed:
+            hop = _PolicyRejectedHop()
+        hop = _ContextCheckedHop(hop, input_capacity=qualified.capacity.token_allowance - 64)
+        return SelectorService(
+            hop,
+            admission=ReservedSelectorAdmission(
+                store=self._billing, operation=operation, cache=cache
+            ),
+        )
+
+    def require_ready(self) -> None:
+        if not self._accounting_ready():
+            raise BillingOperationUnavailable()
+
+
+class _PolicyRejectedHop:
+    async def invoke(
+        self, *, deployment_id: str, prompt: SelectorPrompt, expires_at: float
+    ) -> SelectorHopFailure:
+        return SelectorHopFailure(
+            cause=SelectorCause.POLICY_DENIED, usage=UnattemptedSelectorUsage()
+        )
+
+
+class _ContextCheckedHop:
+    def __init__(self, hop: SelectorModelHop, *, input_capacity: int) -> None:
+        self._hop, self._input_capacity = hop, input_capacity
+
+    async def invoke(
+        self, *, deployment_id: str, prompt: SelectorPrompt, expires_at: float
+    ) -> SelectorHopOutcome:
+        tokens = estimate_tokens(
+            {
+                "messages": [
+                    {"role": "system", "content": prompt.system},
+                    {"role": "user", "content": prompt.user},
+                ]
+            }
+        )
+        # The canonical request estimator plus output and framing margin, before
+        # acquiring capacity or dispatching. Actual provider usage may differ.
+        if tokens + 64 + 256 > self._input_capacity:
+            return SelectorHopFailure(
+                cause=SelectorCause.INPUT_BUDGET_INSUFFICIENT, usage=UnattemptedSelectorUsage()
+            )
+        return await self._hop.invoke(
+            deployment_id=deployment_id, prompt=prompt, expires_at=expires_at
+        )

--- a/src/router/selection/service.py
+++ b/src/router/selection/service.py
@@ -29,7 +29,7 @@ from src.router.selection.request_state import RequestSelectorState
 
 
 class SelectorService:
-    """Isolated prerequisite: deliberately not constructed by production bootstrap."""
+    """One bounded decision composed by the authenticated execution owner."""
 
     def __init__(
         self, hop: SelectorModelHop, *, admission: SelectorAdmission | None = None

--- a/src/router/selection/target_validation.py
+++ b/src/router/selection/target_validation.py
@@ -1,0 +1,22 @@
+from collections.abc import Mapping
+
+from src.providers.resolution import (
+    is_openai_compatible_provider,
+    resolve_provider,
+    resolve_upstream_model,
+)
+
+
+def qualify_chat_target(parameters: Mapping[str, object]) -> None:
+    model = resolve_upstream_model(parameters)
+    if not isinstance(model, str) or not 1 <= len(model.strip()) <= 256:
+        raise ValueError("selector members require a bounded concrete provider model")
+    provider = resolve_provider(parameters)
+    if not is_openai_compatible_provider(provider) and provider not in {
+        "azure",
+        "azure_openai",
+        "anthropic",
+        "gemini",
+        "bedrock",
+    }:
+        raise ValueError("selector members require a supported chat provider")

--- a/src/router/static_filters.py
+++ b/src/router/static_filters.py
@@ -1,0 +1,14 @@
+from collections.abc import Collection
+
+
+def required_request_tags(metadata: object) -> tuple[str, ...]:
+    tags = metadata.get("tags") if isinstance(metadata, dict) else None
+    return (
+        tuple(tag.strip() for tag in tags if isinstance(tag, str) and tag.strip())
+        if isinstance(tags, list)
+        else ()
+    )
+
+
+def tags_allow_deployment(tags: Collection[str], required: tuple[str, ...]) -> bool:
+    return not required or bool(tags and all(tag in tags for tag in required))

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -46,6 +46,8 @@ from src.models.requests import ChatCompletionRequest
 from src.providers.registry import resolve_chat_upstream
 from src.providers.resolution import resolve_provider
 from src.router import ROUTING_MODE_CONTEXT_KEY, require_initial_deployment
+from src.routers.selector_edge import bind_selector_operation
+from src.router.selection.operation import selector_answer_observation
 from src.router.context_policy import RequestTokenDemand, set_request_token_demand
 from src.router.health_state import DeploymentHealthRef
 from src.router.usage import record_router_usage
@@ -131,6 +133,10 @@ async def handle_chat_like_request(
     callback_manager = preflight.callback_manager
     guardrail_middleware = preflight.guardrail_middleware
     has_mcp_tools = chat_request_has_mcp_tools(payload)
+    if payload.stream and has_mcp_tools:
+        raise InvalidRequestError(
+            message="MCP tools are not supported on streaming chat requests yet"
+        )
 
     router = routing_runtime.router
     model_group = router.resolve_model_group(payload.model)
@@ -146,6 +152,14 @@ async def handle_chat_like_request(
             requested_output_tokens=payload.max_tokens,
         ),
     )
+    selector_deadline = bind_selector_operation(
+        request,
+        runtime=routing_runtime,
+        payload=payload,
+        auth=auth,
+        context=request_context,
+        token_estimate=preflight.token_estimate,
+    )
     primary = await require_initial_deployment(
         router=router,
         failover_manager=routing_runtime.failover_manager,
@@ -153,6 +167,8 @@ async def handle_chat_like_request(
         request_context=request_context,
     )
     failover_kwargs = route_failover_kwargs(request_context)
+    if selector_deadline is not None:
+        failover_kwargs["request_deadline"] = selector_deadline
     capture_initial_route_decision(request, request_context)
     api_provider = resolve_provider(primary.deltallm_params)
     request_id = request.headers.get("x-request-id")
@@ -162,16 +178,17 @@ async def handle_chat_like_request(
 
     def track_attempt(deployment):  # noqa: ANN001
         capture_attempted_deployment(request, deployment)
+        observation = selector_answer_observation(request_context)
+        if observation is not None:
+            observation.attempted(
+                deployment.route_group_key or deployment.model_name, deployment.deployment_id
+            )
 
     cache_context = getattr(request.state, "cache_context", None)
     cache_hit = bool(getattr(cache_context, "hit", False)) if cache_context is not None else False
     cache_key = getattr(cache_context, "cache_key", None) if cache_context is not None else None
     try:
         if payload.stream:
-            if has_mcp_tools:
-                raise InvalidRequestError(
-                    message="MCP tools are not supported on streaming chat requests yet"
-                )
             # Validate provider+mode before starting the streaming response,
             # so unsupported stream providers fail as a normal HTTP error.
             resolve_chat_upstream(request, primary.deltallm_params, is_stream=True)
@@ -187,6 +204,13 @@ async def handle_chat_like_request(
             opened_stream = managed_stream.value
             stream_lifecycle = ManagedStreamLifecycle(opened_stream, managed_stream)
             served_deployment = managed_stream.deployment
+            observation = selector_answer_observation(request_context)
+            if observation is not None:
+                observation.answered(
+                    served_deployment.route_group_key or served_deployment.model_name,
+                    served_deployment.deployment_id,
+                    streaming=True,
+                )
             try:
                 update_served_route_decision(
                     request,
@@ -453,6 +477,7 @@ async def handle_chat_like_request(
                     primary_deployment=primary,
                     model_group=model_group,
                     routing_context=request_context,
+                    request_deadline=selector_deadline,
                     timeout_seconds=failover_kwargs.get("timeout_seconds"),
                     retry_max_attempts=failover_kwargs.get("retry_max_attempts"),
                     retryable_error_classes=tuple(
@@ -497,6 +522,13 @@ async def handle_chat_like_request(
             response_transform(payload_data) if response_transform is not None else payload_data
         )
         api_provider = resolve_provider(served_deployment.deltallm_params)
+        observation = selector_answer_observation(request_context)
+        if observation is not None:
+            observation.answered(
+                served_deployment.route_group_key or served_deployment.model_name,
+                served_deployment.deployment_id,
+                streaming=False,
+            )
         await emit_nonstream_success(
             request=request,
             auth=auth,

--- a/src/routers/routing_decision.py
+++ b/src/routers/routing_decision.py
@@ -89,6 +89,9 @@ def capture_initial_route_decision(
     if not isinstance(decision, dict):
         return None
     stored = deepcopy(decision)
+    previous = getattr(request.state, "route_decision", None)
+    if isinstance(previous, dict) and "selector" in previous:
+        stored["selector"] = deepcopy(previous["selector"])
     request.state.route_decision = stored
     _refresh_request_resolution(request)
     return stored

--- a/src/routers/selector_edge.py
+++ b/src/routers/selector_edge.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from uuid import UUID
+
+from fastapi import Request
+
+from src.billing.operation_reservation import BillingOperationUnavailable
+from src.cache.execution_eligibility import ResponseCacheEligibility
+from src.models.requests import ChatCompletionRequest
+from src.models.errors import ProxyError, RoutingFailureAction
+from src.models.responses import UserAPIKeyAuth
+from src.router.execution import RequestDeadline
+from src.router.runtime_generation import RoutingRuntimeGeneration
+from src.router.selection.contracts import SelectorDecision
+from src.router.selection.operation import (
+    SelectorOperation,
+    SelectorPrincipal,
+    bind_selector_preparation,
+)
+from src.router.selection.request_context import set_request_selector_state
+from src.router.selection.request_state import RequestSelectorState
+from src.router.selection.runtime import SelectorExecutionFactory
+from src.routers.routing_decision import attach_selector_decision
+from src.services.model_visibility import (
+    ensure_model_allowed,
+    get_callable_target_policy_mode_from_app,
+    get_tier_policy_mode_from_app,
+    get_tier_policy_missing_service_mode_from_app,
+)
+from src.telemetry.event_identity import get_or_create_billing_event_id
+from src.telemetry.selector_decision import ProtectedSelectorDecision
+
+
+def bind_selector_operation(
+    request: Request,
+    *,
+    runtime: RoutingRuntimeGeneration,
+    payload: ChatCompletionRequest,
+    auth: UserAPIKeyAuth,
+    context: dict[str, object],
+    token_estimate: int,
+) -> RequestDeadline | None:
+    """Transport composition after normalized preflight and whole-response cache miss."""
+    group = runtime.router.resolve_model_group(payload.model)
+    if group not in runtime.selector_reachable_groups:
+        return None
+    cache = getattr(request.state, "response_cache_eligibility", None)
+    factory = getattr(request.app.state, "selector_execution_factory", None)
+    if not isinstance(cache, ResponseCacheEligibility) or not isinstance(
+        factory, SelectorExecutionFactory
+    ):
+        raise BillingOperationUnavailable()
+    cache.require_provider_execution()
+    policy = runtime.router.config.route_group_policies.get(group)
+    deadline = runtime.failover_manager.create_request_deadline(
+        policy.timeout_seconds if policy else None
+    )
+    state = RequestSelectorState(deadline)
+    set_request_selector_state(context, state)
+    operation = SelectorOperation(
+        state=state,
+        selectors=runtime.selectors,
+        factory=factory,
+        principal=SelectorPrincipal(
+            api_key=auth.api_key,
+            user_id=auth.user_id,
+            team_id=auth.team_id,
+            organization_id=auth.organization_id,
+            owner_account_id=auth.owner_account_id,
+        ),
+        operation_id=UUID(get_or_create_billing_event_id(request)),
+        model=payload.model,
+        payload=payload,
+        token_estimate=token_estimate,
+        cache=cache,
+        capacity_owner=runtime.router.state,
+        authorize=lambda target: _authorize(request, runtime, auth, target),
+        observe=lambda decision: attach_selector_decision(
+            request, ProtectedSelectorDecision.from_decision(decision)
+        ),
+        run_connected=lambda work: _while_connected(request, work),
+        context=context,
+        planner=runtime.router,
+    )
+    bind_selector_preparation(context, operation)
+    return deadline
+
+
+def _authorize(
+    request: Request, runtime: RoutingRuntimeGeneration, auth: UserAPIKeyAuth, target: str
+) -> None:
+    ensure_model_allowed(
+        auth,
+        target,
+        callable_target_grant_service=getattr(
+            request.app.state, "callable_target_grant_service", None
+        ),
+        callable_target_grant_snapshot=runtime.authorization_snapshot,
+        tier_policy_service=getattr(request.app.state, "tier_policy_service", None),
+        policy_mode=get_callable_target_policy_mode_from_app(request.app),
+        tier_policy_mode=get_tier_policy_mode_from_app(request.app),
+        tier_policy_missing_service_mode=get_tier_policy_missing_service_mode_from_app(request.app),
+    )
+
+
+class SelectorClientDisconnectedError(ProxyError):
+    status_code = 499
+    error_type = "client_disconnected"
+    message = "Client disconnected"
+
+
+async def _disconnected(request: Request) -> None:
+    # The admitted body has already been fully consumed. A blocking receive is
+    # required: is_disconnected's immediate cancellation misses middleware checkpoints.
+    while (await request.receive())["type"] != "http.disconnect":
+        pass
+
+
+async def _while_connected(request: Request, work: Awaitable[SelectorDecision]) -> SelectorDecision:
+    """Two bounded request-owned tasks; both are joined, never detached."""
+    task = asyncio.ensure_future(work)
+    disconnect = asyncio.create_task(_disconnected(request))
+    try:
+        done, _ = await asyncio.wait((task, disconnect), return_when=asyncio.FIRST_COMPLETED)
+        if disconnect in done:
+            await disconnect
+            task.cancel()
+            # Cancel the provider task, but unwind middleware with a normal typed
+            # failure. Raising CancelledError inside BaseHTTPMiddleware's child can
+            # otherwise leave the outer request waiting forever for a response.
+            raise SelectorClientDisconnectedError(
+                code="client_disconnected",
+                affects_deployment_health=False,
+                routing_failure_action=RoutingFailureAction.FAIL_FAST,
+            )
+        return await task
+    finally:
+        for child in (task, disconnect):
+            if not child.done():
+                child.cancel()
+        await asyncio.gather(task, disconnect, return_exceptions=True)

--- a/src/services/route_group_cache_contract.py
+++ b/src/services/route_group_cache_contract.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import math
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from src.route_group_config import ModelMode, RoutingStrategyName
 from src.router.context_policy import parse_context_routing_policy
 from src.router.policy_validation import ALLOWED_RETRYABLE_ERROR_CLASSES
+from src.route_policy_contract import (
+    LLMTierSelectorPolicy,
+    RoutePolicyMember,
+    validate_selector_assignments,
+)
+from src.router.selection.policy import ensure_selector_activation_supported
 
-ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION = 2
+ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION = 3
 ROUTE_GROUP_RUNTIME_CACHE_MAX_BYTES = 4 * 1024 * 1024
 
 
@@ -82,6 +88,7 @@ class _CacheMember(BaseModel):
     enabled: bool = True
     weight: int | None = Field(default=None, ge=1)
     priority: int | None = Field(default=None, ge=0)
+    lane: str | None = Field(default=None, max_length=32, pattern=r"^[a-z][a-z0-9_-]{0,31}$")
 
 
 class _CacheGroup(BaseModel):
@@ -99,6 +106,22 @@ class _CacheGroup(BaseModel):
     default_prompt: dict[str, str] | None = None
     access_groups: list[str] | None = None
     members: list[_CacheMember]
+    selector: LLMTierSelectorPolicy | None = None
+
+    @model_validator(mode="after")
+    def validate_selector(self) -> _CacheGroup:
+        if self.selector is None and any(member.lane is not None for member in self.members):
+            raise ValueError("member lanes require an active selector")
+        if self.selector is not None:
+            validate_selector_assignments(
+                self.selector,
+                [RoutePolicyMember.model_validate(member.model_dump()) for member in self.members],
+                group_mode=self.mode,
+            )
+            ensure_selector_activation_supported(
+                self.model_dump(), semantics_version=self.policy_semantics_version or 3
+            )
+        return self
 
     @field_validator("context")
     @classmethod
@@ -113,8 +136,8 @@ class _CacheGroup(BaseModel):
 class RouteGroupRuntimeCacheEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
 
-    schema_version: Literal[2]
-    selector_activation_state: Literal["inactive"]
+    schema_version: Literal[3]
+    selector_activation_state: Literal["validated-v3"]
     revision: int = Field(ge=0)
     groups: list[_CacheGroup]
     database_initialized: bool | None

--- a/src/services/route_groups.py
+++ b/src/services/route_groups.py
@@ -181,10 +181,10 @@ class RouteGroupRuntimeCache:
             snapshot = RouteGroupRuntimeSnapshot(
                 revision=revision,
                 groups=[
-                    group.model_dump(mode="python", exclude_unset=True) for group in payload.groups
+                    group.model_dump(mode="json", exclude_unset=True) for group in payload.groups
                 ],
                 database_initialized=payload.database_initialized,
-                selector_activation_state=RouteSelectorActivationState.INACTIVE,
+                selector_activation_state=RouteSelectorActivationState.VALIDATED,
             )
         except (TypeError, ValueError, ValidationError):
             self._record_failure(RouteGroupCacheFailureReason.INVALID_PAYLOAD)
@@ -199,7 +199,7 @@ class RouteGroupRuntimeCache:
         try:
             serialized = RouteGroupRuntimeCacheEnvelope(
                 schema_version=ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION,
-                selector_activation_state=RouteSelectorActivationState.INACTIVE,
+                selector_activation_state=RouteSelectorActivationState.VALIDATED,
                 revision=snapshot.revision,
                 groups=snapshot.groups,
                 database_initialized=snapshot.database_initialized,
@@ -266,9 +266,10 @@ def route_groups_from_config(
         )
         if policy.get("context") is None:
             policy.pop("context", None)
-        policy.pop("selector", None)
-        for member in policy["members"]:
-            member.pop("lane", None)
+        if item.selector is None:
+            policy.pop("selector", None)
+            for member in policy["members"]:
+                member.pop("lane", None)
         groups.append(policy)
     return groups
 
@@ -276,7 +277,7 @@ def route_groups_from_config(
 def _require_runtime_snapshot_selector_activation_validated(
     snapshot: RouteGroupRuntimeSnapshot,
 ) -> None:
-    if snapshot.selector_activation_state != RouteSelectorActivationState.INACTIVE:
+    if snapshot.selector_activation_state != RouteSelectorActivationState.VALIDATED:
         raise UnvalidatedRouteGroupSnapshotError(
             "route-group runtime snapshot has not passed the selector activation gate"
         )
@@ -313,7 +314,7 @@ async def load_route_group_snapshot_result(
             snapshot=RouteGroupRuntimeSnapshot(
                 revision=0,
                 groups=route_groups_from_config(cfg, deployment_modes=deployment_modes),
-                selector_activation_state=RouteSelectorActivationState.INACTIVE,
+                selector_activation_state=RouteSelectorActivationState.VALIDATED,
             ),
             source="config_only",
             database_available=True,
@@ -337,7 +338,7 @@ async def load_route_group_snapshot_result(
             snapshot=RouteGroupRuntimeSnapshot(
                 revision=0,
                 groups=route_groups_from_config(cfg, deployment_modes=deployment_modes),
-                selector_activation_state=RouteSelectorActivationState.INACTIVE,
+                selector_activation_state=RouteSelectorActivationState.VALIDATED,
             ),
             source="config_db_unavailable",
             database_available=False,
@@ -355,7 +356,7 @@ async def load_route_group_snapshot_result(
         snapshot=RouteGroupRuntimeSnapshot(
             revision=snapshot.revision,
             groups=route_groups_from_config(cfg, deployment_modes=deployment_modes),
-            selector_activation_state=RouteSelectorActivationState.INACTIVE,
+            selector_activation_state=RouteSelectorActivationState.VALIDATED,
         ),
         source="config_db_empty",
         database_available=True,

--- a/src/services/route_policy_simulation.py
+++ b/src/services/route_policy_simulation.py
@@ -41,11 +41,8 @@ from src.router.context_policy import (
 )
 from src.router.runtime_generation import RoutingRuntimeGeneration
 from src.router.route_group_validation import deployment_modes_by_id
-from src.router.selection.policy import (
-    SELECTOR_POLICY_SEMANTICS_VERSION,
-    ensure_selector_activation_supported,
-)
 from src.router.simulation_state import RoutingSimulationState, RoutingStateSnapshotMiss
+from src.router.selection.reachability import selector_reachable_groups
 from src.services.prompt_registry import apply_route_preferences_to_metadata, parse_prompt_reference
 
 _MAX_SAMPLE_ATTEMPTS = 50
@@ -152,10 +149,10 @@ class RoutePolicySimulationService:
                     available_members=membership.inventory,
                     workload_mode=group.mode,
                 )
-                ensure_selector_activation_supported(
-                    normalized,
-                    semantics_version=SELECTOR_POLICY_SEMANTICS_VERSION,
-                )
+                if normalized.get("selector") is not None:
+                    raise ValueError(
+                        "Selector policy simulation is not supported until offline evaluation is available"
+                    )
             except ValueError as exc:
                 raise RoutePolicySimulationInvalidError(str(exc)) from exc
             warnings.extend(policy_warnings)
@@ -167,6 +164,16 @@ class RoutePolicySimulationService:
                 base_strategy=group.routing_strategy,
             )
 
+        selector_groups = [
+            str(item["key"])
+            for item in runtime_groups
+            if item.get("selector") is not None
+            and int(item.get("policy_semantics_version") or 3) >= 3
+        ]
+        if group_key in selector_reachable_groups(selector_groups, self._runtime.failover_config):
+            raise RoutePolicySimulationInvalidError(
+                "Selector policy simulation is not supported until offline evaluation is available"
+            )
         metadata, prompt, prompt_warnings = await self._resolve_prompt(
             group_key,
             dict(request.metadata),
@@ -509,6 +516,7 @@ def _apply_policy_override(
         )
         patched["timeouts"] = policy.get("timeouts")
         patched["retry"] = policy.get("retry")
+        patched.pop("selector", None)
         context = merge_context_policy_block(group.get("context"), policy)
         if context is None:
             patched.pop("context", None)

--- a/tests/bootstrap/test_runtime_services_bootstrap.py
+++ b/tests/bootstrap/test_runtime_services_bootstrap.py
@@ -81,6 +81,10 @@ def _install_runtime_service_fakes(
     tier_policy_reload_error: Exception | None = None,
     prompt_registry_error: Exception | None = None,
 ) -> None:
+    monkeypatch.setattr(
+        "src.bootstrap.runtime_services.configure_selector_execution", lambda state, spend: None
+    )
+
     class FakeGuardrailRegistry:
         def __init__(self) -> None:
             self.loaded = None

--- a/tests/bootstrap/test_selector.py
+++ b/tests/bootstrap/test_selector.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+
+import pytest
+from starlette.datastructures import State
+
+from src.billing.operation_reservation import BillingOperationUnavailable
+from src.bootstrap.selector import configure_selector_execution
+from src.db.billing_operation_recovery import BillingOperationRecovery
+from src.router.selection.runtime import SelectorExecutionFactory
+from src.router.runtime_generation import RoutingRuntimeGenerationStore
+
+
+def test_selector_composition_reuses_spend_owner_and_tracks_worker_health():
+    spend = SimpleNamespace(
+        db=object(),
+        config=SimpleNamespace(
+            enabled=True, worker_enabled=True, max_pending_events=100, max_attempts=10
+        ),
+        worker_health=SimpleNamespace(ready=True),
+    )
+    state = State(
+        {
+            "http_client": object(),
+            "provider_error_mapper_registry": object(),
+            "settings": SimpleNamespace(openai_base_url="https://mock.test/v1"),
+            "route_group_repository": SimpleNamespace(),
+        }
+    )
+    state.routing_runtime_generation_store = RoutingRuntimeGenerationStore()
+    configure_selector_execution(state, spend)
+    assert isinstance(state.selector_execution_factory, SelectorExecutionFactory)
+    assert isinstance(spend.operation_recovery, BillingOperationRecovery)
+    assert spend.operation_recovery.selector_events_only
+    state.route_group_repository.selector_activation_check()
+    spend.worker_health.ready = False
+    with pytest.raises(BillingOperationUnavailable):
+        state.route_group_repository.selector_activation_check()
+
+
+@pytest.mark.parametrize("enabled,worker", [(False, False), (True, False)])
+@pytest.mark.parametrize("selectors", [{}, {"selected": object()}])
+def test_selector_cannot_start_without_durable_spend_worker(
+    monkeypatch, enabled, worker, selectors
+):
+    state = State()
+    state.routing_runtime_generation_store = RoutingRuntimeGenerationStore()
+    spend = SimpleNamespace(config=SimpleNamespace(enabled=enabled, worker_enabled=worker))
+    monkeypatch.setattr(
+        "src.bootstrap.selector.require_routing_runtime_generation",
+        lambda _: SimpleNamespace(selectors=selectors),
+    )
+    if selectors:
+        with pytest.raises(RuntimeError, match="durable spend outbox"):
+            configure_selector_execution(state, spend)
+    else:
+        configure_selector_execution(state, spend)
+        assert state.selector_execution_factory is None
+    previous = SimpleNamespace(selectors={})
+    state.routing_runtime_generation_store.replace(previous)
+    with pytest.raises(BillingOperationUnavailable):
+        state.routing_runtime_generation_store.replace(
+            SimpleNamespace(selectors={"selected": object()})
+        )
+    assert state.routing_runtime_generation_store.require_snapshot() is previous

--- a/tests/config/test_dynamic.py
+++ b/tests/config/test_dynamic.py
@@ -216,7 +216,7 @@ class FakeRouteGroupCache:
                 RouteGroupRuntimeSnapshot(
                     0,
                     self.stale_groups,
-                    selector_activation_state=RouteSelectorActivationState.INACTIVE,
+                    selector_activation_state=RouteSelectorActivationState.VALIDATED,
                 ),
                 "l1_cache",
             )
@@ -237,7 +237,7 @@ class FakeRouteGroupRepository:
         return RouteGroupRuntimeSnapshot(
             self.revision,
             self.groups,
-            selector_activation_state=RouteSelectorActivationState.INACTIVE,
+            selector_activation_state=RouteSelectorActivationState.VALIDATED,
         )
 
 

--- a/tests/db/test_route_policy_repository.py
+++ b/tests/db/test_route_policy_repository.py
@@ -366,7 +366,7 @@ async def test_publish_policy_uses_null_to_delete_context_without_ambiguous_omis
 async def test_runtime_policy_member_list_excludes_omitted_base_members() -> None:
     snapshot = await RouteGroupRepository(_RuntimeRouteGroupDB()).load_runtime_snapshot()
 
-    assert snapshot.selector_activation_state == RouteSelectorActivationState.INACTIVE
+    assert snapshot.selector_activation_state == RouteSelectorActivationState.VALIDATED
     assert snapshot.groups[0]["members"] == [
         {
             "deployment_id": "dep-b",
@@ -379,7 +379,7 @@ async def test_runtime_policy_member_list_excludes_omitted_base_members() -> Non
 
 @pytest.mark.asyncio
 async def test_runtime_loading_rejects_published_v3_selector() -> None:
-    with pytest.raises(RouteSelectorActivationUnsupportedError, match="cannot be activated"):
+    with pytest.raises(RouteSelectorActivationUnsupportedError, match="unknown_capacity=exclude"):
         await RouteGroupRepository(_RuntimeSelectorRouteGroupDB()).load_runtime_snapshot()
 
 
@@ -616,7 +616,7 @@ async def test_selector_draft_preserves_opaque_stored_fields_and_reaches_activat
     transaction.draft_policy = record.policy.policy_json
     transaction.draft_semantics_version = 3
     transaction.executions.clear()
-    with pytest.raises(RouteSelectorActivationUnsupportedError, match="cannot be activated"):
+    with pytest.raises(RouteSelectorActivationUnsupportedError, match="unknown_capacity=exclude"):
         await repository.publish_latest_draft("support-route")
 
     assert transaction.executions == []
@@ -628,7 +628,7 @@ async def test_direct_selector_publication_is_explicitly_rejected() -> None:
     transaction = _RoutePolicyDB(member_rows=_selector_member_rows())
     prisma = _TransactionalRoutePolicyDB(transaction)
 
-    with pytest.raises(RouteSelectorActivationUnsupportedError, match="cannot be activated"):
+    with pytest.raises(RouteSelectorActivationUnsupportedError, match="unknown_capacity=exclude"):
         await RouteGroupRepository(prisma).publish_policy(
             "support-route",
             _selector_policy(),
@@ -710,7 +710,7 @@ async def test_publish_latest_selector_draft_is_explicitly_rejected() -> None:
     )
     prisma = _TransactionalRoutePolicyDB(transaction)
 
-    with pytest.raises(RouteSelectorActivationUnsupportedError, match="cannot be activated"):
+    with pytest.raises(RouteSelectorActivationUnsupportedError, match="unknown_capacity=exclude"):
         await RouteGroupRepository(prisma).publish_latest_draft("support-route")
 
     assert transaction.executions == []
@@ -726,7 +726,7 @@ async def test_rollback_to_v3_selector_is_explicitly_rejected() -> None:
     )
     prisma = _TransactionalRoutePolicyDB(transaction)
 
-    with pytest.raises(RouteSelectorActivationUnsupportedError, match="cannot be activated"):
+    with pytest.raises(RouteSelectorActivationUnsupportedError, match="unknown_capacity=exclude"):
         await RouteGroupRepository(prisma).rollback_policy(
             "support-route",
             target_version=3,
@@ -748,7 +748,7 @@ async def test_rollback_to_v3_selector_tolerates_trusted_opaque_fields_before_ga
     )
     prisma = _TransactionalRoutePolicyDB(transaction)
 
-    with pytest.raises(RouteSelectorActivationUnsupportedError, match="cannot be activated"):
+    with pytest.raises(RouteSelectorActivationUnsupportedError, match="unknown_capacity=exclude"):
         await RouteGroupRepository(prisma).rollback_policy(
             "support-route",
             target_version=3,

--- a/tests/db/test_selector_activation.py
+++ b/tests/db/test_selector_activation.py
@@ -1,0 +1,251 @@
+import json
+from copy import deepcopy
+
+import pytest
+
+from src.db.route_groups import RouteGroupRepository
+from src.db.route_policy_lifecycle import RoutePolicyStateConflictError
+from src.router.selection.policy import RouteSelectorActivationUnsupportedError
+from tests.db import test_route_policy_selector_integration as fixtures
+
+selector_database = fixtures.selector_database
+pytestmark = pytest.mark.postgres
+
+
+async def qualify(db, policy):
+    policy["context"] = {"mode": "eligible-only", "unknown_capacity": "exclude"}
+    info = {
+        "mode": "chat",
+        "chat_capabilities": {"streaming": True},
+        "max_tokens": 32768,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000002,
+        "rpm_limit": 100,
+        "tpm_limit": 1000000,
+    }
+    await db.execute_raw(
+        "UPDATE deltallm_modeldeployment SET model_info=$2::jsonb,deltallm_params=jsonb_build_object('model','openai/mock') WHERE deployment_id=ANY($1::text[])",
+        [member["deployment_id"] for member in policy["members"]],
+        json.dumps(info),
+    )
+    return info
+
+
+async def test_selector_publish_draft_remove_and_rollback_are_versioned_atomic_mutations(
+    selector_database,
+):
+    db, group, policy = selector_database
+    await qualify(db, policy)
+    repository = RouteGroupRepository(db, selector_activation_check=lambda: None)
+    revision = await repository.get_runtime_revision()
+    first = await repository.publish_policy(group, policy)
+    assert first.policy.version == 1
+    snapshot = await repository.load_runtime_snapshot()
+    active = next(item for item in snapshot.groups if item["key"] == group)
+    assert active["selector"]["kind"] == "llm-tier"
+    assert {member["lane"] for member in active["members"]} == {"economy", "quality"}
+    await repository.save_draft_policy(group, {"strategy": "weighted"})
+    second = await repository.publish_latest_draft(group)
+    assert (
+        second.version == 2
+        and second.policy_json["selector"] == first.policy.policy_json["selector"]
+    )
+    third = await repository.publish_policy(group, {"selector": None})
+    assert third.policy.version == 3 and "selector" not in third.policy.policy_json
+    fourth = await repository.rollback_policy(group, target_version=1)
+    assert fourth.version == 4 and fourth.policy_json == first.policy.policy_json
+    assert await repository.get_runtime_revision() == revision + 4
+    rows = await fixtures._rows(db, group)
+    assert [row["status"] for row in rows] == ["archived", "archived", "archived", "published"]
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "readiness",
+        "chat_capabilities",
+        "max_tokens",
+        "input_cost_per_token",
+        "output_cost_per_token",
+        "rpm_limit",
+        "tpm_limit",
+    ],
+)
+async def test_unqualified_selector_cannot_archive_a_working_policy(selector_database, missing):
+    db, group, policy = selector_database
+    info = await qualify(db, policy)
+    repository = RouteGroupRepository(
+        db, selector_activation_check=(None if missing == "readiness" else lambda: None)
+    )
+    await repository.publish_policy(group, {"strategy": "weighted"})
+    revision = await repository.get_runtime_revision()
+    if missing != "readiness":
+        info.pop(missing)
+        await db.execute_raw(
+            "UPDATE deltallm_modeldeployment SET model_info=$2::jsonb WHERE deployment_id=$1",
+            policy["selector"]["classifier_deployment_id"],
+            json.dumps(info),
+        )
+    error = RouteSelectorActivationUnsupportedError if missing == "readiness" else ValueError
+    with pytest.raises(error):
+        await repository.publish_policy(group, policy)
+    assert await repository.get_runtime_revision() == revision
+    current = await repository.get_published_policy(group)
+    assert current.version == 1 and current.policy_json == {"strategy": "weighted"}
+
+
+async def test_active_selector_model_metadata_edit_rolls_back_atomically(selector_database):
+    from src.db.repositories import ModelDeploymentRepository
+    from src.db.route_policy_lifecycle import RoutePolicyStateConflictError
+
+    db, group, policy = selector_database
+    info = await qualify(db, policy)
+    repository = RouteGroupRepository(db, selector_activation_check=lambda: None)
+    await repository.publish_policy(group, policy)
+    revision = await repository.get_runtime_revision()
+    models = ModelDeploymentRepository(db)
+    classifier = policy["selector"]["classifier_deployment_id"]
+    record = await models.get_by_deployment_id(classifier)
+    invalid = dict(info)
+    invalid.pop("chat_capabilities")
+    with pytest.raises(RoutePolicyStateConflictError, match="chat_capabilities"):
+        await models.update(
+            classifier,
+            model_name=record.model_name,
+            named_credential_id=None,
+            deltallm_params=record.deltallm_params,
+            model_info=invalid,
+        )
+    assert (await models.get_by_deployment_id(classifier)).model_info == info
+    assert await repository.get_runtime_revision() == revision
+
+
+async def test_rollback_to_now_unqualified_selector_is_a_safe_policy_error(selector_database):
+    db, group, policy = selector_database
+    await qualify(db, policy)
+    repository = RouteGroupRepository(db, selector_activation_check=lambda: None)
+    await repository.publish_policy(group, policy)
+    await repository.publish_policy(group, {"selector": None})
+    revision = await repository.get_runtime_revision()
+    await db.execute_raw(
+        "UPDATE deltallm_modeldeployment SET model_info=model_info-'chat_capabilities' WHERE deployment_id=$1",
+        policy["selector"]["classifier_deployment_id"],
+    )
+    with pytest.raises(RouteSelectorActivationUnsupportedError, match="chat_capabilities"):
+        await repository.rollback_policy(group, target_version=1)
+    assert (await repository.get_published_policy(group)).version == 2
+    assert await repository.get_runtime_revision() == revision
+
+
+async def test_selector_lifecycle_qualifies_projection_and_preserves_opaque_member_fields(
+    selector_database,
+):
+    db, group, policy = selector_database
+    await qualify(db, policy)
+    repository = RouteGroupRepository(db, selector_activation_check=lambda: None)
+    first = (await repository.publish_policy(group, policy)).policy
+    stored = deepcopy(first.policy_json)
+    extension = {"nested": ["retained", {"revision": 7}]}
+    stored["members"][0]["server_extension"] = extension
+    await db.execute_raw(
+        "UPDATE deltallm_routepolicy SET policy_json=$2::jsonb WHERE route_policy_id=$1",
+        first.route_policy_id,
+        json.dumps(stored),
+    )
+    before = await fixtures._rows(db, group)
+    revision = await repository.get_runtime_revision()
+    with pytest.raises(ValueError):
+        await repository.publish_policy(group, {"members": stored["members"]})
+    assert await fixtures._rows(db, group) == before
+    assert await repository.get_runtime_revision() == revision
+
+    direct = (await repository.publish_policy(group, {"strategy": "weighted"})).policy
+    assert direct.policy_json["members"][0]["server_extension"] == extension
+    draft = await repository.save_draft_policy(group, {"strategy": "priority-based-routing"})
+    assert draft.policy.policy_json["members"][0]["server_extension"] == extension
+    published = await repository.publish_latest_draft(group)
+    removed = (await repository.publish_policy(group, {"selector": None})).policy
+    assert "selector" not in removed.policy_json
+    assert "lane" not in removed.policy_json["members"][0]
+    assert removed.policy_json["members"][0]["server_extension"] == extension
+    rolled = await repository.rollback_policy(group, target_version=first.version)
+    assert rolled.policy_json == stored
+    assert [direct.version, published.version, removed.version, rolled.version] == [2, 3, 4, 5]
+    assert await repository.get_runtime_revision() == revision + 4
+    assert [row["status"] for row in await fixtures._rows(db, group)] == [
+        "archived",
+        "archived",
+        "archived",
+        "archived",
+        "published",
+    ]
+
+
+@pytest.mark.parametrize("disabled_by", ["group", "policy"])
+@pytest.mark.parametrize("missing", ["chat_capabilities", "max_tokens"])
+async def test_activation_only_qualifies_effectively_enabled_members(
+    selector_database, disabled_by, missing
+):
+    db, group, policy = selector_database
+    info = await qualify(db, policy)
+    extra_id = f"{group}-disabled"
+    info.pop(missing)
+    repository = RouteGroupRepository(db, selector_activation_check=lambda: None)
+    try:
+        await db.execute_raw(
+            """
+            INSERT INTO deltallm_modeldeployment
+                (deployment_id, model_name, deltallm_params, model_info, created_at, updated_at)
+            VALUES ($1, $1, '{"model":"openai/mock"}'::jsonb, $2::jsonb, NOW(), NOW())
+            """,
+            extra_id,
+            json.dumps(info),
+        )
+        await repository.upsert_member(
+            group,
+            deployment_id=extra_id,
+            enabled=disabled_by != "group",
+            weight=None,
+            priority=None,
+        )
+        member = {"deployment_id": extra_id, "lane": "quality"}
+        if disabled_by == "policy":
+            member["enabled"] = False
+        policy["members"].append(member)
+        await repository.publish_policy(group, policy)
+        # All publication paths must use the same effective-membership rule.
+        await repository.save_draft_policy(group, {"strategy": "weighted"})
+        await repository.publish_latest_draft(group)
+        await repository.rollback_policy(group, target_version=1)
+        # An unrelated active-group edit must not requalify disabled inventory.
+        await repository.upsert_member(
+            group,
+            deployment_id=policy["members"][1]["deployment_id"],
+            enabled=True,
+            weight=2,
+            priority=None,
+        )
+        before = await fixtures._rows(db, group)
+        revision = await repository.get_runtime_revision()
+        if disabled_by == "group":
+            with pytest.raises(RoutePolicyStateConflictError):
+                await repository.upsert_member(
+                    group,
+                    deployment_id=extra_id,
+                    enabled=True,
+                    weight=None,
+                    priority=None,
+                )
+            assert not next(
+                m for m in await repository.list_members(group) if m.deployment_id == extra_id
+            ).enabled
+        else:
+            member["enabled"] = True
+            with pytest.raises(RouteSelectorActivationUnsupportedError):
+                await repository.publish_policy(group, policy)
+        assert await fixtures._rows(db, group) == before
+        assert await repository.get_runtime_revision() == revision
+    finally:
+        await db.execute_raw(
+            "DELETE FROM deltallm_modeldeployment WHERE deployment_id=$1", extra_id
+        )

--- a/tests/performance/realtime_selector_profile.py
+++ b/tests/performance/realtime_selector_profile.py
@@ -1,0 +1,156 @@
+"""Fixed-provider, constant-arrival PR 4 integration profile, including gateway TTFT.
+
+Run: python -m tests.performance.realtime_selector_profile --output-dir <directory>
+Uses the same admitted HTTP path with/without selection. Billing and Redis are
+fakes; PostgreSQL/Redis integration tests qualify durability separately. This is
+not a deployment-capacity certificate or a real-model savings evaluation.
+"""
+
+import argparse
+import asyncio
+from collections import Counter
+import json
+import logging
+from pathlib import Path
+from time import perf_counter
+
+import httpx
+
+from scripts.measure_gateway_load import (
+    RequestResult,
+    run_constant_arrival,
+    summarize,
+    write_results,
+)
+from tests.conftest import test_app as app_fixture
+from tests.performance.routing_cache_profile import instrument_async_methods, queue_slope
+from tests.router.selection.test_realtime import configure
+from tests.router.selection.provider_fixtures import response_body
+from tests.test_routing_cache_identity import _publish
+
+
+async def measure(output_dir, *, selector, streaming):
+    app = await app_fixture.__wrapped__()
+    calls, durations = Counter(), Counter()
+
+    async def provider(request):
+        data = json.loads(request.content)
+        purpose = "selector" if data.get("max_tokens") == 64 else "answer"
+        calls[purpose] += 1
+        started = perf_counter()
+        await asyncio.sleep(0.001)  # Fixed mock provider latency for both profiles.
+        durations[purpose] += perf_counter() - started
+        if data.get("stream"):
+            chunk = {
+                "id": "fixed",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": data["model"],
+                "choices": [{"index": 0, "delta": {"content": "OK"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 13, "completion_tokens": 1, "total_tokens": 14},
+            }
+            return httpx.Response(
+                200,
+                text=f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n",
+                headers={"content-type": "text/event-stream"},
+            )
+        return httpx.Response(
+            200, json=response_body(text='{"lane":"economy"}' if purpose == "selector" else "OK")
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(provider)) as upstream:
+        billing, policy = configure(app, upstream)
+        for entry in app.state.model_registry["backing"]:
+            entry["model_info"].update(rpm_limit=10000, tpm_limit=100000000)
+        if not selector:
+            policy.pop("selector")
+            for member in policy["members"]:
+                member.pop("lane")
+        _publish(app, [policy])
+        key = next(iter(app.state._test_repo.records.values()))
+        key.rpm_limit, key.tpm_limit = 10000, 100000000
+        redis_calls, redis_seconds = Counter(), Counter()
+        instrument_async_methods(app.state.redis, redis_calls, redis_seconds)
+        first_body = {}
+
+        async def observed_app(scope, receive, send):
+            request_id = dict(scope["headers"]).get(b"x-request-id", b"").decode()
+
+            async def observed_send(message):
+                if message["type"] == "http.response.body" and message.get("body"):
+                    first_body.setdefault(request_id, perf_counter())
+                await send(message)
+
+            await app(scope, receive, observed_send)
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=observed_app), base_url="http://test"
+        ) as client:
+
+            async def send(index, request_id):
+                started = perf_counter()
+                result = await client.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-test", "x-request-id": request_id},
+                    json={
+                        "model": "gpt-4o-mini",
+                        "messages": [{"role": "user", "content": f"fixed {index}"}],
+                        "max_tokens": 1,
+                        "stream": streaming,
+                    },
+                )
+                at = first_body.pop(request_id, None)
+                return RequestResult(
+                    status_code=result.status_code,
+                    bytes_received=len(result.content),
+                    ttft_seconds=(at - started if streaming and at is not None else None),
+                )
+
+            assert (await send(-1, "warmup")).status_code == 200
+            calls.clear()
+            durations.clear()
+            redis_calls.clear()
+            redis_seconds.clear()
+            billing.reset_mock()
+            run = await run_constant_arrival(
+                rate=10, duration_seconds=20, max_in_flight=16, request=send
+            )
+    report = summarize(run, target_rate=10)
+    logical = {
+        name: getattr(billing, name).await_count
+        for name in ("reserve", "dispatch", "accept_selector", "unattempted")
+    }
+    case = f"{'selector' if selector else 'baseline'}-{'stream' if streaming else 'nonstream'}"
+    report.update(
+        case=case,
+        environment="ASGI; fake billing/Redis; each provider hop fixed 1ms; TTFT observed at first ASGI body",
+        billing_operations=logical,
+        provider_calls=dict(calls),
+        provider_seconds=dict(durations),
+        redis_calls=dict(redis_calls),
+        **queue_slope(run, 20),
+    )
+    write_results(run, report, output_dir / case)
+    print(json.dumps(report), flush=True)
+    assert report["success_count"] == 200 and not report["generator_dropped_count"]
+    assert calls["answer"] == 200 and calls["selector"] == (200 if selector else 0)
+    assert logical == {
+        "reserve": 200 if selector else 0,
+        "dispatch": 200 if selector else 0,
+        "accept_selector": 200 if selector else 0,
+        "unattempted": 0,
+    }
+
+
+async def main(output_dir):
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("src.services.key_service").setLevel(logging.WARNING)
+    for streaming in (False, True):
+        for selector in (False, True):
+            await measure(output_dir, selector=selector, streaming=streaming)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    asyncio.run(main(parser.parse_args().output_dir))

--- a/tests/router/selection/test_activation.py
+++ b/tests/router/selection/test_activation.py
@@ -1,0 +1,89 @@
+from dataclasses import replace
+
+import pytest
+
+from src.db.route_groups import RouteGroupRepository
+from src.db.route_policy_lifecycle import RoutePolicyValidationContext, StoredRoutePolicyDocument
+from src.router.policy_validation import PolicyMemberInventoryItem, validate_route_policy
+from src.router.selection.activation import validate_selector_activation_inventory
+
+
+def qualified_inventory(selector_policy):
+    info = {
+        "chat_capabilities": {},
+        "max_tokens": 32768,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000002,
+        "rpm_limit": 100,
+        "tpm_limit": 1000000,
+    }
+    return {
+        key: PolicyMemberInventoryItem(
+            deployment_id=key,
+            workload_mode="chat",
+            model_info=info,
+            provider_model="openai/mock",
+        )
+        for key in (selector_policy.classifier_deployment_id, "quality")
+    }
+
+
+def document(selector_policy):
+    return {
+        "selector": selector_policy.model_dump(mode="json"),
+        "members": [
+            {"deployment_id": selector_policy.classifier_deployment_id, "lane": "economy"},
+            {"deployment_id": "quality", "lane": "quality"},
+        ],
+    }
+
+
+@pytest.mark.parametrize("missing_model", [False, True])
+def test_disabled_inventory_needs_neither_lane_nor_activation_metadata(
+    selector_policy, missing_model
+):
+    inventory = qualified_inventory(selector_policy)
+    inventory["disabled"] = PolicyMemberInventoryItem(
+        deployment_id="disabled",
+        enabled=False,
+        workload_mode=None if missing_model else "chat",
+    )
+    policy = document(selector_policy)
+    policy["members"].append({"deployment_id": "disabled"})
+    normalized, _ = validate_route_policy(
+        policy,
+        available_members=inventory,
+        workload_mode="chat",
+        semantics_version=3,
+    )
+    validate_selector_activation_inventory(normalized, inventory)
+    # The same gate still rejects disabling the classifier or emptying an active lane.
+    for key in (selector_policy.classifier_deployment_id, "quality"):
+        invalid = {**inventory, key: replace(inventory[key], enabled=False)}
+        with pytest.raises(ValueError):
+            validate_route_policy(
+                policy,
+                available_members=invalid,
+                workload_mode="chat",
+                semantics_version=3,
+            )
+
+
+def test_prepared_policy_write_separates_preserved_storage_and_validated_projection(
+    selector_policy,
+):
+    inventory = qualified_inventory(selector_policy)
+    stored = document(selector_policy)
+    stored["members"][0]["server_extension"] = {"opaque": ["retained"]}
+    context = RoutePolicyValidationContext("selected", "chat", inventory)
+    repository = RouteGroupRepository(selector_activation_check=lambda: None)
+    prepared = repository._prepare_policy_write(
+        {"strategy": "weighted"},
+        current=StoredRoutePolicyDocument(stored, 3),
+        context=context,
+    )
+    assert prepared.document["members"][0]["server_extension"] == {"opaque": ["retained"]}
+    assert "server_extension" not in prepared.normalized["members"][0]
+    prepared.normalized["members"][0]["weight"] = 12
+    assert "weight" not in prepared.document["members"][0]
+    repository._require_selector_publication(prepared.normalized, context)

--- a/tests/router/selection/test_disconnect.py
+++ b/tests/router/selection/test_disconnect.py
@@ -1,0 +1,68 @@
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from tests.router.selection.test_realtime import configure
+
+pytestmark = pytest.mark.app
+
+
+async def test_http_disconnect_during_selector_cancels_provider_before_response_headers(test_app):
+    started, closed = asyncio.Event(), asyncio.Event()
+    calls = []
+
+    async def provider(request):
+        calls.append(json.loads(request.content)["model"])
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            closed.set()
+
+    receive_queue = asyncio.Queue()
+    body = json.dumps(
+        {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}], "stream": True}
+    ).encode()
+    receive_queue.put_nowait({"type": "http.request", "body": body, "more_body": False})
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/chat/completions",
+        "raw_path": b"/v1/chat/completions",
+        "query_string": b"",
+        "root_path": "",
+        "server": ("test", 80),
+        "client": ("127.0.0.1", 1234),
+        "headers": [
+            (b"authorization", b"Bearer sk-test"),
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(body)).encode()),
+        ],
+    }
+    async with httpx.AsyncClient(transport=httpx.MockTransport(provider)) as upstream:
+        billing, _ = configure(test_app, upstream)
+        task = asyncio.create_task(test_app(scope, receive_queue.get, send))
+        try:
+            await asyncio.wait_for(started.wait(), timeout=2)
+            receive_queue.put_nowait({"type": "http.disconnect"})
+            await asyncio.wait_for(task, timeout=2)
+            assert closed.is_set() and calls == ["classifier"]
+            starts = [message for message in sent if message["type"] == "http.response.start"]
+            assert len(starts) == 1 and starts[0]["status"] == 499
+            assert not any(b"text/event-stream" in value for _, value in starts[0]["headers"])
+            billing.dispatch.assert_awaited_once()
+            billing.accept_selector.assert_not_awaited()
+            billing.unattempted.assert_not_awaited()
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)

--- a/tests/router/selection/test_execution_contracts.py
+++ b/tests/router/selection/test_execution_contracts.py
@@ -1,0 +1,152 @@
+import asyncio
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.chat_capabilities import ChatRoutingCapabilities
+from src.models.errors import InvalidRequestError
+from src.models.requests import ChatCompletionRequest
+from src.router.context_policy import ContextRoutingPolicy
+from src.router.failover import FallbackConfig
+from src.router.selection.eligibility import (
+    capability_allows,
+    chat_requirements,
+    set_selector_capability_eligibility,
+)
+from src.router.selection.planning import selector_context_policy
+from src.router.selection.qualification import selector_price_snapshot
+from src.router.selection.reachability import (
+    require_batch_selector_support,
+    selector_reachable_groups,
+)
+from src.routers.selector_edge import _while_connected, SelectorClientDisconnectedError
+
+
+@pytest.mark.parametrize(
+    "field", ["fallbacks", "context_window_fallbacks", "content_policy_fallbacks"]
+)
+def test_batch_rejects_direct_and_transitive_selector_targets_even_through_cycles(field):
+    reachable = selector_reachable_groups(
+        ["selected"],
+        FallbackConfig(**{field: {"root": ["middle"], "middle": ["root", "selected"]}}),
+    )
+    assert reachable == {"root", "middle", "selected"}
+    for group in reachable:
+        with pytest.raises(InvalidRequestError) as error:
+            require_batch_selector_support(group, reachable)
+        assert error.value.code == "batch_model_router_selector_unsupported"
+    require_batch_selector_support("ordinary", reachable)
+
+
+@pytest.mark.parametrize(
+    "block,feature",
+    [
+        ({"type": "image_url", "image_url": {"url": "https://private.test/image"}}, "image"),
+        ({"type": "input_audio", "input_audio": {"data": "private", "format": "wav"}}, "audio"),
+        ({"type": "file", "file": {"file_id": "private"}}, "file"),
+        ({"type": "unrecognized"}, "unknown"),
+    ],
+)
+def test_hard_capabilities_inspect_content_outside_classifier_prompt_bounds(block, feature):
+    payload = ChatCompletionRequest.model_validate(
+        {
+            "model": "group",
+            "messages": [{"role": "user", "content": [block]}]
+            + [{"role": "user", "content": "hello"}] * 100,
+        }
+    )
+    assert chat_requirements(payload) == {feature}
+    context = {}
+    capabilities = {
+        "basic": ChatRoutingCapabilities(),
+        "capable": ChatRoutingCapabilities(**({feature: True} if feature != "unknown" else {})),
+    }
+    set_selector_capability_eligibility(context, payload, capabilities)
+    assert not capability_allows(context, "basic")
+    assert capability_allows(context, "capable") == (feature != "unknown")
+
+
+def test_selector_fallback_intersects_inherited_and_own_context_limits():
+    inherited = ContextRoutingPolicy(
+        mode="smallest-sufficient", default_output_tokens=2048, safety_margin_tokens=0
+    )
+    own = ContextRoutingPolicy(
+        unknown_capacity="exclude", default_output_tokens=1024, safety_margin_tokens=256
+    )
+    result = selector_context_policy(inherited, own)
+    assert result == ContextRoutingPolicy(
+        mode="smallest-sufficient",
+        unknown_capacity="exclude",
+        default_output_tokens=2048,
+        safety_margin_tokens=256,
+    )
+    assert selector_context_policy(None, own) is own
+
+
+def test_realtime_selector_price_ignores_batch_rates_but_not_unmodelled_dimensions():
+    info = {
+        "input_cost_per_token": "0.001",
+        "output_cost_per_token": "0.002",
+        "batch_input_cost_per_token": "0.0005",
+        "batch_output_cost_per_token": "0.001",
+    }
+    assert selector_price_snapshot(info).input_cost_per_token == Decimal("0.001")
+    with pytest.raises(ValueError, match="unsupported provider billing"):
+        selector_price_snapshot({**info, "input_cost_per_audio_token": "0.01"})
+
+
+@pytest.mark.parametrize("disconnect", [True, False])
+async def test_connection_owner_cancels_and_joins_work(disconnect):
+    started, closed = asyncio.Event(), asyncio.Event()
+
+    async def work():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            closed.set()
+
+    async def receive():
+        await started.wait()
+        if not disconnect:
+            await asyncio.Event().wait()
+        return {"type": "http.disconnect"}
+
+    request = SimpleNamespace(receive=receive)
+    task = asyncio.create_task(_while_connected(request, work()))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    if not disconnect:
+        task.cancel()
+    with pytest.raises(SelectorClientDisconnectedError if disconnect else asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1)
+    assert closed.is_set()
+
+
+async def test_batch_worker_rejects_selector_before_planning_or_provider(monkeypatch):
+    from tests.test_batch_worker import (
+        _AllowAllCallableTargetGrantService,
+        _build_chat_batch_worker,
+        _build_chat_batch_item,
+        _build_chat_batch_job,
+    )
+    from src.batch.worker_types import capture_batch_routing_runtime
+
+    worker, _ = _build_chat_batch_worker(deployment_params={"provider": "vllm", "model": "gpt-oss"})
+    worker.app.state.callable_target_grant_service = _AllowAllCallableTargetGrantService()
+    runtime = capture_batch_routing_runtime(worker.app.state)
+    from dataclasses import replace
+
+    runtime = replace(runtime, selector_reachable_groups=frozenset({"gpt-oss"}))
+    monkeypatch.setattr(
+        "src.batch.chat_worker_execution.capture_batch_routing_runtime", lambda _: runtime
+    )
+    planner = AsyncMock(side_effect=AssertionError("must not plan"))
+    monkeypatch.setattr("src.batch.chat_worker_execution.require_initial_deployment", planner)
+    with pytest.raises(InvalidRequestError) as error:
+        await worker._prepare_item_for_execution(
+            _build_chat_batch_job(), _build_chat_batch_item("selector-1", "hello")
+        )
+    assert error.value.code == "batch_model_router_selector_unsupported"
+    planner.assert_not_awaited()

--- a/tests/router/selection/test_lane_bounds.py
+++ b/tests/router/selection/test_lane_bounds.py
@@ -1,0 +1,107 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.route_policy_contract import LLMTierSelectorPolicy, SelectorLane
+from src.router import RedisStateBackend, Router, RouterConfig, RoutingStrategy
+from src.router import build_deployment_registry, build_route_group_policies
+from src.router.candidates import invalidate_candidate_plan_cache
+from src.router.selection.contracts import SelectorInvariantError
+from tests.router.selection.test_planning import decide, group, ids, plan, routing
+
+
+def ranked_router(size):
+    policy = LLMTierSelectorPolicy(
+        kind="llm-tier",
+        classifier_deployment_id="deployment-0",
+        lanes=tuple(
+            SelectorLane(id=f"lane-{rank}", rank=rank, description=f"Capability {rank}")
+            for rank in range(size)
+        ),
+    )
+    groups = [
+        {
+            "key": "selected",
+            "mode": "chat",
+            "strategy": "priority-based-routing",
+            "selector": policy.model_dump(mode="json"),
+            "members": [
+                {
+                    "deployment_id": f"deployment-{rank}",
+                    "lane": f"lane-{rank}",
+                    "priority": size - rank,
+                }
+                for rank in range(size)
+            ],
+        }
+    ]
+    backend = RedisStateBackend(redis=None)
+    router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=backend,
+        config=RouterConfig(route_group_policies=build_route_group_policies(groups)),
+        deployment_registry=build_deployment_registry(
+            {
+                "backing": [
+                    {
+                        "deployment_id": f"deployment-{rank}",
+                        "deltallm_params": {"model": "openai/mock"},
+                    }
+                    for rank in range(size)
+                ]
+            },
+            route_groups=groups,
+        ),
+    )
+    return router, backend, policy
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "size,rank", [(size, rank) for size in range(2, 9) for rank in range(size)]
+)
+async def test_every_supported_lane_count_and_rank_preserves_upward_only_order(
+    size, rank, policy_identity
+):
+    router, backend, policy = ranked_router(size)
+    context = {}
+    _, provider = await decide(context, policy, policy_identity, f'{{"lane":"lane-{rank}"}}')
+    result = await plan(router, context)
+    assert ids(result.deployments) == [f"deployment-{item}" for item in range(rank, size)]
+    assert result.minimum_rank == rank and len(result.lanes) == size
+    backend.get_cooldown_batch = AsyncMock(return_value={f"deployment-{rank}": True})
+    invalidate_candidate_plan_cache(context)
+    escalated = await plan(router, context)
+    assert ids(escalated.deployments) == [f"deployment-{item}" for item in range(rank + 1, size)]
+    provider.invoke.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fallback_with_no_sufficient_rank_cannot_downgrade(selector_policy, policy_identity):
+    _, _, policy = ranked_router(8)
+    context = {}
+    _, provider = await decide(context, policy, policy_identity, '{"lane":"lane-7"}')
+    router, _ = routing([group(selector_policy)])
+    result = await plan(router, context)
+    assert result.minimum_rank == 7
+    assert result.deployments == () and all(not lane.deployments for lane in result.lanes)
+    assert result.rejection_reason == "no_eligible_selector_lane"
+    provider.invoke.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_caller_metadata_cannot_supply_or_override_a_decision(
+    selector_policy, policy_identity
+):
+    router, _ = routing([group(selector_policy)])
+    context = {"metadata": {"_deltallm_selector_state": {"minimum_rank": 0}, "lane": "economy"}}
+    assert (await plan(router, context)).rejection_reason == "selector_decision_required"
+    await decide(context, selector_policy, policy_identity, '{"lane":"quality"}')
+    assert ids((await plan(router, context)).deployments) == ["quality-a", "quality-b"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_internal_state_is_not_treated_as_an_unclassified_request(selector_policy):
+    router, _ = routing([group(selector_policy)])
+    with pytest.raises(SelectorInvariantError):
+        await plan(router, {"_deltallm_selector_state": {"minimum_rank": 0}})

--- a/tests/router/selection/test_planned_failover.py
+++ b/tests/router/selection/test_planned_failover.py
@@ -1,0 +1,54 @@
+import pytest
+
+from src.models.errors import RoutingFailureAction, ServiceUnavailableError
+from src.router import CooldownManager, FallbackConfig, FailoverManager
+from src.router.candidates import invalidate_candidate_plan_cache
+from tests.router.selection.test_planning import decide, group, ids, plan, routing
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lane", ["economy", "quality"])
+@pytest.mark.parametrize("retry_count", [0, 1, 2])
+async def test_failover_consumes_lane_plan_without_reclassification(
+    selector_policy, policy_identity, lane, retry_count
+):
+    router, backend = routing([group(selector_policy)])
+    context = {"routing_mode": "chat"}
+    operation, provider = await decide(
+        context, selector_policy, policy_identity, f'{{"lane":"{lane}"}}'
+    )
+    candidate_plan = await plan(router, context)
+    manager = FailoverManager(
+        FallbackConfig(num_retries=retry_count, backoff_max=0, backoff_jitter=False),
+        router,
+        backend,
+        CooldownManager(backend),
+    )
+    attempts = []
+
+    async def answer(deployment):
+        attempts.append(deployment.deployment_id)
+        invalidate_candidate_plan_cache(context)
+        if deployment.deployment_id != "quality-b":
+            raise ServiceUnavailableError(
+                message="mock unavailable",
+                affects_deployment_health=False,
+                routing_failure_action=RoutingFailureAction.RETRY_OR_NEXT,
+            )
+        return "answer"
+
+    result, served = await manager.execute_with_failover(
+        primary_deployment=candidate_plan.deployments[0],
+        model_group="selected",
+        execute=answer,
+        return_deployment=True,
+        routing_context=context,
+        request_deadline=operation.deadline,
+    )
+    expected_order = ids(candidate_plan.deployments)
+    assert attempts == [expected_order[0]] * (retry_count + 1) + expected_order[1:]
+    assert result == "answer" and served.deployment_id == "quality-b"
+    assert ids((await plan(router, context)).deployments) == expected_order
+    for deployment_id in set(attempts):
+        assert await backend.get_active_requests(deployment_id) == 0
+    provider.invoke.assert_awaited_once()

--- a/tests/router/selection/test_planning.py
+++ b/tests/router/selection/test_planning.py
@@ -1,0 +1,298 @@
+import asyncio
+from copy import deepcopy
+from dataclasses import FrozenInstanceError
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.models.errors import TimeoutError as RequestTimeoutError
+from src.router import (
+    RedisStateBackend,
+    Router,
+    RouterConfig,
+    RoutingStrategy,
+    build_deployment_registry,
+    build_route_group_policies,
+)
+from src.router.candidates import invalidate_candidate_plan_cache
+from src.router.context_policy import RequestTokenDemand, set_request_token_demand
+from src.router.selection.contracts import SelectorInvariantError, SelectorOperationAbortedError
+from src.router.selection.request_context import set_request_selector_state
+from src.router.selection.service import SelectorService
+from tests.router.selection.test_service import hop, select, state
+
+
+def group(policy, *, key="selected", strategy="priority-based-routing"):
+    return {
+        "key": key,
+        "mode": "chat",
+        "strategy": strategy,
+        "selector": policy.model_dump(mode="json") if policy is not None else None,
+        "members": [
+            {"deployment_id": "classifier-concrete", "lane": "economy", "priority": 50},
+            {"deployment_id": "economy-b", "lane": "economy", "priority": 10},
+            {"deployment_id": "quality-a", "lane": "quality", "priority": 0},
+            {"deployment_id": "quality-b", "lane": "quality", "priority": 100},
+        ],
+    }
+
+
+def routing(groups, *, context_policy=None, pre_call_checks=False):
+    entries = [
+        {
+            "deployment_id": name,
+            "deltallm_params": {"model": "openai/mock"},
+            "model_info": {"mode": "chat", "max_tokens": capacity, "rpm_limit": 10},
+        }
+        for name, capacity in (
+            ("classifier-concrete", 8000),
+            ("economy-b", 32000),
+            ("quality-a", 128000),
+            ("quality-b", 64000),
+        )
+    ]
+    groups = deepcopy(groups)
+    if context_policy is not None:
+        for item in groups:
+            item["context"] = context_policy
+    backend = RedisStateBackend(redis=None)
+    router = Router(
+        strategy=RoutingStrategy.SIMPLE_SHUFFLE,
+        state_backend=backend,
+        config=RouterConfig(
+            route_group_policies=build_route_group_policies(groups),
+            enable_pre_call_checks=pre_call_checks,
+        ),
+        deployment_registry=build_deployment_registry({"backing": entries}, route_groups=groups),
+    )
+    return router, backend
+
+
+async def decide(context, policy, identity, text='{"lane":"economy"}'):
+    operation, provider = state(), hop(text)
+    set_request_selector_state(context, operation)
+    await select(SelectorService(provider), operation, policy, identity)
+    return operation, provider
+
+
+def ids(deployments):
+    return [deployment.deployment_id for deployment in deployments]
+
+
+async def plan(router, context, key="selected"):
+    return (await router.plan_deployments([key], context))[key]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text,rank,expected",
+    [
+        ('{"lane":"economy"}', 0, ["economy-b", "classifier-concrete", "quality-a", "quality-b"]),
+        ('{"lane":"quality"}', 1, ["quality-a", "quality-b"]),
+        ('{"lane":"injected-deployment"}', 1, ["quality-a", "quality-b"]),
+    ],
+)
+async def test_selected_lane_then_upward_only_with_strategy_inside_each_lane(
+    selector_policy, policy_identity, text, rank, expected
+):
+    router, _ = routing([group(selector_policy)])
+    context = {}
+    operation, provider = await decide(context, selector_policy, policy_identity, text)
+    result = await plan(router, context)
+    assert ids(result.deployments) == expected
+    assert result.minimum_rank == rank
+    assert [(lane.lane, lane.rank) for lane in result.lanes] == [("economy", 0), ("quality", 1)]
+    assert not any(lane.deployments for lane in result.lanes if lane.rank < rank)
+    assert operation.decision_for_planning().minimum_rank == rank
+    provider.invoke.assert_awaited_once()
+    with pytest.raises(FrozenInstanceError):
+        result.lanes[0].rank = 7
+    with pytest.raises(FrozenInstanceError):
+        result.minimum_rank = 7
+
+
+@pytest.mark.asyncio
+async def test_undecided_plan_is_not_executable_and_is_replaced_after_selection(
+    selector_policy, policy_identity
+):
+    router, _ = routing([group(selector_policy)])
+    context, operation = {}, state()
+    set_request_selector_state(context, operation)
+    pending = await plan(router, context)
+    assert pending.deployments == () and pending.minimum_rank is None
+    assert pending.rejection_reason == "selector_decision_required"
+    assert sum(len(lane.deployments) for lane in pending.lanes) == 4
+    assert await plan(router, context) is pending
+    provider = hop('{"lane":"quality"}')
+    await select(SelectorService(provider), operation, selector_policy, policy_identity)
+    selected = await plan(router, context)
+    assert selected is not pending and selected.minimum_rank == 1
+    assert ids(selected.deployments) == ["quality-a", "quality-b"]
+    assert await plan(router, context) is selected
+    invalidate_candidate_plan_cache(context)
+    assert ids((await plan(router, context)).deployments) == ["quality-a", "quality-b"]
+    provider.invoke.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_context_changes_replan_without_reclassifying(selector_policy, policy_identity):
+    router, _ = routing(
+        [group(selector_policy)],
+        context_policy={"mode": "smallest-sufficient", "safety_margin_tokens": 0},
+    )
+    context = {}
+    _, provider = await decide(context, selector_policy, policy_identity)
+    set_request_token_demand(context, RequestTokenDemand(1000, 64))
+    first = await plan(router, context)
+    assert ids(first.deployments) == ["classifier-concrete", "economy-b", "quality-b", "quality-a"]
+    set_request_token_demand(context, RequestTokenDemand(40000, 64))
+    second = await plan(router, context)
+    assert second is not first and ids(second.deployments) == ["quality-b", "quality-a"]
+    assert second.minimum_rank == 0 and second.lanes[0].deployments == ()
+    assert first.lanes[0].deployments  # Existing immutable plan was not mutated.
+    provider.invoke.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("constraint", ["health", "cooldown", "capacity", "tags", "mode"])
+async def test_hard_filters_cannot_be_bypassed_by_economy_selection(
+    selector_policy, policy_identity, constraint
+):
+    router, backend = routing([group(selector_policy)], pre_call_checks=True)
+    context = {"routing_mode": "chat"}
+    _, provider = await decide(context, selector_policy, policy_identity)
+    economy = {"classifier-concrete", "economy-b"}
+    if constraint == "health":
+        backend.get_health_batch = AsyncMock(
+            return_value={name: {"healthy": "false"} for name in economy}
+        )
+    elif constraint == "cooldown":
+        backend.get_cooldown_batch = AsyncMock(return_value={name: True for name in economy})
+    elif constraint == "capacity":
+        backend.get_usage_batch = AsyncMock(return_value={name: {"rpm": 10} for name in economy})
+    else:
+        for deployment in router.deployment_registry["selected"]:
+            if constraint == "tags":
+                deployment.tags = ["allowed"] if deployment.deployment_id not in economy else []
+                context["metadata"] = {"tags": ["allowed"]}
+            elif deployment.deployment_id in economy:
+                deployment.model_info["mode"] = "embedding"
+    result = await plan(router, context)
+    assert ids(result.deployments) == ["quality-a", "quality-b"]
+    assert result.filtered_count == 2 and result.lanes[0].deployments == ()
+    provider.invoke.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_lower_lane_when_quality_is_unavailable(selector_policy, policy_identity):
+    router, backend = routing([group(selector_policy)])
+    backend.get_cooldown_batch = AsyncMock(return_value={"quality-a": True, "quality-b": True})
+    context = {}
+    await decide(context, selector_policy, policy_identity, '{"lane":"quality"}')
+    result = await plan(router, context)
+    assert result.deployments == () and result.minimum_rank == 1
+    assert result.rejection_reason == "no_eligible_selector_lane"
+    assert result.filtered_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fallback_plans_reuse_rank_not_lane_name_and_leave_plain_groups_unchanged(
+    selector_policy, policy_identity
+):
+    primary = group(selector_policy)
+    fallback = group(selector_policy, key="fallback")
+    fallback["selector"]["lanes"][0]["id"] = "basic"
+    fallback["selector"]["lanes"][1]["id"] = "advanced"
+    fallback["selector"]["default_lane"] = "advanced"
+    for member in fallback["members"]:
+        member["lane"] = "basic" if member["lane"] == "economy" else "advanced"
+    router, _ = routing([primary, fallback, group(None, key="plain")])
+    context = {}
+    operation, provider = await decide(
+        context, selector_policy, policy_identity, '{"lane":"quality"}'
+    )
+    results = await router.plan_deployments(["selected", "fallback", "plain"], context)
+    assert ids(results["fallback"].deployments) == ["quality-a", "quality-b"]
+    assert results["fallback"].lanes[1].lane == "advanced"
+    assert results["fallback"].minimum_rank == results["selected"].minimum_rank == 1
+    assert operation.decision_for_planning().lane == "quality"
+    assert ids(results["plain"].deployments) == [
+        "quality-a",
+        "economy-b",
+        "classifier-concrete",
+        "quality-b",
+    ]
+    assert results["plain"].lanes == () and results["plain"].minimum_rank is None
+    provider.invoke.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal", ["cancelled", "failed", "expired"])
+async def test_terminal_operation_never_returns_cached_candidates(
+    selector_policy, policy_identity, terminal
+):
+    router, _ = routing([group(selector_policy)])
+    context, operation = {}, state()
+    set_request_selector_state(context, operation)
+    await plan(router, context)
+    if terminal == "expired":
+        # Deterministically expire the owned deadline, without sleeping.
+        await select(SelectorService(hop()), operation, selector_policy, policy_identity)
+        await plan(router, context)
+        object.__setattr__(operation.deadline, "expires_at", 0.0)
+        expected = RequestTimeoutError
+    else:
+        expected = (
+            asyncio.CancelledError if terminal == "cancelled" else SelectorOperationAbortedError
+        )
+
+        async def fail():
+            if terminal == "cancelled":
+                raise asyncio.CancelledError()
+            raise RuntimeError("injected execution failure")
+
+        with pytest.raises((asyncio.CancelledError, RuntimeError)):
+            await operation.select_once(fail)
+    with pytest.raises(expected):
+        await plan(router, context)
+
+
+@pytest.mark.asyncio
+async def test_replacing_operation_owner_is_rejected(selector_policy):
+    router, _ = routing([group(selector_policy)])
+    context, operation = {}, state()
+    set_request_selector_state(context, operation)
+    pending = await plan(router, context)
+    set_request_selector_state(context, operation)
+    assert await plan(router, context) is pending
+    with pytest.raises(SelectorInvariantError):
+        set_request_selector_state(context, state())
+
+
+def test_projection_is_immutable_and_detached_from_authored_document(selector_policy):
+    authored = group(selector_policy)
+    policy = build_route_group_policies([authored])["selected"]
+    authored["members"][0]["lane"] = "quality"
+    authored["selector"]["lanes"][0]["description"] = "mutated"
+    assert policy.selector.members[0].lane == "economy"
+    assert policy.selector.policy.lanes[0].description == "Routine work"
+    with pytest.raises(FrozenInstanceError):
+        policy.selector = None
+
+
+@pytest.mark.parametrize("kind", ["unassigned", "duplicate", "empty_lane", "wrong_mode"])
+def test_current_invalid_lane_projection_fails_closed(selector_policy, kind):
+    authored = group(selector_policy)
+    if kind == "unassigned":
+        authored["members"][0].pop("lane")
+    elif kind == "duplicate":
+        authored["members"].append(authored["members"][0])
+    elif kind == "empty_lane":
+        for member in authored["members"]:
+            member["lane"] = "economy"
+    else:
+        authored["mode"] = "embedding"
+    with pytest.raises(ValueError):
+        build_route_group_policies([authored])
+    authored["policy_semantics_version"] = 1
+    assert build_route_group_policies([authored])["selected"].selector is None

--- a/tests/router/selection/test_planning_dependencies.py
+++ b/tests/router/selection/test_planning_dependencies.py
@@ -1,0 +1,115 @@
+from collections import Counter
+import random
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.router import RoutingStrategy
+from src.router.candidates import invalidate_candidate_plan_cache
+from src.router.selection.request_context import set_request_selector_state
+from src.router.selection.service import SelectorService
+from tests.router.selection.test_planning import decide, group, ids, plan, routing
+from tests.router.selection.test_service import hop, select, state
+
+STATE_READS = (
+    "get_health_batch",
+    "get_cooldown_batch",
+    "get_active_requests_batch",
+    "get_usage_batch",
+    "get_latency_windows_batch",
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strategy", list(RoutingStrategy))
+async def test_lanes_reuse_one_batched_strategy_snapshot(
+    selector_policy, policy_identity, strategy, monkeypatch
+):
+    router, backend = routing([group(selector_policy, strategy=strategy.value)])
+    reads = {}
+    for name in STATE_READS:
+        reads[name] = AsyncMock(wraps=getattr(backend, name))
+        monkeypatch.setattr(backend, name, reads[name])
+    implementation = router._strategies[strategy]
+    query = implementation.state_query()
+    order = AsyncMock(wraps=implementation.order)
+    monkeypatch.setattr(implementation, "order", order)
+    context = {}
+    _, provider = await decide(context, selector_policy, policy_identity)
+    result = await plan(router, context)
+
+    assert Counter(ids(result.deployments)) == Counter(
+        ["classifier-concrete", "economy-b", "quality-a", "quality-b"]
+    )
+    assert set(ids(result.deployments[:2])) == {"classifier-concrete", "economy-b"}
+    assert order.await_count == 2
+    assert order.call_args_list[0].args[2] is order.call_args_list[1].args[2]
+    assert {name: call.await_count for name, call in reads.items()} == {
+        "get_health_batch": 1,
+        "get_cooldown_batch": 1,
+        "get_active_requests_batch": int(query.active_requests),
+        "get_usage_batch": int(query.usage),
+        "get_latency_windows_batch": int(query.latency_window_ms is not None),
+    }
+    assert await plan(router, context) is result
+    assert order.await_count == 2 and reads["get_health_batch"].await_count == 1
+    provider.invoke.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strategy", list(RoutingStrategy))
+async def test_selector_free_order_and_dependency_counts_are_unchanged(strategy, monkeypatch):
+    router, backend = routing([group(None, strategy=strategy.value)])
+    reads = {}
+    for name in STATE_READS:
+        reads[name] = AsyncMock(wraps=getattr(backend, name))
+        monkeypatch.setattr(backend, name, reads[name])
+    implementation = router._strategies[strategy]
+    original = implementation.order
+    order = AsyncMock(wraps=original)
+    monkeypatch.setattr(implementation, "order", order)
+    context = {}
+    previous_random_state = random.getstate()
+    random.seed(304)
+    try:
+        result = await plan(router, context)
+        reads_before = {name: call.await_count for name, call in reads.items()}
+        assert reads_before["get_health_batch"] == reads_before["get_cooldown_batch"] == 1
+        assert order.await_count == 1
+        assert result.lanes == () and result.minimum_rank is None
+        assert set(context) == {"_deltallm_candidate_plans"}
+        random.seed(304)
+        legacy_order = await original(*order.call_args.args)
+        assert ids(result.deployments) == ids(legacy_order)
+        assert await plan(router, context) is result
+        assert reads_before == {name: call.await_count for name, call in reads.items()}
+    finally:
+        random.setstate(previous_random_state)
+
+
+@pytest.mark.asyncio
+async def test_planning_unreached_selector_fallback_never_invokes_a_provider(
+    selector_policy, policy_identity, monkeypatch
+):
+    router, backend = routing([group(None, key="primary"), group(selector_policy)])
+    health = AsyncMock(wraps=backend.get_health_batch)
+    monkeypatch.setattr(backend, "get_health_batch", health)
+    provider, operation, context = hop(), state(), {}
+    set_request_selector_state(context, operation)
+    results = await router.plan_deployments(["primary", "selected"], context)
+    assert results["primary"].deployments
+    assert not results["selected"].deployments
+    assert results["selected"].rejection_reason == "selector_decision_required"
+    assert operation.decision_for_planning() is None
+    provider.invoke.assert_not_awaited()
+    health.assert_awaited_once()
+
+    await select(SelectorService(provider), operation, selector_policy, policy_identity)
+    changed = await router.plan_deployments(["primary", "selected"], context)
+    assert changed["primary"] is results["primary"]
+    assert changed["selected"] is not results["selected"]
+    assert changed["selected"].minimum_rank == 0
+    assert health.await_count == 2
+    invalidate_candidate_plan_cache(context)
+    await router.plan_deployments(["primary", "selected"], context)
+    provider.invoke.assert_awaited_once()

--- a/tests/router/selection/test_realtime.py
+++ b/tests/router/selection/test_realtime.py
@@ -1,0 +1,277 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from src.billing.operation_reservation import ComponentState, ReservedOperation
+from src.billing.operation_reservation import BillingOperationUnavailable
+from src.router.selection.runtime import SelectorExecutionFactory
+from tests.router.selection.provider_fixtures import registry, response_body
+from tests.test_routing_cache_identity import _enable_cache, _publish
+
+pytestmark = pytest.mark.app
+
+
+def configure(test_app, client):
+    info = {
+        "mode": "chat",
+        "max_tokens": 32768,
+        "rpm_limit": 100,
+        "tpm_limit": 1_000_000,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000002,
+        "chat_capabilities": {
+            "tools": True,
+            "json_object": True,
+            "json_schema": True,
+            "streaming": True,
+        },
+    }
+    test_app.state.model_registry = {
+        "backing": [
+            {
+                "deployment_id": key,
+                "model_info": dict(info),
+                "deltallm_params": {
+                    "model": f"openai/{key}",
+                    "api_key": "provider-private",
+                    "api_base": "https://mock.test/v1",
+                },
+            }
+            for key in ("classifier", "quality")
+        ]
+    }
+    policy = {
+        "key": "gpt-4o-mini",
+        "mode": "chat",
+        "strategy": "priority-based-routing",
+        "context": {"mode": "eligible-only", "unknown_capacity": "exclude"},
+        "selector": {
+            "kind": "llm-tier",
+            "classifier_deployment_id": "classifier",
+            "lanes": [
+                {"id": "economy", "rank": 0, "description": "Routine"},
+                {"id": "quality", "rank": 1, "description": "Complex"},
+            ],
+        },
+        "members": [
+            {"deployment_id": "classifier", "lane": "economy"},
+            {"deployment_id": "quality", "lane": "quality"},
+        ],
+    }
+    billing = AsyncMock()
+    billing.reserve.side_effect = lambda op, **kwargs: ReservedOperation(
+        operation=op,
+        selector_state=ComponentState.RESERVED,
+        answer_state=ComponentState.UNATTEMPTED,
+    )
+    test_app.state.http_client = client
+    test_app.state.provider_error_mapper_registry = registry(client)
+    test_app.state.selector_execution_factory = SelectorExecutionFactory(
+        client=client,
+        adapters=registry(client),
+        billing=billing,
+        default_openai_base_url="https://mock.test/v1",
+        accounting_ready=lambda: True,
+    )
+    _enable_cache(test_app)
+    _publish(test_app, [policy])
+    return billing, policy
+
+
+@pytest.mark.parametrize("endpoint", ["/v1/chat/completions", "/v1/responses"])
+@pytest.mark.parametrize(
+    "lane,selected", [("economy", "classifier"), ("quality", "quality"), ("unknown", "quality")]
+)
+async def test_realtime_selector_is_billed_once_and_cached_public_usage_is_answer_only(
+    client, test_app, endpoint, lane, selected
+):
+    calls = []
+
+    def handle(request):
+        data = json.loads(request.content)
+        calls.append(data)
+        text = f'{{"lane":"{lane}"}}' if len(calls) == 1 else "answer"
+        return httpx.Response(200, json=response_body(text=text))
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, _ = configure(test_app, upstream)
+        body = {
+            "model": "gpt-4o-mini",
+            **(
+                {"input": "hello"}
+                if endpoint.endswith("responses")
+                else {"messages": [{"role": "user", "content": "hello"}]}
+            ),
+        }
+        headers = {"Authorization": "Bearer sk-test"}
+        result = await client.post(endpoint, json=body, headers=headers)
+        assert result.status_code == 200, result.text
+        assert len(calls) == 2
+        assert calls[0]["model"] == "classifier" and calls[0]["max_tokens"] == 64
+        assert calls[1]["model"] == selected
+        assert result.json()["usage"]["total_tokens"] == 18
+        billing.reserve.assert_awaited_once()
+        billing.dispatch.assert_awaited_once()
+        billing.accept_selector.assert_awaited_once()
+        charge = billing.accept_selector.call_args.args[1]
+        assert charge.customer_charge == charge.provider_cost
+        assert charge.attribution.api_key != "sk-test"
+        assert all(
+            "selector" not in key.lower() and "lane" not in key.lower() for key in result.headers
+        )
+        cached = await client.post(endpoint, json=body, headers=headers)
+        assert cached.status_code == 200 and cached.headers["x-deltallm-cache-hit"] == "true", (
+            cached.text
+        )
+        assert len(calls) == 2
+        billing.reserve.assert_awaited_once()
+
+
+@pytest.mark.parametrize("endpoint", ["/v1/chat/completions", "/v1/responses"])
+async def test_stream_is_opened_only_after_durable_selector_receipt(client, test_app, endpoint):
+    calls = []
+    billing = None
+
+    def handle(request):
+        data = json.loads(request.content)
+        calls.append(data)
+        if not data.get("stream"):
+            assert len(calls) == 1
+            return httpx.Response(200, json=response_body(text='{"lane":"quality"}'))
+        billing.accept_selector.assert_awaited_once()
+        assert data["model"] == "quality"
+        frames = [
+            {
+                "id": "stream-1",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": "quality",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "answer"},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "stream-1",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": "quality",
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 13, "completion_tokens": 5, "total_tokens": 18},
+            },
+        ]
+        return httpx.Response(
+            200,
+            text="".join(f"data: {json.dumps(frame)}\n\n" for frame in frames) + "data: [DONE]\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, _ = configure(test_app, upstream)
+        body = {
+            "model": "gpt-4o-mini",
+            "stream": True,
+            **(
+                {"input": "hello"}
+                if endpoint.endswith("responses")
+                else {"messages": [{"role": "user", "content": "hello"}]}
+            ),
+        }
+        response = await client.post(
+            endpoint, json=body, headers={"Authorization": "Bearer sk-test"}
+        )
+        assert response.status_code == 200, response.text
+        assert "answer" in response.text, response.text
+        assert len(calls) == 2
+        assert "model_router_selector" not in response.text and "minimum_rank" not in response.text
+
+
+@pytest.mark.parametrize(
+    "phase,provider_calls", [("reserve", 0), ("dispatch", 0), ("accept_selector", 1)]
+)
+async def test_billing_failure_never_defaults_or_dispatches_an_answer(
+    client, test_app, phase, provider_calls
+):
+    calls = []
+
+    def handle(request):
+        calls.append(json.loads(request.content))
+        return httpx.Response(200, json=response_body())
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, _ = configure(test_app, upstream)
+        getattr(billing, phase).side_effect = BillingOperationUnavailable()
+        result = await client.post(
+            "/v1/chat/completions",
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert result.status_code == 503, result.text
+        assert len(calls) == provider_calls
+        generation = test_app.state.routing_runtime_generation_store.require_snapshot()
+        cooldowns = await generation.router.state.get_cooldown_batch(
+            [deployment.health_ref for deployment in generation.deployment_registry["gpt-4o-mini"]]
+        )
+        assert not any(cooldowns.values())
+
+
+@pytest.mark.parametrize("stream", [False, True])
+async def test_answer_failure_keeps_selector_charge_and_is_not_a_successful_stream(
+    client, test_app, stream
+):
+    calls = []
+
+    def handle(request):
+        calls.append(json.loads(request.content))
+        if len(calls) == 1:
+            return httpx.Response(200, json=response_body(text='{"lane":"quality"}'))
+        return httpx.Response(503, json={"error": {"message": "temporarily unavailable"}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, _ = configure(test_app, upstream)
+        response = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o-mini",
+                "stream": stream,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 503, response.text
+        assert len(calls) == 2
+        billing.accept_selector.assert_awaited_once()
+        assert billing.accept_selector.call_args.args[1].customer_charge > 0
+
+
+async def test_parent_deadline_cancels_selector_and_leaves_no_answer_or_reported_receipt(
+    client, test_app
+):
+    calls, cancelled = [], asyncio.Event()
+
+    async def handle(request):
+        calls.append(json.loads(request.content))
+        try:
+            await asyncio.sleep(10)
+        finally:
+            cancelled.set()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, policy = configure(test_app, upstream)
+        policy["timeouts"] = {"global_ms": 100}
+        _publish(test_app, [policy])
+        result = await client.post(
+            "/v1/chat/completions",
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert result.status_code == 408, result.text
+        assert len(calls) == 1 and cancelled.is_set()
+        billing.dispatch.assert_awaited_once()
+        billing.accept_selector.assert_not_awaited()

--- a/tests/router/selection/test_realtime_admission.py
+++ b/tests/router/selection/test_realtime_admission.py
@@ -1,0 +1,134 @@
+from copy import deepcopy
+import json
+
+import httpx
+import pytest
+
+from src.callbacks import CallbackManager, CustomLogger
+from src.metrics.selector import decisions, terminal_lanes
+from src.router.candidates import AttemptPermit, AttemptRejectionReason
+from tests.router.selection.provider_fixtures import response_body
+from tests.router.selection.test_realtime import configure
+from tests.router.selection.test_realtime_lifecycle import BODY, HEADERS
+from tests.test_routing_cache_identity import _publish
+
+pytestmark = pytest.mark.app
+
+
+@pytest.mark.parametrize("endpoint", ["/v1/chat/completions", "/v1/responses"])
+@pytest.mark.parametrize("from_hook", [False, True])
+async def test_streaming_mcp_rejection_precedes_selector_economic_work(
+    client, test_app, endpoint, from_hook
+):
+    tools = [{"type": "mcp", "server": "docs"}]
+    calls = []
+
+    class AddMCPTools(CustomLogger):
+        async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+            return {**data, "tools": tools}
+
+    def handle(request):
+        calls.append(json.loads(request.content)["model"])
+        return httpx.Response(200, json=response_body(text='{"lane":"quality"}'))
+
+    body = (
+        deepcopy(BODY)
+        if endpoint.endswith("completions")
+        else {"model": BODY["model"], "input": "hello"}
+    )
+    body["stream"] = True
+    if from_hook:
+        manager = CallbackManager()
+        manager.register_callback(AddMCPTools())
+        test_app.state.callback_manager = manager
+    else:
+        body["tools"] = tools
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, _ = configure(test_app, upstream)
+        response = await client.post(endpoint, headers=HEADERS, json=body)
+        assert response.status_code == 400, response.text
+        assert response.json()["error"]["message"] == (
+            "MCP tools are not supported on streaming chat requests yet"
+        )
+        assert calls == []
+        billing.reserve.assert_not_awaited()
+        billing.dispatch.assert_not_awaited()
+        billing.accept_selector.assert_not_awaited()
+        billing.unattempted.assert_not_awaited()
+
+
+@pytest.mark.parametrize("reason", ["tags", "capacity", "context"])
+async def test_classifier_policy_or_capacity_denial_defaults_without_dispatch_or_charge(
+    client, test_app, reason
+):
+    calls = []
+
+    def handle(request):
+        calls.append(json.loads(request.content)["model"])
+        return httpx.Response(200, json=response_body(text="answer"))
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, policy = configure(test_app, upstream)
+        body = deepcopy(BODY)
+        if reason == "tags":
+            test_app.state.model_registry["backing"][1]["model_info"]["tags"] = ["eu"]
+            body["metadata"] = {"tags": ["eu"]}
+            _publish(test_app, [policy])
+        elif reason == "context":
+            test_app.state.model_registry["backing"][0]["model_info"]["max_tokens"] = 512
+            _publish(test_app, [policy])
+        else:
+            runtime = test_app.state.routing_runtime_generation_store.require_snapshot()
+            original = runtime.router.state.acquire_attempt
+
+            async def acquire(ref, capacity, **kwargs):
+                if ref.deployment_id == "classifier":
+                    return AttemptPermit(
+                        ref.deployment_id,
+                        ref,
+                        False,
+                        "redis",
+                        rejection_reason=AttemptRejectionReason.CAPACITY,
+                    )
+                return await original(ref, capacity, **kwargs)
+
+            runtime.router.state.acquire_attempt = acquire
+        response = await client.post("/v1/chat/completions", headers=HEADERS, json=body)
+        assert response.status_code == 200, response.text
+        assert calls == ["quality"]
+        billing.dispatch.assert_not_awaited()
+        billing.accept_selector.assert_not_awaited()
+        billing.unattempted.assert_awaited_once()
+
+
+async def test_terminal_selector_metrics_are_emitted_once_and_cache_hit_does_not_recount(
+    client, test_app
+):
+    calls = []
+
+    def handle(request):
+        calls.append(json.loads(request.content)["model"])
+        return httpx.Response(
+            200, json=response_body(text='{"lane":"quality"}' if len(calls) == 1 else "answer")
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        configure(test_app, upstream)
+        before = terminal_lanes.labels(rank="1")._value.get()
+        decision_before = decisions.labels(cause="classified", rank="1")._value.get()
+        for _ in range(2):
+            response = await client.post("/v1/chat/completions", headers=HEADERS, json=BODY)
+            assert response.status_code == 200, response.text
+        assert terminal_lanes.labels(rank="1")._value.get() == before + 1
+        assert decisions.labels(cause="classified", rank="1")._value.get() == decision_before + 1
+        assert calls == ["classifier", "quality"]
+
+
+@pytest.mark.parametrize("invalid", [{"tools": "true"}, {"unknown": True}, [], True])
+async def test_admin_model_capability_contract_rejects_invalid_flags(test_app, invalid):
+    from fastapi import HTTPException
+    from src.api.admin.endpoints.models import _normalize_model_info_or_400
+
+    with pytest.raises(HTTPException) as error:
+        _normalize_model_info_or_400({"chat_capabilities": invalid})
+    assert error.value.status_code == 400

--- a/tests/router/selection/test_realtime_fallbacks.py
+++ b/tests/router/selection/test_realtime_fallbacks.py
@@ -1,0 +1,269 @@
+from copy import deepcopy
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from src.db.callable_targets import CallableTargetBindingRecord
+from src.router.failover import FallbackConfig
+from src.router.runtime_generation import with_authorization_snapshot
+from tests.router.selection.provider_fixtures import response_body
+from tests.router.selection.test_realtime import configure
+from tests.test_routing_cache_identity import _publish
+
+pytestmark = pytest.mark.app
+
+
+async def configure_fallback(
+    test_app, upstream, *, authorize=True, second=False, fallback_field="fallbacks"
+):
+    billing, selected = configure(test_app, upstream)
+    selected["key"] = "selected"
+    entries = test_app.state.model_registry["backing"]
+    plain = deepcopy(entries[0])
+    plain["deployment_id"] = "plain"
+    plain["deltallm_params"]["model"] = "openai/plain"
+    entries.append(plain)
+    groups = [
+        {"key": "gpt-4o-mini", "mode": "chat", "members": [{"deployment_id": "plain"}]},
+        selected,
+    ]
+    targets = ["selected"]
+    if second:
+        later = deepcopy(selected)
+        later["key"] = "later"
+        later["selector"]["classifier_deployment_id"] = "classifier-2"
+        later["selector"]["lanes"][0]["id"] = "silver"
+        later["selector"]["lanes"][1]["id"] = "gold"
+        later["members"] = [
+            {"deployment_id": "classifier-2", "lane": "silver"},
+            {"deployment_id": "quality-2", "lane": "gold"},
+        ]
+        for source in entries[:2]:
+            extra = deepcopy(source)
+            extra["deployment_id"] += "-2"
+            extra["deltallm_params"]["model"] += "-2"
+            entries.append(extra)
+        groups.append(later)
+        targets.append("later")
+    if authorize:
+        grants = test_app.state.callable_target_grant_service
+        grants.repository.bindings.extend(
+            CallableTargetBindingRecord(
+                callable_target_binding_id=f"binding-{key}",
+                callable_key=key,
+                scope_type="organization",
+                scope_id="org-default",
+                enabled=True,
+            )
+            for key in targets
+        )
+        await grants.reload()
+    runtime = _publish(
+        test_app,
+        groups,
+        failover_config=FallbackConfig(**{fallback_field: {"gpt-4o-mini": targets}}, backoff_max=0),
+    )
+    runtime = with_authorization_snapshot(
+        runtime, test_app.state.callable_target_grant_service.snapshot()
+    )
+    test_app.state.routing_runtime_generation_store.replace(runtime)
+    return billing
+
+
+@pytest.mark.parametrize(
+    "field,code",
+    [
+        ("context_window_fallbacks", "context_length_exceeded"),
+        ("content_policy_fallbacks", "content_filter"),
+    ],
+)
+async def test_classified_fallback_lazily_executes_one_selector(client, test_app, field, code):
+    calls = []
+
+    def handle(request):
+        model = json.loads(request.content)["model"]
+        calls.append(model)
+        if model == "plain":
+            return httpx.Response(400, json={"error": {"message": code, "code": code}})
+        return httpx.Response(
+            200,
+            json=response_body(text='{"lane":"quality"}' if model == "classifier" else "answer"),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing = await configure_fallback(test_app, upstream, fallback_field=field)
+        response = await client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer sk-test"},
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert response.status_code == 200, response.text
+        assert calls == ["plain", "classifier", "quality"]
+        billing.reserve.assert_awaited_once()
+
+
+@pytest.mark.parametrize("fail_primary", [False, True])
+async def test_first_selector_is_lazy_on_ordinary_fallback(client, test_app, fail_primary):
+    calls = []
+
+    def handle(request):
+        data = json.loads(request.content)
+        calls.append(data["model"])
+        if data["model"] == "plain" and fail_primary:
+            return httpx.Response(503, json={"error": {"message": "mock unavailable"}})
+        return httpx.Response(
+            200,
+            json=response_body(
+                text='{"lane":"quality"}' if data["model"] == "classifier" else "answer"
+            ),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing = await configure_fallback(test_app, upstream)
+        response = await client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer sk-test"},
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert response.status_code == 200, response.text
+        assert calls == (["plain", "classifier", "quality"] if fail_primary else ["plain"])
+        assert billing.reserve.await_count == int(fail_primary)
+        assert billing.accept_selector.await_count == int(fail_primary)
+
+
+async def test_later_selector_fallback_reuses_minimum_rank_with_different_lane_names(
+    client, test_app
+):
+    calls = []
+
+    def handle(request):
+        data = json.loads(request.content)
+        calls.append(data["model"])
+        if data["model"] in {"plain", "quality"}:
+            return httpx.Response(503, json={"error": {"message": "mock unavailable"}})
+        return httpx.Response(
+            200,
+            json=response_body(
+                text='{"lane":"quality"}' if data["model"] == "classifier" else "answer"
+            ),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing = await configure_fallback(test_app, upstream, second=True)
+        response = await client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer sk-test"},
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert response.status_code == 200, response.text
+        assert calls == ["plain", "classifier", "quality", "quality-2"]
+        billing.reserve.assert_awaited_once()
+        billing.accept_selector.assert_awaited_once()
+
+
+async def test_local_context_rejection_reaches_selector_without_dispatching_primary(
+    client, test_app
+):
+    calls = []
+
+    def handle(request):
+        model = json.loads(request.content)["model"]
+        calls.append(model)
+        return httpx.Response(
+            200,
+            json=response_body(text='{"lane":"quality"}' if model == "classifier" else "answer"),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing = await configure_fallback(
+            test_app, upstream, fallback_field="context_window_fallbacks"
+        )
+        current = test_app.state.routing_runtime_generation_store.require_snapshot()
+        groups = deepcopy(list(current.route_groups))
+        groups[0]["context"] = {"mode": "eligible-only", "unknown_capacity": "exclude"}
+        test_app.state.model_registry["backing"][-1]["model_info"]["max_tokens"] = 128
+        _publish(test_app, groups, failover_config=current.failover_config)
+        response = await client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer sk-test"},
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert response.status_code == 200, response.text
+        assert calls == ["classifier", "quality"]
+        billing.reserve.assert_awaited_once()
+
+
+@pytest.mark.parametrize("endpoint", ["/v1/chat/completions", "/v1/responses"])
+async def test_local_context_fallback_planning_obeys_original_deadline(client, test_app, endpoint):
+    entered, cancelled = asyncio.Event(), asyncio.Event()
+    calls = []
+
+    def handle(request):
+        calls.append(request)
+        return httpx.Response(200, json=response_body(text='{"lane":"quality"}'))
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing = await configure_fallback(
+            test_app, upstream, fallback_field="context_window_fallbacks"
+        )
+        current = test_app.state.routing_runtime_generation_store.require_snapshot()
+        groups = deepcopy(list(current.route_groups))
+        groups[0]["context"] = {"mode": "eligible-only", "unknown_capacity": "exclude"}
+        groups[0]["timeouts"] = {"global_seconds": 0.1}
+        test_app.state.model_registry["backing"][-1]["model_info"]["max_tokens"] = 128
+        runtime = _publish(test_app, groups, failover_config=current.failover_config)
+        original = runtime.router.plan_deployments
+
+        async def blocked_planning(group_keys, context):
+            if list(group_keys) == ["selected"]:
+                entered.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    cancelled.set()
+            return await original(group_keys, context)
+
+        runtime.router.plan_deployments = blocked_planning
+        body = {"model": "gpt-4o-mini"}
+        if endpoint.endswith("completions"):
+            body["messages"] = [{"role": "user", "content": "hello"}]
+        else:
+            body["input"] = "hello"
+        task = asyncio.create_task(
+            client.post(endpoint, headers={"Authorization": "Bearer sk-test"}, json=body)
+        )
+        try:
+            await asyncio.wait_for(entered.wait(), 2)
+            response = await asyncio.wait_for(asyncio.shield(task), 1)
+            assert response.status_code == 408, response.text
+            assert cancelled.is_set()
+            assert not calls
+            billing.reserve.assert_not_awaited()
+            billing.dispatch.assert_not_awaited()
+            billing.accept_selector.assert_not_awaited()
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+
+async def test_selector_fallback_authorization_denial_cannot_dispatch_or_bill_hidden_target(
+    client, test_app
+):
+    calls = []
+
+    def handle(request):
+        calls.append(json.loads(request.content)["model"])
+        return httpx.Response(503, json={"error": {"message": "mock unavailable"}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing = await configure_fallback(test_app, upstream, authorize=False)
+        response = await client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer sk-test"},
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert response.status_code == 403, response.text
+        assert calls == ["plain"]
+        billing.reserve.assert_not_awaited()

--- a/tests/router/selection/test_realtime_lifecycle.py
+++ b/tests/router/selection/test_realtime_lifecycle.py
@@ -1,0 +1,167 @@
+import asyncio
+from copy import deepcopy
+import json
+
+import httpx
+import pytest
+
+from tests.router.selection.provider_fixtures import response_body
+from tests.router.selection.test_realtime import configure
+from tests.test_routing_cache_identity import _publish
+
+pytestmark = pytest.mark.app
+HEADERS = {"Authorization": "Bearer sk-test"}
+BODY = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]}
+
+
+async def test_equivalent_capability_reload_keeps_cache_identity_and_changed_capability_invalidates(
+    test_app,
+):
+    from src.chat_capabilities import ChatRoutingCapabilities
+
+    async with httpx.AsyncClient() as upstream:
+        _, policy = configure(test_app, upstream)
+        before = test_app.state.routing_runtime_generation_store.require_snapshot()
+        for entry in test_app.state.model_registry["backing"]:
+            entry["model_info"]["chat_capabilities"] = ChatRoutingCapabilities.model_validate(
+                entry["model_info"]["chat_capabilities"]
+            ).model_dump()
+        same = _publish(test_app, [deepcopy(policy)])
+        assert same.generation_id != before.generation_id
+        assert same.routing_fingerprints == before.routing_fingerprints
+        test_app.state.model_registry["backing"][1]["model_info"]["chat_capabilities"]["image"] = (
+            True
+        )
+        changed = _publish(test_app, [deepcopy(policy)])
+        assert (
+            changed.routing_fingerprints["gpt-4o-mini"]
+            != before.routing_fingerprints["gpt-4o-mini"]
+        )
+
+
+@pytest.mark.parametrize("feature", ["image", "audio", "file", "multiple_choices"])
+async def test_unsupported_hard_capability_never_pays_for_classification(client, test_app, feature):
+    calls = []
+
+    def handle(request):
+        calls.append(request)
+        return httpx.Response(200, json=response_body(text='{"lane":"economy"}'))
+
+    body = deepcopy(BODY)
+    if feature == "multiple_choices":
+        body["n"] = 2
+    else:
+        block = {
+            "image": {"type": "image_url", "image_url": {"url": "https://mock.test/image"}},
+            "audio": {"type": "input_audio", "input_audio": {"data": "private", "format": "wav"}},
+            "file": {"type": "file", "file": {"file_id": "private"}},
+        }[feature]
+        body["messages"][0]["content"] = [block]
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, _ = configure(test_app, upstream)
+        response = await client.post("/v1/chat/completions", headers=HEADERS, json=body)
+        assert response.status_code in (400, 503), response.text
+        assert not calls
+        billing.reserve.assert_not_awaited()
+
+
+async def test_model_reload_during_classification_does_not_change_pinned_answer(client, test_app):
+    calls = []
+    policy = None
+
+    def handle(request):
+        model = json.loads(request.content)["model"]
+        calls.append(model)
+        if len(calls) == 1:
+            test_app.state.model_registry = deepcopy(test_app.state.model_registry)
+            test_app.state.model_registry["backing"][1]["deltallm_params"]["model"] = (
+                "openai/quality-new"
+            )
+            _publish(test_app, [deepcopy(policy)])
+        return httpx.Response(
+            200,
+            json=response_body(text='{"lane":"quality"}' if model == "classifier" else "answer"),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, policy = configure(test_app, upstream)
+        response = await client.post("/v1/chat/completions", headers=HEADERS, json=BODY)
+        assert response.status_code == 200, response.text
+        assert calls == ["classifier", "quality"]
+        response = await client.post("/v1/chat/completions", headers=HEADERS, json=BODY)
+        assert response.status_code == 200, response.text
+        assert calls == ["classifier", "quality", "classifier", "quality-new"]
+        assert billing.reserve.await_count == 2
+
+
+async def test_mcp_continuation_reuses_selector_and_original_deadline(client, test_app):
+    from tests.mcp.test_chat_execution import (
+        _RecordingAuditService,
+        _RecordingGateway,
+        _request_payload,
+        _tool_call_response,
+    )
+
+    calls = []
+
+    def handle(request):
+        data = json.loads(request.content)
+        calls.append(data)
+        if data["model"] == "classifier":
+            return httpx.Response(200, json=response_body(text='{"lane":"quality"}'))
+        if any(message["role"] == "tool" for message in data["messages"]):
+            return httpx.Response(200, json=response_body(text="final answer"))
+        return httpx.Response(200, json=_tool_call_response())
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, _ = configure(test_app, upstream)
+        gateway = _RecordingGateway()
+        test_app.state.mcp_gateway_service = gateway
+        test_app.state.audit_service = _RecordingAuditService()
+        manager = (
+            test_app.state.routing_runtime_generation_store.require_snapshot().failover_manager
+        )
+        original = manager.execute_with_failover
+        deadlines = []
+
+        async def execute(*args, **kwargs):
+            deadlines.append(kwargs["request_deadline"])
+            return await original(*args, **kwargs)
+
+        manager.execute_with_failover = execute
+        response = await client.post(
+            "/v1/chat/completions",
+            headers=HEADERS,
+            json=_request_payload().model_dump(exclude_none=True),
+        )
+        assert response.status_code == 200, response.text
+        assert [call["model"] for call in calls] == ["classifier", "quality", "quality"]
+        assert gateway.tool_calls == ["docs.search"]
+        assert len(deadlines) == 2 and deadlines[0] is deadlines[1]
+        billing.reserve.assert_awaited_once()
+        billing.accept_selector.assert_awaited_once()
+
+
+async def test_selector_timeout_defaults_but_retains_unknown_dispatched_usage(client, test_app):
+    calls, cancelled = [], asyncio.Event()
+
+    async def handle(request):
+        model = json.loads(request.content)["model"]
+        calls.append(model)
+        if model == "classifier":
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+        return httpx.Response(200, json=response_body(text="answer"))
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as upstream:
+        billing, policy = configure(test_app, upstream)
+        policy["selector"]["timeout_ms"] = 100
+        _publish(test_app, [policy])
+        response = await client.post("/v1/chat/completions", headers=HEADERS, json=BODY)
+        assert response.status_code == 200, response.text
+        assert calls == ["classifier", "quality"] and cancelled.is_set()
+        billing.dispatch.assert_awaited_once()
+        billing.accept_selector.assert_not_awaited()
+        billing.unattempted.assert_not_awaited()

--- a/tests/router/selection/test_structure.py
+++ b/tests/router/selection/test_structure.py
@@ -11,6 +11,22 @@ NEW_MODULES = (
     "router/selection/provider.py",
     "router/selection/request_state.py",
     "router/selection/service.py",
+    "router/selection/lanes.py",
+    "router/selection/planning.py",
+    "router/selection/request_context.py",
+    "router/group_policy.py",
+    "router/group_execution.py",
+    "router/initial_selection.py",
+    "router/static_filters.py",
+    "router/selection/activation.py",
+    "router/selection/answer_observation.py",
+    "router/selection/eligibility.py",
+    "router/selection/operation.py",
+    "router/selection/qualification.py",
+    "router/selection/reachability.py",
+    "router/selection/runtime.py",
+    "router/selection/target_validation.py",
+    "chat_capabilities.py",
     "providers/chat_hop.py",
     "providers/chat_upstream.py",
 )
@@ -34,7 +50,7 @@ def test_new_boundaries_are_small_typed_and_request_free(module):
             assert name not in {"create_task", "AsyncClient", "Client", "create_pool"}
 
 
-def test_selector_service_is_not_wired_into_production():
+def test_selector_execution_is_owned_by_the_authenticated_edge_and_selection_package():
     targets = {
         "src.router.selection.service",
         "src.router.selection.provider",
@@ -43,11 +59,33 @@ def test_selector_service_is_not_wired_into_production():
     for path in (ROOT / "src").rglob("*.py"):
         if path.is_relative_to(ROOT / "src/router/selection"):
             continue
+        if path == ROOT / "src/routers/selector_edge.py":
+            continue
         for node in ast.walk(ast.parse(path.read_text())):
             if isinstance(node, ast.ImportFrom):
                 assert node.module not in targets, path
             elif isinstance(node, ast.Import):
                 assert not any(alias.name in targets for alias in node.names), path
+
+
+def test_planning_does_not_own_selector_provider_execution():
+    for module in (
+        "router/router.py",
+        "router/selection/planning.py",
+        "router/selection/request_context.py",
+    ):
+        tree = ast.parse((ROOT / "src" / module).read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in {"invoke", "select_once", "create_task"}, module
+    tree = ast.parse((ROOT / "src/router/router.py").read_text())
+    assert len((ROOT / "src/router/router.py").read_text().splitlines()) < 800
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name in {
+            "plan_deployments",
+            "_plan_eligible_group",
+        }:
+            assert node.end_lineno - node.lineno < 80
 
 
 def test_answer_facade_and_selector_bridge_share_one_signing_and_transport_owner():
@@ -61,3 +99,22 @@ def test_answer_facade_and_selector_bridge_share_one_signing_and_transport_owner
         )
     service = (ROOT / "src/router/selection/service.py").read_text()
     assert "httpx" not in service and "record_router_usage" not in service
+
+
+def test_selector_execution_requires_authenticated_cache_admission_and_shared_accounting():
+    edge = (ROOT / "src/routers/chat.py").read_text()
+    assert (
+        edge.index("preflight = await run_text_preflight")
+        < edge.index("selector_deadline = bind_selector_operation")
+        < edge.index("primary = await require_initial_deployment")
+    )
+    source = (ROOT / "src/router/selection/runtime.py").read_text()
+    assert "AccountedSelectorHop(store=self._billing" in source
+    assert "ReservedSelectorAdmission(" in source and "CapacityAdmittedSelectorHop(" in source
+    bootstrap = (ROOT / "src/bootstrap/selector.py").read_text()
+    assert "BillingOperationRecovery(" in bootstrap and "selector_events_only=True" in bootstrap
+    edge = (ROOT / "src/routers/selector_edge.py").read_text()
+    assert "cache.require_provider_execution()" in edge
+    for node in ast.walk(ast.parse(edge)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            assert node.end_lineno - node.lineno < 80, node.name

--- a/tests/services/test_route_group_cache_contract.py
+++ b/tests/services/test_route_group_cache_contract.py
@@ -51,11 +51,39 @@ INVALID_GROUP_FIELDS = [
 ]
 
 
+@pytest.mark.asyncio
+async def test_active_selector_roundtrips_l1_l2_and_old_inactive_envelope_reloads():
+    from tests.test_ui_route_groups import _selector_policy_payload
+
+    group = {
+        "key": "selected",
+        "mode": "chat",
+        "policy_semantics_version": 3,
+        "context": {"unknown_capacity": "exclude"},
+        **_selector_policy_payload(),
+    }
+    repository = _FakeRouteGroupRepository([group])
+    redis = _FakeRedis()
+    cache = RouteGroupRuntimeCache(redis)
+    original, source = await cache.get_snapshot(repository)
+    assert source == "db"
+    assert (await cache.get_snapshot(repository))[1] == "l1_cache"
+    cached, source = await RouteGroupRuntimeCache(redis).get_snapshot(repository)
+    assert source == "l2_cache" and cached.groups == original.groups
+    assert build_route_group_policies(cached.groups)["selected"].selector is not None
+    envelope = json.loads(redis.values[_runtime_cache_key(1)])
+    envelope.update(schema_version=2, selector_activation_state="inactive-v1")
+    redis.values[_runtime_cache_key(1)] = json.dumps(envelope)
+    repaired, source = await RouteGroupRuntimeCache(redis).get_snapshot(repository)
+    assert source == "db" and repaired.groups == original.groups
+    assert repository.calls == 2
+
+
 def invalid_envelope(fields):
     return json.dumps(
         {
-            "schema_version": 2,
-            "selector_activation_state": "inactive",
+            "schema_version": 3,
+            "selector_activation_state": "validated-v3",
             "revision": 1,
             "database_initialized": True,
             "groups": [{"key": "corrupt", "members": [], **fields}],

--- a/tests/services/test_route_groups.py
+++ b/tests/services/test_route_groups.py
@@ -53,7 +53,7 @@ class _FakeRouteGroupRepository:
             self.revision,
             list(self.groups),
             database_initialized=self.database_initialized,
-            selector_activation_state=RouteSelectorActivationState.INACTIVE,
+            selector_activation_state=RouteSelectorActivationState.VALIDATED,
         )
 
 
@@ -157,12 +157,23 @@ def test_selector_free_config_runtime_shape_is_unchanged():
     ]
 
 
-def test_file_config_selector_activation_is_explicitly_rejected():
-    with pytest.raises(RouteSelectorActivationUnsupportedError, match="cannot be activated"):
+def test_file_config_selector_activation_requires_safe_context_policy():
+    with pytest.raises(RouteSelectorActivationUnsupportedError, match="unknown_capacity=exclude"):
         route_groups_from_config(
             _selector_config(),
             deployment_modes={"dep-mini": "chat", "dep-large": "chat"},
         )
+
+
+def test_file_config_retains_selector_and_lanes_for_qualified_runtime_publication():
+    document = _selector_config().model_dump(mode="json")
+    document["router_settings"]["route_groups"][0]["context"] = {"unknown_capacity": "exclude"}
+    cfg = AppConfig.model_validate(document)
+    groups = route_groups_from_config(
+        cfg, deployment_modes={"dep-mini": "chat", "dep-large": "chat"}
+    )
+    assert groups[0]["selector"]["kind"] == "llm-tier"
+    assert {member["lane"] for member in groups[0]["members"]} == {"economy", "quality"}
 
 
 def test_file_config_selector_requires_loaded_deployment_inventory():
@@ -211,7 +222,7 @@ async def test_l2_cached_selector_snapshot_reloads_durable_authority():
     redis.values[_runtime_cache_key(1)] = json.dumps(
         {
             "schema_version": ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION,
-            "selector_activation_state": "inactive",
+            "selector_activation_state": "validated-v3",
             "revision": 1,
             "database_initialized": True,
             "groups": [
@@ -259,7 +270,7 @@ async def test_l2_cache_ignores_legacy_envelope_and_reloads_durable_state():
     assert repository.calls == 1
     rewritten = json.loads(redis.values[_runtime_cache_key(1)])
     assert rewritten["schema_version"] == ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION
-    assert rewritten["selector_activation_state"] == "inactive"
+    assert rewritten["selector_activation_state"] == "validated-v3"
 
 
 @pytest.mark.asyncio
@@ -268,7 +279,7 @@ async def test_l2_cache_ignores_invalid_nested_snapshot_and_reloads_durable_stat
     redis.values[_runtime_cache_key(1)] = json.dumps(
         {
             "schema_version": ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION,
-            "selector_activation_state": "inactive",
+            "selector_activation_state": "validated-v3",
             "revision": 1,
             "database_initialized": True,
             "groups": [
@@ -299,7 +310,7 @@ async def test_l2_cache_ignores_unknown_nested_fields_and_reloads_durable_state(
     redis.values[_runtime_cache_key(1)] = json.dumps(
         {
             "schema_version": ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION,
-            "selector_activation_state": "inactive",
+            "selector_activation_state": "validated-v3",
             "revision": 1,
             "database_initialized": True,
             "groups": [
@@ -326,7 +337,7 @@ async def test_l2_cache_ignores_member_lane_without_active_selector():
     redis.values[_runtime_cache_key(1)] = json.dumps(
         {
             "schema_version": ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION,
-            "selector_activation_state": "inactive",
+            "selector_activation_state": "validated-v3",
             "revision": 1,
             "database_initialized": True,
             "groups": [
@@ -358,7 +369,7 @@ async def test_invalid_l2_cache_uses_config_only_after_durable_load_fails():
     redis.values[_runtime_cache_key(1)] = json.dumps(
         {
             "schema_version": ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION,
-            "selector_activation_state": "inactive",
+            "selector_activation_state": "validated-v3",
             "revision": 1,
             "database_initialized": True,
             "groups": [
@@ -780,7 +791,7 @@ async def test_older_in_flight_database_load_cannot_overwrite_newer_generation()
             return RouteGroupRuntimeSnapshot(
                 revision,
                 groups,
-                selector_activation_state=RouteSelectorActivationState.INACTIVE,
+                selector_activation_state=RouteSelectorActivationState.VALIDATED,
             )
 
     cfg = AppConfig.model_validate({"router_settings": {"route_groups": []}})

--- a/tests/services/test_route_policy_publication.py
+++ b/tests/services/test_route_policy_publication.py
@@ -56,7 +56,7 @@ class _Repository:
     ) -> RoutePolicyWriteResult | None:
         if not self.group_exists:
             return None
-        effective, warnings = RouteGroupRepository(None)._prepare_policy_write(
+        prepared = RouteGroupRepository(None)._prepare_policy_write(
             policy_json,
             current=None,
             context=RoutePolicyValidationContext(
@@ -73,11 +73,11 @@ class _Repository:
             ),
         )
         ensure_selector_activation_supported(
-            effective, semantics_version=CURRENT_POLICY_SEMANTICS_VERSION
+            prepared.normalized, semantics_version=CURRENT_POLICY_SEMANTICS_VERSION
         )
         self.document_calls.append(policy_json)
         return RoutePolicyWriteResult(
-            _policy(group_key, effective, published_by=published_by), warnings
+            _policy(group_key, prepared.document, published_by=published_by), prepared.warnings
         )
 
     async def publish_latest_draft(
@@ -176,7 +176,7 @@ async def test_selector_publication_is_rejected_before_repository_or_refresh() -
         refresh_runtime=refresh,
     )
 
-    with pytest.raises(ValueError, match="cannot be activated"):
+    with pytest.raises(ValueError, match="unknown_capacity=exclude"):
         await service.publish_document(
             "support",
             {

--- a/tests/test_redis_namespace.py
+++ b/tests/test_redis_namespace.py
@@ -64,6 +64,6 @@ def test_route_group_runtime_keyspace_isolates_environment_and_revision() -> Non
     staging = RouteGroupRuntimeRedisKeyspace(environment="Staging West")
     production = RouteGroupRuntimeRedisKeyspace(environment="production")
 
-    assert staging.snapshot(7) == ("deltallm:staging-west:v2:route-group-runtime:r7")
+    assert staging.snapshot(7) == ("deltallm:staging-west:v3:route-group-runtime:r7")
     assert staging.snapshot(7) != staging.snapshot(8)
     assert staging.snapshot(7) != production.snapshot(7)

--- a/tests/test_route_group_redis_integration.py
+++ b/tests/test_route_group_redis_integration.py
@@ -38,7 +38,7 @@ class _MutableRouteGroupRepository:
         return RouteGroupRuntimeSnapshot(
             self.revision,
             list(self.groups),
-            selector_activation_state=RouteSelectorActivationState.INACTIVE,
+            selector_activation_state=RouteSelectorActivationState.VALIDATED,
         )
 
 
@@ -158,8 +158,8 @@ async def test_route_group_cache_recovers_after_real_redis_write_outage() -> Non
         raw_envelope = await redis.get(keyspace.snapshot(2))
         assert raw_envelope is not None
         envelope = json.loads(raw_envelope)
-        assert envelope["schema_version"] == 2
-        assert envelope["selector_activation_state"] == "inactive"
+        assert envelope["schema_version"] == 3
+        assert envelope["selector_activation_state"] == "validated-v3"
         cache._l1_entry = None
         _, cached_source = await load_route_groups(repository, cfg, route_group_cache=cache)
         assert cached_source == "l2_cache"
@@ -189,7 +189,7 @@ async def test_route_group_cache_repairs_invalid_nested_real_redis_snapshot(fiel
     cache_key = keyspace.snapshot(1)
     invalid_envelope = {
         "schema_version": ROUTE_GROUP_RUNTIME_CACHE_SCHEMA_VERSION,
-        "selector_activation_state": "inactive",
+        "selector_activation_state": "validated-v3",
         "revision": 1,
         "database_initialized": True,
         "groups": [

--- a/tests/test_route_policy_selector_contract.py
+++ b/tests/test_route_policy_selector_contract.py
@@ -314,11 +314,15 @@ def test_selector_activation_gate_is_version_aware():
     policy = _policy()
 
     ensure_selector_activation_supported(policy, semantics_version=2)
-    with pytest.raises(RouteSelectorActivationUnsupportedError, match="cannot be activated"):
+    with pytest.raises(RouteSelectorActivationUnsupportedError, match="unknown_capacity=exclude"):
         ensure_selector_activation_supported(
             policy,
             semantics_version=SELECTOR_POLICY_SEMANTICS_VERSION,
         )
+    policy["context"] = {"unknown_capacity": "exclude"}
+    ensure_selector_activation_supported(
+        policy, semantics_version=SELECTOR_POLICY_SEMANTICS_VERSION
+    )
 
 
 def test_routing_fingerprint_is_stable_for_equivalent_normalized_policy():

--- a/tests/test_routing_cache_identity.py
+++ b/tests/test_routing_cache_identity.py
@@ -34,10 +34,11 @@ def _group():
     }
 
 
-def _fingerprints(groups, *, default_strategy=RoutingStrategy.SIMPLE_SHUFFLE):
+def _fingerprints(groups, *, default_strategy=RoutingStrategy.SIMPLE_SHUFFLE, model_entries=None):
     registry = build_deployment_registry(
         {
-            "gpt-4o-mini": [
+            "gpt-4o-mini": model_entries
+            or [
                 {
                     "deltallm_params": {"model": "openai/small"},
                     "model_info": {"mode": "chat", "weight": 3},
@@ -120,6 +121,14 @@ def test_inherited_strategy_and_disabled_group_ownership_affect_identity():
 
 
 def test_version_aware_selector_and_lane_fingerprint_without_activation():
+    entries = [
+        {"deployment_id": deployment_id, "deltallm_params": {"model": "openai/small"}}
+        for deployment_id in ("gpt-4o-mini-0", "quality-only")
+    ]
+
+    def fingerprints(groups):
+        return _fingerprints(groups, model_entries=entries)
+
     group = _group()
     group["selector"] = {
         "kind": "llm-tier",
@@ -130,19 +139,29 @@ def test_version_aware_selector_and_lane_fingerprint_without_activation():
         ],
     }
     group["members"][0]["lane"] = "economy"
+    group["members"].append({"deployment_id": "quality-only", "lane": "quality"})
     changed = deepcopy(group)
     changed["members"][0]["lane"] = "quality"
-    assert _fingerprints([group]) != _fingerprints([changed])
+    changed["members"][1]["lane"] = "economy"
+    assert fingerprints([group]) != fingerprints([changed])
     changed = deepcopy(group)
     changed["selector"]["timeout_ms"] = 1000
-    assert _fingerprints([group]) != _fingerprints([changed])
+    assert fingerprints([group]) != fingerprints([changed])
     historical = {**group, "policy_semantics_version": 1}
-    assert _fingerprints([historical]) == _fingerprints(
-        [{**historical, "selector": {"opaque": True}, "members": _group()["members"]}]
+    assert fingerprints([historical]) == fingerprints(
+        [
+            {
+                **historical,
+                "selector": {"opaque": True},
+                "members": [
+                    {"deployment_id": member["deployment_id"]} for member in group["members"]
+                ],
+            }
+        ]
     )
     # Current file configuration has no stored database semantics version.
     file_group = {key: value for key, value in group.items() if key != "policy_semantics_version"}
-    assert _fingerprints([file_group]) == _fingerprints([group])
+    assert fingerprints([file_group]) == fingerprints([group])
 
 
 @pytest.mark.parametrize("custom_key", [None, "private custom key"])

--- a/tests/test_selector_charge.py
+++ b/tests/test_selector_charge.py
@@ -364,7 +364,7 @@ async def test_exact_ledger_batch_addition_is_independent_of_ambient_decimal_pre
     assert key_update.args[2] == ["9007199254740992.000000000000000003"]
 
 
-def test_selector_charging_is_not_invoked_by_production_request_paths() -> None:
+def test_production_selector_receipts_use_journal_not_direct_best_effort_spend() -> None:
     for path in (Path(__file__).parents[1] / "src").rglob("*.py"):
         for node in ast.walk(ast.parse(path.read_text())):
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):

--- a/tests/test_selector_prerequisite_structure.py
+++ b/tests/test_selector_prerequisite_structure.py
@@ -9,6 +9,7 @@ MODULES = (
     "billing/routing_costs.py",
     "cache/execution_eligibility.py",
     "db/billing_operations.py",
+    "db/soft_selector_admission.py",
     "db/billing_operation_recovery.py",
     "db/routing_costs.py",
     "db/spend_components.py",

--- a/tests/test_soft_selector_operations_postgres.py
+++ b/tests/test_soft_selector_operations_postgres.py
@@ -1,0 +1,291 @@
+import asyncio
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from src.billing.operation_reservation import BillingOperationUnavailable, SoftSelectorOperation
+from src.billing.spend import SpendTrackingService
+from src.billing.spend_ingestion import SpendIngestionConfig, SpendIngestionService
+from src.db.billing_operation_recovery import BillingOperationRecovery
+from src.db.billing_operations import BillingOperationRepository
+from tests import test_billing_operations_postgres as operation_fixtures
+from tests.test_billing_operations_postgres import deadline, hold
+
+operation_db = operation_fixtures.operation_db
+selector_billing_db = operation_fixtures.selector_billing_db
+
+pytestmark = pytest.mark.postgres
+
+
+async def test_soft_admission_query_plan_uses_one_counter_and_never_reads_history(operation_db):
+    import json
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from src.db.soft_selector_admission import check_soft_selector_admission
+
+    db, _, charge = operation_db
+    operation = soft_operation(charge)
+    await db.execute_raw(
+        "UPDATE deltallm_teamtable SET model_max_budget=jsonb_build_object($2::text,100) WHERE team_id=$1",
+        operation.attribution.team_id,
+        operation.attribution.model_group,
+    )
+    await db.execute_raw(
+        "INSERT INTO deltallm_teammodelspend(team_id,model,spend,spend_exact,updated_at) "
+        "SELECT $1,'plan-fixture-'||n,0,0,NOW() FROM generate_series(1,10000) n",
+        operation.attribution.team_id,
+    )
+    await db.execute_raw("ANALYZE deltallm_teammodelspend")
+    captured = AsyncMock(return_value=[{}])
+    await check_soft_selector_admission(SimpleNamespace(query_raw=captured), operation)
+    captured.assert_awaited_once()
+    sql, *parameters = captured.call_args.args
+    rows = await db.query_raw("EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " + sql, *parameters)
+    report = rows[0]["QUERY PLAN"][0]
+    pending, nodes = [report["Plan"]], []
+    while pending:
+        node = pending.pop()
+        nodes.append(
+            {
+                key: node[key]
+                for key in (
+                    "Node Type",
+                    "Relation Name",
+                    "Index Name",
+                    "Actual Rows",
+                    "Actual Loops",
+                )
+                if key in node
+            }
+        )
+        pending.extend(node.get("Plans", []))
+    assert report["Plan"]["Actual Rows"] == 1
+    assert "deltallm_spendlog_events" not in sql and "SUM(" not in sql.upper()
+    counter_nodes = [
+        node for node in nodes if node.get("Relation Name") == "deltallm_teammodelspend"
+    ]
+    assert len(counter_nodes) == 1
+    assert counter_nodes[0]["Node Type"] == "Index Scan"
+    assert counter_nodes[0]["Actual Rows"] == counter_nodes[0]["Actual Loops"] == 1
+    print(
+        json.dumps(
+            {
+                "execution_ms": report["Execution Time"],
+                "planning_ms": report["Planning Time"],
+                "nodes": nodes,
+            }
+        )
+    )
+
+
+def soft_operation(charge):
+    return SoftSelectorOperation(
+        attribution=charge.attribution,
+        owner_token=uuid4(),
+        pricing=charge.pricing,
+        admission_allowance=charge.customer_charge * 10,
+        expires_at=datetime.now(UTC) + timedelta(seconds=60),
+    )
+
+
+@pytest.mark.parametrize(
+    "table,column,scope",
+    [
+        ("deltallm_verificationtoken", "token", "api_key"),
+        ("deltallm_usertable", "user_id", "user_id"),
+        ("deltallm_teamtable", "team_id", "team_id"),
+        ("deltallm_organizationtable", "organization_id", "organization_id"),
+    ],
+)
+async def test_soft_selector_admission_includes_allowance_in_each_budget_scope(
+    operation_db, table, column, scope
+):
+    db, _, charge = operation_db
+    operation = soft_operation(charge)
+    scope_id = getattr(operation.attribution, scope)
+    await db.execute_raw(
+        f"UPDATE {table} SET max_budget=$2::numeric::double precision WHERE {column}=$1",
+        scope_id,
+        str(operation.admission_allowance / 2),
+    )
+    with pytest.raises(BillingOperationUnavailable):
+        await BillingOperationRepository(db).reserve(operation, expires_at=deadline())
+    rows = await db.query_raw(
+        "SELECT operation_id FROM deltallm_billing_operations WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+    assert not rows and await hold(db, operation) == 0
+
+
+async def test_soft_actual_selector_charge_can_exceed_admission_estimate(operation_db):
+    db, _, charge = operation_db
+    operation = soft_operation(charge).model_copy(
+        update={"admission_allowance": charge.customer_charge / 2}
+    )
+    store = BillingOperationRepository(db)
+    await store.reserve(operation, expires_at=deadline())
+    await store.dispatch(operation, component="selector", expires_at=deadline())
+    await store.accept_selector(operation, charge, expires_at=deadline())
+    row = (
+        await db.query_raw(
+            "SELECT selector_state FROM deltallm_billing_operations WHERE operation_id=$1",
+            str(operation.attribution.operation_id),
+        )
+    )[0]
+    assert row["selector_state"] == "accepted"
+
+
+async def test_soft_selector_receipt_settles_once_without_holds_or_answer_reservation(operation_db):
+    db, _, charge = operation_db
+    operation = soft_operation(charge)
+    store = BillingOperationRepository(db)
+    admitted = await store.reserve(operation, expires_at=deadline())
+    assert admitted.answer_state == "unattempted"
+    assert await hold(db, operation) == 0
+    await store.dispatch(operation, component="selector", expires_at=deadline())
+    await store.accept_selector(operation, charge, expires_at=deadline())
+    recovery = BillingOperationRecovery(
+        store, max_pending_events=100000, max_attempts=10, selector_events_only=True
+    )
+    service = SpendIngestionService(
+        db_client=db,
+        writer=SpendTrackingService(db),
+        operation_recovery=recovery,
+        config=SpendIngestionConfig(enabled=True, worker_enabled=False),
+    )
+    await service._process_batch(await service._claim_batch())
+    await store.accept_selector(operation, charge, expires_at=deadline())
+    assert await service._claim_batch() == []
+    row = (
+        await db.query_raw(
+            "SELECT selector_state,closed_at,selector_allowance::text AS allowance FROM deltallm_billing_operations WHERE operation_id=$1",
+            str(operation.attribution.operation_id),
+        )
+    )[0]
+    assert row["selector_state"] == "settled" and row["closed_at"] is not None
+    assert Decimal(row["allowance"]) == 0
+    spend = (
+        await db.query_raw(
+            "SELECT spend_exact::text AS amount FROM deltallm_verificationtoken WHERE token=$1",
+            operation.attribution.api_key,
+        )
+    )[0]
+    assert Decimal(spend["amount"]) == charge.customer_charge
+
+
+async def test_soft_admission_allows_concurrent_overshoot_without_reserving_accounts(operation_db):
+    db, _, charge = operation_db
+    operation = soft_operation(charge)
+    await db.execute_raw(
+        "UPDATE deltallm_verificationtoken SET max_budget=$2::numeric::double precision WHERE token=$1",
+        operation.attribution.api_key,
+        str(operation.admission_allowance * 2),
+    )
+    store = BillingOperationRepository(db)
+    operations = [
+        operation.model_copy(
+            update={
+                "attribution": operation.attribution.model_copy(update={"operation_id": uuid4()}),
+                "owner_token": uuid4(),
+            }
+        )
+        for _ in range(4)
+    ]
+    admitted = await asyncio.gather(
+        *(store.reserve(candidate, expires_at=deadline()) for candidate in operations)
+    )
+    assert len(admitted) == 4 and await hold(db, operation) == 0
+    for candidate in operations:
+        await store.unattempted(candidate, component="selector", expires_at=deadline())
+
+
+async def test_soft_unknown_dispatch_remains_pending_without_replaying_or_inventing_free_usage(
+    operation_db,
+):
+    db, _, charge = operation_db
+    operation = soft_operation(charge)
+    store = BillingOperationRepository(db)
+    await store.reserve(operation, expires_at=deadline())
+    await store.dispatch(operation, component="selector", expires_at=deadline())
+    await db.execute_raw(
+        "UPDATE deltallm_billing_operations SET created_at=NOW()-interval '10 minutes',expires_at=NOW()-interval '5 minutes' WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+    await BillingOperationRecovery(store, max_pending_events=100000, max_attempts=10).recover()
+    row = (
+        await db.query_raw(
+            "SELECT selector_state,selector_receipt,closed_at FROM deltallm_billing_operations WHERE operation_id=$1",
+            str(operation.attribution.operation_id),
+        )
+    )[0]
+    assert row == {"selector_state": "pending", "selector_receipt": None, "closed_at": None}
+    with pytest.raises(BillingOperationUnavailable):
+        await store.dispatch(operation, component="selector", expires_at=deadline())
+
+
+async def test_soft_selector_does_not_require_a_preexisting_team_model_counter(operation_db):
+    db, _, charge = operation_db
+    await db.execute_raw(
+        "DELETE FROM deltallm_teammodelspend WHERE team_id=$1 AND model=$2",
+        charge.attribution.team_id,
+        charge.attribution.model_group,
+    )
+    operation = soft_operation(charge)
+    store = BillingOperationRepository(db)
+    await store.reserve(operation, expires_at=deadline())
+    await store.unattempted(operation, component="selector", expires_at=deadline())
+    assert await hold(db, operation) == 0
+
+
+@pytest.mark.parametrize("missing_counter", [False, True])
+async def test_soft_selector_team_model_budget_denies_exhausted_or_missing_counter(
+    operation_db, missing_counter
+):
+    db, _, charge = operation_db
+    operation = soft_operation(charge)
+    await db.execute_raw(
+        "UPDATE deltallm_teamtable SET model_max_budget=jsonb_build_object($2::text,$3::numeric) WHERE team_id=$1",
+        charge.attribution.team_id,
+        charge.attribution.model_group,
+        str(operation.admission_allowance / 2),
+    )
+    if missing_counter:
+        await db.execute_raw(
+            "DELETE FROM deltallm_teammodelspend WHERE team_id=$1 AND model=$2",
+            charge.attribution.team_id,
+            charge.attribution.model_group,
+        )
+        await db.execute_raw(
+            "UPDATE deltallm_teamtable SET model_max_budget=jsonb_build_object($2::text,100) WHERE team_id=$1",
+            charge.attribution.team_id,
+            charge.attribution.model_group,
+        )
+    with pytest.raises(BillingOperationUnavailable):
+        await BillingOperationRepository(db).reserve(operation, expires_at=deadline())
+    assert await hold(db, operation) == 0
+    assert not await db.query_raw(
+        "SELECT operation_id FROM deltallm_billing_operations WHERE operation_id=$1",
+        str(operation.attribution.operation_id),
+    )
+
+
+@pytest.mark.parametrize(
+    "field", ["api_key", "user_id", "team_id", "organization_id", "owner_account_id"]
+)
+async def test_soft_journal_rechecks_durable_attribution_before_admission(operation_db, field):
+    db, _, charge = operation_db
+    operation = soft_operation(charge)
+    operation = operation.model_copy(
+        update={"attribution": operation.attribution.model_copy(update={field: "unrelated-scope"})}
+    )
+    with pytest.raises(BillingOperationUnavailable):
+        await BillingOperationRepository(db).reserve(operation, expires_at=deadline())
+    assert (
+        await db.query_raw(
+            "SELECT operation_id FROM deltallm_billing_operations WHERE operation_id=$1",
+            str(operation.attribution.operation_id),
+        )
+        == []
+    )

--- a/tests/test_ui_route_group_selector_addresses.py
+++ b/tests/test_ui_route_group_selector_addresses.py
@@ -61,7 +61,7 @@ async def test_selector_draft_retains_contract_across_addressing_routes(
             selector_path + "/policy/publish", headers=HEADERS, json=payload
         )
         assert published.status_code == 400, published.text
-        assert "cannot be activated" in published.text
+    assert "unknown_capacity=exclude" in published.text
     current = await client.get(selector_path + "/policy", headers=HEADERS)
     assert current.status_code == 200, current.text
     assert current.json()["policy"]["status"] == "draft"

--- a/tests/test_ui_route_groups.py
+++ b/tests/test_ui_route_groups.py
@@ -380,27 +380,27 @@ class _FakeRouteGroupRepository:
         group = self.groups.get(group_key)
         if group is None:
             return None
-        effective, warnings = self._prepare_policy_write(group_key, policy_json)
+        prepared = self._prepare_policy_write(group_key, policy_json)
         self._policy_counter += 1
         policy = RoutePolicyRecord(
             route_policy_id=f"p-{self._policy_counter}",
             route_group_id=group.route_group_id,
             version=self._policy_counter,
             status="draft",
-            policy_json=effective,
+            policy_json=prepared.document,
             semantics_version=CURRENT_POLICY_SEMANTICS_VERSION,
             published_by=None,
         )
         self.policies[group_key] = policy
-        return RoutePolicyWriteResult(policy, warnings)
+        return RoutePolicyWriteResult(policy, prepared.warnings)
 
     async def publish_policy(self, group_key: str, policy_json: dict, *, published_by=None):  # noqa: ANN001, ANN201
         group = self.groups.get(group_key)
         if group is None:
             return None
-        effective, warnings = self._prepare_policy_write(group_key, policy_json)
+        prepared = self._prepare_policy_write(group_key, policy_json)
         ensure_selector_activation_supported(
-            effective, semantics_version=CURRENT_POLICY_SEMANTICS_VERSION
+            prepared.normalized, semantics_version=CURRENT_POLICY_SEMANTICS_VERSION
         )
         self._policy_counter += 1
         policy = RoutePolicyRecord(
@@ -408,12 +408,12 @@ class _FakeRouteGroupRepository:
             route_group_id=group.route_group_id,
             version=self._policy_counter,
             status="published",
-            policy_json=effective,
+            policy_json=prepared.document,
             semantics_version=CURRENT_POLICY_SEMANTICS_VERSION,
             published_by=published_by,
         )
         self.policies[group_key] = policy
-        return RoutePolicyWriteResult(policy, warnings)
+        return RoutePolicyWriteResult(policy, prepared.warnings)
 
     async def publish_latest_draft(self, group_key: str, *, published_by=None):  # noqa: ANN001, ANN201
         policy = self.policies.get(group_key)
@@ -1159,7 +1159,7 @@ async def test_route_group_policy_api_rejects_selector_publication(client, test_
     )
 
     assert response.status_code == 400
-    assert "cannot be activated" in response.text
+    assert "unknown_capacity=exclude" in response.text
     assert repository.policies == {}
 
 
@@ -1246,7 +1246,7 @@ async def test_route_group_policy_simulation_rejects_selector(client, test_app):
     )
 
     assert response.status_code == 400
-    assert "cannot be activated" in response.text
+    assert "simulation is not supported" in response.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_route_policy_legacy_identifiers.py
+++ b/tests/test_ui_route_policy_legacy_identifiers.py
@@ -1,0 +1,47 @@
+import pytest
+
+from tests.test_ui_route_groups import (
+    _FakeHotReload,
+    _FakeRouteGroupRepository,
+    _FakeRouteGroupRuntimeCache,
+)
+
+pytestmark = pytest.mark.app
+
+
+async def test_selector_free_policy_validation_keeps_legacy_long_identifiers(client, test_app):
+    test_app.state.settings.master_key = "mk-test"
+    test_app.state.route_group_repository = _FakeRouteGroupRepository()
+    test_app.state.model_hot_reload_manager = _FakeHotReload()
+    test_app.state.route_group_runtime_cache = _FakeRouteGroupRuntimeCache()
+    headers = {"Authorization": "Bearer mk-test"}
+    base = "/ui/api/route-groups"
+    created = await client.post(
+        base, headers=headers, json={"group_key": "long-id", "mode": "chat"}
+    )
+    assert created.status_code == 200, created.text
+    deployment_id = "d" * 300
+    member = await client.post(
+        base + "/long-id/members", headers=headers, json={"deployment_id": deployment_id}
+    )
+    assert member.status_code == 200, member.text
+    policy = {"strategy": "weighted", "members": [{"deployment_id": deployment_id}]}
+    for operation in ("validate", "draft"):
+        response = await client.post(
+            base + "/long-id/policy/" + operation, headers=headers, json=policy
+        )
+        assert response.status_code == 200, response.text
+        document = response.json()["policy"]
+        assert document.get("policy_json", document)["members"][0]["deployment_id"] == deployment_id
+    selector = {
+        "kind": "llm-tier",
+        "classifier_deployment_id": deployment_id,
+        "lanes": [
+            {"id": "economy", "rank": 0, "description": "Easy"},
+            {"id": "quality", "rank": 1, "description": "Hard"},
+        ],
+    }
+    rejected = await client.post(
+        base + "/long-id/policy/validate", headers=headers, json={**policy, "selector": selector}
+    )
+    assert rejected.status_code == 400, rejected.text

--- a/ui/src/lib/api/models.ts
+++ b/ui/src/lib/api/models.ts
@@ -73,7 +73,19 @@ export interface ModelRuntimeParams extends Record<string, unknown> {
   weight?: number | null;
 }
 
+export interface ChatRoutingCapabilities {
+  tools?: boolean;
+  json_object?: boolean;
+  json_schema?: boolean;
+  image?: boolean;
+  audio?: boolean;
+  file?: boolean;
+  streaming?: boolean;
+  multiple_choices?: boolean;
+}
+
 export interface ModelInfo extends Record<string, unknown> {
+  chat_capabilities?: ChatRoutingCapabilities | null;
   mode?: string;
   max_tokens?: number | null;
   max_input_tokens?: number | null;

--- a/ui/tests/modelFormShared.test.ts
+++ b/ui/tests/modelFormShared.test.ts
@@ -82,6 +82,15 @@ test('buildModelPayload sets scheduler capacity and preserves unknown model_info
   assert.equal(payload.model_info.priority, 3);
 });
 
+test('unrelated model-form saves preserve selector capability qualification', () => {
+  const capabilities = { tools: true, streaming: true, image: false, json_schema: true };
+  const existing = { chat_capabilities: capabilities, provider_private_metadata: { region: 'eu' } };
+  const payload = buildModelPayload(chatForm(), [], existing);
+  assert.deepEqual(payload.model_info.chat_capabilities, capabilities);
+  assert.deepEqual(payload.model_info.provider_private_metadata, existing.provider_private_metadata);
+  assert.deepEqual(existing.chat_capabilities, capabilities);
+});
+
 test('buildModelPayload preserves existing scheduler capacity on unrelated saves', () => {
   const existingModel: ModelDeploymentDetail = {
     deployment_id: 'dep-1',


### PR DESCRIPTION
## Summary

Implements **PR 4 — real-time routing integration and direct activation** from #304.
This PR targets `feature/issue-304-model-router`, not `main`; #304 stays open for
PRs 5–6. The base includes the previously verified main-alignment merge `37929ea7`.

An optional, bounded LLM selector can now choose a cost/quality lane for real-time
Chat Completions and Responses. Existing routing strategies, hard eligibility
checks, retries and failover remain authoritative. There is no shadow mode.

### PR 4 delivery checklist

- [x] Immutable lane-aware candidate planning; provider execution stays outside the planner.
- [x] Membership, workload, capabilities, tags, context, health, capacity and authorization remain hard constraints.
- [x] Selected lane followed by upward-only escalation; quality choices never downgrade.
- [x] Existing strategy and context ordering within each eligible lane.
- [x] One decision across retries, ordinary/classified/local-context fallbacks and MCP continuation; pinned immutable runtime generation.
- [x] Chat Completions and Responses, streaming and non-streaming.
- [x] Selection and known durable receipt before stream headers/body; owned cancellation and cleanup on disconnect.
- [x] Activation composed with durable billing, provider capacity, cache eligibility, bounded telemetry and execution readiness.
- [x] Atomic publish, removal and versioned rollback with qualified metadata and effective membership.
- [x] Stable `batch_model_router_selector_unsupported` rejection for direct and fallback-reachable selectors until PR 6.
- [x] Zero selector work on selector-free traffic and response-cache hits; ordinary dependency counts retained.

### Economic and compatibility boundaries

- Customers pay the selector's actual provider cost without markup, linked to the verified caller through the existing durable billing journal/outbox.
- Budgets are intentionally **soft spending controls**, per the approved trade-off. No cross-traffic atomic spending reservations are added.
- Known selector receipts survive answer failure/cancellation; unknown usage remains pending rather than becoming zero. Public OpenAI `usage` stays answer-only.
- Runtime activation requires explicit chat capabilities, known context capacity, concrete supported classifier target, classifier pricing and provider RPM/TPM limits, and healthy durable-accounting ownership.
- Existing policies remain selector-free by default. Cache provenance/keyspaces are versioned; old disposable entries become misses.
- Guided editor/evaluation/analytics work remains PR 5; per-item Batch selection remains PR 6. Simulation remains explicitly unsupported for selectors until that work lands.

### Review findings fixed

- Reject unsupported streaming MCP before any selector reservation, provider call or charge, including hook-transformed requests.
- Bound initial local-context fallback planning by the original request deadline without adding a second cancellation timeout around receipt cleanup.
- Qualify the canonical normalized policy projection while preserving opaque/server-owned stored member fields through publish/draft/removal/rollback.
- Qualify effectively enabled membership, honoring both group-level and policy-level disabling; unsafe re-enabling rolls back atomically.
- Also preserve the legacy response contract for selector-free deployment IDs longer than 256 characters, with an HTTP regression.

## Validation

The reviewed implementation was verified locally before this publishing step. All
five exclusive Python lanes pass: **4,788 tests, no failures or skips**.

| Command | Result |
| --- | --- |
| `.venv/bin/pytest -q -m hermetic --durations=10` | 3,215 passed |
| `.venv/bin/pytest -q -m app --durations=10` | 1,201 passed |
| `DATABASE_URL="$PR4_TEST_DATABASE_URL" .venv/bin/pytest -q -m postgres --durations=10` | 267 passed, real isolated PostgreSQL 15 |
| `REDIS_URL="$PR4_TEST_REDIS_URL" DELTALLM_TEST_REDIS_URL="$PR4_TEST_REDIS_URL" .venv/bin/pytest -q -m redis --durations=10` | 46 passed, real isolated Redis 7 |
| `.venv/bin/pytest -q -m helm --durations=10` | 59 passed |
| `.venv/bin/pytest --collect-only -qq --dependency-lane-report` | Exhaustive, exclusive 4,788-test classification |
| `.venv/bin/pytest -q tests/router/selection tests/services/test_route_policy_publication.py tests/db/test_route_policy_repository.py tests/test_ui_route_groups.py` | 399 passed |
| `DATABASE_URL="$PR4_TEST_DATABASE_URL" .venv/bin/pytest -q tests/db/test_selector_activation.py` | 15 passed |
| `git ls-files -m -o --exclude-standard -z -- '*.py' \| xargs -0 .venv/bin/ruff check` | Passed on all 82 changed/new Python files, before staging |
| `git ls-files -m -o --exclude-standard -z -- '*.py' \| xargs -0 .venv/bin/ruff format --check` | Passed on all 82 files, before staging |
| `.venv/bin/python scripts/docs/export_openapi.py --check` | Current: 227 paths, 295 operations |
| `.venv/bin/mkdocs build --strict --site-dir /private/tmp/deltallm-pr4-review-fixes.O7zXhG/site` | Passed |
| `git diff --check` / `git diff --cached --check` | Passed |

Fourteen new review regressions cover the four findings; the failures were
reproduced before correction. Coverage also includes tenant denial, one selector
attempt, deadline/disconnect cleanup, unavailable accounting/capacity, exact
idempotent receipts, immutable reloads, cache invalidation, and rollback atomicity.
App/PostgreSQL/Redis retain 22/4/2 existing deprecation warnings.

Earlier PR 4 UI validation, unchanged by the review fixes: **206 unit tests passed**,
Node 22 production build/typecheck and touched-file ESLint passed. Full UI lint
retains the clean feature base's **118 errors / 4 warnings**, with no new findings;
the complete generated UI bundle is byte-for-byte identical to the base. No schema,
migration, dependency-lock or CI-selection changes are introduced by PR 4.

### Performance evidence and limitations

- Repeated the unchanged fixed-provider cache harness sequentially against the clean feature base and final PR 4 worktree, with no test suites running: 200/200 per case at 10 RPS for 20 seconds; identical Redis/cache/provider call counts and zero sampled in-flight growth.
- Integrated real-time profile: 200/200 in all four selector/baseline stream/non-stream cases; 200 answer calls per case and exactly 200 selector reserve/dispatch/receipt operations only in selector cases. Baselines have zero selector operations.
- Tail latency is **not** proven equivalent or production-certified. Isolated miss p99 was 15.479 ms before / 34.259 ms after. A prior overlapping test/load run had four 429s during a scheduling stall; its failed result is retained in the design record, not hidden. The integrated repeat overlapped the app suite and is not a clean latency-overhead comparison.
- No real-provider quality, net-savings or deployment-saturation claim; these local mock profiles do not replace PR 5/6 evaluation and qualification.

Detailed ownership, budgets, commands, raw-artifact locations and results:
[model-router design and PR 4 completion/review records](https://github.com/deltawi/deltallm/blob/issue-304-pr4-realtime-routing/docs/project/model-router-design.md).

## Product and documentation impact

- [x] Public API, errors, streaming, authentication and tenant scope reviewed; public usage remains answer-only.
- [x] Settings/defaults/reload behavior reviewed; selector remains opt-in and activation requires qualified immutable runtime state.
- [x] Schema/migrations/rollback reviewed; existing schema and durable owners reused, no new migration.
- [x] Provider capabilities, model metadata, exact pricing and credentials reviewed; explicit capability contract and frozen selector attribution.
- [x] Admin UI types/metadata-preservation tests updated; no new interactive workflow or screenshots in PR 4 (guided editing is PR 5).
- [x] Deployment/readiness/metrics/security reviewed; existing clients, capacity and accounting-worker ownership reused.
- [x] Public configuration/router/model docs and design/verification records updated.
- [x] Generated OpenAPI checked; UI bundle unchanged. Governance and CI files unchanged.

## Rollout and rollback

- Merge into the feature branch only; this PR does not merge or deploy to `main`.
- No schema migration. Keep selectors absent while upgrading API replicas; publish a selector only after all serving replicas support PR 4 and durable spend-outbox readiness/capacity qualification passes.
- Publishing a qualified selector activates real-time selection immediately. Removing the selector or publishing/rolling back to a selector-free revision disables it. Selector-bearing historical revisions are revalidated against current inventory before activation.
- Use a separately bound Route Group for canarying. Monitor selector defaults/failures, TTFT, capacity rejections and durable accounting/recovery; never introduce shadow classification.
- Before a binary rollback to pre-PR-4 code, remove selectors from published/file policies and drain/reconcile outstanding selector accounting. Preserve billing journal/outbox state; do not treat unknown usage as free.
- Batch continues to reject selector-reachable targets explicitly until PR 6 provides per-item parity.
